### PR TITLE
move Make_x to x_ for random

### DIFF
--- a/developer_tools/Makefile
+++ b/developer_tools/Makefile
@@ -170,7 +170,7 @@ ifeq ($(GPU_Enable),1)
 endif
 
 ## Random
-OBJS += Make_normal.o normal.o Make_uniform.o uniform.o
+OBJS += normal_.o normal.o uniform_.o uniform.o
 
 
 ALLOBJS = $(OBJS)
@@ -609,9 +609,9 @@ cuUniform_internal.o :  $(CytnxPATH)/src/random/random_internal_gpu/cuUniform_in
 endif
 ## Random:
 ########################
-Make_normal.o: $(CytnxPATH)/src/random/Make_normal.cpp $(CytnxPATH)/include/random.hpp
+normal_.o: $(CytnxPATH)/src/random/normal_.cpp $(CytnxPATH)/include/random.hpp
 	$(CC)  $(CCFLAGS) $(INCFLAGS) -c $<
-Make_uniform.o: $(CytnxPATH)/src/random/Make_uniform.cpp $(CytnxPATH)/include/random.hpp
+uniform_.o: $(CytnxPATH)/src/random/uniform_.cpp $(CytnxPATH)/include/random.hpp
 	$(CC)  $(CCFLAGS) $(INCFLAGS) -c $<
 normal.o: $(CytnxPATH)/src/random/normal.cpp $(CytnxPATH)/include/random.hpp
 	$(CC)  $(CCFLAGS) $(INCFLAGS) -c $<

--- a/include/random.hpp
+++ b/include/random.hpp
@@ -20,7 +20,7 @@ namespace cytnx {
     // [Storage]
     // =============================================================================================================
     // =============================================================================================================
-    // Make_normal:
+    // normal_:
     //--------------------------------------------------
     /**
     @brief Randomize the memory of a Storage with normal distributon
@@ -30,10 +30,10 @@ namespace cytnx {
     @param[in] seed the seed for the random generator. [Default] Using device entropy.
     @note The Storage sould be real floating type or complex type.
     */
-    void Make_normal(Storage &Sin, const double &mean, const double &std,
-                     const unsigned int &seed = std::random_device()());
+    void normal_(Storage &Sin, const double &mean, const double &std,
+                 const unsigned int &seed = std::random_device()());
 
-    // Make_uniform:
+    // uniform_:
     //--------------------------------------------------
     /**
     @brief Randomize the memory of a Storage with uniform distributon
@@ -46,13 +46,13 @@ namespace cytnx {
         2. In cpu, it generate random number in domain [low,high); but in gpu(cuda), it generate
         random number in domain (low,high]; (cuRandv10)
     */
-    void Make_uniform(Storage &Sin, const double &low = 0, const double &high = 1,
-                      const unsigned int &seed = std::random_device()());
+    void uniform_(Storage &Sin, const double &low = 0, const double &high = 1,
+                  const unsigned int &seed = std::random_device()());
 
     // [Tensor]
     // =============================================================================================================
     // =============================================================================================================
-    // Make_normal:
+    // normal_:
     //-------------------------------------------------
     /**
     @brief Randomize the memory of a Tensor with normal distributon
@@ -62,10 +62,10 @@ namespace cytnx {
     @param[in] seed the seed for the random generator. [Default] Using device entropy.
     @note The Tensor sould be real floating type or complex type.
     */
-    void Make_normal(Tensor &Tin, const double &mean, const double &std,
-                     const unsigned int &seed = std::random_device()());
+    void normal_(Tensor &Tin, const double &mean, const double &std,
+                 const unsigned int &seed = std::random_device()());
 
-    // Make_uniform:
+    // uniform_:
     //--------------------------------------------------
     /**
     @brief Randomize the memory of a Tensor with uniform distributon
@@ -79,13 +79,13 @@ namespace cytnx {
         random number in domain (low,high]; (cuRandv10)
 
     */
-    void Make_uniform(Tensor &Tin, const double &low = 0, const double &high = 1,
-                      const unsigned int &seed = std::random_device()());
+    void uniform_(Tensor &Tin, const double &low = 0, const double &high = 1,
+                  const unsigned int &seed = std::random_device()());
 
     // [UniTensor]
     // =============================================================================================================
     // =============================================================================================================
-    // Make_normal:
+    // normal_:
     //-------------------------------------------------
     /**
     @brief Randomize the memory of a UniTensor with normal distributon
@@ -95,10 +95,10 @@ namespace cytnx {
     @param[in] seed the seed for the random generator. [Default] Using device entropy.
     @note The UniTensor sould be real floating type or complex type.
     */
-    void Make_normal(UniTensor &Tin, const double &mean, const double &std,
-                     const unsigned int &seed = std::random_device()());
+    void normal_(UniTensor &Tin, const double &mean, const double &std,
+                 const unsigned int &seed = std::random_device()());
 
-    // Make_uniform:
+    // uniform_:
     //--------------------------------------------------
     /**
     @brief Randomize the memory of a UniTensor with uniform distributon
@@ -111,8 +111,8 @@ namespace cytnx {
         2. In cpu, it generate random number in domain [low,high); but in gpu(cuda), it generate
         random number in domain (low,high]; (cuRandv10)
     */
-    void Make_uniform(UniTensor &Tin, const double &low = 0, const double &high = 1,
-                      const unsigned int &seed = std::random_device()());
+    void uniform_(UniTensor &Tin, const double &low = 0, const double &high = 1,
+                  const unsigned int &seed = std::random_device()());
 
     // normal:
     //@{
@@ -187,6 +187,21 @@ namespace cytnx {
                    const unsigned int &seed = std::random_device()(),
                    const unsigned int &dtype = Type.Double);
     //@}
+
+    ///@cond
+    // this is going to deprecated:
+    template <class T>
+    void Make_normal(T &In, const double &mean, const double &std,
+                     const unsigned int &seed = std::random_device()()) {
+      normal_(In, mean, std, seed);
+    }
+    template <class T>
+    void Make_uniform(T &In, const double &low, const double &high,
+                      const unsigned int &seed = std::random_device()()) {
+      uniform_(In, low, high, seed);
+    }
+
+    ///@endcond
 
   }  // namespace random
 }  // namespace cytnx

