### PR TITLE
Fix QR bug and cuQuantum QR

### DIFF
--- a/src/linalg/Qr.cpp
+++ b/src/linalg/Qr.cpp
@@ -27,7 +27,7 @@ namespace cytnx {
       Tensor tau, Q, R, D;  // D is not used here.
       tau.Init({n_tau}, in.dtype(), in.device());
       tau.storage().set_zeros();  // if type is complex, S should be real
-      Q.Init(Tin.shape(), in.dtype(), in.device());
+      Q.Init({Tin.shape()[0], Tin.shape()[1]}, in.dtype(), in.device());
       Q.storage().set_zeros();
       R.Init({n_tau, Tin.shape()[1]}, in.dtype(), in.device());
       R.storage().set_zeros();
@@ -53,6 +53,9 @@ namespace cytnx {
         // cytnx_error_msg(true, "[Qr] error,%s", "Currently QR does not support CUDA.\n");
 
         checkCudaErrors(cudaSetDevice(in.device()));
+
+        if (in.shape()[0] < in.shape()[1]) Q = Q[{ac::all(), ac::range(0, in.shape()[0], 1)}];
+
         cytnx::linalg_internal::lii.cuQuantumQr_ii[in.dtype()](
           in._impl->storage()._impl, Q._impl->storage()._impl, R._impl->storage()._impl,
           D._impl->storage()._impl, tau._impl->storage()._impl, in.shape()[0], in.shape()[1],

--- a/src/linalg/Qr.cpp
+++ b/src/linalg/Qr.cpp
@@ -49,23 +49,27 @@ namespace cytnx {
 
       } else {
 #ifdef UNI_GPU
-        cytnx_error_msg(true, "[Qr] error,%s", "Currently QR does not support CUDA.\n");
-        /*
+  #ifdef UNI_CUQUANTUM
+        // cytnx_error_msg(true, "[Qr] error,%s", "Currently QR does not support CUDA.\n");
+
         checkCudaErrors(cudaSetDevice(in.device()));
-        cytnx::linalg_internal::lii.cuQR_ii[in.dtype()](in._impl->storage()._impl,
-                                                U._impl->storage()._impl,
-                                                vT._impl->storage()._impl,
-                                                S._impl->storage()._impl,in.shape()[0],in.shape()[1],
-        false);
+        cytnx::linalg_internal::lii.cuQuantumQr_ii[in.dtype()](
+          in._impl->storage()._impl, Q._impl->storage()._impl, R._impl->storage()._impl,
+          D._impl->storage()._impl, tau._impl->storage()._impl, in.shape()[0], in.shape()[1],
+          false);
 
         std::vector<Tensor> out;
-        out.push_back(S);
-        if(is_U) out.push_back(U);
-        if(is_vT) out.push_back(vT);
+        out.push_back(Q);
+        out.push_back(R);
+
+        if (is_tau) out.push_back(tau);
 
         return out;
-        */
+  #else
+        cytnx_error_msg(true, "[QR] fatal error,%s",
+                        "try to call the cuQuantum section without cuQuantum support.\n");
         return std::vector<Tensor>();
+  #endif
 #else
         cytnx_error_msg(true, "[QR] fatal error,%s",
                         "try to call the gpu section without CUDA support.\n");

--- a/src/linalg/linalg_internal_cpu/QR_internal.cpp
+++ b/src/linalg/linalg_internal_cpu/QR_internal.cpp
@@ -45,7 +45,7 @@ namespace cytnx {
 
       lapack_int ldA = N;
       lapack_int info;
-      lapack_int K = N;
+      lapack_int K = M < N ? M : N;
 
       // call linalg:
       info = LAPACKE_zgelqf(LAPACK_COL_MAJOR, N, M, (lapack_complex_double *)pQ, ldA,
@@ -71,10 +71,11 @@ namespace cytnx {
 
       // getQ:
       // query lwork & alloc
-      lapack_int col = M < N ? N : M;
+      lapack_int col = M;
+      lapack_int row = M >= N ? N : M;
 
       // call linalg:
-      info = LAPACKE_zunglq(LAPACK_COL_MAJOR, N, col, K, (lapack_complex_double *)pQ, ldA,
+      info = LAPACKE_zunglq(LAPACK_COL_MAJOR, row, col, K, (lapack_complex_double *)pQ, ldA,
                             (lapack_complex_double *)ptau);
       cytnx_error_msg(info != 0, "%s %d",
                       "Error in Lapack function 'zunglq': Lapack INFO = ", info);

--- a/src/linalg/linalg_internal_cpu/QR_internal.cpp
+++ b/src/linalg/linalg_internal_cpu/QR_internal.cpp
@@ -98,7 +98,7 @@ namespace cytnx {
 
       lapack_int ldA = N;
       lapack_int info;
-      lapack_int K = N;
+      lapack_int K = M < N ? M : N;
 
       // call linalg:
       info = LAPACKE_cgelqf(LAPACK_COL_MAJOR, N, M, (lapack_complex_float *)pQ, ldA,
@@ -124,10 +124,11 @@ namespace cytnx {
 
       // getQ:
       // query lwork & alloc
-      lapack_int col = M < N ? N : M;
+      lapack_int col = M;
+      lapack_int row = M >= N ? N : M;
 
       // call linalg:
-      info = LAPACKE_cunglq(LAPACK_COL_MAJOR, N, col, K, (lapack_complex_float *)pQ, ldA,
+      info = LAPACKE_cunglq(LAPACK_COL_MAJOR, row, col, K, (lapack_complex_float *)pQ, ldA,
                             (lapack_complex_float *)ptau);
       cytnx_error_msg(info != 0, "%s %d",
                       "Error in Lapack function 'cunglq': Lapack INFO = ", info);
@@ -148,7 +149,7 @@ namespace cytnx {
 
       lapack_int ldA = N;
       lapack_int info;
-      lapack_int K = N;
+      lapack_int K = M < N ? M : N;
 
       // call linalg:
       info = LAPACKE_dgelqf(LAPACK_COL_MAJOR, N, M, pQ, ldA, ptau);
@@ -173,8 +174,10 @@ namespace cytnx {
 
       // getQ:
       // query lwork & alloc
-      lapack_int col = M < N ? N : M;
-      info = LAPACKE_dorglq(LAPACK_COL_MAJOR, N, col, K, pQ, ldA, ptau);
+      lapack_int col = M;
+      lapack_int row = M >= N ? N : M;
+
+      info = LAPACKE_dorglq(LAPACK_COL_MAJOR, row, col, K, pQ, ldA, ptau);
       cytnx_error_msg(info != 0, "%s %d",
                       "Error in Lapack function 'dorglq': Lapack INFO = ", info);
     }
@@ -195,7 +198,7 @@ namespace cytnx {
 
       lapack_int ldA = N;
       lapack_int info;
-      lapack_int K = N;
+      lapack_int K = M < N ? M : N;
 
       // call linalg:
       info = LAPACKE_sgelqf(LAPACK_COL_MAJOR, N, M, pQ, ldA, ptau);
@@ -220,8 +223,10 @@ namespace cytnx {
 
       // getQ:
       // query lwork & alloc
-      lapack_int col = M < N ? N : M;
-      info = LAPACKE_sorglq(LAPACK_COL_MAJOR, N, col, K, pQ, ldA, ptau);
+      lapack_int col = M;
+      lapack_int row = M >= N ? N : M;
+
+      info = LAPACKE_sorglq(LAPACK_COL_MAJOR, row, col, K, pQ, ldA, ptau);
       cytnx_error_msg(info != 0, "%s %d",
                       "Error in Lapack function 'sorglq': Lapack INFO = ", info);
     }

--- a/src/linalg/linalg_internal_gpu/CMakeLists.txt
+++ b/src/linalg/linalg_internal_gpu/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources_local(cytnx
     cuKron_internal.hpp
     cuTensordot_internal.hpp
     cuQuantumGeSvd_internal.hpp
+    cuQuantumQr_internal.hpp
 
     cuAbs_internal.cu
     cuAdd_internal.cu
@@ -64,4 +65,5 @@ target_sources_local(cytnx
     cuKron_internal.cu
     cuTensordot_internal.cu
     cuQuantumGeSvd_internal.cu
+    cuQuantumQr_internal.cu
 )

--- a/src/linalg/linalg_internal_gpu/cuQuantumQr_internal.cu
+++ b/src/linalg/linalg_internal_gpu/cuQuantumQr_internal.cu
@@ -1,0 +1,265 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <unordered_map>
+#include <vector>
+#include <cassert>
+
+#include "cuQuantumQr_internal.hpp"
+
+#ifdef UNI_GPU
+  #ifdef UNI_CUQUANTUM
+    #include <cuda_runtime.h>
+    #include <cutensornet.h>
+
+    #define HANDLE_ERROR(x)                                                           \
+      {                                                                               \
+        const auto err = x;                                                           \
+        if (err != CUTENSORNET_STATUS_SUCCESS) {                                      \
+          printf("Error: %s in line %d\n", cutensornetGetErrorString(err), __LINE__); \
+          fflush(stdout);                                                             \
+        }                                                                             \
+      };
+
+    #define HANDLE_CUDA_ERROR(x)                                                    \
+      {                                                                             \
+        const auto err = x;                                                         \
+        if (err != cudaSuccess) {                                                   \
+          printf("CUDA Error: %s in line %d\n", cudaGetErrorString(err), __LINE__); \
+          fflush(stdout);                                                           \
+        }                                                                           \
+      };
+
+struct GPUTimer {
+  GPUTimer(cudaStream_t stream) : stream_(stream) {
+    cudaEventCreate(&start_);
+    cudaEventCreate(&stop_);
+  }
+
+  ~GPUTimer() {
+    cudaEventDestroy(start_);
+    cudaEventDestroy(stop_);
+  }
+
+  void start() { cudaEventRecord(start_, stream_); }
+
+  float seconds() {
+    cudaEventRecord(stop_, stream_);
+    cudaEventSynchronize(stop_);
+    float time;
+    cudaEventElapsedTime(&time, start_, stop_);
+    return time * 1e-3;
+  }
+
+ private:
+  cudaEvent_t start_, stop_;
+  cudaStream_t stream_;
+};
+
+  #endif
+#endif
+
+// int64_t computeCombinedExtent(const std::unordered_map<int32_t, int64_t> &extentMap,
+//                               const std::vector<int32_t> &modes) {
+//   int64_t combinedExtent{1};
+//   for (auto mode : modes) {
+//     auto it = extentMap.find(mode);
+//     if (it != extentMap.end()) combinedExtent *= it->second;
+//   }
+//   return combinedExtent;
+// }
+
+namespace cytnx {
+  namespace linalg_internal {
+
+#ifdef UNI_GPU
+  #ifdef UNI_CUQUANTUM
+
+    void cuQuantumQr_internal_cd(const boost::intrusive_ptr<Storage_base> &in,
+                                 boost::intrusive_ptr<Storage_base> &Q,
+                                 boost::intrusive_ptr<Storage_base> &R,
+                                 boost::intrusive_ptr<Storage_base> &D,
+                                 boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
+                                 const cytnx_int64 &N, const bool &is_d) {
+      const size_t cuTensornetVersion = cutensornetGetVersion();
+      printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
+
+      // cudaDeviceProp prop;
+      // int deviceId{-1};
+      // HANDLE_CUDA_ERROR( cudaGetDevice(&deviceId) );
+      // HANDLE_CUDA_ERROR( cudaGetDeviceProperties(&prop, deviceId) );
+
+      // printf("===== device info ======\n");
+      // printf("GPU-name:%s\n", prop.name);
+      // printf("GPU-clock:%d\n", prop.clockRate);
+      // printf("GPU-memoryClock:%d\n", prop.memoryClockRate);
+      // printf("GPU-nSM:%d\n", prop.multiProcessorCount);
+      // printf("GPU-major:%d\n", prop.major);
+      // printf("GPU-minor:%d\n", prop.minor);
+      // printf("========================\n");
+
+      // Sphinx: #2
+      /**********************************************
+       * Tensor QR: T_{i,j,m,n} -> Q_{i,x,m} R_{n,x,j}
+       ***********************************************/
+
+      typedef float floatType;
+      cudaDataType_t typeData = CUDA_C_64F;
+
+      // Create vector of modes
+      // int32_t sharedMode = 'x';
+
+      std::vector<int32_t> modesT{'j', 'i'};  // input
+      std::vector<int32_t> modesQ{'s', 'i'};
+      std::vector<int32_t> modesR{'j', 's'};  // QR output
+
+      std::vector<int64_t> extentT{M, N};
+      std::vector<int64_t> extentQ{M, N};
+      std::vector<int64_t> extentR{N, N};
+
+      const int32_t numModesIn = modesT.size();
+      const int32_t numModesQ = modesQ.size();
+      const int32_t numModesR = modesR.size();
+
+      void *D_T = in->Mem;
+      void *D_Q = Q->Mem;
+      void *D_R = R->Mem;
+
+      // Sphinx: #4
+      /******************
+       * cuTensorNet
+       *******************/
+
+      cudaStream_t stream;
+      HANDLE_CUDA_ERROR(cudaStreamCreate(&stream));
+
+      cutensornetHandle_t handle;
+      HANDLE_ERROR(cutensornetCreate(&handle));
+
+      /***************************
+       * Create tensor descriptors
+       ****************************/
+
+      cutensornetTensorDescriptor_t descTensorIn;
+      cutensornetTensorDescriptor_t descTensorQ;
+      cutensornetTensorDescriptor_t descTensorR;
+
+      const int64_t *strides = NULL;  // assuming fortran layout for all tensors
+
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides,
+                                                     modesT.data(), typeData, &descTensorIn));
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesQ, extentQ.data(), strides,
+                                                     modesQ.data(), typeData, &descTensorQ));
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesR, extentR.data(), strides,
+                                                     modesR.data(), typeData, &descTensorR));
+
+      printf("Initialize the cuTensorNet library and create all tensor descriptors.\n");
+
+      // Sphinx: #5
+      /********************************************
+       * Query and allocate required workspace sizes
+       *********************************************/
+
+      cutensornetWorkspaceDescriptor_t workDesc;
+      HANDLE_ERROR(cutensornetCreateWorkspaceDescriptor(handle, &workDesc));
+      HANDLE_ERROR(cutensornetWorkspaceComputeQRSizes(handle, descTensorIn, descTensorQ,
+                                                      descTensorR, workDesc));
+      int64_t hostWorkspaceSize, deviceWorkspaceSize;
+
+      // for tensor QR, it does not matter which cutensornetWorksizePref_t we pick
+      HANDLE_ERROR(cutensornetWorkspaceGetMemorySize(
+        handle, workDesc, CUTENSORNET_WORKSIZE_PREF_RECOMMENDED, CUTENSORNET_MEMSPACE_DEVICE,
+        CUTENSORNET_WORKSPACE_SCRATCH, &deviceWorkspaceSize));
+      HANDLE_ERROR(cutensornetWorkspaceGetMemorySize(
+        handle, workDesc, CUTENSORNET_WORKSIZE_PREF_RECOMMENDED, CUTENSORNET_MEMSPACE_HOST,
+        CUTENSORNET_WORKSPACE_SCRATCH, &hostWorkspaceSize));
+
+      void *devWork = nullptr, *hostWork = nullptr;
+      if (deviceWorkspaceSize > 0) {
+        HANDLE_CUDA_ERROR(cudaMalloc(&devWork, deviceWorkspaceSize));
+      }
+      if (hostWorkspaceSize > 0) {
+        hostWork = malloc(hostWorkspaceSize);
+      }
+      HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_DEVICE,
+                                                 CUTENSORNET_WORKSPACE_SCRATCH, devWork,
+                                                 deviceWorkspaceSize));
+      HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_HOST,
+                                                 CUTENSORNET_WORKSPACE_SCRATCH, hostWork,
+                                                 hostWorkspaceSize));
+
+      // Sphinx: #6
+      /**********
+       * Execution
+       ***********/
+
+      GPUTimer timer{stream};
+      double minTimeCUTENSOR = 1e100;
+      const int numRuns = 1;  // to get stable perf results
+      for (int i = 0; i < numRuns; ++i) {
+        // restore output
+        // cudaMemsetAsync(D_Q, 0, sizeQ, stream);
+        // cudaMemsetAsync(D_R, 0, sizeR, stream);
+        cudaDeviceSynchronize();
+
+        timer.start();
+        HANDLE_ERROR(cutensornetTensorQR(handle, descTensorIn, D_T, descTensorQ, D_Q, descTensorR,
+                                         D_R, workDesc, stream));
+        // Synchronize and measure timing
+        auto time = timer.seconds();
+        minTimeCUTENSOR = (minTimeCUTENSOR < time) ? minTimeCUTENSOR : time;
+      }
+
+      printf("Performing QR\n");
+
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(Q, D_Q, sizeQ, cudaMemcpyDeviceToHost) );
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(R, D_R, sizeR, cudaMemcpyDeviceToHost) );
+
+      cudaDeviceSynchronize();  // device synchronization.
+      printf("%.2f ms\n", minTimeCUTENSOR * 1000.f);
+
+      // Sphinx: #7
+      /***************
+       * Free resources
+       ****************/
+
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorIn));
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorQ));
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorR));
+      HANDLE_ERROR(cutensornetDestroyWorkspaceDescriptor(workDesc));
+      HANDLE_ERROR(cutensornetDestroy(handle));
+
+      // if (T) free(T);
+      // if (Q) free(Q);
+      // if (R) free(R);
+      // if (D_T) cudaFree(D_T);
+      // if (D_Q) cudaFree(D_Q);
+      // if (D_R) cudaFree(D_R);
+      if (devWork) cudaFree(devWork);
+      if (hostWork) free(hostWork);
+
+      printf("Free resource and exit.\n");
+    }
+
+    void cuQuantumQr_internal_cf(const boost::intrusive_ptr<Storage_base> &in,
+                                 boost::intrusive_ptr<Storage_base> &Q,
+                                 boost::intrusive_ptr<Storage_base> &R,
+                                 boost::intrusive_ptr<Storage_base> &D,
+                                 boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
+                                 const cytnx_int64 &N, const bool &is_d) {}
+    void cuQuantumQr_internal_d(const boost::intrusive_ptr<Storage_base> &in,
+                                boost::intrusive_ptr<Storage_base> &Q,
+                                boost::intrusive_ptr<Storage_base> &R,
+                                boost::intrusive_ptr<Storage_base> &D,
+                                boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
+                                const cytnx_int64 &N, const bool &is_d) {}
+    void cuQuantumQr_internal_f(const boost::intrusive_ptr<Storage_base> &in,
+                                boost::intrusive_ptr<Storage_base> &Q,
+                                boost::intrusive_ptr<Storage_base> &R,
+                                boost::intrusive_ptr<Storage_base> &D,
+                                boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
+                                const cytnx_int64 &N, const bool &is_d) {}
+  #endif
+#endif
+  }  // namespace linalg_internal
+}  // namespace cytnx

