### PR TITLE
access bond by label

### DIFF
--- a/include/UniTensor.hpp
+++ b/include/UniTensor.hpp
@@ -121,6 +121,21 @@ namespace cytnx {
     }
     const std::vector<Bond> &bonds() const { return this->_bonds; }
     std::vector<Bond> &bonds() { return this->_bonds; }
+
+    Bond &bond_(const cytnx_uint64 &idx) {
+      cytnx_error_msg(idx >= this->_bonds.size(), "[ERROR][bond] index %d out of bound, total %d\n",
+                      idx, this->_bonds.size());
+      return this->_bonds[idx];
+    }
+
+    Bond &bond_(const std::string &lbl) {
+      auto res = std::find(this->_labels.begin(), this->_labels.end(), lbl);
+      cytnx_error_msg(res == this->_labels.end(), "[ERROR] label %s not exists.\n", lbl.c_str());
+      cytnx_uint64 idx = std::distance(this->_labels.begin(), res);
+
+      return this->bond_(idx);
+    }
+
     const std::string &name() const { return this->_name; }
     cytnx_uint64 rank() const { return this->_labels.size(); }
     void set_name(const std::string &in) { this->_name = in; }
@@ -2148,6 +2163,15 @@ namespace cytnx {
         @see bonds();
     */
     std::vector<Bond> &bonds() { return this->_impl->bonds(); }
+
+    const Bond &bond_(const cytnx_uint64 &idx) const { return this->_impl->bond_(idx); }
+    Bond &bond_(const cytnx_uint64 &idx) { return this->_impl->bond_(idx); }
+
+    const Bond &bond_(const std::string &lbl) const { return this->_impl->bond_(lbl); }
+    Bond &bond_(const std::string &lbl) { return this->_impl->bond_(lbl); }
+
+    Bond bond(const cytnx_uint64 &idx) const { return this->_impl->bond_(idx).clone(); }
+    Bond bond(const std::string &lbl) const { return this->_impl->bond_(lbl).clone(); }
 
     /**
     @brief Get the shape of the UniTensor.

--- a/pybind/unitensor_py.cpp
+++ b/pybind/unitensor_py.cpp
@@ -430,6 +430,10 @@ void unitensor_binding(py::module &m) {
     .def("same_data", &UniTensor::same_data)
     .def("labels", &UniTensor::labels)
     .def("bonds", [](UniTensor &self) { return self.bonds(); })
+    .def("bond_", [](UniTensor &self, const cytnx_uint64 &idx){return self.bond_(idx);} ,py::arg("idx"))
+    .def("bond_", [](UniTensor &self, const std::string &label){return self.bond_(label);} ,py::arg("label"))
+    .def("bond", [](UniTensor &self, const cytnx_uint64 &idx){return self.bond(idx);} ,py::arg("idx"))
+    .def("bond", [](UniTensor &self, const std::string &label){return self.bond(label);} ,py::arg("label"))
     .def("shape", &UniTensor::shape)
     .def("to_", &UniTensor::to_)
     .def(

--- a/src/algo/Hsplit.cpp
+++ b/src/algo/Hsplit.cpp
@@ -36,9 +36,14 @@ namespace cytnx {
         algo_internal::hSplit_internal(targ_ptrs, (char *)_Tn.storage().data(), dims,
                                        _Tn.shape()[0], Type.typeSize(Tin.dtype()));
       } else {
-        // cytnx_error_msg(true, "[ERROR][Vsplit_] currently for GPU is under developing.%s", "\n");
+#ifdef UNI_GPU
         algo_internal::cuhSplit_internal(targ_ptrs, (char *)_Tn.storage().data(), dims,
                                          _Tn.shape()[0], Type.typeSize(Tin.dtype()));
+#else
+        cytnx_error_msg(
+          true, "[ERROR][Hsplit_] input is on GPU but current cytnx is compiled without GPU.%s",
+          "\n");
+#endif
       }
     }
 

--- a/src/algo/Hstack.cpp
+++ b/src/algo/Hstack.cpp
@@ -85,8 +85,14 @@ namespace cytnx {
                                          Type.typeSize(dtype_id));
       } else {
         // cytnx_error_msg(true, "[ERROR][Vstack] currently for GPU is under developing.%s", "\n");
+#ifdef UNI_GPU
         algo_internal::cuhConcate_internal((char *)out.storage().data(), rawPtr, Ds, Dshare, Dcomb,
                                            Type.typeSize(dtype_id));
+#else
+        cytnx_error_msg(
+          true, "[ERROR][Hstack_] input is on GPU but current cytnx is compiled without GPU.%s",
+          "\n");
+#endif
       }
 
       return out;

--- a/src/algo/Vsplit.cpp
+++ b/src/algo/Vsplit.cpp
@@ -37,8 +37,14 @@ namespace cytnx {
                                        _Tn.shape()[1], Type.typeSize(Tin.dtype()));
       } else {
         // cytnx_error_msg(true, "[ERROR][Vsplit_] currently for GPU is under developing.%s", "\n");
+#ifdef UNI_GPU
         algo_internal::cuvSplit_internal(targ_ptrs, (char *)_Tn.storage().data(), dims,
                                          _Tn.shape()[1], Type.typeSize(Tin.dtype()));
+#else
+        cytnx_error_msg(
+          true, "[ERROR][Vsplit_] input is on GPU but current cytnx is compiled without GPU.%s",
+          "\n");
+#endif
       }
     }
     std::vector<Tensor> Vsplit(const Tensor &Tin, const std::vector<cytnx_uint64> &dims) {

--- a/src/algo/Vstack.cpp
+++ b/src/algo/Vstack.cpp
@@ -85,8 +85,14 @@ namespace cytnx {
                                          Type.typeSize(dtype_id));
       } else {
         // cytnx_error_msg(true, "[ERROR][Vstack] currently for GPU is under developing.%s", "\n");
+#ifdef UNI_GPU
         algo_internal::cuvConcate_internal((char *)out.storage().data(), rawPtr, Ds,
                                            Type.typeSize(dtype_id));
+#else
+        cytnx_error_msg(
+          true, "[ERROR][VStack_] input is on GPU but current cytnx is compiled without GPU.%s",
+          "\n");
+#endif
       }
 
       return out;


### PR DESCRIPTION
This PR address #221 

1. Fix bug for Hstack, Vstack, Hsplit, Vsplit GPU does not properly guarded by macro UNI_GPU
2.  add UniTensor.bond(_)(Union[Int, Str])
