### PR TITLE
cuQuantum SVD(truncate)

### DIFF
--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -5,10 +5,9 @@
 #include "UniTensor.hpp"
 #include "algo.hpp"
 
-
 #ifdef UNI_GPU
   #ifdef UNI_CUQUANTUM
-      #include "linalg_internal_gpu/cuQuantumGeSvd_internal.hpp"
+    #include "linalg_internal_gpu/cuQuantumGeSvd_internal.hpp"
   #endif
 #endif
 
@@ -75,96 +74,97 @@ namespace cytnx {
     using namespace std;
     typedef Accessor ac;
 
-  #ifdef UNI_GPU
-    #ifdef UNI_CUQUANTUM
-    void _cuquantum_gesvdj_truncate_Dense_UT(std::vector<UniTensor> &outCyT, const cytnx::UniTensor &Tin,
-                                  const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
-                                  const bool &is_vT, const unsigned int &return_err){
+#ifdef UNI_GPU
+  #ifdef UNI_CUQUANTUM
+    void _cuquantum_gesvdj_truncate_Dense_UT(std::vector<UniTensor> &outCyT,
+                                             const cytnx::UniTensor &Tin,
+                                             const cytnx_uint64 &keepdim, const double &err,
+                                             const bool &is_U, const bool &is_vT,
+                                             const unsigned int &return_err) {
+      // Retrieve tensor from UniTensor
+      Tensor tmp;
+      if (Tin.is_contiguous())
+        tmp = Tin.get_block_();
+      else {
+        tmp = Tin.get_block();
+        tmp.contiguous_();
+      }
 
-        //Retrieve tensor from UniTensor
-        Tensor tmp;
-        if (Tin.is_contiguous())
-          tmp = Tin.get_block_();
-        else {
-          tmp = Tin.get_block();
-          tmp.contiguous_();
-        }
-      
-        vector<cytnx_uint64> tmps = tmp.shape();
-        vector<cytnx_int64> oldshape(tmps.begin(), tmps.end());
-        tmps.clear();
-        vector<string> oldlabel = Tin.labels();
+      vector<cytnx_uint64> tmps = tmp.shape();
+      vector<cytnx_int64> oldshape(tmps.begin(), tmps.end());
+      tmps.clear();
+      vector<string> oldlabel = Tin.labels();
 
-        // collapse as Matrix:
-        cytnx_int64 rowdim = 1;
-        for (cytnx_uint64 i = 0; i < Tin.rowrank(); i++) rowdim *= tmp.shape()[i];
-        tmp.reshape_({rowdim, -1});
+      // collapse as Matrix:
+      cytnx_int64 rowdim = 1;
+      for (cytnx_uint64 i = 0; i < Tin.rowrank(); i++) rowdim *= tmp.shape()[i];
+      tmp.reshape_({rowdim, -1});
 
-        cytnx_uint64 n_singlu = std::max(cytnx_uint64(1), std::min(tmp.shape()[0], tmp.shape()[1]));
-        Tensor in = tmp.contiguous();
-        //if (Tin.dtype() > Type.Float) in = in.astype(Type.Double);
+      cytnx_uint64 n_singlu = std::max(cytnx_uint64(1), std::min(tmp.shape()[0], tmp.shape()[1]));
+      Tensor in = tmp.contiguous();
+      // if (Tin.dtype() > Type.Float) in = in.astype(Type.Double);
 
-        //prepare U, S, vT
-        Tensor U, S, vT;
-        S.Init({n_singlu}, in.dtype() <= 2 ? in.dtype() + 2 : in.dtype(),
-              in.device());  // if type is complex, S should be real
-        U.Init({in.shape()[0], n_singlu}, in.dtype(), in.device());
-        vT.Init({n_singlu, in.shape()[1]}, in.dtype(), in.device());
+      // prepare U, S, vT
+      Tensor U, S, vT;
+      S.Init({n_singlu}, in.dtype() <= 2 ? in.dtype() + 2 : in.dtype(),
+             in.device());  // if type is complex, S should be real
+      U.Init({in.shape()[0], n_singlu}, in.dtype(), in.device());
+      vT.Init({n_singlu, in.shape()[1]}, in.dtype(), in.device());
 
-        linalg_internal::cuQuantumGeSvd_internal_cd(in, keepdim, err, return_err, U, S, vT); 
-        
-        std::vector<Tensor> outT;
-        outT.push_back(S);
-        outT.push_back(U);
-        outT.push_back(vT);
+      linalg_internal::cuQuantumGeSvd_internal_cd(in, keepdim, err, return_err, U, S, vT);
 
-        //set output
-        int t = 0;
-        outCyT.resize(outT.size());
-        cytnx::UniTensor &Cy_S = outCyT[t];
-        cytnx::Bond newBond(outT[0].shape()[0]);
-        Cy_S.Init({newBond, newBond}, {string("_aux_L"), string("_aux_R")}, 1, Type.Double,
-                  Device.cpu,
-                  true);  // it is just reference so no hurt to alias ^^
-        Cy_S.put_block_(outT[t]);
-        t++;
+      std::vector<Tensor> outT;
+      outT.push_back(S);
+      outT.push_back(U);
+      outT.push_back(vT);
 
-        if (is_U) {
-          cytnx::UniTensor &Cy_U = outCyT[t];
-          // shape
-          vector<cytnx_int64> shapeU = vec_clone(oldshape, Tin.rowrank());
-          shapeU.push_back(-1);
+      // set output
+      int t = 0;
+      outCyT.resize(outT.size());
+      cytnx::UniTensor &Cy_S = outCyT[t];
+      cytnx::Bond newBond(outT[0].shape()[0]);
+      Cy_S.Init({newBond, newBond}, {string("_aux_L"), string("_aux_R")}, 1, Type.Double,
+                Tin.device(),
+                true);  // it is just reference so no hurt to alias ^^
+      Cy_S.put_block_(outT[t]);
+      t++;
 
-          outT[t].reshape_(shapeU);
+      if (is_U) {
+        cytnx::UniTensor &Cy_U = outCyT[t];
+        // shape
+        vector<cytnx_int64> shapeU = vec_clone(oldshape, Tin.rowrank());
+        shapeU.push_back(-1);
 
-          Cy_U.Init(outT[t], false, Tin.rowrank());
-          vector<string> labelU = vec_clone(oldlabel, Tin.rowrank());
-          labelU.push_back(Cy_S.labels()[0]);
-          Cy_U.set_labels(labelU);
-          t++;  // U
-        }
+        outT[t].reshape_(shapeU);
 
-        if (is_vT) {
-          cytnx::UniTensor &Cy_vT = outCyT[t];
-          // shape
-          vector<cytnx_int64> shapevT(Tin.rank() - Tin.rowrank() + 1);
-          shapevT[0] = -1;
-          memcpy(&shapevT[1], &oldshape[Tin.rowrank()], sizeof(cytnx_int64) * (shapevT.size() - 1));
+        Cy_U.Init(outT[t], false, Tin.rowrank());
+        vector<string> labelU = vec_clone(oldlabel, Tin.rowrank());
+        labelU.push_back(Cy_S.labels()[0]);
+        Cy_U.set_labels(labelU);
+        t++;  // U
+      }
 
-          outT[t].reshape_(shapevT);
+      if (is_vT) {
+        cytnx::UniTensor &Cy_vT = outCyT[t];
+        // shape
+        vector<cytnx_int64> shapevT(Tin.rank() - Tin.rowrank() + 1);
+        shapevT[0] = -1;
+        memcpy(&shapevT[1], &oldshape[Tin.rowrank()], sizeof(cytnx_int64) * (shapevT.size() - 1));
 
-          Cy_vT.Init(outT[t], false, 1);
-          vector<string> labelvT(shapevT.size());
-          labelvT[0] = Cy_S.labels()[1];
-          std::copy(oldlabel.begin() + Tin.rowrank(), oldlabel.end(), labelvT.begin() + 1);
-          Cy_vT.set_labels(labelvT);
-          t++;  // vT
-        }
+        outT[t].reshape_(shapevT);
 
-        //if (return_err) outCyT.back().Init(outT.back(), false, 0);
+        Cy_vT.Init(outT[t], false, 1);
+        vector<string> labelvT(shapevT.size());
+        labelvT[0] = Cy_S.labels()[1];
+        std::copy(oldlabel.begin() + Tin.rowrank(), oldlabel.end(), labelvT.begin() + 1);
+        Cy_vT.set_labels(labelvT);
+        t++;  // vT
+      }
+
+      // if (return_err) outCyT.back().Init(outT.back(), false, 0);
     }
-    #endif
   #endif
+#endif
 
     void _gesvd_truncate_Dense_UT(std::vector<UniTensor> &outCyT, const cytnx::UniTensor &Tin,
                                   const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
@@ -428,21 +428,21 @@ namespace cytnx {
 
       std::vector<UniTensor> outCyT;
       if (Tin.uten_type() == UTenType.Dense) {
-        if(Tin.device() == -1){
+        if (Tin.device() == -1) {
           _gesvd_truncate_Dense_UT(outCyT, Tin, keepdim, err, is_U, is_vT, return_err);
-        }else{
-          #ifdef UNI_GPU
-            #ifdef UNI_CUQUANTUM
-              _cuquantum_gesvdj_truncate_Dense_UT(outCyT, Tin, keepdim, err, is_U, is_vT, return_err);
-            #else
-              cytnx_error_msg(true, "[cuQuantumSvd] fatal error,%s",
+        } else {
+#ifdef UNI_GPU
+  #ifdef UNI_CUQUANTUM
+          _cuquantum_gesvdj_truncate_Dense_UT(outCyT, Tin, keepdim, err, is_U, is_vT, return_err);
+  #else
+          cytnx_error_msg(true, "[cuQuantumSvd] fatal error,%s",
                           "try to call the cuquantum section without cuQunatum support.\n");
-            #endif
+  #endif
 
-          #else
-              cytnx_error_msg(true, "[cuQuantumSvd] fatal error,%s",
+#else
+          cytnx_error_msg(true, "[cuQuantumSvd] fatal error,%s",
                           "try to call the gpu section without CUDA support.\n");
-          #endif
+#endif
         }
 
       } else if (Tin.uten_type() == UTenType.Block) {
@@ -452,8 +452,6 @@ namespace cytnx {
         cytnx_error_msg(true, "[ERROR] only support gesvd for Dense and Block UniTensor.%s", "\n");
       }
       return outCyT;
-
-
 
     }  // Gesvd_truncate
 

--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -19,100 +19,97 @@ namespace cytnx {
     std::vector<Tensor> Gesvd_truncate(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                        const double &err, const bool &is_U, const bool &is_vT,
                                        const unsigned int &return_err) {
+      if (Tin.device() == Device.cpu) {
+        std::vector<Tensor> tmps = Gesvd(Tin, is_U, is_vT);
 
-      if(Tin.device() == -1){
-      std::vector<Tensor> tmps = Gesvd(Tin, is_U, is_vT);
+        cytnx_uint64 id = 0;
+        cytnx_uint64 Kdim = keepdim;
 
-      cytnx_uint64 id = 0;
-      cytnx_uint64 Kdim = keepdim;
+        Storage ts = tmps[0].storage();
 
-      Storage ts = tmps[0].storage();
-
-      if (ts.size() < keepdim) {
-        Kdim = ts.size();
-      }
-
-      cytnx_uint64 truc_dim = Kdim;
-      for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
-        if (ts.at(i) < err) {
-          truc_dim--;
-        } else {
-          break;
+        if (ts.size() < keepdim) {
+          Kdim = ts.size();
         }
-      }
 
-      if (truc_dim == 0) {
-        truc_dim = 1;
-      }
-      /// std::cout << truc_dim << std::endl;
-      // cytnx_error_msg(tmps[0].shape()[0] < keepdim,"[ERROR] keepdim should be <= the valid # of
-      // singular value, %d!\n",tmps[0].shape()[0]);
-      Tensor terr({1}, Type.Double);
-
-      if (truc_dim != ts.size()) {
-        if (return_err == 1)
-          terr = tmps[id](truc_dim);
-        else if (return_err)
-          terr = tmps[id].get({ac::tilend(truc_dim)});
-
-        tmps[id] = tmps[id].get({ac::range(0, truc_dim)});
-
-        if (is_U) {
-          id++;
-          tmps[id] = tmps[id].get({ac::all(), ac::range(0, truc_dim)});
+        cytnx_uint64 truc_dim = Kdim;
+        for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
+          if (ts.at(i) < err) {
+            truc_dim--;
+          } else {
+            break;
+          }
         }
-        if (is_vT) {
-          id++;
-          tmps[id] = tmps[id].get({ac::range(0, truc_dim), ac::all()});
+
+        if (truc_dim == 0) {
+          truc_dim = 1;
         }
+        /// std::cout << truc_dim << std::endl;
+        // cytnx_error_msg(tmps[0].shape()[0] < keepdim,"[ERROR] keepdim should be <= the valid # of
+        // singular value, %d!\n",tmps[0].shape()[0]);`
+        Tensor terr({1}, Type.Double);
+
+        if (truc_dim != ts.size()) {
+          if (return_err == 1)
+            terr = tmps[id](truc_dim);
+          else if (return_err)
+            terr = tmps[id].get({ac::tilend(truc_dim)});
+
+          tmps[id] = tmps[id].get({ac::range(0, truc_dim)});
+
+          if (is_U) {
+            id++;
+            tmps[id] = tmps[id].get({ac::all(), ac::range(0, truc_dim)});
+          }
+          if (is_vT) {
+            id++;
+            tmps[id] = tmps[id].get({ac::range(0, truc_dim), ac::all()});
+          }
+        }
+        if (return_err) tmps.push_back(terr);
+
+        return tmps;
+
+      } else {
+#ifdef UNI_GPU
+  #ifdef UNI_CUQUANTUM
+        cytnx_error_msg(
+          Tin.shape().size() != 2,
+          "[Gesvd_truncate] error, Gesvd_truncate can only operate on rank-2 Tensor.%s", "\n");
+
+        Tensor in = Tin.contiguous();
+
+        // cytnx_uint64 n_singlu = std::min(keepdim, std::min(Tin.shape()[0], Tin.shape()[1]));
+        cytnx_uint64 n_singlu = std::max(cytnx_uint64(1), std::min(Tin.shape()[0], Tin.shape()[1]));
+        // if (Tin.dtype() > Type.Float) in = in.astype(Type.Double);
+        // prepare U, S, vT
+        Tensor U, S, vT, terr;
+        S.Init({n_singlu}, in.dtype() <= 2 ? in.dtype() + 2 : in.dtype(),
+               in.device());  // if type is complex, S should be real
+        U.Init({in.shape()[0], n_singlu}, in.dtype(), in.device());
+        vT.Init({n_singlu, in.shape()[1]}, in.dtype(), in.device());
+        terr.Init({1}, in.dtype(), in.device());
+        cytnx::linalg_internal::lii.cuQuantumGeSvd_ii[in.dtype()](in, keepdim, err, return_err, U,
+                                                                  S, vT, terr);
+        std::vector<Tensor> outT;
+
+        outT.push_back(S);
+        if (is_U) outT.push_back(U);
+        if (is_vT) outT.push_back(vT);
+        if (return_err) outT.push_back(terr);
+
+        return outT;
+
+  #else
+        cytnx_error_msg(true, "[Gesvd_truncate] fatal error,%s",
+                        "try to call the cuquantum section without cuQunatum support.\n");
+        return std::vector<Tensor>();
+  #endif
+#else
+        cytnx_error_msg(true, "[Gesvd_truncate] fatal error,%s",
+                        "try to call the gpu section without CUDA support.\n");
+        return std::vector<Tensor>();
+#endif
       }
-      if (return_err) tmps.push_back(terr);
-
-      return tmps;
-
-      }else{
-        #ifdef UNI_GPU
-          #ifdef UNI_CUQUANTUM
-            cytnx_error_msg(Tin.shape().size() != 2,
-                            "[Gesvd_truncate] error, Gesvd_truncate can only operate on rank-2 Tensor.%s", "\n");
-                            
-            Tensor in = Tin.contiguous();
-
-            cytnx_uint64 n_singlu = std::min(keepdim, std::min(Tin.shape()[0], Tin.shape()[1]));
-
-            // if (Tin.dtype() > Type.Float) in = in.astype(Type.Double);
-            // prepare U, S, vT
-            Tensor U, S, vT;
-            S.Init({n_singlu}, in.dtype() <= 2 ? in.dtype() + 2 : in.dtype(),
-                  in.device());  // if type is complex, S should be real
-            U.Init({in.shape()[0], n_singlu}, in.dtype(), in.device());
-            vT.Init({n_singlu, in.shape()[1]}, in.dtype(), in.device());
-
-            // linalg_internal::cuQuantumGeSvd_internal_cd(in, keepdim, err, return_err, U, S, vT);
-            cytnx::linalg_internal::lii.cuQuantumGeSvd_ii[in.dtype()](in, keepdim, err, return_err, U, S,
-                                                                      vT);
-
-            std::vector<Tensor> outT;
-            outT.push_back(S);
-            if(is_U) outT.push_back(U);
-            if(is_vT) outT.push_back(vT);
-            cytnx_warning_msg(return_err,
-                  "[Gesvd_truncate] The result for return_err != 0 will not returned for Gesvd_truncate on cuda device.%s",
-                  "\n");
-
-            return outT;
-          #else
-          cytnx_error_msg(true, "[Gesvd_truncate] fatal error,%s",
-                "try to call the cuquantum section without cuQunatum support.\n");
-          return std::vector<Tensor>();
-          #endif
-        #else
-          cytnx_error_msg(true, "[Gesvd_truncate] fatal error,%s",
-                          "try to call the gpu section without CUDA support.\n");
-          return std::vector<Tensor>();
-        #endif
-      }
-      
     }
   }  // namespace linalg
 }  // namespace cytnx
@@ -146,7 +143,10 @@ namespace cytnx {
       // collapse as Matrix:
       cytnx_int64 rowdim = 1;
       for (cytnx_uint64 i = 0; i < Tin.rowrank(); i++) rowdim *= Tin.shape()[i];
-      vector<Tensor> outT = cytnx::linalg::Gesvd_truncate(tmp.reshape({rowdim, -1}), keepdim, err, is_U, is_vT, return_err);
+
+      // pass to tensor API
+      vector<Tensor> outT = cytnx::linalg::Gesvd_truncate(tmp.reshape({rowdim, -1}), keepdim, err,
+                                                          is_U, is_vT, return_err);
 
       // set output
       int t = 0;
@@ -191,7 +191,7 @@ namespace cytnx {
         t++;  // vT
       }
 
-      // if (return_err) outCyT.back().Init(outT.back(), false, 0);
+      if (return_err) outCyT.back().Init(outT.back(), false, 0);
     }
   #endif
 #endif
@@ -458,7 +458,7 @@ namespace cytnx {
 
       std::vector<UniTensor> outCyT;
       if (Tin.uten_type() == UTenType.Dense) {
-        if (Tin.device() == -1) {
+        if (Tin.device() == Device.cpu) {
           _gesvd_truncate_Dense_UT(outCyT, Tin, keepdim, err, is_U, is_vT, return_err);
         } else {
 #ifdef UNI_GPU

--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -19,6 +19,8 @@ namespace cytnx {
     std::vector<Tensor> Gesvd_truncate(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                        const double &err, const bool &is_U, const bool &is_vT,
                                        const unsigned int &return_err) {
+
+      if(Tin.device() == -1){
       std::vector<Tensor> tmps = Gesvd(Tin, is_U, is_vT);
 
       cytnx_uint64 id = 0;
@@ -67,6 +69,50 @@ namespace cytnx {
       if (return_err) tmps.push_back(terr);
 
       return tmps;
+
+      }else{
+        #ifdef UNI_GPU
+          #ifdef UNI_CUQUANTUM
+            cytnx_error_msg(Tin.shape().size() != 2,
+                            "[Gesvd_truncate] error, Gesvd_truncate can only operate on rank-2 Tensor.%s", "\n");
+                            
+            Tensor in = Tin.contiguous();
+
+            cytnx_uint64 n_singlu = std::min(keepdim, std::min(Tin.shape()[0], Tin.shape()[1]));
+
+            // if (Tin.dtype() > Type.Float) in = in.astype(Type.Double);
+            // prepare U, S, vT
+            Tensor U, S, vT;
+            S.Init({n_singlu}, in.dtype() <= 2 ? in.dtype() + 2 : in.dtype(),
+                  in.device());  // if type is complex, S should be real
+            U.Init({in.shape()[0], n_singlu}, in.dtype(), in.device());
+            vT.Init({n_singlu, in.shape()[1]}, in.dtype(), in.device());
+
+            // linalg_internal::cuQuantumGeSvd_internal_cd(in, keepdim, err, return_err, U, S, vT);
+            cytnx::linalg_internal::lii.cuQuantumGeSvd_ii[in.dtype()](in, keepdim, err, return_err, U, S,
+                                                                      vT);
+
+            std::vector<Tensor> outT;
+            outT.push_back(S);
+            if(is_U) outT.push_back(U);
+            if(is_vT) outT.push_back(vT);
+            cytnx_warning_msg(return_err,
+                  "[Gesvd_truncate] The result for return_err != 0 will not returned for Gesvd_truncate on cuda device.%s",
+                  "\n");
+
+            return outT;
+          #else
+          cytnx_error_msg(true, "[Gesvd_truncate] fatal error,%s",
+                "try to call the cuquantum section without cuQunatum support.\n");
+          return std::vector<Tensor>();
+          #endif
+        #else
+          cytnx_error_msg(true, "[Gesvd_truncate] fatal error,%s",
+                          "try to call the gpu section without CUDA support.\n");
+          return std::vector<Tensor>();
+        #endif
+      }
+      
     }
   }  // namespace linalg
 }  // namespace cytnx
@@ -99,28 +145,8 @@ namespace cytnx {
 
       // collapse as Matrix:
       cytnx_int64 rowdim = 1;
-      for (cytnx_uint64 i = 0; i < Tin.rowrank(); i++) rowdim *= tmp.shape()[i];
-      tmp.reshape_({rowdim, -1});
-
-      cytnx_uint64 n_singlu = std::min(keepdim, std::min(tmp.shape()[0], tmp.shape()[1]));
-      Tensor in = tmp.contiguous();
-      // if (Tin.dtype() > Type.Float) in = in.astype(Type.Double);
-
-      // prepare U, S, vT
-      Tensor U, S, vT;
-      S.Init({n_singlu}, in.dtype() <= 2 ? in.dtype() + 2 : in.dtype(),
-             in.device());  // if type is complex, S should be real
-      U.Init({in.shape()[0], n_singlu}, in.dtype(), in.device());
-      vT.Init({n_singlu, in.shape()[1]}, in.dtype(), in.device());
-
-      // linalg_internal::cuQuantumGeSvd_internal_cd(in, keepdim, err, return_err, U, S, vT);
-      cytnx::linalg_internal::lii.cuQuantumGeSvd_ii[in.dtype()](in, keepdim, err, return_err, U, S,
-                                                                vT);
-
-      std::vector<Tensor> outT;
-      outT.push_back(S);
-      outT.push_back(U);
-      outT.push_back(vT);
+      for (cytnx_uint64 i = 0; i < Tin.rowrank(); i++) rowdim *= Tin.shape()[i];
+      vector<Tensor> outT = cytnx::linalg::Gesvd_truncate(tmp.reshape({rowdim, -1}), keepdim, err, is_U, is_vT, return_err);
 
       // set output
       int t = 0;
@@ -441,11 +467,13 @@ namespace cytnx {
   #else
           cytnx_error_msg(true, "[cuQuantumSvd] fatal error,%s",
                           "try to call the cuquantum section without cuQunatum support.\n");
+          return std::vector<cytnx::UniTensor>();
   #endif
 
 #else
           cytnx_error_msg(true, "[cuQuantumSvd] fatal error,%s",
                           "try to call the gpu section without CUDA support.\n");
+          return std::vector<cytnx::UniTensor>();
 #endif
         }
 

--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -100,7 +100,7 @@ namespace cytnx {
       for (cytnx_uint64 i = 0; i < Tin.rowrank(); i++) rowdim *= tmp.shape()[i];
       tmp.reshape_({rowdim, -1});
 
-      cytnx_uint64 n_singlu = std::max(cytnx_uint64(1), std::min(tmp.shape()[0], tmp.shape()[1]));
+      cytnx_uint64 n_singlu = std::min(keepdim, std::min(tmp.shape()[0], tmp.shape()[1]));
       Tensor in = tmp.contiguous();
       // if (Tin.dtype() > Type.Float) in = in.astype(Type.Double);
 

--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -5,6 +5,8 @@
 #include "UniTensor.hpp"
 #include "algo.hpp"
 
+#include "linalg_internal_interface.hpp"
+
 #ifdef UNI_GPU
   #ifdef UNI_CUQUANTUM
     #include "linalg_internal_gpu/cuQuantumGeSvd_internal.hpp"
@@ -111,7 +113,9 @@ namespace cytnx {
       U.Init({in.shape()[0], n_singlu}, in.dtype(), in.device());
       vT.Init({n_singlu, in.shape()[1]}, in.dtype(), in.device());
 
-      linalg_internal::cuQuantumGeSvd_internal_cd(in, keepdim, err, return_err, U, S, vT);
+      // linalg_internal::cuQuantumGeSvd_internal_cd(in, keepdim, err, return_err, U, S, vT);
+      cytnx::linalg_internal::lii.cuQuantumGeSvd_ii[in.dtype()](in, keepdim, err, return_err, U, S,
+                                                                vT);
 
       std::vector<Tensor> outT;
       outT.push_back(S);

--- a/src/linalg/linalg_internal_gpu/CMakeLists.txt
+++ b/src/linalg/linalg_internal_gpu/CMakeLists.txt
@@ -30,7 +30,7 @@ target_sources_local(cytnx
     cuMaxMin_internal.hpp
     cuKron_internal.hpp
     cuTensordot_internal.hpp
-
+    cuQuantumGeSvd_internal.hpp
 
     cuAbs_internal.cu
     cuAdd_internal.cu
@@ -63,4 +63,5 @@ target_sources_local(cytnx
     cuMaxMin_internal.cu
     cuKron_internal.cu
     cuTensordot_internal.cu
+    cuQuantumGeSvd_internal.cu
 )

--- a/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.cu
+++ b/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.cu
@@ -1,0 +1,345 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <unordered_map>
+#include <vector>
+#include <cassert>
+
+#include "cuQuantumGeSvd_internal.hpp"
+
+#ifdef UNI_GPU
+ #ifdef UNI_CUQUANTUM
+   #include <cuda_runtime.h>
+   #include <cutensornet.h>
+
+  //  #define HANDLE_ERROR(x)                                           \
+  //  { const auto err = x;                                             \
+  //  if( err != CUTENSORNET_STATUS_SUCCESS )                           \
+  //  { printf("Error: %s in line %d\n", cutensornetGetErrorString(err), __LINE__); return err; } \
+  //  };
+
+  //  #define HANDLE_CUDA_ERROR(x)                                      \
+  //  {  const auto err = x;                                            \
+  //     if( err != cudaSuccess )                                       \
+  //     { printf("Error: %s in line %d\n", cudaGetErrorString(err), __LINE__); return err; } \
+  //  };
+    #define HANDLE_ERROR(x)                                                           \
+      {                                                                               \
+        const auto err = x;                                                           \
+        if (err != CUTENSORNET_STATUS_SUCCESS) {                                      \
+          printf("Error: %s in line %d\n", cutensornetGetErrorString(err), __LINE__); \
+          fflush(stdout);                                                             \
+        }                                                                             \
+      };
+
+    #define HANDLE_CUDA_ERROR(x)                                                    \
+      {                                                                             \
+        const auto err = x;                                                         \
+        if (err != cudaSuccess) {                                                   \
+          printf("CUDA Error: %s in line %d\n", cudaGetErrorString(err), __LINE__); \
+          fflush(stdout);                                                           \
+        }                                                                           \
+      };
+
+   struct GPUTimer
+   {
+      GPUTimer(cudaStream_t stream): stream_(stream)
+      {
+         cudaEventCreate(&start_);
+         cudaEventCreate(&stop_);
+      }
+
+      ~GPUTimer()
+      {
+         cudaEventDestroy(start_);
+         cudaEventDestroy(stop_);
+      }
+
+      void start()
+      {
+         cudaEventRecord(start_, stream_);
+      }
+
+      float seconds()
+      {
+         cudaEventRecord(stop_, stream_);
+         cudaEventSynchronize(stop_);
+         float time;
+         cudaEventElapsedTime(&time, start_, stop_);
+         return time * 1e-3;
+      }
+
+      private:
+      cudaEvent_t start_, stop_;
+      cudaStream_t stream_;
+   };
+
+ #endif
+#endif
+
+
+int64_t computeCombinedExtent(const std::unordered_map<int32_t, int64_t> &extentMap, 
+                                const std::vector<int32_t> &modes)
+{
+   int64_t combinedExtent{1};
+   for (auto mode: modes)
+   {
+      auto it = extentMap.find(mode);
+      if (it != extentMap.end())
+         combinedExtent *= it->second;
+   }
+   return combinedExtent;
+}
+
+
+namespace cytnx {
+  namespace linalg_internal {
+
+  #ifdef UNI_GPU
+    #ifdef UNI_CUQUANTUM
+    /// cuGeSvd
+    void cuQuantumGeSvd_internal_cd(const Tensor &Tin, const cytnx_uint64 &keepdim,
+                                       const double &err, const unsigned int &return_err, Tensor U, Tensor S, Tensor vT) {
+
+          const size_t cuTensornetVersion = cutensornetGetVersion();
+          printf("cuTensorNet-vers:%ld\n",cuTensornetVersion);
+
+          cudaDeviceProp prop;
+          int deviceId = Tin.device();
+          HANDLE_CUDA_ERROR( cudaSetDevice(deviceId));
+          HANDLE_CUDA_ERROR( cudaGetDevice(&deviceId) );
+          HANDLE_CUDA_ERROR( cudaGetDeviceProperties(&prop, deviceId) );
+
+          printf("===== device info ======\n");
+          printf("GPU-name:%s\n", prop.name);
+          printf("GPU-clock:%d\n", prop.clockRate);
+          printf("GPU-memoryClock:%d\n", prop.memoryClockRate);
+          printf("GPU-nSM:%d\n", prop.multiProcessorCount);
+          printf("GPU-major:%d\n", prop.major);
+          printf("GPU-minor:%d\n", prop.minor);
+          printf("========================\n");
+      
+          typedef float floatType;
+          cudaDataType_t typeData = CUDA_R_32F;
+            /******************
+         * cuTensorNet
+         *******************/
+
+         cudaStream_t stream;
+         HANDLE_CUDA_ERROR( cudaStreamCreate(&stream) );
+
+         cutensornetHandle_t handle;
+         HANDLE_ERROR( cutensornetCreate(&handle) );
+
+         /**************************
+         * Create tensor descriptors
+         ***************************/
+         std::vector<int32_t> modesT{1,2};
+         std::vector<int32_t> modesU{1,0};
+         std::vector<int32_t> modesV{0,2};
+
+         std::vector<int64_t> extentT{(int64_t)Tin.shape()[1], (int64_t)Tin.shape()[0]};
+         std::vector<int64_t> extentU{(int64_t)U.shape()[1], (int64_t)U.shape()[0]};
+         std::vector<int64_t> extentV{(int64_t)vT.shape()[1], (int64_t)vT.shape()[0]};
+
+         const int32_t numModesIn = modesT.size();
+         const int32_t numModesU = modesU.size();
+         const int32_t numModesV = modesV.size();
+
+         void* D_T = Tin._impl->storage()._impl->Mem;
+         void* D_U = U._impl->storage()._impl->Mem;
+         void* D_S = S._impl->storage()._impl->Mem;
+         void* D_V = vT._impl->storage()._impl->Mem;
+
+
+         cutensornetTensorDescriptor_t descTensorIn;
+         cutensornetTensorDescriptor_t descTensorU;
+         cutensornetTensorDescriptor_t descTensorV;
+
+
+         const int64_t* strides = NULL; // assuming fortran layout for all tensors
+
+         HANDLE_ERROR( cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides, modesT.data(), typeData, &descTensorIn) );
+         HANDLE_ERROR( cutensornetCreateTensorDescriptor(handle, numModesU, extentU.data(), strides, modesU.data(), typeData, &descTensorU) );
+         HANDLE_ERROR( cutensornetCreateTensorDescriptor(handle, numModesV, extentV.data(), strides, modesV.data(), typeData, &descTensorV) );
+         
+         printf("Initialize the cuTensorNet library and create all tensor descriptors.\n");
+
+         /**********************************************
+         * Setup SVD algorithm and truncation parameters
+         ***********************************************/
+
+         cutensornetTensorSVDConfig_t svdConfig;
+         HANDLE_ERROR( cutensornetCreateTensorSVDConfig(handle, &svdConfig) );
+
+         // set up truncation parameters
+         double absCutoff = 1e-2;
+         HANDLE_ERROR( cutensornetTensorSVDConfigSetAttribute(handle, 
+                                                svdConfig, 
+                                                CUTENSORNET_TENSOR_SVD_CONFIG_ABS_CUTOFF, 
+                                                &absCutoff, 
+                                                sizeof(absCutoff)) );
+         double relCutoff = 4e-2;
+         HANDLE_ERROR( cutensornetTensorSVDConfigSetAttribute(handle, 
+                                                svdConfig, 
+                                                CUTENSORNET_TENSOR_SVD_CONFIG_REL_CUTOFF, 
+                                                &relCutoff, 
+                                                sizeof(relCutoff)) );
+         
+         // optional: choose gesvdj algorithm with customized parameters. Default is gesvd.
+         cutensornetTensorSVDAlgo_t svdAlgo = CUTENSORNET_TENSOR_SVD_ALGO_GESVDJ;
+         HANDLE_ERROR( cutensornetTensorSVDConfigSetAttribute(handle, 
+                                                svdConfig, 
+                                                CUTENSORNET_TENSOR_SVD_CONFIG_ALGO, 
+                                                &svdAlgo, 
+                                                sizeof(svdAlgo)) );
+         cutensornetGesvdjParams_t gesvdjParams{/*tol=*/1e-12, /*maxSweeps=*/80};
+         HANDLE_ERROR( cutensornetTensorSVDConfigSetAttribute(handle, 
+                                                svdConfig, 
+                                                CUTENSORNET_TENSOR_SVD_CONFIG_ALGO_PARAMS, 
+                                                &gesvdjParams, 
+                                                sizeof(gesvdjParams)) );
+         printf("Set up SVDConfig to use GESVDJ algorithm with truncation\n");
+         
+         /********************************************************
+         * Create SVDInfo to record runtime SVD truncation details
+         *********************************************************/
+
+         cutensornetTensorSVDInfo_t svdInfo; 
+         HANDLE_ERROR( cutensornetCreateTensorSVDInfo(handle, &svdInfo)) ;
+
+         // Sphinx: #6
+         /**************************************************************
+         * Query the required workspace sizes and allocate memory
+         **************************************************************/
+
+         cutensornetWorkspaceDescriptor_t workDesc;
+         HANDLE_ERROR( cutensornetCreateWorkspaceDescriptor(handle, &workDesc) );
+         HANDLE_ERROR( cutensornetWorkspaceComputeSVDSizes(handle, descTensorIn, descTensorU, descTensorV, svdConfig, workDesc) );
+         int64_t hostWorkspaceSize, deviceWorkspaceSize;
+         // for tensor SVD, it does not matter which cutensornetWorksizePref_t we pick
+         HANDLE_ERROR( cutensornetWorkspaceGetMemorySize(handle,
+                                                         workDesc,
+                                                         CUTENSORNET_WORKSIZE_PREF_RECOMMENDED,
+                                                         CUTENSORNET_MEMSPACE_DEVICE,
+                                                         CUTENSORNET_WORKSPACE_SCRATCH,
+                                                         &deviceWorkspaceSize) );
+         HANDLE_ERROR( cutensornetWorkspaceGetMemorySize(handle,
+                                                         workDesc,
+                                                         CUTENSORNET_WORKSIZE_PREF_RECOMMENDED,
+                                                         CUTENSORNET_MEMSPACE_HOST,
+                                                         CUTENSORNET_WORKSPACE_SCRATCH,
+                                                         &hostWorkspaceSize) );
+
+         void *devWork = nullptr, *hostWork = nullptr;
+         if (deviceWorkspaceSize > 0) {
+            HANDLE_CUDA_ERROR( cudaMalloc(&devWork, deviceWorkspaceSize) );
+         }
+         if (hostWorkspaceSize > 0) {
+            hostWork = malloc(hostWorkspaceSize);
+         }
+         HANDLE_ERROR( cutensornetWorkspaceSetMemory(handle,
+                                                   workDesc,
+                                                   CUTENSORNET_MEMSPACE_DEVICE,
+                                                   CUTENSORNET_WORKSPACE_SCRATCH,
+                                                   devWork,
+                                                   deviceWorkspaceSize) );
+         HANDLE_ERROR( cutensornetWorkspaceSetMemory(handle,
+                                                   workDesc,
+                                                   CUTENSORNET_MEMSPACE_HOST,
+                                                   CUTENSORNET_WORKSPACE_SCRATCH,
+                                                   hostWork,
+                                                   hostWorkspaceSize) );
+
+         // Sphinx: #7
+         /**********
+         * Execution
+         ***********/
+      
+         GPUTimer timer{stream};
+         double minTimeCUTENSOR = 1e100;
+         const int numRuns = 1; // to get stable perf results
+         for (int i=0; i < numRuns; ++i)
+         {  
+            // // restore output
+            // cudaMemsetAsync(D_U, 0, sizeU, stream);
+            // cudaMemsetAsync(D_S, 0, sizeS, stream);
+            // cudaMemsetAsync(D_V, 0, sizeV, stream);
+            // cudaDeviceSynchronize();
+            
+            // With value-based truncation, `cutensornetTensorSVD` can potentially update the shared extent in descTensorU/V.
+            // We here restore descTensorU/V to the original problem.
+            HANDLE_ERROR( cutensornetDestroyTensorDescriptor(descTensorU) );
+            HANDLE_ERROR( cutensornetDestroyTensorDescriptor(descTensorV) );
+            HANDLE_ERROR( cutensornetCreateTensorDescriptor(handle, numModesU, extentU.data(), strides, modesU.data(), typeData, &descTensorU) );
+            HANDLE_ERROR( cutensornetCreateTensorDescriptor(handle, numModesV, extentV.data(), strides, modesV.data(), typeData, &descTensorV) );
+
+            timer.start();
+            HANDLE_ERROR( cutensornetTensorSVD(handle, 
+                              descTensorIn, D_T, 
+                              descTensorU, D_U, 
+                              D_S, 
+                              descTensorV, D_V, 
+                              svdConfig, 
+                              svdInfo,
+                              workDesc,
+                              stream) );
+            // Synchronize and measure timing
+            auto time = timer.seconds();
+            minTimeCUTENSOR = (minTimeCUTENSOR < time) ? minTimeCUTENSOR : time;
+         }
+
+         printf("Performing SVD\n");
+
+         // HANDLE_CUDA_ERROR( cudaMemcpyAsync(U, D_U, sizeU, cudaMemcpyDeviceToHost) );
+         // HANDLE_CUDA_ERROR( cudaMemcpyAsync(S, D_S, sizeS, cudaMemcpyDeviceToHost) );
+         // HANDLE_CUDA_ERROR( cudaMemcpyAsync(V, D_V, sizeV, cudaMemcpyDeviceToHost) );
+
+         // Sphinx: #8
+         /*************************************
+         * Query runtime truncation information
+         **************************************/
+
+         double discardedWeight{0};
+         int64_t reducedExtent{0};
+         cutensornetGesvdjStatus_t gesvdjStatus;
+         cudaDeviceSynchronize(); // device synchronization.
+         HANDLE_ERROR( cutensornetTensorSVDInfoGetAttribute( handle, svdInfo, CUTENSORNET_TENSOR_SVD_INFO_DISCARDED_WEIGHT, &discardedWeight, sizeof(discardedWeight)) );
+         HANDLE_ERROR( cutensornetTensorSVDInfoGetAttribute( handle, svdInfo, CUTENSORNET_TENSOR_SVD_INFO_REDUCED_EXTENT, &reducedExtent, sizeof(reducedExtent)) );
+         HANDLE_ERROR( cutensornetTensorSVDInfoGetAttribute( handle, svdInfo, CUTENSORNET_TENSOR_SVD_INFO_ALGO_STATUS, &gesvdjStatus, sizeof(gesvdjStatus)) );
+
+         printf("elapsed time: %.2f ms\n", minTimeCUTENSOR * 1000.f);
+         printf("GESVDJ residual: %.4f, runtime sweeps = %d\n", gesvdjStatus.residual, gesvdjStatus.sweeps);
+         printf("reduced extent found at runtime: %lu\n", reducedExtent);
+         printf("discarded weight: %.2f\n", discardedWeight);
+
+         // Sphinx: #9
+         /***************
+         * Free resources
+         ****************/
+         
+         HANDLE_ERROR( cutensornetDestroyTensorDescriptor(descTensorIn) );
+         HANDLE_ERROR( cutensornetDestroyTensorDescriptor(descTensorU) );
+         HANDLE_ERROR( cutensornetDestroyTensorDescriptor(descTensorV) );
+         HANDLE_ERROR( cutensornetDestroyTensorSVDConfig(svdConfig) );
+         HANDLE_ERROR( cutensornetDestroyTensorSVDInfo(svdInfo) );
+         HANDLE_ERROR( cutensornetDestroyWorkspaceDescriptor(workDesc) );
+         HANDLE_ERROR( cutensornetDestroy(handle) );
+
+         // if (T) free(T);
+         // if (U) free(U);
+         // if (S) free(S);
+         // if (V) free(V);
+         // if (D_T) cudaFree(D_T);
+         // if (D_U) cudaFree(D_U);
+         // if (D_S) cudaFree(D_S);
+         // if (D_V) cudaFree(D_V);
+         if (devWork) cudaFree(devWork);
+         if (hostWork) free(hostWork);
+
+         printf("Free resource and exit.\n");
+    }
+    #endif
+  #endif
+  }  // namespace linalg_internal
+}  // namespace cytnx

--- a/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.cu
+++ b/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.cu
@@ -87,10 +87,10 @@ namespace cytnx {
   #ifdef UNI_CUQUANTUM
     /// cuGeSvd
     void cuQuantumGeSvd_internal_cd(const Tensor &Tin, const cytnx_uint64 &keepdim,
-                                    const double &err, const unsigned int &return_err, Tensor U,
-                                    Tensor S, Tensor vT) {
+                                    const double &err, const unsigned int &return_err, Tensor &U,
+                                    Tensor &S, Tensor &vT) {
       const size_t cuTensornetVersion = cutensornetGetVersion();
-      printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
+      // printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
 
       cudaDeviceProp prop;
       int deviceId = Tin.device();
@@ -98,14 +98,14 @@ namespace cytnx {
       HANDLE_CUDA_ERROR(cudaGetDevice(&deviceId));
       HANDLE_CUDA_ERROR(cudaGetDeviceProperties(&prop, deviceId));
 
-      printf("===== device info ======\n");
-      printf("GPU-name:%s\n", prop.name);
-      printf("GPU-clock:%d\n", prop.clockRate);
-      printf("GPU-memoryClock:%d\n", prop.memoryClockRate);
-      printf("GPU-nSM:%d\n", prop.multiProcessorCount);
-      printf("GPU-major:%d\n", prop.major);
-      printf("GPU-minor:%d\n", prop.minor);
-      printf("========================\n");
+      // printf("===== device info ======\n");
+      // printf("GPU-name:%s\n", prop.name);
+      // printf("GPU-clock:%d\n", prop.clockRate);
+      // printf("GPU-memoryClock:%d\n", prop.memoryClockRate);
+      // printf("GPU-nSM:%d\n", prop.multiProcessorCount);
+      // printf("GPU-major:%d\n", prop.major);
+      // printf("GPU-minor:%d\n", prop.minor);
+      // printf("========================\n");
 
       typedef float floatType;
       cudaDataType_t typeData = CUDA_C_64F;
@@ -152,7 +152,7 @@ namespace cytnx {
       HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesV, extentV.data(), strides,
                                                      modesV.data(), typeData, &descTensorV));
 
-      printf("Initialize the cuTensorNet library and create all tensor descriptors.\n");
+      // printf("Initialize the cuTensorNet library and create all tensor descriptors.\n");
 
       /**********************************************
        * Setup SVD algorithm and truncation parameters
@@ -179,7 +179,7 @@ namespace cytnx {
       HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(handle, svdConfig,
                                                           CUTENSORNET_TENSOR_SVD_CONFIG_ALGO_PARAMS,
                                                           &gesvdjParams, sizeof(gesvdjParams)));
-      printf("Set up SVDConfig to use GESVDJ algorithm with truncation\n");
+      // printf("Set up SVDConfig to use GESVDJ algorithm with truncation\n");
 
       /********************************************************
        * Create SVDInfo to record runtime SVD truncation details
@@ -252,7 +252,7 @@ namespace cytnx {
         minTimeCUTENSOR = (minTimeCUTENSOR < time) ? minTimeCUTENSOR : time;
       }
 
-      printf("Performing SVD\n");
+      // printf("Performing SVD\n");
 
       // HANDLE_CUDA_ERROR( cudaMemcpyAsync(U, D_U, sizeU, cudaMemcpyDeviceToHost) );
       // HANDLE_CUDA_ERROR( cudaMemcpyAsync(S, D_S, sizeS, cudaMemcpyDeviceToHost) );
@@ -277,11 +277,11 @@ namespace cytnx {
                                                         CUTENSORNET_TENSOR_SVD_INFO_ALGO_STATUS,
                                                         &gesvdjStatus, sizeof(gesvdjStatus)));
 
-      printf("elapsed time: %.2f ms\n", minTimeCUTENSOR * 1000.f);
-      printf("GESVDJ residual: %.4f, runtime sweeps = %d\n", gesvdjStatus.residual,
-             gesvdjStatus.sweeps);
-      printf("reduced extent found at runtime: %lu\n", reducedExtent);
-      printf("discarded weight: %.2f\n", discardedWeight);
+      // printf("elapsed time: %.2f ms\n", minTimeCUTENSOR * 1000.f);
+      // printf("GESVDJ residual: %.4f, runtime sweeps = %d\n", gesvdjStatus.residual,
+      //        gesvdjStatus.sweeps);
+      // printf("reduced extent found at runtime: %lu\n", reducedExtent);
+      // printf("discarded weight: %.2f\n", discardedWeight);
 
       // Sphinx: #9
       /***************
@@ -296,22 +296,660 @@ namespace cytnx {
       HANDLE_ERROR(cutensornetDestroyWorkspaceDescriptor(workDesc));
       HANDLE_ERROR(cutensornetDestroy(handle));
 
-      // std::cout<<S;
-      // std::cout<<U;
-      // std::cout<<vT;
-      // if (T) free(T);
-      // if (U) free(U);
-      // if (S) free(S);
-      // if (V) free(V);
-      // if (D_T) cudaFree(D_T);
-      // if (D_U) cudaFree(D_U);
-      // if (D_S) cudaFree(D_S);
-      // if (D_V) cudaFree(D_V);
       if (devWork) cudaFree(devWork);
       if (hostWork) free(hostWork);
 
-      printf("Free resource and exit.\n");
+      // printf("Free resource and exit.\n");
     }
+
+    void cuQuantumGeSvd_internal_cf(const Tensor &Tin, const cytnx_uint64 &keepdim,
+                                    const double &err, const unsigned int &return_err, Tensor &U,
+                                    Tensor &S, Tensor &vT) {
+      const size_t cuTensornetVersion = cutensornetGetVersion();
+      // printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
+
+      cudaDeviceProp prop;
+      int deviceId = Tin.device();
+      HANDLE_CUDA_ERROR(cudaSetDevice(deviceId));
+      HANDLE_CUDA_ERROR(cudaGetDevice(&deviceId));
+      HANDLE_CUDA_ERROR(cudaGetDeviceProperties(&prop, deviceId));
+
+      // printf("===== device info ======\n");
+      // printf("GPU-name:%s\n", prop.name);
+      // printf("GPU-clock:%d\n", prop.clockRate);
+      // printf("GPU-memoryClock:%d\n", prop.memoryClockRate);
+      // printf("GPU-nSM:%d\n", prop.multiProcessorCount);
+      // printf("GPU-major:%d\n", prop.major);
+      // printf("GPU-minor:%d\n", prop.minor);
+      // printf("========================\n");
+
+      typedef float floatType;
+      cudaDataType_t typeData = CUDA_C_32F;
+      /******************
+       * cuTensorNet
+       *******************/
+
+      cudaStream_t stream;
+      HANDLE_CUDA_ERROR(cudaStreamCreate(&stream));
+
+      cutensornetHandle_t handle;
+      HANDLE_ERROR(cutensornetCreate(&handle));
+
+      /**************************
+       * Create tensor descriptors
+       ***************************/
+      std::vector<int32_t> modesT{'j', 'i'};
+      std::vector<int32_t> modesU{'s', 'i'};
+      std::vector<int32_t> modesV{'j', 's'};
+
+      std::vector<int64_t> extentT{(int64_t)Tin.shape()[1], (int64_t)Tin.shape()[0]};
+      std::vector<int64_t> extentU{(int64_t)U.shape()[1], (int64_t)U.shape()[0]};
+      std::vector<int64_t> extentV{(int64_t)vT.shape()[1], (int64_t)vT.shape()[0]};
+
+      const int32_t numModesIn = modesT.size();
+      const int32_t numModesU = modesU.size();
+      const int32_t numModesV = modesV.size();
+
+      void *D_T = Tin._impl->storage()._impl->Mem;
+      void *D_U = U._impl->storage()._impl->Mem;
+      void *D_S = S._impl->storage()._impl->Mem;
+      void *D_V = vT._impl->storage()._impl->Mem;
+
+      cutensornetTensorDescriptor_t descTensorIn;
+      cutensornetTensorDescriptor_t descTensorU;
+      cutensornetTensorDescriptor_t descTensorV;
+
+      const int64_t *strides = NULL;  // assuming fortran layout for all tensors
+
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides,
+                                                     modesT.data(), typeData, &descTensorIn));
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesU, extentU.data(), strides,
+                                                     modesU.data(), typeData, &descTensorU));
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesV, extentV.data(), strides,
+                                                     modesV.data(), typeData, &descTensorV));
+
+      // printf("Initialize the cuTensorNet library and create all tensor descriptors.\n");
+
+      /**********************************************
+       * Setup SVD algorithm and truncation parameters
+       ***********************************************/
+
+      cutensornetTensorSVDConfig_t svdConfig;
+      HANDLE_ERROR(cutensornetCreateTensorSVDConfig(handle, &svdConfig));
+
+      // set up truncation parameters
+      double absCutoff = err;
+      HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(handle, svdConfig,
+                                                          CUTENSORNET_TENSOR_SVD_CONFIG_ABS_CUTOFF,
+                                                          &absCutoff, sizeof(absCutoff)));
+      double relCutoff = 0;
+      HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(handle, svdConfig,
+                                                          CUTENSORNET_TENSOR_SVD_CONFIG_REL_CUTOFF,
+                                                          &relCutoff, sizeof(relCutoff)));
+
+      // optional: choose gesvdj algorithm with customized parameters. Default is gesvd.
+      cutensornetTensorSVDAlgo_t svdAlgo = CUTENSORNET_TENSOR_SVD_ALGO_GESVDJ;
+      HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(
+        handle, svdConfig, CUTENSORNET_TENSOR_SVD_CONFIG_ALGO, &svdAlgo, sizeof(svdAlgo)));
+      cutensornetGesvdjParams_t gesvdjParams{/*tol=*/0, /*maxSweeps=*/80};
+      HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(handle, svdConfig,
+                                                          CUTENSORNET_TENSOR_SVD_CONFIG_ALGO_PARAMS,
+                                                          &gesvdjParams, sizeof(gesvdjParams)));
+      // printf("Set up SVDConfig to use GESVDJ algorithm with truncation\n");
+
+      /********************************************************
+       * Create SVDInfo to record runtime SVD truncation details
+       *********************************************************/
+
+      cutensornetTensorSVDInfo_t svdInfo;
+      HANDLE_ERROR(cutensornetCreateTensorSVDInfo(handle, &svdInfo));
+
+      // Sphinx: #6
+      /**************************************************************
+       * Query the required workspace sizes and allocate memory
+       **************************************************************/
+
+      cutensornetWorkspaceDescriptor_t workDesc;
+      HANDLE_ERROR(cutensornetCreateWorkspaceDescriptor(handle, &workDesc));
+      HANDLE_ERROR(cutensornetWorkspaceComputeSVDSizes(handle, descTensorIn, descTensorU,
+                                                       descTensorV, svdConfig, workDesc));
+      int64_t hostWorkspaceSize, deviceWorkspaceSize;
+      // for tensor SVD, it does not matter which cutensornetWorksizePref_t we pick
+      HANDLE_ERROR(cutensornetWorkspaceGetMemorySize(
+        handle, workDesc, CUTENSORNET_WORKSIZE_PREF_RECOMMENDED, CUTENSORNET_MEMSPACE_DEVICE,
+        CUTENSORNET_WORKSPACE_SCRATCH, &deviceWorkspaceSize));
+      HANDLE_ERROR(cutensornetWorkspaceGetMemorySize(
+        handle, workDesc, CUTENSORNET_WORKSIZE_PREF_RECOMMENDED, CUTENSORNET_MEMSPACE_HOST,
+        CUTENSORNET_WORKSPACE_SCRATCH, &hostWorkspaceSize));
+
+      void *devWork = nullptr, *hostWork = nullptr;
+      if (deviceWorkspaceSize > 0) {
+        HANDLE_CUDA_ERROR(cudaMalloc(&devWork, deviceWorkspaceSize));
+      }
+      if (hostWorkspaceSize > 0) {
+        hostWork = malloc(hostWorkspaceSize);
+      }
+      HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_DEVICE,
+                                                 CUTENSORNET_WORKSPACE_SCRATCH, devWork,
+                                                 deviceWorkspaceSize));
+      HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_HOST,
+                                                 CUTENSORNET_WORKSPACE_SCRATCH, hostWork,
+                                                 hostWorkspaceSize));
+
+      // Sphinx: #7
+      /**********
+       * Execution
+       ***********/
+
+      GPUTimer timer{stream};
+      double minTimeCUTENSOR = 1e100;
+      const int numRuns = 1;  // to get stable perf results
+      for (int i = 0; i < numRuns; ++i) {
+        // // restore output
+        // cudaMemsetAsync(D_U, 0, sizeU, stream);
+        // cudaMemsetAsync(D_S, 0, sizeS, stream);
+        // cudaMemsetAsync(D_V, 0, sizeV, stream);
+        // cudaDeviceSynchronize();
+
+        // With value-based truncation, `cutensornetTensorSVD` can potentially update the shared
+        // extent in descTensorU/V. We here restore descTensorU/V to the original problem.
+        HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorU));
+        HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorV));
+        HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesU, extentU.data(), strides,
+                                                       modesU.data(), typeData, &descTensorU));
+        HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesV, extentV.data(), strides,
+                                                       modesV.data(), typeData, &descTensorV));
+
+        timer.start();
+        HANDLE_ERROR(cutensornetTensorSVD(handle, descTensorIn, D_T, descTensorU, D_U, D_S,
+                                          descTensorV, D_V, svdConfig, svdInfo, workDesc, stream));
+        // Synchronize and measure timing
+        auto time = timer.seconds();
+        minTimeCUTENSOR = (minTimeCUTENSOR < time) ? minTimeCUTENSOR : time;
+      }
+
+      // printf("Performing SVD\n");
+
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(U, D_U, sizeU, cudaMemcpyDeviceToHost) );
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(S, D_S, sizeS, cudaMemcpyDeviceToHost) );
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(V, D_V, sizeV, cudaMemcpyDeviceToHost) );
+
+      // Sphinx: #8
+      /*************************************
+       * Query runtime truncation information
+       **************************************/
+
+      double discardedWeight{0};
+      int64_t reducedExtent{0};
+      cutensornetGesvdjStatus_t gesvdjStatus;
+      cudaDeviceSynchronize();  // device synchronization.
+      HANDLE_ERROR(cutensornetTensorSVDInfoGetAttribute(
+        handle, svdInfo, CUTENSORNET_TENSOR_SVD_INFO_DISCARDED_WEIGHT, &discardedWeight,
+        sizeof(discardedWeight)));
+      HANDLE_ERROR(cutensornetTensorSVDInfoGetAttribute(handle, svdInfo,
+                                                        CUTENSORNET_TENSOR_SVD_INFO_REDUCED_EXTENT,
+                                                        &reducedExtent, sizeof(reducedExtent)));
+      HANDLE_ERROR(cutensornetTensorSVDInfoGetAttribute(handle, svdInfo,
+                                                        CUTENSORNET_TENSOR_SVD_INFO_ALGO_STATUS,
+                                                        &gesvdjStatus, sizeof(gesvdjStatus)));
+
+      // printf("elapsed time: %.2f ms\n", minTimeCUTENSOR * 1000.f);
+      // printf("GESVDJ residual: %.4f, runtime sweeps = %d\n", gesvdjStatus.residual,
+      //        gesvdjStatus.sweeps);
+      // printf("reduced extent found at runtime: %lu\n", reducedExtent);
+      // printf("discarded weight: %.2f\n", discardedWeight);
+
+      // Sphinx: #9
+      /***************
+       * Free resources
+       ****************/
+
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorIn));
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorU));
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorV));
+      HANDLE_ERROR(cutensornetDestroyTensorSVDConfig(svdConfig));
+      HANDLE_ERROR(cutensornetDestroyTensorSVDInfo(svdInfo));
+      HANDLE_ERROR(cutensornetDestroyWorkspaceDescriptor(workDesc));
+      HANDLE_ERROR(cutensornetDestroy(handle));
+
+      if (devWork) cudaFree(devWork);
+      if (hostWork) free(hostWork);
+
+      // printf("Free resource and exit.\n");
+    }
+
+    void cuQuantumGeSvd_internal_d(const Tensor &Tin, const cytnx_uint64 &keepdim,
+                                   const double &err, const unsigned int &return_err, Tensor &U,
+                                   Tensor &S, Tensor &vT) {
+      const size_t cuTensornetVersion = cutensornetGetVersion();
+      // printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
+
+      cudaDeviceProp prop;
+      int deviceId = Tin.device();
+      HANDLE_CUDA_ERROR(cudaSetDevice(deviceId));
+      HANDLE_CUDA_ERROR(cudaGetDevice(&deviceId));
+      HANDLE_CUDA_ERROR(cudaGetDeviceProperties(&prop, deviceId));
+
+      // printf("===== device info ======\n");
+      // printf("GPU-name:%s\n", prop.name);
+      // printf("GPU-clock:%d\n", prop.clockRate);
+      // printf("GPU-memoryClock:%d\n", prop.memoryClockRate);
+      // printf("GPU-nSM:%d\n", prop.multiProcessorCount);
+      // printf("GPU-major:%d\n", prop.major);
+      // printf("GPU-minor:%d\n", prop.minor);
+      // printf("========================\n");
+
+      typedef float floatType;
+      cudaDataType_t typeData = CUDA_R_64F;
+      /******************
+       * cuTensorNet
+       *******************/
+
+      cudaStream_t stream;
+      HANDLE_CUDA_ERROR(cudaStreamCreate(&stream));
+
+      cutensornetHandle_t handle;
+      HANDLE_ERROR(cutensornetCreate(&handle));
+
+      /**************************
+       * Create tensor descriptors
+       ***************************/
+      std::vector<int32_t> modesT{'j', 'i'};
+      std::vector<int32_t> modesU{'s', 'i'};
+      std::vector<int32_t> modesV{'j', 's'};
+
+      std::vector<int64_t> extentT{(int64_t)Tin.shape()[1], (int64_t)Tin.shape()[0]};
+      std::vector<int64_t> extentU{(int64_t)U.shape()[1], (int64_t)U.shape()[0]};
+      std::vector<int64_t> extentV{(int64_t)vT.shape()[1], (int64_t)vT.shape()[0]};
+
+      const int32_t numModesIn = modesT.size();
+      const int32_t numModesU = modesU.size();
+      const int32_t numModesV = modesV.size();
+
+      void *D_T = Tin._impl->storage()._impl->Mem;
+      void *D_U = U._impl->storage()._impl->Mem;
+      void *D_S = S._impl->storage()._impl->Mem;
+      void *D_V = vT._impl->storage()._impl->Mem;
+
+      cutensornetTensorDescriptor_t descTensorIn;
+      cutensornetTensorDescriptor_t descTensorU;
+      cutensornetTensorDescriptor_t descTensorV;
+
+      const int64_t *strides = NULL;  // assuming fortran layout for all tensors
+
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides,
+                                                     modesT.data(), typeData, &descTensorIn));
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesU, extentU.data(), strides,
+                                                     modesU.data(), typeData, &descTensorU));
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesV, extentV.data(), strides,
+                                                     modesV.data(), typeData, &descTensorV));
+
+      // printf("Initialize the cuTensorNet library and create all tensor descriptors.\n");
+
+      /**********************************************
+       * Setup SVD algorithm and truncation parameters
+       ***********************************************/
+
+      cutensornetTensorSVDConfig_t svdConfig;
+      HANDLE_ERROR(cutensornetCreateTensorSVDConfig(handle, &svdConfig));
+
+      // set up truncation parameters
+      double absCutoff = err;
+      HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(handle, svdConfig,
+                                                          CUTENSORNET_TENSOR_SVD_CONFIG_ABS_CUTOFF,
+                                                          &absCutoff, sizeof(absCutoff)));
+      double relCutoff = 0;
+      HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(handle, svdConfig,
+                                                          CUTENSORNET_TENSOR_SVD_CONFIG_REL_CUTOFF,
+                                                          &relCutoff, sizeof(relCutoff)));
+
+      // optional: choose gesvdj algorithm with customized parameters. Default is gesvd.
+      cutensornetTensorSVDAlgo_t svdAlgo = CUTENSORNET_TENSOR_SVD_ALGO_GESVDJ;
+      HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(
+        handle, svdConfig, CUTENSORNET_TENSOR_SVD_CONFIG_ALGO, &svdAlgo, sizeof(svdAlgo)));
+      cutensornetGesvdjParams_t gesvdjParams{/*tol=*/0, /*maxSweeps=*/80};
+      HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(handle, svdConfig,
+                                                          CUTENSORNET_TENSOR_SVD_CONFIG_ALGO_PARAMS,
+                                                          &gesvdjParams, sizeof(gesvdjParams)));
+      // printf("Set up SVDConfig to use GESVDJ algorithm with truncation\n");
+
+      /********************************************************
+       * Create SVDInfo to record runtime SVD truncation details
+       *********************************************************/
+
+      cutensornetTensorSVDInfo_t svdInfo;
+      HANDLE_ERROR(cutensornetCreateTensorSVDInfo(handle, &svdInfo));
+
+      // Sphinx: #6
+      /**************************************************************
+       * Query the required workspace sizes and allocate memory
+       **************************************************************/
+
+      cutensornetWorkspaceDescriptor_t workDesc;
+      HANDLE_ERROR(cutensornetCreateWorkspaceDescriptor(handle, &workDesc));
+      HANDLE_ERROR(cutensornetWorkspaceComputeSVDSizes(handle, descTensorIn, descTensorU,
+                                                       descTensorV, svdConfig, workDesc));
+      int64_t hostWorkspaceSize, deviceWorkspaceSize;
+      // for tensor SVD, it does not matter which cutensornetWorksizePref_t we pick
+      HANDLE_ERROR(cutensornetWorkspaceGetMemorySize(
+        handle, workDesc, CUTENSORNET_WORKSIZE_PREF_RECOMMENDED, CUTENSORNET_MEMSPACE_DEVICE,
+        CUTENSORNET_WORKSPACE_SCRATCH, &deviceWorkspaceSize));
+      HANDLE_ERROR(cutensornetWorkspaceGetMemorySize(
+        handle, workDesc, CUTENSORNET_WORKSIZE_PREF_RECOMMENDED, CUTENSORNET_MEMSPACE_HOST,
+        CUTENSORNET_WORKSPACE_SCRATCH, &hostWorkspaceSize));
+
+      void *devWork = nullptr, *hostWork = nullptr;
+      if (deviceWorkspaceSize > 0) {
+        HANDLE_CUDA_ERROR(cudaMalloc(&devWork, deviceWorkspaceSize));
+      }
+      if (hostWorkspaceSize > 0) {
+        hostWork = malloc(hostWorkspaceSize);
+      }
+      HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_DEVICE,
+                                                 CUTENSORNET_WORKSPACE_SCRATCH, devWork,
+                                                 deviceWorkspaceSize));
+      HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_HOST,
+                                                 CUTENSORNET_WORKSPACE_SCRATCH, hostWork,
+                                                 hostWorkspaceSize));
+
+      // Sphinx: #7
+      /**********
+       * Execution
+       ***********/
+
+      GPUTimer timer{stream};
+      double minTimeCUTENSOR = 1e100;
+      const int numRuns = 1;  // to get stable perf results
+      for (int i = 0; i < numRuns; ++i) {
+        // // restore output
+        // cudaMemsetAsync(D_U, 0, sizeU, stream);
+        // cudaMemsetAsync(D_S, 0, sizeS, stream);
+        // cudaMemsetAsync(D_V, 0, sizeV, stream);
+        // cudaDeviceSynchronize();
+
+        // With value-based truncation, `cutensornetTensorSVD` can potentially update the shared
+        // extent in descTensorU/V. We here restore descTensorU/V to the original problem.
+        HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorU));
+        HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorV));
+        HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesU, extentU.data(), strides,
+                                                       modesU.data(), typeData, &descTensorU));
+        HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesV, extentV.data(), strides,
+                                                       modesV.data(), typeData, &descTensorV));
+
+        timer.start();
+        HANDLE_ERROR(cutensornetTensorSVD(handle, descTensorIn, D_T, descTensorU, D_U, D_S,
+                                          descTensorV, D_V, svdConfig, svdInfo, workDesc, stream));
+        // Synchronize and measure timing
+        auto time = timer.seconds();
+        minTimeCUTENSOR = (minTimeCUTENSOR < time) ? minTimeCUTENSOR : time;
+      }
+
+      // printf("Performing SVD\n");
+
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(U, D_U, sizeU, cudaMemcpyDeviceToHost) );
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(S, D_S, sizeS, cudaMemcpyDeviceToHost) );
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(V, D_V, sizeV, cudaMemcpyDeviceToHost) );
+
+      // Sphinx: #8
+      /*************************************
+       * Query runtime truncation information
+       **************************************/
+
+      double discardedWeight{0};
+      int64_t reducedExtent{0};
+      cutensornetGesvdjStatus_t gesvdjStatus;
+      cudaDeviceSynchronize();  // device synchronization.
+      HANDLE_ERROR(cutensornetTensorSVDInfoGetAttribute(
+        handle, svdInfo, CUTENSORNET_TENSOR_SVD_INFO_DISCARDED_WEIGHT, &discardedWeight,
+        sizeof(discardedWeight)));
+      HANDLE_ERROR(cutensornetTensorSVDInfoGetAttribute(handle, svdInfo,
+                                                        CUTENSORNET_TENSOR_SVD_INFO_REDUCED_EXTENT,
+                                                        &reducedExtent, sizeof(reducedExtent)));
+      HANDLE_ERROR(cutensornetTensorSVDInfoGetAttribute(handle, svdInfo,
+                                                        CUTENSORNET_TENSOR_SVD_INFO_ALGO_STATUS,
+                                                        &gesvdjStatus, sizeof(gesvdjStatus)));
+
+      // printf("elapsed time: %.2f ms\n", minTimeCUTENSOR * 1000.f);
+      // printf("GESVDJ residual: %.4f, runtime sweeps = %d\n", gesvdjStatus.residual,
+      //        gesvdjStatus.sweeps);
+      // printf("reduced extent found at runtime: %lu\n", reducedExtent);
+      // printf("discarded weight: %.2f\n", discardedWeight);
+
+      // Sphinx: #9
+      /***************
+       * Free resources
+       ****************/
+
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorIn));
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorU));
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorV));
+      HANDLE_ERROR(cutensornetDestroyTensorSVDConfig(svdConfig));
+      HANDLE_ERROR(cutensornetDestroyTensorSVDInfo(svdInfo));
+      HANDLE_ERROR(cutensornetDestroyWorkspaceDescriptor(workDesc));
+      HANDLE_ERROR(cutensornetDestroy(handle));
+
+      if (devWork) cudaFree(devWork);
+      if (hostWork) free(hostWork);
+
+      // printf("Free resource and exit.\n");
+    }
+
+    void cuQuantumGeSvd_internal_f(const Tensor &Tin, const cytnx_uint64 &keepdim,
+                                   const double &err, const unsigned int &return_err, Tensor &U,
+                                   Tensor &S, Tensor &vT) {
+      const size_t cuTensornetVersion = cutensornetGetVersion();
+      // printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
+
+      cudaDeviceProp prop;
+      int deviceId = Tin.device();
+      HANDLE_CUDA_ERROR(cudaSetDevice(deviceId));
+      HANDLE_CUDA_ERROR(cudaGetDevice(&deviceId));
+      HANDLE_CUDA_ERROR(cudaGetDeviceProperties(&prop, deviceId));
+
+      // printf("===== device info ======\n");
+      // printf("GPU-name:%s\n", prop.name);
+      // printf("GPU-clock:%d\n", prop.clockRate);
+      // printf("GPU-memoryClock:%d\n", prop.memoryClockRate);
+      // printf("GPU-nSM:%d\n", prop.multiProcessorCount);
+      // printf("GPU-major:%d\n", prop.major);
+      // printf("GPU-minor:%d\n", prop.minor);
+      // printf("========================\n");
+
+      typedef float floatType;
+      cudaDataType_t typeData = CUDA_R_32F;
+      /******************
+       * cuTensorNet
+       *******************/
+
+      cudaStream_t stream;
+      HANDLE_CUDA_ERROR(cudaStreamCreate(&stream));
+
+      cutensornetHandle_t handle;
+      HANDLE_ERROR(cutensornetCreate(&handle));
+
+      /**************************
+       * Create tensor descriptors
+       ***************************/
+      std::vector<int32_t> modesT{'j', 'i'};
+      std::vector<int32_t> modesU{'s', 'i'};
+      std::vector<int32_t> modesV{'j', 's'};
+
+      std::vector<int64_t> extentT{(int64_t)Tin.shape()[1], (int64_t)Tin.shape()[0]};
+      std::vector<int64_t> extentU{(int64_t)U.shape()[1], (int64_t)U.shape()[0]};
+      std::vector<int64_t> extentV{(int64_t)vT.shape()[1], (int64_t)vT.shape()[0]};
+
+      const int32_t numModesIn = modesT.size();
+      const int32_t numModesU = modesU.size();
+      const int32_t numModesV = modesV.size();
+
+      void *D_T = Tin._impl->storage()._impl->Mem;
+      void *D_U = U._impl->storage()._impl->Mem;
+      void *D_S = S._impl->storage()._impl->Mem;
+      void *D_V = vT._impl->storage()._impl->Mem;
+
+      cutensornetTensorDescriptor_t descTensorIn;
+      cutensornetTensorDescriptor_t descTensorU;
+      cutensornetTensorDescriptor_t descTensorV;
+
+      const int64_t *strides = NULL;  // assuming fortran layout for all tensors
+
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides,
+                                                     modesT.data(), typeData, &descTensorIn));
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesU, extentU.data(), strides,
+                                                     modesU.data(), typeData, &descTensorU));
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesV, extentV.data(), strides,
+                                                     modesV.data(), typeData, &descTensorV));
+
+      // printf("Initialize the cuTensorNet library and create all tensor descriptors.\n");
+
+      /**********************************************
+       * Setup SVD algorithm and truncation parameters
+       ***********************************************/
+
+      cutensornetTensorSVDConfig_t svdConfig;
+      HANDLE_ERROR(cutensornetCreateTensorSVDConfig(handle, &svdConfig));
+
+      // set up truncation parameters
+      double absCutoff = err;
+      HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(handle, svdConfig,
+                                                          CUTENSORNET_TENSOR_SVD_CONFIG_ABS_CUTOFF,
+                                                          &absCutoff, sizeof(absCutoff)));
+      double relCutoff = 0;
+      HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(handle, svdConfig,
+                                                          CUTENSORNET_TENSOR_SVD_CONFIG_REL_CUTOFF,
+                                                          &relCutoff, sizeof(relCutoff)));
+
+      // optional: choose gesvdj algorithm with customized parameters. Default is gesvd.
+      cutensornetTensorSVDAlgo_t svdAlgo = CUTENSORNET_TENSOR_SVD_ALGO_GESVDJ;
+      HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(
+        handle, svdConfig, CUTENSORNET_TENSOR_SVD_CONFIG_ALGO, &svdAlgo, sizeof(svdAlgo)));
+      cutensornetGesvdjParams_t gesvdjParams{/*tol=*/0, /*maxSweeps=*/80};
+      HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(handle, svdConfig,
+                                                          CUTENSORNET_TENSOR_SVD_CONFIG_ALGO_PARAMS,
+                                                          &gesvdjParams, sizeof(gesvdjParams)));
+      // printf("Set up SVDConfig to use GESVDJ algorithm with truncation\n");
+
+      /********************************************************
+       * Create SVDInfo to record runtime SVD truncation details
+       *********************************************************/
+
+      cutensornetTensorSVDInfo_t svdInfo;
+      HANDLE_ERROR(cutensornetCreateTensorSVDInfo(handle, &svdInfo));
+
+      // Sphinx: #6
+      /**************************************************************
+       * Query the required workspace sizes and allocate memory
+       **************************************************************/
+
+      cutensornetWorkspaceDescriptor_t workDesc;
+      HANDLE_ERROR(cutensornetCreateWorkspaceDescriptor(handle, &workDesc));
+      HANDLE_ERROR(cutensornetWorkspaceComputeSVDSizes(handle, descTensorIn, descTensorU,
+                                                       descTensorV, svdConfig, workDesc));
+      int64_t hostWorkspaceSize, deviceWorkspaceSize;
+      // for tensor SVD, it does not matter which cutensornetWorksizePref_t we pick
+      HANDLE_ERROR(cutensornetWorkspaceGetMemorySize(
+        handle, workDesc, CUTENSORNET_WORKSIZE_PREF_RECOMMENDED, CUTENSORNET_MEMSPACE_DEVICE,
+        CUTENSORNET_WORKSPACE_SCRATCH, &deviceWorkspaceSize));
+      HANDLE_ERROR(cutensornetWorkspaceGetMemorySize(
+        handle, workDesc, CUTENSORNET_WORKSIZE_PREF_RECOMMENDED, CUTENSORNET_MEMSPACE_HOST,
+        CUTENSORNET_WORKSPACE_SCRATCH, &hostWorkspaceSize));
+
+      void *devWork = nullptr, *hostWork = nullptr;
+      if (deviceWorkspaceSize > 0) {
+        HANDLE_CUDA_ERROR(cudaMalloc(&devWork, deviceWorkspaceSize));
+      }
+      if (hostWorkspaceSize > 0) {
+        hostWork = malloc(hostWorkspaceSize);
+      }
+      HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_DEVICE,
+                                                 CUTENSORNET_WORKSPACE_SCRATCH, devWork,
+                                                 deviceWorkspaceSize));
+      HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_HOST,
+                                                 CUTENSORNET_WORKSPACE_SCRATCH, hostWork,
+                                                 hostWorkspaceSize));
+
+      // Sphinx: #7
+      /**********
+       * Execution
+       ***********/
+
+      GPUTimer timer{stream};
+      double minTimeCUTENSOR = 1e100;
+      const int numRuns = 1;  // to get stable perf results
+      for (int i = 0; i < numRuns; ++i) {
+        // // restore output
+        // cudaMemsetAsync(D_U, 0, sizeU, stream);
+        // cudaMemsetAsync(D_S, 0, sizeS, stream);
+        // cudaMemsetAsync(D_V, 0, sizeV, stream);
+        // cudaDeviceSynchronize();
+
+        // With value-based truncation, `cutensornetTensorSVD` can potentially update the shared
+        // extent in descTensorU/V. We here restore descTensorU/V to the original problem.
+        HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorU));
+        HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorV));
+        HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesU, extentU.data(), strides,
+                                                       modesU.data(), typeData, &descTensorU));
+        HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesV, extentV.data(), strides,
+                                                       modesV.data(), typeData, &descTensorV));
+
+        timer.start();
+        HANDLE_ERROR(cutensornetTensorSVD(handle, descTensorIn, D_T, descTensorU, D_U, D_S,
+                                          descTensorV, D_V, svdConfig, svdInfo, workDesc, stream));
+        // Synchronize and measure timing
+        auto time = timer.seconds();
+        minTimeCUTENSOR = (minTimeCUTENSOR < time) ? minTimeCUTENSOR : time;
+      }
+
+      // printf("Performing SVD\n");
+
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(U, D_U, sizeU, cudaMemcpyDeviceToHost) );
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(S, D_S, sizeS, cudaMemcpyDeviceToHost) );
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(V, D_V, sizeV, cudaMemcpyDeviceToHost) );
+
+      // Sphinx: #8
+      /*************************************
+       * Query runtime truncation information
+       **************************************/
+
+      double discardedWeight{0};
+      int64_t reducedExtent{0};
+      cutensornetGesvdjStatus_t gesvdjStatus;
+      cudaDeviceSynchronize();  // device synchronization.
+      HANDLE_ERROR(cutensornetTensorSVDInfoGetAttribute(
+        handle, svdInfo, CUTENSORNET_TENSOR_SVD_INFO_DISCARDED_WEIGHT, &discardedWeight,
+        sizeof(discardedWeight)));
+      HANDLE_ERROR(cutensornetTensorSVDInfoGetAttribute(handle, svdInfo,
+                                                        CUTENSORNET_TENSOR_SVD_INFO_REDUCED_EXTENT,
+                                                        &reducedExtent, sizeof(reducedExtent)));
+      HANDLE_ERROR(cutensornetTensorSVDInfoGetAttribute(handle, svdInfo,
+                                                        CUTENSORNET_TENSOR_SVD_INFO_ALGO_STATUS,
+                                                        &gesvdjStatus, sizeof(gesvdjStatus)));
+
+      // printf("elapsed time: %.2f ms\n", minTimeCUTENSOR * 1000.f);
+      // printf("GESVDJ residual: %.4f, runtime sweeps = %d\n", gesvdjStatus.residual,
+      //        gesvdjStatus.sweeps);
+      // printf("reduced extent found at runtime: %lu\n", reducedExtent);
+      // printf("discarded weight: %.2f\n", discardedWeight);
+
+      // Sphinx: #9
+      /***************
+       * Free resources
+       ****************/
+
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorIn));
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorU));
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorV));
+      HANDLE_ERROR(cutensornetDestroyTensorSVDConfig(svdConfig));
+      HANDLE_ERROR(cutensornetDestroyTensorSVDInfo(svdInfo));
+      HANDLE_ERROR(cutensornetDestroyWorkspaceDescriptor(workDesc));
+      HANDLE_ERROR(cutensornetDestroy(handle));
+
+      if (devWork) cudaFree(devWork);
+      if (hostWork) free(hostWork);
+
+      // printf("Free resource and exit.\n");
+    }
+
   #endif
 #endif
   }  // namespace linalg_internal