--- a/src/linalg/linalg_internal_gpu/cuQuantumQr_internal.cu
+++ b/src/linalg/linalg_internal_gpu/cuQuantumQr_internal.cu
@@ -113,9 +113,11 @@ namespace cytnx {
       std::vector<int32_t> modesQ{'s', 'i'};
       std::vector<int32_t> modesR{'j', 's'};  // QR output
 
-      std::vector<int64_t> extentT{M, N};
-      std::vector<int64_t> extentQ{M, N};
-      std::vector<int64_t> extentR{N, N};
+      int n_tau = std::max(1, int(std::min(M, N)));
+
+      std::vector<int64_t> extentT{N, M};
+      std::vector<int64_t> extentQ{n_tau, M};
+      std::vector<int64_t> extentR{N, n_tau};
 
       const int32_t numModesIn = modesT.size();
       const int32_t numModesQ = modesQ.size();

--- a/src/linalg/linalg_internal_gpu/cuQuantumQr_internal.cu
+++ b/src/linalg/linalg_internal_gpu/cuQuantumQr_internal.cu
@@ -81,33 +81,15 @@ namespace cytnx {
                                  boost::intrusive_ptr<Storage_base> &D,
                                  boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
                                  const cytnx_int64 &N, const bool &is_d) {
-      const size_t cuTensornetVersion = cutensornetGetVersion();
-      printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
+      // const size_t cuTensornetVersion = cutensornetGetVersion();
+      // printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
 
-      // cudaDeviceProp prop;
-      // int deviceId{-1};
-      // HANDLE_CUDA_ERROR( cudaGetDevice(&deviceId) );
-      // HANDLE_CUDA_ERROR( cudaGetDeviceProperties(&prop, deviceId) );
-
-      // printf("===== device info ======\n");
-      // printf("GPU-name:%s\n", prop.name);
-      // printf("GPU-clock:%d\n", prop.clockRate);
-      // printf("GPU-memoryClock:%d\n", prop.memoryClockRate);
-      // printf("GPU-nSM:%d\n", prop.multiProcessorCount);
-      // printf("GPU-major:%d\n", prop.major);
-      // printf("GPU-minor:%d\n", prop.minor);
-      // printf("========================\n");
-
-      // Sphinx: #2
       /**********************************************
        * Tensor QR: T_{i,j,m,n} -> Q_{i,x,m} R_{n,x,j}
        ***********************************************/
 
       typedef float floatType;
       cudaDataType_t typeData = CUDA_C_64F;
-
-      // Create vector of modes
-      // int32_t sharedMode = 'x';
 
       std::vector<int32_t> modesT{'j', 'i'};  // input
       std::vector<int32_t> modesQ{'s', 'i'};
@@ -127,7 +109,6 @@ namespace cytnx {
       void *D_Q = Q->Mem;
       void *D_R = R->Mem;
 
-      // Sphinx: #4
       /******************
        * cuTensorNet
        *******************/
@@ -157,7 +138,6 @@ namespace cytnx {
 
       printf("Initialize the cuTensorNet library and create all tensor descriptors.\n");
 
-      // Sphinx: #5
       /********************************************
        * Query and allocate required workspace sizes
        *********************************************/
@@ -189,8 +169,6 @@ namespace cytnx {
       HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_HOST,
                                                  CUTENSORNET_WORKSPACE_SCRATCH, hostWork,
                                                  hostWorkspaceSize));
-
-      // Sphinx: #6
       /**********
        * Execution
        ***********/
@@ -212,15 +190,13 @@ namespace cytnx {
         minTimeCUTENSOR = (minTimeCUTENSOR < time) ? minTimeCUTENSOR : time;
       }
 
-      printf("Performing QR\n");
-
+      // printf("Performing QR\n");
       // HANDLE_CUDA_ERROR( cudaMemcpyAsync(Q, D_Q, sizeQ, cudaMemcpyDeviceToHost) );
       // HANDLE_CUDA_ERROR( cudaMemcpyAsync(R, D_R, sizeR, cudaMemcpyDeviceToHost) );
 
       cudaDeviceSynchronize();  // device synchronization.
-      printf("%.2f ms\n", minTimeCUTENSOR * 1000.f);
 
-      // Sphinx: #7
+      // printf("%.2f ms\n", minTimeCUTENSOR * 1000.f);
       /***************
        * Free resources
        ****************/
@@ -231,16 +207,10 @@ namespace cytnx {
       HANDLE_ERROR(cutensornetDestroyWorkspaceDescriptor(workDesc));
       HANDLE_ERROR(cutensornetDestroy(handle));
 
-      // if (T) free(T);
-      // if (Q) free(Q);
-      // if (R) free(R);
-      // if (D_T) cudaFree(D_T);
-      // if (D_Q) cudaFree(D_Q);
-      // if (D_R) cudaFree(D_R);
       if (devWork) cudaFree(devWork);
       if (hostWork) free(hostWork);
 
-      printf("Free resource and exit.\n");
+      // printf("Free resource and exit.\n");
     }
 
     void cuQuantumQr_internal_cf(const boost::intrusive_ptr<Storage_base> &in,
@@ -248,19 +218,412 @@ namespace cytnx {
                                  boost::intrusive_ptr<Storage_base> &R,
                                  boost::intrusive_ptr<Storage_base> &D,
                                  boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
-                                 const cytnx_int64 &N, const bool &is_d) {}
+                                 const cytnx_int64 &N, const bool &is_d) {
+      // const size_t cuTensornetVersion = cutensornetGetVersion();
+      // printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
+
+      /**********************************************
+       * Tensor QR: T_{i,j,m,n} -> Q_{i,x,m} R_{n,x,j}
+       ***********************************************/
+
+      typedef float floatType;
+      cudaDataType_t typeData = CUDA_C_32F;
+
+      std::vector<int32_t> modesT{'j', 'i'};  // input
+      std::vector<int32_t> modesQ{'s', 'i'};
+      std::vector<int32_t> modesR{'j', 's'};  // QR output
+
+      int n_tau = std::max(1, int(std::min(M, N)));
+
+      std::vector<int64_t> extentT{N, M};
+      std::vector<int64_t> extentQ{n_tau, M};
+      std::vector<int64_t> extentR{N, n_tau};
+
+      const int32_t numModesIn = modesT.size();
+      const int32_t numModesQ = modesQ.size();
+      const int32_t numModesR = modesR.size();
+
+      void *D_T = in->Mem;
+      void *D_Q = Q->Mem;
+      void *D_R = R->Mem;
+
+      /******************
+       * cuTensorNet
+       *******************/
+
+      cudaStream_t stream;
+      HANDLE_CUDA_ERROR(cudaStreamCreate(&stream));
+
+      cutensornetHandle_t handle;
+      HANDLE_ERROR(cutensornetCreate(&handle));
+
+      /***************************
+       * Create tensor descriptors
+       ****************************/
+
+      cutensornetTensorDescriptor_t descTensorIn;
+      cutensornetTensorDescriptor_t descTensorQ;
+      cutensornetTensorDescriptor_t descTensorR;
+
+      const int64_t *strides = NULL;  // assuming fortran layout for all tensors
+
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides,
+                                                     modesT.data(), typeData, &descTensorIn));
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesQ, extentQ.data(), strides,
+                                                     modesQ.data(), typeData, &descTensorQ));
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesR, extentR.data(), strides,
+                                                     modesR.data(), typeData, &descTensorR));
+
+      printf("Initialize the cuTensorNet library and create all tensor descriptors.\n");
+
+      /********************************************
+       * Query and allocate required workspace sizes
+       *********************************************/
+
+      cutensornetWorkspaceDescriptor_t workDesc;
+      HANDLE_ERROR(cutensornetCreateWorkspaceDescriptor(handle, &workDesc));
+      HANDLE_ERROR(cutensornetWorkspaceComputeQRSizes(handle, descTensorIn, descTensorQ,
+                                                      descTensorR, workDesc));
+      int64_t hostWorkspaceSize, deviceWorkspaceSize;
+
+      // for tensor QR, it does not matter which cutensornetWorksizePref_t we pick
+      HANDLE_ERROR(cutensornetWorkspaceGetMemorySize(
+        handle, workDesc, CUTENSORNET_WORKSIZE_PREF_RECOMMENDED, CUTENSORNET_MEMSPACE_DEVICE,
+        CUTENSORNET_WORKSPACE_SCRATCH, &deviceWorkspaceSize));
+      HANDLE_ERROR(cutensornetWorkspaceGetMemorySize(
+        handle, workDesc, CUTENSORNET_WORKSIZE_PREF_RECOMMENDED, CUTENSORNET_MEMSPACE_HOST,
+        CUTENSORNET_WORKSPACE_SCRATCH, &hostWorkspaceSize));
+
+      void *devWork = nullptr, *hostWork = nullptr;
+      if (deviceWorkspaceSize > 0) {
+        HANDLE_CUDA_ERROR(cudaMalloc(&devWork, deviceWorkspaceSize));
+      }
+      if (hostWorkspaceSize > 0) {
+        hostWork = malloc(hostWorkspaceSize);
+      }
+      HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_DEVICE,
+                                                 CUTENSORNET_WORKSPACE_SCRATCH, devWork,
+                                                 deviceWorkspaceSize));
+      HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_HOST,
+                                                 CUTENSORNET_WORKSPACE_SCRATCH, hostWork,
+                                                 hostWorkspaceSize));
+      /**********
+       * Execution
+       ***********/
+
+      GPUTimer timer{stream};
+      double minTimeCUTENSOR = 1e100;
+      const int numRuns = 1;  // to get stable perf results
+      for (int i = 0; i < numRuns; ++i) {
+        // restore output
+        // cudaMemsetAsync(D_Q, 0, sizeQ, stream);
+        // cudaMemsetAsync(D_R, 0, sizeR, stream);
+        cudaDeviceSynchronize();
+
+        timer.start();
+        HANDLE_ERROR(cutensornetTensorQR(handle, descTensorIn, D_T, descTensorQ, D_Q, descTensorR,
+                                         D_R, workDesc, stream));
+        // Synchronize and measure timing
+        auto time = timer.seconds();
+        minTimeCUTENSOR = (minTimeCUTENSOR < time) ? minTimeCUTENSOR : time;
+      }
+
+      // printf("Performing QR\n");
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(Q, D_Q, sizeQ, cudaMemcpyDeviceToHost) );
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(R, D_R, sizeR, cudaMemcpyDeviceToHost) );
+
+      cudaDeviceSynchronize();  // device synchronization.
+
+      // printf("%.2f ms\n", minTimeCUTENSOR * 1000.f);
+      /***************
+       * Free resources
+       ****************/
+
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorIn));
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorQ));
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorR));
+      HANDLE_ERROR(cutensornetDestroyWorkspaceDescriptor(workDesc));
+      HANDLE_ERROR(cutensornetDestroy(handle));
+
+      if (devWork) cudaFree(devWork);
+      if (hostWork) free(hostWork);
+
+      // printf("Free resource and exit.\n");
+    }
     void cuQuantumQr_internal_d(const boost::intrusive_ptr<Storage_base> &in,
                                 boost::intrusive_ptr<Storage_base> &Q,
                                 boost::intrusive_ptr<Storage_base> &R,
                                 boost::intrusive_ptr<Storage_base> &D,
                                 boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
-                                const cytnx_int64 &N, const bool &is_d) {}
+                                const cytnx_int64 &N, const bool &is_d) {
+      // const size_t cuTensornetVersion = cutensornetGetVersion();
+      // printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
+
+      /**********************************************
+       * Tensor QR: T_{i,j,m,n} -> Q_{i,x,m} R_{n,x,j}
+       ***********************************************/
+
+      typedef float floatType;
+      cudaDataType_t typeData = CUDA_R_64F;
+
+      std::vector<int32_t> modesT{'j', 'i'};  // input
+      std::vector<int32_t> modesQ{'s', 'i'};
+      std::vector<int32_t> modesR{'j', 's'};  // QR output
+
+      int n_tau = std::max(1, int(std::min(M, N)));
+
+      std::vector<int64_t> extentT{N, M};
+      std::vector<int64_t> extentQ{n_tau, M};
+      std::vector<int64_t> extentR{N, n_tau};
+
+      const int32_t numModesIn = modesT.size();
+      const int32_t numModesQ = modesQ.size();
+      const int32_t numModesR = modesR.size();
+
+      void *D_T = in->Mem;
+      void *D_Q = Q->Mem;
+      void *D_R = R->Mem;
+
+      /******************
+       * cuTensorNet
+       *******************/
+
+      cudaStream_t stream;
+      HANDLE_CUDA_ERROR(cudaStreamCreate(&stream));
+
+      cutensornetHandle_t handle;
+      HANDLE_ERROR(cutensornetCreate(&handle));
+
+      /***************************
+       * Create tensor descriptors
+       ****************************/
+
+      cutensornetTensorDescriptor_t descTensorIn;
+      cutensornetTensorDescriptor_t descTensorQ;
+      cutensornetTensorDescriptor_t descTensorR;
+
+      const int64_t *strides = NULL;  // assuming fortran layout for all tensors
+
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides,
+                                                     modesT.data(), typeData, &descTensorIn));
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesQ, extentQ.data(), strides,
+                                                     modesQ.data(), typeData, &descTensorQ));
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesR, extentR.data(), strides,
+                                                     modesR.data(), typeData, &descTensorR));
+
+      printf("Initialize the cuTensorNet library and create all tensor descriptors.\n");
+
+      /********************************************
+       * Query and allocate required workspace sizes
+       *********************************************/
+
+      cutensornetWorkspaceDescriptor_t workDesc;
+      HANDLE_ERROR(cutensornetCreateWorkspaceDescriptor(handle, &workDesc));
+      HANDLE_ERROR(cutensornetWorkspaceComputeQRSizes(handle, descTensorIn, descTensorQ,
+                                                      descTensorR, workDesc));
+      int64_t hostWorkspaceSize, deviceWorkspaceSize;
+
+      // for tensor QR, it does not matter which cutensornetWorksizePref_t we pick
+      HANDLE_ERROR(cutensornetWorkspaceGetMemorySize(
+        handle, workDesc, CUTENSORNET_WORKSIZE_PREF_RECOMMENDED, CUTENSORNET_MEMSPACE_DEVICE,
+        CUTENSORNET_WORKSPACE_SCRATCH, &deviceWorkspaceSize));
+      HANDLE_ERROR(cutensornetWorkspaceGetMemorySize(
+        handle, workDesc, CUTENSORNET_WORKSIZE_PREF_RECOMMENDED, CUTENSORNET_MEMSPACE_HOST,
+        CUTENSORNET_WORKSPACE_SCRATCH, &hostWorkspaceSize));
+
+      void *devWork = nullptr, *hostWork = nullptr;
+      if (deviceWorkspaceSize > 0) {
+        HANDLE_CUDA_ERROR(cudaMalloc(&devWork, deviceWorkspaceSize));
+      }
+      if (hostWorkspaceSize > 0) {
+        hostWork = malloc(hostWorkspaceSize);
+      }
+      HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_DEVICE,
+                                                 CUTENSORNET_WORKSPACE_SCRATCH, devWork,
+                                                 deviceWorkspaceSize));
+      HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_HOST,
+                                                 CUTENSORNET_WORKSPACE_SCRATCH, hostWork,
+                                                 hostWorkspaceSize));
+      /**********
+       * Execution
+       ***********/
+
+      GPUTimer timer{stream};
+      double minTimeCUTENSOR = 1e100;
+      const int numRuns = 1;  // to get stable perf results
+      for (int i = 0; i < numRuns; ++i) {
+        // restore output
+        // cudaMemsetAsync(D_Q, 0, sizeQ, stream);
+        // cudaMemsetAsync(D_R, 0, sizeR, stream);
+        cudaDeviceSynchronize();
+
+        timer.start();
+        HANDLE_ERROR(cutensornetTensorQR(handle, descTensorIn, D_T, descTensorQ, D_Q, descTensorR,
+                                         D_R, workDesc, stream));
+        // Synchronize and measure timing
+        auto time = timer.seconds();
+        minTimeCUTENSOR = (minTimeCUTENSOR < time) ? minTimeCUTENSOR : time;
+      }
+
+      // printf("Performing QR\n");
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(Q, D_Q, sizeQ, cudaMemcpyDeviceToHost) );
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(R, D_R, sizeR, cudaMemcpyDeviceToHost) );
+
+      cudaDeviceSynchronize();  // device synchronization.
+
+      // printf("%.2f ms\n", minTimeCUTENSOR * 1000.f);
+      /***************
+       * Free resources
+       ****************/
+
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorIn));
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorQ));
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorR));
+      HANDLE_ERROR(cutensornetDestroyWorkspaceDescriptor(workDesc));
+      HANDLE_ERROR(cutensornetDestroy(handle));
+
+      if (devWork) cudaFree(devWork);
+      if (hostWork) free(hostWork);
+
+      // printf("Free resource and exit.\n");
+    }
     void cuQuantumQr_internal_f(const boost::intrusive_ptr<Storage_base> &in,
                                 boost::intrusive_ptr<Storage_base> &Q,
                                 boost::intrusive_ptr<Storage_base> &R,
                                 boost::intrusive_ptr<Storage_base> &D,
                                 boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
-                                const cytnx_int64 &N, const bool &is_d) {}
+                                const cytnx_int64 &N, const bool &is_d) {
+      // const size_t cuTensornetVersion = cutensornetGetVersion();
+      // printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
+
+      /**********************************************
+       * Tensor QR: T_{i,j,m,n} -> Q_{i,x,m} R_{n,x,j}
+       ***********************************************/
+
+      typedef float floatType;
+      cudaDataType_t typeData = CUDA_R_32F;
+
+      std::vector<int32_t> modesT{'j', 'i'};  // input
+      std::vector<int32_t> modesQ{'s', 'i'};
+      std::vector<int32_t> modesR{'j', 's'};  // QR output
+
+      int n_tau = std::max(1, int(std::min(M, N)));
+
+      std::vector<int64_t> extentT{N, M};
+      std::vector<int64_t> extentQ{n_tau, M};
+      std::vector<int64_t> extentR{N, n_tau};
+
+      const int32_t numModesIn = modesT.size();
+      const int32_t numModesQ = modesQ.size();
+      const int32_t numModesR = modesR.size();
+
+      void *D_T = in->Mem;
+      void *D_Q = Q->Mem;
+      void *D_R = R->Mem;
+
+      /******************
+       * cuTensorNet
+       *******************/
+
+      cudaStream_t stream;
+      HANDLE_CUDA_ERROR(cudaStreamCreate(&stream));
+
+      cutensornetHandle_t handle;
+      HANDLE_ERROR(cutensornetCreate(&handle));
+
+      /***************************
+       * Create tensor descriptors
+       ****************************/
+
+      cutensornetTensorDescriptor_t descTensorIn;
+      cutensornetTensorDescriptor_t descTensorQ;
+      cutensornetTensorDescriptor_t descTensorR;
+
+      const int64_t *strides = NULL;  // assuming fortran layout for all tensors
+
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides,
+                                                     modesT.data(), typeData, &descTensorIn));
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesQ, extentQ.data(), strides,
+                                                     modesQ.data(), typeData, &descTensorQ));
+      HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesR, extentR.data(), strides,
+                                                     modesR.data(), typeData, &descTensorR));
+
+      printf("Initialize the cuTensorNet library and create all tensor descriptors.\n");
+
+      /********************************************
+       * Query and allocate required workspace sizes
+       *********************************************/
+
+      cutensornetWorkspaceDescriptor_t workDesc;
+      HANDLE_ERROR(cutensornetCreateWorkspaceDescriptor(handle, &workDesc));
+      HANDLE_ERROR(cutensornetWorkspaceComputeQRSizes(handle, descTensorIn, descTensorQ,
+                                                      descTensorR, workDesc));
+      int64_t hostWorkspaceSize, deviceWorkspaceSize;
+
+      // for tensor QR, it does not matter which cutensornetWorksizePref_t we pick
+      HANDLE_ERROR(cutensornetWorkspaceGetMemorySize(
+        handle, workDesc, CUTENSORNET_WORKSIZE_PREF_RECOMMENDED, CUTENSORNET_MEMSPACE_DEVICE,
+        CUTENSORNET_WORKSPACE_SCRATCH, &deviceWorkspaceSize));
+      HANDLE_ERROR(cutensornetWorkspaceGetMemorySize(
+        handle, workDesc, CUTENSORNET_WORKSIZE_PREF_RECOMMENDED, CUTENSORNET_MEMSPACE_HOST,
+        CUTENSORNET_WORKSPACE_SCRATCH, &hostWorkspaceSize));
+
+      void *devWork = nullptr, *hostWork = nullptr;
+      if (deviceWorkspaceSize > 0) {
+        HANDLE_CUDA_ERROR(cudaMalloc(&devWork, deviceWorkspaceSize));
+      }
+      if (hostWorkspaceSize > 0) {
+        hostWork = malloc(hostWorkspaceSize);
+      }
+      HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_DEVICE,
+                                                 CUTENSORNET_WORKSPACE_SCRATCH, devWork,
+                                                 deviceWorkspaceSize));
+      HANDLE_ERROR(cutensornetWorkspaceSetMemory(handle, workDesc, CUTENSORNET_MEMSPACE_HOST,
+                                                 CUTENSORNET_WORKSPACE_SCRATCH, hostWork,
+                                                 hostWorkspaceSize));
+      /**********
+       * Execution
+       ***********/
+
+      GPUTimer timer{stream};
+      double minTimeCUTENSOR = 1e100;
+      const int numRuns = 1;  // to get stable perf results
+      for (int i = 0; i < numRuns; ++i) {
+        // restore output
+        // cudaMemsetAsync(D_Q, 0, sizeQ, stream);
+        // cudaMemsetAsync(D_R, 0, sizeR, stream);
+        cudaDeviceSynchronize();
+
+        timer.start();
+        HANDLE_ERROR(cutensornetTensorQR(handle, descTensorIn, D_T, descTensorQ, D_Q, descTensorR,
+                                         D_R, workDesc, stream));
+        // Synchronize and measure timing
+        auto time = timer.seconds();
+        minTimeCUTENSOR = (minTimeCUTENSOR < time) ? minTimeCUTENSOR : time;
+      }
+
+      // printf("Performing QR\n");
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(Q, D_Q, sizeQ, cudaMemcpyDeviceToHost) );
+      // HANDLE_CUDA_ERROR( cudaMemcpyAsync(R, D_R, sizeR, cudaMemcpyDeviceToHost) );
+
+      cudaDeviceSynchronize();  // device synchronization.
+
+      // printf("%.2f ms\n", minTimeCUTENSOR * 1000.f);
+      /***************
+       * Free resources
+       ****************/
+
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorIn));
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorQ));
+      HANDLE_ERROR(cutensornetDestroyTensorDescriptor(descTensorR));
+      HANDLE_ERROR(cutensornetDestroyWorkspaceDescriptor(workDesc));
+      HANDLE_ERROR(cutensornetDestroy(handle));
+
+      if (devWork) cudaFree(devWork);
+      if (hostWork) free(hostWork);
+
+      // printf("Free resource and exit.\n");
+    }
   #endif
 #endif
   }  // namespace linalg_internal

