### PR TITLE
add UniTensor.from to convert btwn sym/non-sym

### DIFF
--- a/include/Tensor.hpp
+++ b/include/Tensor.hpp
@@ -602,6 +602,13 @@ namespace cytnx {
       std::vector<cytnx_int64> tmp = accs;
       return (*this)[tmp];
     }
+    const Tproxy operator[](const std::vector<cytnx_uint64> &accs) const {
+      std::vector<cytnx::Accessor> acc_in;
+      for (int i = 0; i < accs.size(); i++) {
+        acc_in.push_back(cytnx::Accessor(accs[i]));
+      }
+      return Tproxy(this->_impl, acc_in);
+    }
     const Tproxy operator[](const std::vector<cytnx_int64> &accs) const {
       std::vector<cytnx::Accessor> acc_in;
       for (int i = 0; i < accs.size(); i++) {

--- a/include/UniTensor.hpp
+++ b/include/UniTensor.hpp
@@ -396,6 +396,8 @@ namespace cytnx {
     virtual const cytnx_int16 &at_for_sparse(const std::vector<cytnx_uint64> &locator,
                                              const cytnx_int16 &aux) const;
 
+    virtual void from_(const boost::intrusive_ptr<UniTensor_base> &rhs, const bool &force);
+
     virtual void group_basis_();
     virtual const std::vector<cytnx_uint64> &get_qindices(const cytnx_uint64 &bidx) const;
     virtual std::vector<cytnx_uint64> &get_qindices(const cytnx_uint64 &bidx);
@@ -956,6 +958,8 @@ namespace cytnx {
      */
     void truncate_(const cytnx_int64 &bond_idx, const cytnx_uint64 &dim);
     void truncate_(const std::string &bond_idx, const cytnx_uint64 &dim);
+
+    void from_(const boost::intrusive_ptr<UniTensor_base> &rhs, const bool &force);
 
     void group_basis_() {
       cytnx_warning_msg(true, "[WARNING] group basis will not have any effect on DensUniTensor.%s",
@@ -1617,6 +1621,7 @@ namespace cytnx {
         "This operation will destroy block structure. [Suggest] using get/set_block(s) to do "
         "operation on the block(s).");
     }
+    void from_(const boost::intrusive_ptr<UniTensor_base> &rhs, const bool &force);
 
     void group_basis_();
 
@@ -3914,6 +3919,11 @@ namespace cytnx {
     void _Load(std::fstream &f);
     void _Save(std::fstream &f) const;
     /// @endcond
+
+    UniTensor &from(const UniTensor &rhs, const bool &force = false) {
+      this->_impl->from_(rhs._impl, force);
+      return *this;
+    }
 
   };  // class UniTensor
 

--- a/src/UniTensor_base.cpp
+++ b/src/UniTensor_base.cpp
@@ -677,4 +677,8 @@ namespace cytnx {
                     "\n");
   }
 
+  void UniTensor_base::from_(const boost::intrusive_ptr<UniTensor_base> &rhs, const bool &force) {
+    cytnx_error_msg(true, "[ERROR] fatal internal, cannot call on a un-initialize UniTensor_base%s",
+                    "\n");
+  }
 }  // namespace cytnx

--- a/test.cc
+++ b/test.cc
@@ -32,6 +32,16 @@ pair<std::string, cytnx_int64> operator>>(const std::string &a, const cytnx_int6
 // }
 
 int main(int argc, char *argv[]) {
+  Bond bdSp(BD_IN, {Qs(0) >> 1, Qs(1) >> 1});
+
+  auto UTSp_sym = UniTensor({bdSp, bdSp.redirect(), Bond(BD_IN, {Qs(1) >> 1})});
+  auto TSp = zeros({2, 2, 1});
+  TSp[{0, 1, 0}] = 1;
+  auto UTSp = UniTensor(TSp);
+
+  UTSp_sym.from(UTSp);
+  return 0;
+
   auto ss1 = (2, 3);
   return 0;
 


### PR DESCRIPTION
This PR address #182, #136

1. add conversion between Symmetry and non-Symmetry UniTensor with `UniTensor.from(In:UniTensor, force:Bool=false)`
* Setting force=true will only check if two UniTensor has same shape. 