--- a/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.cu
+++ b/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.cu
@@ -8,9 +8,9 @@
 #include "cuQuantumGeSvd_internal.hpp"
 
 #ifdef UNI_GPU
- #ifdef UNI_CUQUANTUM
-   #include <cuda_runtime.h>
-   #include <cutensornet.h>
+  #ifdef UNI_CUQUANTUM
+    #include <cuda_runtime.h>
+    #include <cutensornet.h>
 
   //  #define HANDLE_ERROR(x)                                           \
   //  { const auto err = x;                                             \
@@ -41,305 +41,278 @@
         }                                                                           \
       };
 
-   struct GPUTimer
-   {
-      GPUTimer(cudaStream_t stream): stream_(stream)
-      {
-         cudaEventCreate(&start_);
-         cudaEventCreate(&stop_);
-      }
+struct GPUTimer {
+  GPUTimer(cudaStream_t stream) : stream_(stream) {
+    cudaEventCreate(&start_);
+    cudaEventCreate(&stop_);
+  }
 
-      ~GPUTimer()
-      {
-         cudaEventDestroy(start_);
-         cudaEventDestroy(stop_);
-      }
+  ~GPUTimer() {
+    cudaEventDestroy(start_);
+    cudaEventDestroy(stop_);
+  }
 
-      void start()
-      {
-         cudaEventRecord(start_, stream_);
-      }
+  void start() { cudaEventRecord(start_, stream_); }
 
-      float seconds()
-      {
-         cudaEventRecord(stop_, stream_);
-         cudaEventSynchronize(stop_);
-         float time;
-         cudaEventElapsedTime(&time, start_, stop_);
-         return time * 1e-3;
-      }
+  float seconds() {
+    cudaEventRecord(stop_, stream_);
+    cudaEventSynchronize(stop_);
+    float time;
+    cudaEventElapsedTime(&time, start_, stop_);
+    return time * 1e-3;
+  }
 
-      private:
-      cudaEvent_t start_, stop_;
-      cudaStream_t stream_;
-   };
+ private:
+  cudaEvent_t start_, stop_;
+  cudaStream_t stream_;
+};
 