--- a/src/linalg/linalg_internal_gpu/cuQuantumQr_internal.hpp
+++ b/src/linalg/linalg_internal_gpu/cuQuantumQr_internal.hpp
@@ -1,0 +1,57 @@
+#ifndef __cuQuantumQr_internal_H__
+#define __cuQuantumQr_internal_H__
+
+#include <assert.h>
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include "Storage.hpp"
+#include "Type.hpp"
+#include "cytnx_error.hpp"
+#include "lapack_wrapper.hpp"
+#include "linalg/linalg_internal_interface.hpp"
+
+#ifdef UNI_GPU
+  #ifdef UNI_CUQUANTUM
+    #include <cutensornet.h>
+    #include <cuda_runtime.h>
+  #endif
+#endif
+
+namespace cytnx {
+  namespace linalg_internal {
+
+#ifdef UNI_GPU
+  #ifdef UNI_CUQUANTUM
+    /// cuSvd
+    void cuQuantumQr_internal_cd(const boost::intrusive_ptr<Storage_base> &in,
+                                 boost::intrusive_ptr<Storage_base> &Q,
+                                 boost::intrusive_ptr<Storage_base> &R,
+                                 boost::intrusive_ptr<Storage_base> &D,
+                                 boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
+                                 const cytnx_int64 &N, const bool &is_d);
+    void cuQuantumQr_internal_cf(const boost::intrusive_ptr<Storage_base> &in,
+                                 boost::intrusive_ptr<Storage_base> &Q,
+                                 boost::intrusive_ptr<Storage_base> &R,
+                                 boost::intrusive_ptr<Storage_base> &D,
+                                 boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
+                                 const cytnx_int64 &N, const bool &is_d);
+    void cuQuantumQr_internal_d(const boost::intrusive_ptr<Storage_base> &in,
+                                boost::intrusive_ptr<Storage_base> &Q,
+                                boost::intrusive_ptr<Storage_base> &R,
+                                boost::intrusive_ptr<Storage_base> &D,
+                                boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
+                                const cytnx_int64 &N, const bool &is_d);
+    void cuQuantumQr_internal_f(const boost::intrusive_ptr<Storage_base> &in,
+                                boost::intrusive_ptr<Storage_base> &Q,
+                                boost::intrusive_ptr<Storage_base> &R,
+                                boost::intrusive_ptr<Storage_base> &D,
+                                boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
+                                const cytnx_int64 &N, const bool &is_d);
+  #endif
+#endif
+
+  }  // namespace linalg_internal
+}  // namespace cytnx
+
+#endif

