### PR TITLE
remove default printing of mkl interface

### DIFF
--- a/cytnx/__init__.py
+++ b/cytnx/__init__.py
@@ -9,12 +9,24 @@ if ('numpy' in sys.modules) or ('scipy' in sys.modules):
 
 ## [NOTE!!] These part has to execute first before import numpy!
 #set_mkl_ilp64()
-def init_mkl():
+def _init_mkl():
     a = zeros(2)
     b = zeros(2)
     linalg.Dot(a,b)
     return 0
-init_mkl()
+_init_mkl()
+
+
+def get_mkl_interface():
+    code = get_mkl_code()
+    if code < 0:
+        raise Warning("does not compile with mkl.")
+
+    if(code%2):
+        return "ilp64"
+    else:
+        return "lp64"
+
 
 import numpy
 from .Storage_conti import *

--- a/include/linalg.hpp
+++ b/include/linalg.hpp
@@ -12,6 +12,7 @@
 
 namespace cytnx {
   int set_mkl_ilp64();
+  int get_mkl_code();
 
   /**
    * @brief The addtion operator between two UniTensor.

--- a/pybind/cytnx.cpp
+++ b/pybind/cytnx.cpp
@@ -51,6 +51,7 @@ PYBIND11_MODULE(cytnx, m) {
   m.attr("User_debug") = cytnx::User_debug;
 
   m.def("set_mkl_ilp64", &cytnx::set_mkl_ilp64);
+  m.def("get_mkl_code", &cytnx::get_mkl_code);
 
   // global vars
   // m.attr("cytnxdevice") = cytnx::cytnxdevice;

--- a/src/linalg/Add.cpp
+++ b/src/linalg/Add.cpp
@@ -5,6 +5,7 @@
 
 namespace cytnx {
   int set_mkl_ilp64() { return cytnx::linalg_internal::lii.set_mkl_ilp64(); }
+  int get_mkl_code() { return cytnx::linalg_internal::lii.get_mkl_code(); }
   namespace linalg {
     Tensor Add(const Tensor &Lt, const Tensor &Rt) {
       cytnx_error_msg(Lt.device() != Rt.device(),

--- a/src/linalg/linalg_internal_interface.cpp
+++ b/src/linalg/linalg_internal_interface.cpp
@@ -13,17 +13,21 @@ namespace cytnx {
 
     linalg_internal_interface lii;
 
+    int linalg_internal_interface::get_mkl_code() { return this->mkl_code; }
+
     int linalg_internal_interface::set_mkl_ilp64() {
+      int code = 0;
 #ifdef UNI_MKL
-      int code = mkl_set_interface_layer(MKL_INTERFACE_ILP64);
-      std::cout << "MKL interface code: " << code;
-      if (code % 2)
-        std::cout << " >> using [ilp64] interface" << std::endl;
-      else
-        std::cout << " >> using [ lp64] interface" << std::endl;
+      code = mkl_set_interface_layer(MKL_INTERFACE_ILP64);
+      this->mkl_code = code;
+      // std::cout << "MKL interface code: " << code;
+      // if (code % 2)
+      //   std::cout << " >> using [ilp64] interface" << std::endl;
+      // else
+      //   std::cout << " >> using [ lp64] interface" << std::endl;
 
 #endif
-      return 0;
+      return code;
     }
     linalg_internal_interface::~linalg_internal_interface() {
 #ifdef UNI_GPU
@@ -35,6 +39,7 @@ namespace cytnx {
 #endif
     }
     linalg_internal_interface::linalg_internal_interface() {
+      mkl_code = -1;
 #ifdef UNI_MKL
       this->set_mkl_ilp64();
 #endif

--- a/src/linalg/linalg_internal_interface.hpp
+++ b/src/linalg/linalg_internal_interface.hpp
@@ -215,6 +215,7 @@ namespace cytnx {
 
       std::vector<axpy_oii> axpy_ii;
       std::vector<ger_oii> ger_ii;
+      int mkl_code;
 
 #ifdef UNI_GPU
       std::vector<std::vector<Arithmeticfunc_oii>> cuAri_ii;
@@ -247,6 +248,7 @@ namespace cytnx {
       linalg_internal_interface();
       ~linalg_internal_interface();
       int set_mkl_ilp64();
+      int get_mkl_code();
     };
     extern linalg_internal_interface lii;
   }  // namespace linalg_internal


### PR DESCRIPTION
This PR address #222

1. remove default print
2. add 
```python
>>> cytnx.get_mkl_interface()
```

return either `'ilp64'` or `'lp64'`