- #endif
+  #endif
 #endif
 
-
-int64_t computeCombinedExtent(const std::unordered_map<int32_t, int64_t> &extentMap, 
-                                const std::vector<int32_t> &modes)
-{
-   int64_t combinedExtent{1};
-   for (auto mode: modes)
-   {
-      auto it = extentMap.find(mode);
-      if (it != extentMap.end())
-         combinedExtent *= it->second;
-   }
-   return combinedExtent;
+int64_t computeCombinedExtent(const std::unordered_map<int32_t, int64_t> &extentMap,
+                              const std::vector<int32_t> &modes) {
+  int64_t combinedExtent{1};
+  for (auto mode : modes) {
+    auto it = extentMap.find(mode);
+    if (it != extentMap.end()) combinedExtent *= it->second;
+  }
+  return combinedExtent;
 }
-
 
 namespace cytnx {
   namespace linalg_internal {
 
-  #ifdef UNI_GPU
-    #ifdef UNI_CUQUANTUM
+#ifdef UNI_GPU
+  #ifdef UNI_CUQUANTUM
     /// cuGeSvd
     void cuQuantumGeSvd_internal_cd(const Tensor &Tin, const cytnx_uint64 &keepdim,
-                                       const double &err, const unsigned int &return_err, Tensor U, Tensor S, Tensor vT) {
+                                    const double &err, const unsigned int &return_err, Tensor U,
+                                    Tensor S, Tensor vT) {
+      const size_t cuTensornetVersion = cutensornetGetVersion();
+      printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
 
-          const size_t cuTensornetVersion = cutensornetGetVersion();
-          printf("cuTensorNet-vers:%ld\n",cuTensornetVersion);
+      cudaDeviceProp prop;
+      int deviceId = Tin.device();
+      HANDLE_CUDA_ERROR(cudaSetDevice(deviceId));
+      HANDLE_CUDA_ERROR(cudaGetDevice(&deviceId));
+      HANDLE_CUDA_ERROR(cudaGetDeviceProperties(&prop, deviceId));
 
-          cudaDeviceProp prop;
-          int deviceId = Tin.device();
-          HANDLE_CUDA_ERROR( cudaSetDevice(deviceId));
-          HANDLE_CUDA_ERROR( cudaGetDevice(&deviceId) );
-          HANDLE_CUDA_ERROR( cudaGetDeviceProperties(&prop, deviceId) );
+      printf("===== device info ======\n");
+      printf("GPU-name:%s\n", prop.name);
+      printf("GPU-clock:%d\n", prop.clockRate);
+      printf("GPU-memoryClock:%d\n", prop.memoryClockRate);
+      printf("GPU-nSM:%d\n", prop.multiProcessorCount);
+      printf("GPU-major:%d\n", prop.major);
+      printf("GPU-minor:%d\n", prop.minor);
+      printf("========================\n");
 
-          printf("===== device info ======\n");
-          printf("GPU-name:%s\n", prop.name);
-          printf("GPU-clock:%d\n", prop.clockRate);
-          printf("GPU-memoryClock:%d\n", prop.memoryClockRate);
-          printf("GPU-nSM:%d\n", prop.multiProcessorCount);
-          printf("GPU-major:%d\n", prop.major);
-          printf("GPU-minor:%d\n", prop.minor);
-          printf("========================\n");
-      
-          typedef float floatType;
-          cudaDataType_t typeData = CUDA_R_32F;
-            /******************
-         * cuTensorNet
-         *******************/
+      typedef float floatType;
+      cudaDataType_t typeData = CUDA_R_64F;
+      /******************
+       * cuTensorNet
+       *******************/
 
-         cudaStream_t stream;
-         HANDLE_CUDA_ERROR( cudaStreamCreate(&stream) );
+      cudaStream_t stream;
+      HANDLE_CUDA_ERROR(cudaStreamCreate(&stream));
 
-         cutensornetHandle_t handle;
-         HANDLE_ERROR( cutensornetCreate(&handle) );
+      cutensornetHandle_t handle;
+      HANDLE_ERROR(cutensornetCreate(&handle));
 
-         /**************************
-         * Create tensor descriptors
-         ***************************/
-         std::vector<int32_t> modesT{1,2};
-         std::vector<int32_t> modesU{1,0};
-         std::vector<int32_t> modesV{0,2};
+      /**************************
+       * Create tensor descriptors
+       ***************************/
+      std::vector<int32_t> modesT{'j', 'i'};
+      std::vector<int32_t> modesU{'s', 'i'};
+      std::vector<int32_t> modesV{'j', 's'};
 
-         std::vector<int64_t> extentT{(int64_t)Tin.shape()[1], (int64_t)Tin.shape()[0]};
-         std::vector<int64_t> extentU{(int64_t)U.shape()[1], (int64_t)U.shape()[0]};
-         std::vector<int64_t> extentV{(int64_t)vT.shape()[1], (int64_t)vT.shape()[0]};
+      std::vector<int64_t> extentT{(int64_t)Tin.shape()[1], (int64_t)Tin.shape()[0]};
+      std::vector<int64_t> extentU{(int64_t)U.shape()[1], (int64_t)U.shape()[0]};
+      std::vector<int64_t> extentV{(int64_t)vT.shape()[1], (int64_t)vT.shape()[0]};
 
-         const int32_t numModesIn = modesT.size();
-         const int32_t numModesU = modesU.size();
-         const int32_t numModesV = modesV.size();
+      const int32_t numModesIn = modesT.size();
+      const int32_t numModesU = modesU.size();
+      const int32_t numModesV = modesV.size();
 
-         void* D_T = Tin._impl->storage()._impl->Mem;
-         void* D_U = U._impl->storage()._impl->Mem;
-         void* D_S = S._impl->storage()._impl->Mem;
-         void* D_V = vT._impl->storage()._impl->Mem;
+      void *D_T = Tin._impl->storage()._impl->Mem;
+      void *D_U = U._impl->storage()._impl->Mem;
+      void *D_S = S._impl->storage()._impl->Mem;
+      void *D_V = vT._impl->storage()._impl->Mem;
 
+      cutensornetTensorDescriptor_t descTensorIn;
+      cutensornetTensorDescriptor_t descTensorU;
+      cutensornetTensorDescriptor_t descTensorV;
 
-         cutensornetTensorDescriptor_t descTensorIn;
-         cutensornetTensorDescriptor_t descTensorU;
-         cutensornetTensorDescriptor_t descTensorV;
+      const int64_t *strides = NULL;  // assuming fortran layout for all tensors
 
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides,
+                                                     modesT.data(), typeData, &descTensorIn));
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesU, extentU.data(), strides,
+                                                     modesU.data(), typeData, &descTensorU));
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesV, extentV.data(), strides,
+                                                     modesV.data(), typeData, &descTensorV));
 