--- a/src/linalg/linalg_internal_interface.cpp
+++ b/src/linalg/linalg_internal_interface.cpp
@@ -1373,6 +1373,12 @@ namespace cytnx {
       cuQuantumGeSvd_ii[Type.ComplexFloat] = cuQuantumGeSvd_internal_cf;
       cuQuantumGeSvd_ii[Type.Double] = cuQuantumGeSvd_internal_d;
       cuQuantumGeSvd_ii[Type.Float] = cuQuantumGeSvd_internal_f;
+
+      cuQuantumQr_ii = vector<cuQuantumQr_oii>(N_Type);
+      cuQuantumQr_ii[Type.ComplexDouble] = cuQuantumQr_internal_cd;
+      cuQuantumQr_ii[Type.ComplexFloat] = cuQuantumQr_internal_cf;
+      cuQuantumQr_ii[Type.Double] = cuQuantumQr_internal_d;
+      cuQuantumQr_ii[Type.Float] = cuQuantumQr_internal_f;
   #endif
 
   #ifdef UNI_CUTENSOR

--- a/src/linalg/linalg_internal_interface.hpp
+++ b/src/linalg/linalg_internal_interface.hpp
@@ -69,6 +69,7 @@
 
   #ifdef UNI_CUQUANTUM
     #include "linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.hpp"
+    #include "linalg/linalg_internal_gpu/cuQuantumQr_internal.hpp"
   #endif
 #endif
 
@@ -188,6 +189,12 @@ namespace cytnx {
     typedef void (*cuQuantumGeSvd_oii)(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                        const double &err, const unsigned int &return_err, Tensor &U,
                                        Tensor &S, Tensor &vT, Tensor &terr);
+    typedef void (*cuQuantumQr_oii)(const boost::intrusive_ptr<Storage_base> &in,
+                                    boost::intrusive_ptr<Storage_base> &Q,
+                                    boost::intrusive_ptr<Storage_base> &R,
+                                    boost::intrusive_ptr<Storage_base> &D,
+                                    boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
+                                    const cytnx_int64 &N, const bool &is_d);
   #endif
 #endif
     class linalg_internal_interface {
@@ -256,6 +263,7 @@ namespace cytnx {
 
   #ifdef UNI_CUQUANTUM
       std::vector<cuQuantumGeSvd_oii> cuQuantumGeSvd_ii;
+      std::vector<cuQuantumQr_oii> cuQuantumQr_ii;
   #endif
 #endif
 


### PR DESCRIPTION
Part of this PR address https://github.com/Cytnx-dev/Cytnx/issues/203 and https://github.com/Cytnx-dev/Cytnx/issues/68.

cuQuantum QR routine will now be used when the input UniTensor is on cuda device.
In that routine I currently disable the `return_tau = true` option since the API doesn't store tau or provide ways to retrieve it.