--- a/pybind/random_py.cpp
+++ b/pybind/random_py.cpp
@@ -23,46 +23,46 @@ void random_binding(py::module &m) {
   pybind11::module m_random = m.def_submodule("random", "random related.");
 
   m_random.def(
-    "Make_normal",
+    "normal_",
     [](cytnx::Tensor &Tin, const double &mean, const double &std, const long long &seed) {
-      cytnx::random::Make_normal(Tin, mean, std, seed);
+      cytnx::random::normal_(Tin, mean, std, seed);
     },
     py::arg("Tin"), py::arg("mean"), py::arg("std"), py::arg("seed") = std::random_device()());
 
   m_random.def(
-    "Make_normal",
+    "normal_",
     [](cytnx::Storage &Sin, const double &mean, const double &std, const long long &seed) {
-      cytnx::random::Make_normal(Sin, mean, std, seed);
+      cytnx::random::normal_(Sin, mean, std, seed);
     },
     py::arg("Sin"), py::arg("mean"), py::arg("std"), py::arg("seed") = std::random_device()());
 
   m_random.def(
-    "Make_normal",
+    "normal_",
     [](cytnx::UniTensor &Tin, const double &mean, const double &std, const long long &seed) {
-      cytnx::random::Make_normal(Tin, mean, std, seed);
+      cytnx::random::normal_(Tin, mean, std, seed);
     },
     py::arg("Tin"), py::arg("mean"), py::arg("std"), py::arg("seed") = std::random_device()());
 
   m_random.def(
-    "Make_uniform",
+    "uniform_",
     [](cytnx::Tensor &Tin, const double &low, const double &high, const long long &seed) {
-      cytnx::random::Make_uniform(Tin, low, high, seed);
+      cytnx::random::uniform_(Tin, low, high, seed);
     },
     py::arg("Tin"), py::arg("low") = double(0), py::arg("high") = double(1.0),
     py::arg("seed") = std::random_device()());
 
   m_random.def(
-    "Make_uniform",
+    "uniform_",
     [](cytnx::Storage &Sin, const double &low, const double &high, const long long &seed) {
-      cytnx::random::Make_uniform(Sin, low, high, seed);
+      cytnx::random::uniform_(Sin, low, high, seed);
     },
     py::arg("Sin"), py::arg("low") = double(0), py::arg("high") = double(1.0),
     py::arg("seed") = std::random_device()());
 
   m_random.def(
-    "Make_uniform",
+    "uniform_",
     [](cytnx::UniTensor &Tin, const double &low, const double &high, const long long &seed) {
-      cytnx::random::Make_uniform(Tin, low, high, seed);
+      cytnx::random::uniform_(Tin, low, high, seed);
     },
     py::arg("Tin"), py::arg("low") = double(0), py::arg("high") = double(1.0),
     py::arg("seed") = std::random_device()());

--- a/src/linalg/Lanczos_ER.cpp
+++ b/src/linalg/Lanczos_ER.cpp
@@ -78,7 +78,7 @@ namespace cytnx {
           /// construct a random vector for next iteration:
           while (1) {
             bool is_orth = true;
-            cytnx::random::Make_normal(buffer[0], 0., 1.0);
+            cytnx::random::normal_(buffer[0], 0., 1.0);
             buffer[0] /= buffer[0].Norm().item();
             for (cytnx_uint32 ig = 0; ig < converged_ev.size(); ig++) {
               Tensor Res = Vectordot(converged_ev[ig], buffer[0], true);  // reuse variable here.
@@ -186,7 +186,7 @@ namespace cytnx {
                     ///construct a random vector for next iteration:
                     while(1){
                         bool is_orth=true;
-                        cytnx::random::Make_normal(buffer[0],0.,1.0);
+                        cytnx::random::normal_(buffer[0],0.,1.0);
                         buffer[0]/=buffer[0].Norm().item();
                         for(cytnx_uint32 ig=0;ig<converged_ev.size();ig++){
                             Elast = Vectordot(buffer[0],converged_ev[ig]).item<cytnx_double>();
@@ -286,7 +286,7 @@ namespace cytnx {
                     ///construct a random vector for next iteration:
                     while(1){
                         bool is_orth=true;
-                        cytnx::random::Make_normal(buffer[0],0.,1.0);
+                        cytnx::random::normal_(buffer[0],0.,1.0);
                         buffer[0]/=buffer[0].Norm().item();
                         for(cytnx_uint32 ig=0;ig<converged_ev.size();ig++){
                             Elast = Vectordot(buffer[0],converged_ev[ig]).item<cytnx_float>();
@@ -385,7 +385,7 @@ namespace cytnx {
                     ///construct a random vector for next iteration:
                     while(1){
                         bool is_orth=true;
-                        cytnx::random::Make_normal(buffer[0],0.,1.0);
+                        cytnx::random::normal_(buffer[0],0.,1.0);
                         buffer[0]/=buffer[0].Norm().item();
                         for(cytnx_uint32 ig=0;ig<converged_ev.size();ig++){
                             Tensor Res = Vectordot(converged_ev[ig],buffer[0],true); //reuse
@@ -484,7 +484,7 @@ namespace cytnx {
                     ///construct a random vector for next iteration:
                     while(1){
                         bool is_orth=true;
-                        cytnx::random::Make_normal(buffer[0],0.,1.0);
+                        cytnx::random::normal_(buffer[0],0.,1.0);
                         buffer[0]/=buffer[0].Norm().item();
                         for(cytnx_uint32 ig=0;ig<converged_ev.size();ig++){
                             Tensor Res = Vectordot(converged_ev[ig],buffer[0],true); //reuse

--- a/src/random/CMakeLists.txt
+++ b/src/random/CMakeLists.txt
@@ -2,8 +2,8 @@ target_sources_local(cytnx
     PRIVATE
     random_internal_interface.hpp
     random_internal_interface.cpp
-    Make_normal.cpp
-    Make_uniform.cpp
+    normal_.cpp
+    uniform_.cpp
     normal.cpp
     uniform.cpp
 )

--- a/src/random/normal.cpp
+++ b/src/random/normal.cpp
@@ -5,13 +5,13 @@ namespace cytnx {
     Tensor normal(const cytnx_uint64 &Nelem, const double &mean, const double &std,
                   const int &device, const unsigned int &seed, const unsigned int &dtype) {
       Tensor out({Nelem}, dtype, device);
-      Make_normal(out, mean, std, seed);
+      normal_(out, mean, std, seed);
       return out;
     }
     Tensor normal(const std::vector<cytnx_uint64> &Nelem, const double &mean, const double &std,
                   const int &device, const unsigned int &seed, const unsigned int &dtype) {
       Tensor out(Nelem, dtype, device);
-      Make_normal(out, mean, std, seed);
+      normal_(out, mean, std, seed);
       return out;
     }
 

--- a/src/random/normal_.cpp
+++ b/src/random/normal_.cpp
@@ -3,48 +3,42 @@
 
 namespace cytnx {
   namespace random {
-    void Make_normal(Storage &Sin, const double &mean, const double &std,
-                     const unsigned int &seed) {
+    void normal_(Storage &Sin, const double &mean, const double &std, const unsigned int &seed) {
       cytnx_error_msg(
         (Sin.dtype() < 1) || (Sin.dtype() > 4),
-        "[ERROR][Random.Make_normal] Normal distribution only accept real/imag floating type.%s",
-        "\n");
+        "[ERROR][Random.normal_] Normal distribution only accept real/imag floating type.%s", "\n");
       if (Sin.device() == Device.cpu) {
         random_internal::rii.Normal[Sin.dtype()](Sin._impl, mean, std, seed);
       } else {
 #ifdef UNI_GPU
         random_internal::rii.cuNormal[Sin.dtype()](Sin._impl, mean, std, seed);
 #else
-        cytnx_error_msg(true, "[ERROR][Make_normal] Tensor is on GPU without CUDA support.%s",
-                        "\n");
+        cytnx_error_msg(true, "[ERROR][normal_] Tensor is on GPU without CUDA support.%s", "\n");
 #endif
       }
     }
-    void Make_normal(Tensor &Tin, const double &mean, const double &std, const unsigned int &seed) {
+    void normal_(Tensor &Tin, const double &mean, const double &std, const unsigned int &seed) {
       cytnx_error_msg(
         (Tin.dtype() < 1) || (Tin.dtype() > 4),
-        "[ERROR][Random.Make_normal] Normal distribution only accept real/imag floating type.%s",
-        "\n");
+        "[ERROR][Random.normal_] Normal distribution only accept real/imag floating type.%s", "\n");
       if (Tin.device() == Device.cpu) {
         random_internal::rii.Normal[Tin.dtype()](Tin._impl->storage()._impl, mean, std, seed);
       } else {
 #ifdef UNI_GPU
         random_internal::rii.cuNormal[Tin.dtype()](Tin._impl->storage()._impl, mean, std, seed);
 #else
-        cytnx_error_msg(true, "[ERROR][Make_normal] Tensor is on GPU without CUDA support.%s",
-                        "\n");
+        cytnx_error_msg(true, "[ERROR][normal_] Tensor is on GPU without CUDA support.%s", "\n");
 #endif
       }
     }
 
-    void Make_normal(UniTensor &Tin, const double &mean, const double &std,
-                     const unsigned int &seed) {
+    void normal_(UniTensor &Tin, const double &mean, const double &std, const unsigned int &seed) {
       if (Tin.uten_type() != UTenType.Dense) {
         for (cytnx_int64 i = 0; i < Tin.get_blocks_().size(); i++) {
-          Make_normal(Tin.get_blocks_()[i], mean, std, seed + i);
+          normal_(Tin.get_blocks_()[i], mean, std, seed + i);
         }
       } else {
-        Make_normal(Tin.get_block_(), mean, std, seed);
+        normal_(Tin.get_block_(), mean, std, seed);
       }
     }
 

--- a/src/random/uniform.cpp
+++ b/src/random/uniform.cpp
@@ -5,13 +5,13 @@ namespace cytnx {
     Tensor uniform(const cytnx_uint64 &Nelem, const double &low, const double &high,
                    const int &device, const unsigned int &seed, const unsigned int &dtype) {
       Tensor out({Nelem}, dtype, device);
-      Make_uniform(out, low, high, seed);
+      uniform_(out, low, high, seed);
       return out;
     }
     Tensor uniform(const std::vector<cytnx_uint64> &Nelem, const double &low, const double &high,
                    const int &device, const unsigned int &seed, const unsigned int &dtype) {
       Tensor out(Nelem, dtype, device);
-      Make_uniform(out, low, high, seed);
+      uniform_(out, low, high, seed);
       return out;
     }
 

--- a/src/random/uniform_.cpp
+++ b/src/random/uniform_.cpp
@@ -3,14 +3,13 @@
 
 namespace cytnx {
   namespace random {
-    void Make_uniform(Storage &Sin, const double &low, const double &high,
-                      const unsigned int &seed) {
+    void uniform_(Storage &Sin, const double &low, const double &high, const unsigned int &seed) {
       cytnx_error_msg(
         (Sin.dtype() < 1) || (Sin.dtype() > 4),
-        "[ERROR][Random.Make_uniform] Uniform distribution only accept real/imag floating type.%s",
+        "[ERROR][Random.uniform_] Uniform distribution only accept real/imag floating type.%s",
         "\n");
       cytnx_error_msg(high <= low,
-                      "[ERROR][Random.Make_uniform] higher-bound should be > lower-bound.%s", "\n");
+                      "[ERROR][Random.uniform_] higher-bound should be > lower-bound.%s", "\n");
       if (Sin.device() == Device.cpu) {
         random_internal::rii.Uniform[Sin.dtype()](Sin._impl, low, high, seed);
       } else {
@@ -20,19 +19,17 @@ namespace cytnx {
         // Sin = low + Sin*(high-low); // we need Storage arithmetic!
 
 #else
-        cytnx_error_msg(true, "[ERROR][Make_uniform] Tensor is on GPU without CUDA support.%s",
-                        "\n");
+        cytnx_error_msg(true, "[ERROR][uniform_] Tensor is on GPU without CUDA support.%s", "\n");
 #endif
       }
     }
-    void Make_uniform(Tensor &Tin, const double &low, const double &high,
-                      const unsigned int &seed) {
+    void uniform_(Tensor &Tin, const double &low, const double &high, const unsigned int &seed) {
       cytnx_error_msg(
         (Tin.dtype() < 1) || (Tin.dtype() > 4),
-        "[ERROR][Random.Make_uniform] Uniform distribution only accept real/imag floating type.%s",
+        "[ERROR][Random.uniform_] Uniform distribution only accept real/imag floating type.%s",
         "\n");
       cytnx_error_msg(high <= low,
-                      "[ERROR][Random.Make_uniform] higher-bound should be > lower-bound.%s", "\n");
+                      "[ERROR][Random.uniform_] higher-bound should be > lower-bound.%s", "\n");
       if (Tin.device() == Device.cpu) {
         random_internal::rii.Uniform[Tin.dtype()](Tin._impl->storage()._impl, low, high, seed);
       } else {
@@ -41,20 +38,18 @@ namespace cytnx {
         random_internal::rii.cuUniform[Tin.dtype()](Tin._impl->storage()._impl, low, high, seed);
         // Tin = low + Tin*(high-low);
 #else
-        cytnx_error_msg(true, "[ERROR][Make_uniform] Tensor is on GPU without CUDA support.%s",
-                        "\n");
+        cytnx_error_msg(true, "[ERROR][uniform_] Tensor is on GPU without CUDA support.%s", "\n");
 #endif
       }
     }
 
-    void Make_uniform(UniTensor &Tin, const double &low, const double &high,
-                      const unsigned int &seed) {
+    void uniform_(UniTensor &Tin, const double &low, const double &high, const unsigned int &seed) {
       if (Tin.uten_type() != UTenType.Dense) {
         for (cytnx_int64 i = 0; i < Tin.get_blocks_().size(); i++) {
-          Make_uniform(Tin.get_blocks_()[i], low, high, seed + i);
+          uniform_(Tin.get_blocks_()[i], low, high, seed + i);
         }
       } else {
-        Make_uniform(Tin.get_block_(), low, high, seed);
+        uniform_(Tin.get_block_(), low, high, seed);
       }
     }
 

--- a/test.cc
+++ b/test.cc
@@ -44,7 +44,7 @@ int main(int argc, char *argv[]) {
   bool is_diag = true;
   auto labels = std::vector<std::string>();
   auto T = UniTensor(bonds, labels, rowrank, cytnx::Type.Double, cytnx::Device.cpu, is_diag);
-  random::Make_uniform(T, 0, 10, 0);
+  random::uniform_(T, 0, 10, 0);
   std::cout << T << std::endl;
   std::vector<UniTensor> svds = linalg::Svd(T);
   auto S = svds[0];
@@ -122,7 +122,7 @@ int main(int argc, char *argv[]) {
 
   AY = AY.astype(Type.ComplexDouble);
 
-  random::Make_normal(AY.get_block_(),0,0.2);
+  random::normal_(AY.get_block_(),0,0.2);
 
   print(AY);
 
@@ -147,7 +147,7 @@ int main(int argc, char *argv[]) {
   BUT4 = BUT4.astype(Type.ComplexDouble);
 
   for (int i = 0; i < BUT4.get_blocks_().size(); i++) {
-    random::Make_normal(BUT4.get_blocks_()[i], 0, 0.2);
+    random::normal_(BUT4.get_blocks_()[i], 0, 0.2);
   }
 
   print(BUT4);


### PR DESCRIPTION
This PR address #197, 

1. change Make_uniform(), Make_normal() to uniform_() and normal_()
2. still keep Make_uniform/normal (as a wrapper to uniform_ and normal_) with deprecated notice. 