-         const int64_t* strides = NULL; // assuming fortran layout for all tensors
+      printf("Initialize the cuTensorNet library and create all tensor descriptors.\n");
 
-         HANDLE_ERROR( cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides, modesT.data(), typeData, &descTensorIn) );
-         HANDLE_ERROR( cutensornetCreateTensorDescriptor(handle, numModesU, extentU.data(), strides, modesU.data(), typeData, &descTensorU) );
-         HANDLE_ERROR( cutensornetCreateTensorDescriptor(handle, numModesV, extentV.data(), strides, modesV.data(), typeData, &descTensorV) );
-         
-         printf("Initialize the cuTensorNet library and create all tensor descriptors.\n");
+      /**********************************************
+       * Setup SVD algorithm and truncation parameters
+       ***********************************************/
 
-         /**********************************************
-         * Setup SVD algorithm and truncation parameters
-         ***********************************************/
+      cutensornetTensorSVDConfig_t svdConfig;
+      HANDLE_ERROR(cutensornetCreateTensorSVDConfig(handle, &svdConfig));
 
-         cutensornetTensorSVDConfig_t svdConfig;
-         HANDLE_ERROR( cutensornetCreateTensorSVDConfig(handle, &svdConfig) );
+      // set up truncation parameters
+      double absCutoff = 0;
+      HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(handle, svdConfig,
+                                                          CUTENSORNET_TENSOR_SVD_CONFIG_ABS_CUTOFF,
+                                                          &absCutoff, sizeof(absCutoff)));
+      double relCutoff = 0;
+      HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(handle, svdConfig,
+                                                          CUTENSORNET_TENSOR_SVD_CONFIG_REL_CUTOFF,
+                                                          &relCutoff, sizeof(relCutoff)));
 
-         // set up truncation parameters
-         double absCutoff = 1e-2;
-         HANDLE_ERROR( cutensornetTensorSVDConfigSetAttribute(handle, 
-                                                svdConfig, 
-                                                CUTENSORNET_TENSOR_SVD_CONFIG_ABS_CUTOFF, 
-                                                &absCutoff, 
-                                                sizeof(absCutoff)) );
-         double relCutoff = 4e-2;
-         HANDLE_ERROR( cutensornetTensorSVDConfigSetAttribute(handle, 
-                                                svdConfig, 
-                                                CUTENSORNET_TENSOR_SVD_CONFIG_REL_CUTOFF, 
-                                                &relCutoff, 
-                                                sizeof(relCutoff)) );
-         
-         // optional: choose gesvdj algorithm with customized parameters. Default is gesvd.
-         cutensornetTensorSVDAlgo_t svdAlgo = CUTENSORNET_TENSOR_SVD_ALGO_GESVDJ;
-         HANDLE_ERROR( cutensornetTensorSVDConfigSetAttribute(handle, 
-                                                svdConfig, 
-                                                CUTENSORNET_TENSOR_SVD_CONFIG_ALGO, 
-                                                &svdAlgo, 
-                                                sizeof(svdAlgo)) );
-         cutensornetGesvdjParams_t gesvdjParams{/*tol=*/1e-12, /*maxSweeps=*/80};
-         HANDLE_ERROR( cutensornetTensorSVDConfigSetAttribute(handle, 
-                                                svdConfig, 
-                                                CUTENSORNET_TENSOR_SVD_CONFIG_ALGO_PARAMS, 
-                                                &gesvdjParams, 
-                                                sizeof(gesvdjParams)) );
-         printf("Set up SVDConfig to use GESVDJ algorithm with truncation\n");
-         
-         /********************************************************
-         * Create SVDInfo to record runtime SVD truncation details
-         *********************************************************/
+      // optional: choose gesvdj algorithm with customized parameters. Default is gesvd.
+      cutensornetTensorSVDAlgo_t svdAlgo = CUTENSORNET_TENSOR_SVD_ALGO_GESVDJ;
+      HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(
+        handle, svdConfig, CUTENSORNET_TENSOR_SVD_CONFIG_ALGO, &svdAlgo, sizeof(svdAlgo)));
+      cutensornetGesvdjParams_t gesvdjParams{/*tol=*/0, /*maxSweeps=*/80};
+      HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(handle, svdConfig,
+                                                          CUTENSORNET_TENSOR_SVD_CONFIG_ALGO_PARAMS,
+                                                          &gesvdjParams, sizeof(gesvdjParams)));
+      printf("Set up SVDConfig to use GESVDJ algorithm with truncation\n");
 
-         cutensornetTensorSVDInfo_t svdInfo; 
-         HANDLE_ERROR( cutensornetCreateTensorSVDInfo(handle, &svdInfo)) ;
+      /********************************************************
+       * Create SVDInfo to record runtime SVD truncation details
+       *********************************************************/
 
-         // Sphinx: #6
-         /**************************************************************
-         * Query the required workspace sizes and allocate memory
-         **************************************************************/
+      cutensornetTensorSVDInfo_t svdInfo;
+      HANDLE_ERROR(cutensornetCreateTensorSVDInfo(handle, &svdInfo));
 
-         cutensornetWorkspaceDescriptor_t workDesc;
-         HANDLE_ERROR( cutensornetCreateWorkspaceDescriptor(handle, &workDesc) );
-         HANDLE_ERROR( cutensornetWorkspaceComputeSVDSizes(handle, descTensorIn, descTensorU, descTensorV, svdConfig, workDesc) );
-         int64_t hostWorkspaceSize, deviceWorkspaceSize;
-         // for tensor SVD, it does not matter which cutensornetWorksizePref_t we pick
-         HANDLE_ERROR( cutensornetWorkspaceGetMemorySize(handle,
-                                                         workDesc,
-                                                         CUTENSORNET_WORKSIZE_PREF_RECOMMENDED,
-                                                         CUTENSORNET_MEMSPACE_DEVICE,
-                                                         CUTENSORNET_WORKSPACE_SCRATCH,
-                                                         &deviceWorkspaceSize) );
-         HANDLE_ERROR( cutensornetWorkspaceGetMemorySize(handle,
-                                                         workDesc,
-                                                         CUTENSORNET_WORKSIZE_PREF_RECOMMENDED,
-                                                         CUTENSORNET_MEMSPACE_HOST,
-                                                         CUTENSORNET_WORKSPACE_SCRATCH,
-                                                         &hostWorkspaceSize) );
+      // Sphinx: #6
+      /**************************************************************
+       * Query the required workspace sizes and allocate memory
+       **************************************************************/
 
-         void *devWork = nullptr, *hostWork = nullptr;
-         if (deviceWorkspaceSize > 0) {
-            HANDLE_CUDA_ERROR( cudaMalloc(&devWork, deviceWorkspaceSize) );
-         }
-         if (hostWorkspaceSize > 0) {
-            hostWork = malloc(hostWorkspaceSize);
-         }
-         HANDLE_ERROR( cutensornetWorkspaceSetMemory(handle,
-                                                   workDesc,
-                                                   CUTENSORNET_MEMSPACE_DEVICE,
-                                                   CUTENSORNET_WORKSPACE_SCRATCH,
-                                                   devWork,
-                                                   deviceWorkspaceSize) );
-         HANDLE_ERROR( cutensornetWorkspaceSetMemory(handle,
-                                                   workDesc,
-                                                   CUTENSORNET_MEMSPACE_HOST,
-                                                   CUTENSORNET_WORKSPACE_SCRATCH,
-                                                   hostWork,
-                                                   hostWorkspaceSize) );
+      cutensornetWorkspaceDescriptor_t workDesc;
+      HANDLE_ERROR(cutensornetCreateWorkspaceDescriptor(handle, &workDesc));
+      HANDLE_ERROR(cutensornetWorkspaceComputeSVDSizes(handle, descTensorIn, descTensorU,
+                                                       descTensorV, svdConfig, workDesc));
+      int64_t hostWorkspaceSize, deviceWorkspaceSize;
+      // for tensor SVD, it does not matter which cutensornetWorksizePref_t we pick
+      HANDLE_ERROR(cutensornetWorkspaceGetMemorySize(
+        handle, workDesc, CUTENSORNET_WORKSIZE_PREF_RECOMMENDED, CUTENSORNET_MEMSPACE_DEVICE,
+        CUTENSORNET_WORKSPACE_SCRATCH, &deviceWorkspaceSize));
+      HANDLE_ERROR(cutensornetWorkspaceGetMemorySize(
+        handle, workDesc, CUTENSORNET_WORKSIZE_PREF_RECOMMENDED, CUTENSORNET_MEMSPACE_HOST,
+        CUTENSORNET_WORKSPACE_SCRATCH, &hostWorkspaceSize));
 
-         // Sphinx: #7
-         /**********
-         * Execution
-         ***********/
-      
-         GPUTimer timer{stream};
-         double minTimeCUTENSOR = 1e100;
-         const int numRuns = 1; // to get stable perf results
-         for (int i=0; i < numRuns; ++i)
-         {  
-            // // restore output
-            // cudaMemsetAsync(D_U, 0, sizeU, stream);
-            // cudaMemsetAsync(D_S, 0, sizeS, stream);
-            // cudaMemsetAsync(D_V, 0, sizeV, stream);
-            // cudaDeviceSynchronize();
-            
-            // With value-based truncation, `cutensornetTensorSVD` can potentially update the shared extent in descTensorU/V.
-            // We here restore descTensorU/V to the original problem.
-            HANDLE_ERROR( cutensornetDestroyTensorDescriptor(descTensorU) );
-            HANDLE_ERROR( cutensornetDestroyTensorDescriptor(descTensorV) );
-            HANDLE_ERROR( cutensornetCreateTensorDescriptor(handle, numModesU, extentU.data(), strides, modesU.data(), typeData, &descTensorU) );
-            HANDLE_ERROR( cutensornetCreateTensorDescriptor(handle, numModesV, extentV.data(), strides, modesV.data(), typeData, &descTensorV) );
+      void *devWork = nullptr, *hostWork = nullptr;
+      if (deviceWorkspaceSize > 0) {
+        HANDLE_CUDA_ERROR(cudaMalloc(&devWork, deviceWorkspaceSize));
+      }
+      if (hostWorkspaceSize > 0) {
+        hostWork = malloc(hostWorkspaceSize);
+      }
+      HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_DEVICE,
+                                                 CUTENSORNET_WORKSPACE_SCRATCH, devWork,
+                                                 deviceWorkspaceSize));
+      HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_HOST,
+                                                 CUTENSORNET_WORKSPACE_SCRATCH, hostWork,
+                                                 hostWorkspaceSize));
 
-            timer.start();
-            HANDLE_ERROR( cutensornetTensorSVD(handle, 
-                              descTensorIn, D_T, 
-                              descTensorU, D_U, 
-                              D_S, 
-                              descTensorV, D_V, 
-                              svdConfig, 
-                              svdInfo,
-                              workDesc,
-                              stream) );
-            // Synchronize and measure timing
-            auto time = timer.seconds();
-            minTimeCUTENSOR = (minTimeCUTENSOR < time) ? minTimeCUTENSOR : time;
-         }
+      // Sphinx: #7
+      /**********
+       * Execution
+       ***********/
 
-         printf("Performing SVD\n");
+      GPUTimer timer{stream};
+      double minTimeCUTENSOR = 1e100;
+      const int numRuns = 1;  // to get stable perf results
+      for (int i = 0; i < numRuns; ++i) {
+        // // restore output
+        // cudaMemsetAsync(D_U, 0, sizeU, stream);
+        // cudaMemsetAsync(D_S, 0, sizeS, stream);
+        // cudaMemsetAsync(D_V, 0, sizeV, stream);
+        // cudaDeviceSynchronize();
 
-         // HANDLE_CUDA_ERROR( cudaMemcpyAsync(U, D_U, sizeU, cudaMemcpyDeviceToHost) );
-         // HANDLE_CUDA_ERROR( cudaMemcpyAsync(S, D_S, sizeS, cudaMemcpyDeviceToHost) );
-         // HANDLE_CUDA_ERROR( cudaMemcpyAsync(V, D_V, sizeV, cudaMemcpyDeviceToHost) );
+        // With value-based truncation, `cutensornetTensorSVD` can potentially update the shared
+        // extent in descTensorU/V. We here restore descTensorU/V to the original problem.
+        HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorU));
+        HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorV));
+        HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesU, extentU.data(), strides,
+                                                       modesU.data(), typeData, &descTensorU));
+        HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesV, extentV.data(), strides,
+                                                       modesV.data(), typeData, &descTensorV));
 
-         // Sphinx: #8
-         /*************************************
-         * Query runtime truncation information
-         **************************************/
+        timer.start();
+        HANDLE_ERROR(cutensornetTensorSVD(handle, descTensorIn, D_T, descTensorU, D_U, D_S,
+                                          descTensorV, D_V, svdConfig, svdInfo, workDesc, stream));
+        // Synchronize and measure timing
+        auto time = timer.seconds();
+        minTimeCUTENSOR = (minTimeCUTENSOR < time) ? minTimeCUTENSOR : time;
+      }
 
-         double discardedWeight{0};
-         int64_t reducedExtent{0};
-         cutensornetGesvdjStatus_t gesvdjStatus;
-         cudaDeviceSynchronize(); // device synchronization.
-         HANDLE_ERROR( cutensornetTensorSVDInfoGetAttribute( handle, svdInfo, CUTENSORNET_TENSOR_SVD_INFO_DISCARDED_WEIGHT, &discardedWeight, sizeof(discardedWeight)) );
-         HANDLE_ERROR( cutensornetTensorSVDInfoGetAttribute( handle, svdInfo, CUTENSORNET_TENSOR_SVD_INFO_REDUCED_EXTENT, &reducedExtent, sizeof(reducedExtent)) );
-         HANDLE_ERROR( cutensornetTensorSVDInfoGetAttribute( handle, svdInfo, CUTENSORNET_TENSOR_SVD_INFO_ALGO_STATUS, &gesvdjStatus, sizeof(gesvdjStatus)) );
+      printf("Performing SVD\n");
 
-         printf("elapsed time: %.2f ms\n", minTimeCUTENSOR * 1000.f);
-         printf("GESVDJ residual: %.4f, runtime sweeps = %d\n", gesvdjStatus.residual, gesvdjStatus.sweeps);
-         printf("reduced extent found at runtime: %lu\n", reducedExtent);
-         printf("discarded weight: %.2f\n", discardedWeight);
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(U, D_U, sizeU, cudaMemcpyDeviceToHost) );
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(S, D_S, sizeS, cudaMemcpyDeviceToHost) );
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(V, D_V, sizeV, cudaMemcpyDeviceToHost) );
 
-         // Sphinx: #9
-         /***************
-         * Free resources
-         ****************/
-         
-         HANDLE_ERROR( cutensornetDestroyTensorDescriptor(descTensorIn) );
-         HANDLE_ERROR( cutensornetDestroyTensorDescriptor(descTensorU) );
-         HANDLE_ERROR( cutensornetDestroyTensorDescriptor(descTensorV) );
-         HANDLE_ERROR( cutensornetDestroyTensorSVDConfig(svdConfig) );
-         HANDLE_ERROR( cutensornetDestroyTensorSVDInfo(svdInfo) );
-         HANDLE_ERROR( cutensornetDestroyWorkspaceDescriptor(workDesc) );
-         HANDLE_ERROR( cutensornetDestroy(handle) );
+      // Sphinx: #8
+      /*************************************
+       * Query runtime truncation information
+       **************************************/
 
-         // if (T) free(T);
-         // if (U) free(U);
-         // if (S) free(S);
-         // if (V) free(V);
-         // if (D_T) cudaFree(D_T);
-         // if (D_U) cudaFree(D_U);
-         // if (D_S) cudaFree(D_S);
-         // if (D_V) cudaFree(D_V);
-         if (devWork) cudaFree(devWork);
-         if (hostWork) free(hostWork);
+      double discardedWeight{0};
+      int64_t reducedExtent{0};
+      cutensornetGesvdjStatus_t gesvdjStatus;
+      cudaDeviceSynchronize();  // device synchronization.
+      HANDLE_ERROR(cutensornetTensorSVDInfoGetAttribute(
+        handle, svdInfo, CUTENSORNET_TENSOR_SVD_INFO_DISCARDED_WEIGHT, &discardedWeight,
+        sizeof(discardedWeight)));
+      HANDLE_ERROR(cutensornetTensorSVDInfoGetAttribute(handle, svdInfo,
+                                                        CUTENSORNET_TENSOR_SVD_INFO_REDUCED_EXTENT,
+                                                        &reducedExtent, sizeof(reducedExtent)));
+      HANDLE_ERROR(cutensornetTensorSVDInfoGetAttribute(handle, svdInfo,
+                                                        CUTENSORNET_TENSOR_SVD_INFO_ALGO_STATUS,
+                                                        &gesvdjStatus, sizeof(gesvdjStatus)));
 
-         printf("Free resource and exit.\n");
+      printf("elapsed time: %.2f ms\n", minTimeCUTENSOR * 1000.f);
+      printf("GESVDJ residual: %.4f, runtime sweeps = %d\n", gesvdjStatus.residual,
+             gesvdjStatus.sweeps);
+      printf("reduced extent found at runtime: %lu\n", reducedExtent);
+      printf("discarded weight: %.2f\n", discardedWeight);
+
+      // Sphinx: #9
+      /***************
+       * Free resources
+       ****************/
+
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorIn));
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorU));
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorV));
+      HANDLE_ERROR(cutensornetDestroyTensorSVDConfig(svdConfig));
+      HANDLE_ERROR(cutensornetDestroyTensorSVDInfo(svdInfo));
+      HANDLE_ERROR(cutensornetDestroyWorkspaceDescriptor(workDesc));
+      HANDLE_ERROR(cutensornetDestroy(handle));
+
+      // std::cout<<S;
+      // std::cout<<U;
+      // std::cout<<vT;
+      // if (T) free(T);
+      // if (U) free(U);
+      // if (S) free(S);
+      // if (V) free(V);
+      // if (D_T) cudaFree(D_T);
+      // if (D_U) cudaFree(D_U);
+      // if (D_S) cudaFree(D_S);
+      // if (D_V) cudaFree(D_V);
+      if (devWork) cudaFree(devWork);
+      if (hostWork) free(hostWork);
+
+      printf("Free resource and exit.\n");
     }
-    #endif
   #endif
+#endif
   }  // namespace linalg_internal
 }  // namespace cytnx

--- a/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.cu
+++ b/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.cu
@@ -108,7 +108,7 @@ namespace cytnx {
       printf("========================\n");
 
       typedef float floatType;
-      cudaDataType_t typeData = CUDA_R_64F;
+      cudaDataType_t typeData = CUDA_C_64F;
       /******************
        * cuTensorNet
        *******************/
@@ -162,7 +162,7 @@ namespace cytnx {
       HANDLE_ERROR(cutensornetCreateTensorSVDConfig(handle, &svdConfig));
 
       // set up truncation parameters
-      double absCutoff = 0;
+      double absCutoff = err;
       HANDLE_ERROR(cutensornetTensorSVDConfigSetAttribute(handle, svdConfig,
                                                           CUTENSORNET_TENSOR_SVD_CONFIG_ABS_CUTOFF,
                                                           &absCutoff, sizeof(absCutoff)));

--- a/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.hpp
+++ b/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.hpp
@@ -1,0 +1,36 @@
+#ifndef __cuQuantumGeSvd_internal_H__
+#define __cuQuantumGeSvd_internal_H__
+
+#include <assert.h>
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include "Storage.hpp"
+#include "Type.hpp"
+#include "cytnx_error.hpp"
+#include "lapack_wrapper.hpp"
+#include "linalg/linalg_internal_interface.hpp"
+
+
+#ifdef UNI_GPU
+  #ifdef UNI_CUQUANTUM
+    #include <cutensornet.h>
+    #include <cuda_runtime.h>
+  #endif
+#endif
+
+namespace cytnx {
+  namespace linalg_internal {
+    
+  #ifdef UNI_GPU
+    #ifdef UNI_CUQUANTUM
+    /// cuSvd
+    void cuQuantumGeSvd_internal_cd(const Tensor &Tin, const cytnx_uint64 &keepdim,
+                                       const double &err, const unsigned int &return_err, Tensor U, Tensor S, Tensor vT);
+    #endif
+  #endif
+
+  }  // namespace linalg_internal
+}  // namespace cytnx
+
+#endif

--- a/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.hpp
+++ b/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.hpp
@@ -11,7 +11,6 @@
 #include "lapack_wrapper.hpp"
 #include "linalg/linalg_internal_interface.hpp"
 
-
 #ifdef UNI_GPU
   #ifdef UNI_CUQUANTUM
     #include <cutensornet.h>
@@ -21,14 +20,15 @@
 
 namespace cytnx {
   namespace linalg_internal {
-    
-  #ifdef UNI_GPU
-    #ifdef UNI_CUQUANTUM
+
+#ifdef UNI_GPU
+  #ifdef UNI_CUQUANTUM
     /// cuSvd
     void cuQuantumGeSvd_internal_cd(const Tensor &Tin, const cytnx_uint64 &keepdim,
-                                       const double &err, const unsigned int &return_err, Tensor U, Tensor S, Tensor vT);
-    #endif
+                                    const double &err, const unsigned int &return_err, Tensor U,
+                                    Tensor S, Tensor vT);
   #endif
+#endif
 
   }  // namespace linalg_internal
 }  // namespace cytnx

--- a/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.hpp
+++ b/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.hpp
@@ -25,8 +25,17 @@ namespace cytnx {
   #ifdef UNI_CUQUANTUM
     /// cuSvd
     void cuQuantumGeSvd_internal_cd(const Tensor &Tin, const cytnx_uint64 &keepdim,
-                                    const double &err, const unsigned int &return_err, Tensor U,
-                                    Tensor S, Tensor vT);
+                                    const double &err, const unsigned int &return_err, Tensor &U,
+                                    Tensor &S, Tensor &vT);
+    void cuQuantumGeSvd_internal_cf(const Tensor &Tin, const cytnx_uint64 &keepdim,
+                                    const double &err, const unsigned int &return_err, Tensor &U,
+                                    Tensor &S, Tensor &vT);
+    void cuQuantumGeSvd_internal_d(const Tensor &Tin, const cytnx_uint64 &keepdim,
+                                   const double &err, const unsigned int &return_err, Tensor &U,
+                                   Tensor &S, Tensor &vT);
+    void cuQuantumGeSvd_internal_f(const Tensor &Tin, const cytnx_uint64 &keepdim,
+                                   const double &err, const unsigned int &return_err, Tensor &U,
+                                   Tensor &S, Tensor &vT);
   #endif
 #endif
 

--- a/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.hpp
+++ b/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.hpp
@@ -26,16 +26,16 @@ namespace cytnx {
     /// cuSvd
     void cuQuantumGeSvd_internal_cd(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                     const double &err, const unsigned int &return_err, Tensor &U,
-                                    Tensor &S, Tensor &vT);
+                                    Tensor &S, Tensor &vT, Tensor &terr);
     void cuQuantumGeSvd_internal_cf(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                     const double &err, const unsigned int &return_err, Tensor &U,
-                                    Tensor &S, Tensor &vT);
+                                    Tensor &S, Tensor &vT, Tensor &terr);
     void cuQuantumGeSvd_internal_d(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                    const double &err, const unsigned int &return_err, Tensor &U,
-                                   Tensor &S, Tensor &vT);
+                                   Tensor &S, Tensor &vT, Tensor &terr);
     void cuQuantumGeSvd_internal_f(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                    const double &err, const unsigned int &return_err, Tensor &U,
-                                   Tensor &S, Tensor &vT);
+                                   Tensor &S, Tensor &vT, Tensor &terr);
   #endif
 #endif
 

--- a/src/linalg/linalg_internal_interface.cpp
+++ b/src/linalg/linalg_internal_interface.cpp
@@ -1367,6 +1367,14 @@ namespace cytnx {
       cuOuter_ii[Type.Bool][Type.Int16] = cuOuter_internal_bti16;
       cuOuter_ii[Type.Bool][Type.Bool] = cuOuter_internal_btb;
 
+  #ifdef UNI_CUQUANTUM
+      cuQuantumGeSvd_ii = vector<cuQuantumGeSvd_oii>(N_Type);
+      cuQuantumGeSvd_ii[Type.ComplexDouble] = cuQuantumGeSvd_internal_cd;
+      cuQuantumGeSvd_ii[Type.ComplexFloat] = cuQuantumGeSvd_internal_cf;
+      cuQuantumGeSvd_ii[Type.Double] = cuQuantumGeSvd_internal_d;
+      cuQuantumGeSvd_ii[Type.Float] = cuQuantumGeSvd_internal_f;
+  #endif
+
   #ifdef UNI_CUTENSOR
       cuTensordot_ii = vector<Tensordotfunc_oii>(N_Type);
       cuTensordot_ii[Type.ComplexDouble] = cuTensordot_internal_cd;

--- a/src/linalg/linalg_internal_interface.hpp
+++ b/src/linalg/linalg_internal_interface.hpp
@@ -187,7 +187,7 @@ namespace cytnx {
   #ifdef UNI_CUQUANTUM
     typedef void (*cuQuantumGeSvd_oii)(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                        const double &err, const unsigned int &return_err, Tensor &U,
-                                       Tensor &S, Tensor &vT);
+                                       Tensor &S, Tensor &vT, Tensor &terr);
   #endif
 #endif
     class linalg_internal_interface {

--- a/src/linalg/linalg_internal_interface.hpp
+++ b/src/linalg/linalg_internal_interface.hpp
@@ -66,6 +66,10 @@
   #ifdef UNI_CUTENSOR
     #include "linalg/linalg_internal_gpu/cuTensordot_internal.hpp"
   #endif
+
+  #ifdef UNI_CUQUANTUM
+    #include "linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.hpp"
+  #endif
 #endif
 
 namespace cytnx {
@@ -179,7 +183,13 @@ namespace cytnx {
     typedef void (*Tensordotfunc_oii)(Tensor &out, const Tensor &Lin, const Tensor &Rin,
                                       const std::vector<cytnx_uint64> &idxl,
                                       const std::vector<cytnx_uint64> &idxr);
-
+#ifdef UNI_GPU
+  #ifdef UNI_CUQUANTUM
+    typedef void (*cuQuantumGeSvd_oii)(const Tensor &Tin, const cytnx_uint64 &keepdim,
+                                       const double &err, const unsigned int &return_err, Tensor &U,
+                                       Tensor &S, Tensor &vT);
+  #endif
+#endif
     class linalg_internal_interface {
      public:
       std::vector<std::vector<Arithmeticfunc_oii>> Ari_ii;
@@ -243,6 +253,10 @@ namespace cytnx {
       std::vector<MaxMinfunc_oii> cuSum_ii;
       std::vector<std::vector<Kronfunc_oii>> cuKron_ii;
       std::vector<Tensordotfunc_oii> cuTensordot_ii;
+
+  #ifdef UNI_CUQUANTUM
+      std::vector<cuQuantumGeSvd_oii> cuQuantumGeSvd_ii;
+  #endif
 #endif
 
       linalg_internal_interface();


### PR DESCRIPTION
This PR address https://github.com/Cytnx-dev/Cytnx/issues/239, also #68

Now `Gesvd_truncate()` support cuQuantum/cuTensornet's SVD routine when the input is on cuda device.

Currently only the complex double type is supported, will finished the rest types in the following commits.

