### PR TITLE
Tweak ncon and network & Fix failed tests

### DIFF
--- a/src/RegularNetwork.cpp
+++ b/src/RegularNetwork.cpp
@@ -903,6 +903,8 @@ namespace cytnx {
         _parse_ORDER_line_(ORDER_tokens, contract_order, 999999);
         CtTree.build_contraction_tree_by_tokens(this->name2pos, ORDER_tokens);
         this->einsum_path = CtTree_to_eisumpath(CtTree, names);
+      } else {
+        CtTree.build_default_contraction_tree();
       }
     }
   }
@@ -972,9 +974,7 @@ namespace cytnx {
             // root->left->utensor.print_diagram(1);
             // root->right->utensor.print_diagram(1);
             root->utensor = Contract(root->left->utensor, root->right->utensor);
-            // cout << "Contract:" << root->left->utensor.name() << " " <<
-            // root->right->utensor.name()
-            // << endl; root->left->utensor.print_diagram(); root->right->utensor.print_diagram();
+            // root->left->utensor.print_diagram(); root->right->utensor.print_diagram();
             // root->utensor.print_diagram(); root->utensor.set_name(root->left->utensor.name() +
             // root->right->utensor.name());
             root->left->clear_utensor();  // remove intermediate unitensor to save heap space
@@ -1008,7 +1008,6 @@ namespace cytnx {
       if (TOUT_labels.size()) {
         out.permute_(TOUT_labels, TOUT_iBondNum);
       }
-
       // UniTensor out;
       return out;
 
@@ -1074,6 +1073,7 @@ namespace cytnx {
   void RegularNetwork::construct(const vector<string> &alias, const vector<vector<string>> &lbls,
                                  const vector<string> &outlbl, const cytnx_int64 &outrk,
                                  const string &order, const bool optim) {
+    this->clear();
     for (int i = 0; i < alias.size(); i++) {
       this->names.push_back(alias[i]);
       this->name2pos[alias[i]] = names.size() - 1;  // register
@@ -1086,6 +1086,7 @@ namespace cytnx {
     this->TOUT_iBondNum = outlbl.size() - outrk;
 
     if (order.length()) {
+      this->order_line = order;
       // checking if all TN are set in ORDER.
       _parse_ORDER_line_(this->ORDER_tokens, order, 0);
       vector<string> TN_names;
@@ -1132,11 +1133,8 @@ namespace cytnx {
     }
     // cout<<this->TOUT_labels.size();
     if (this->TOUT_labels.size() == 0) {
-      // cout<<expected_TOUT;
       this->TOUT_labels = expected_TOUT;
-      // cout<<this->TOUT_labels;
     } else {
-      // cout<<this->TOUT_labels;
       bool err = false;
       if (expected_TOUT.size() != TOUT_labels.size()) {
         err = true;
@@ -1157,6 +1155,54 @@ namespace cytnx {
         cytnx_error_msg(true, "%s", "\n");
       }
     }
-  }
+
+    // maintain TOUT leg position
+    TOUT_pos = vector<pair<int, int>>();
+    for (int i = 0; i < TOUT_labels.size(); i++) {
+      for (int j = 0; j < label_arr.size(); j++) {
+        vector<string>::iterator it;
+        it = find(this->label_arr[j].begin(), this->label_arr[j].end(), TOUT_labels[i]);
+        if (it != this->label_arr[j].end()) {
+          TOUT_pos.push_back(make_pair(j, distance(label_arr[j].begin(), it)));
+          break;
+        }
+      }
+    }
+
+    // get int_label
+    std::map<std::string, cytnx_int64> lblmap = std::map<std::string, cytnx_int64>();
+    this->int_modes = std::vector<std::vector<cytnx_int64>>(this->label_arr.size());
+    this->int_out_mode = std::vector<cytnx_int64>(this->TOUT_labels.size());
+    cytnx_int64 lbl_int = 0;
+    for (size_t i = 0; i < this->label_arr.size(); i++) {
+      this->int_modes[i] = std::vector<cytnx_int64>(this->label_arr[i].size());
+      for (size_t j = 0; j < this->label_arr[i].size(); j++) {
+        lblmap.insert(std::pair<std::string, cytnx_int64>(this->label_arr[i][j], lbl_int));
+        this->int_modes[i][j] = lblmap[this->label_arr[i][j]];
+        lbl_int += 1;
+      }
+    }
+    for (size_t i = 0; i < TOUT_labels.size(); i++) {
+      this->int_out_mode[i] = lblmap[this->TOUT_labels[i]];
+    }
+
+#ifdef UNI_GPU
+  #ifdef UNI_CUQUANTUM
+    this->optimizerInfo = nullptr;
+  #endif
+#endif
+
+    vector<string> names;
+    for (int i = 0; i < this->names.size(); i++) {
+      names.push_back(this->names[i]);
+      CtTree.base_nodes[i].name = this->names[i];
+    }
+    if (ORDER_tokens.size() != 0) {
+      CtTree.build_contraction_tree_by_tokens(this->name2pos, ORDER_tokens);
+    } else {
+      CtTree.build_default_contraction_tree();
+    }
+    this->einsum_path = CtTree_to_eisumpath(CtTree, names);
+  }  // end construct
 
 }  // namespace cytnx

--- a/src/ncon.cpp
+++ b/src/ncon.cpp
@@ -8,16 +8,18 @@ namespace cytnx {
                  const bool check_network /*= false*/, const bool optimize /*= false*/,
                  std::vector<cytnx_int64> cont_order /*= std::vector<cytnx_int64>()*/,
                  const std::vector<std::string> &out_labels /*= std::vector<std::string>()*/) {
-    string net_in = "";
+    vector<string> alias;
+    vector<vector<string>> lbls;
     map<cytnx_int64, vector<cytnx_uint64>> posbond2tensor;
     for (cytnx_uint64 i = 0; i < tensor_list_in.size(); i++) {
-      net_in.append("t"), net_in.append(to_string(i)), net_in.append(": ");
-      vector<cytnx_int64> bds = connect_list_in[i];
-      for (cytnx_uint64 j = 0; j < bds.size(); j++) {
-        net_in.append(to_string(bds[j]));
-        if (j != bds.size() - 1) net_in.append(",");
+      string name = "t" + to_string(i);
+      alias.push_back(name);
+
+      vector<string> lbl;
+      for (cytnx_uint64 j = 0; j < connect_list_in[i].size(); j++) {
+        lbl.push_back(to_string(connect_list_in[i][j]));
       }
-      net_in.append("\n");
+      lbls.push_back(lbl);
     }
     vector<cytnx_int64> positive;
     for (cytnx_uint64 i = 0; i < connect_list_in.size(); i++) {
@@ -33,7 +35,7 @@ namespace cytnx {
       for (cytnx_uint64 j = 0; j < connect_list_in[i].size(); j++) {
         if (connect_list_in[i][j] > 0) {
           cytnx_error_msg(check_network and posbond2tensor[connect_list_in[i][j]].size() != 2,
-                          "[Error][ncon][RegularNetwork] connect list contains not exactly two "
+                          "[Error][ncon] connect list contains not exactly two "
                           "positive same number%s",
                           "\n");
         }
@@ -58,7 +60,8 @@ namespace cytnx {
     string str_order = "";
     if (!st.empty()) str_order.append(st.top()), st.pop();
     string op[2];
-    cytnx_int64 oprcnt = 0, needed_parentheses = tensor_list_in.size() - 1;
+    cytnx_int64 oprcnt = 0;
+    cytnx_int64 needed_parentheses = tensor_list_in.size() - 1;
     while (!st.empty()) {
       string ele = st.top();
       st.pop();
@@ -76,32 +79,17 @@ namespace cytnx {
       }
     }
     str_order = string(needed_parentheses, '(').append(str_order);
-    str_order = "ORDER: " + str_order;
-    vector<cytnx_int64> outlbl2;
-    for (cytnx_uint64 i = 0; i < connect_list_in.size(); i++) {
-      for (cytnx_uint64 j = 0; j < connect_list_in[i].size(); j++) {
-        if (connect_list_in[i][j] <= 0) outlbl2.push_back(-connect_list_in[i][j]);
-      }
-    }
-    sort(outlbl2.begin(), outlbl2.end());
-    string str_tout = "TOUT: ;";  // Only row space labels
-    for (cytnx_uint64 i = 0; i < outlbl2.size(); i++) {
-      str_tout.append("-" + to_string(outlbl2[i]));
-      if (i != outlbl2.size() - 1) str_tout.append(",");
-    }
-    str_tout.append("\n");
+    std::cout << str_order << std::endl;
     UniTensor out;
     Network N;
-    // cout << net_in + str_tout + str_order << '\n';
-    N.FromString(str_split(net_in + str_tout + str_order, true, "\n"));
+    N.construct(alias, lbls, out_labels, 1, str_order, optimize);
     for (cytnx_uint64 i = 0; i < tensor_list_in.size(); i++) {
-      N.PutUniTensor("t" + to_string(i), tensor_list_in[i]);
+      N.PutUniTensor(i, tensor_list_in[i]);
     }
-    // cout << N;
     if (!optimize) {
-      N.setOrder(false, str_order.substr(7));
-      out = N.Launch();  // Remove "ORDER: "
+      out = N.Launch();
     } else {
+      N.setOrder(true, "");
       out = N.Launch();
     }
     if (!out_labels.empty()) out.set_labels(out_labels);

--- a/tests/Network_test.cpp
+++ b/tests/Network_test.cpp
@@ -44,10 +44,21 @@ TEST_F(NetworkTest, Network_dense_order_line) {
   net.PutUniTensors({"A", "B", "C"}, {utdnA, utdnB, utdnC});
   EXPECT_TRUE(AreNearlyEqTensor(net.Launch().get_block(), utdnAns.get_block(), 1e-12));
 }
+
 TEST_F(NetworkTest, Network_dense_specified_order) {
   auto net = Network();
   net.FromString({"A: a,b,c", "B: c,d", "C: d,e", "TOUT: a,b;e"});
   net.PutUniTensors({"A", "B", "C"}, {utdnA, utdnB, utdnC});
   net.setOrder(false, "(A,(B,C))");
+  EXPECT_TRUE(AreNearlyEqTensor(net.Launch().get_block(), utdnAns.get_block(), 1e-12));
+}
+
+TEST_F(NetworkTest, Network_dense_reuse) {
+  auto net = Network();
+  net.FromString({"A: a,b,c", "B: c,d", "C: d,e", "TOUT: a,b;e"});
+  net.PutUniTensors({"A", "B", "C"}, {utdnA, utdnB, utdnC});
+  net.setOrder(false, "(A,(B,C))");
+  EXPECT_TRUE(AreNearlyEqTensor(net.Launch().get_block(), utdnAns.get_block(), 1e-12));
+  net.PutUniTensors({"A", "B", "C"}, {utdnA, utdnC, utdnB});
   EXPECT_TRUE(AreNearlyEqTensor(net.Launch().get_block(), utdnAns.get_block(), 1e-12));
 }

--- a/tests/gpu/Network_test.cpp
+++ b/tests/gpu/Network_test.cpp
@@ -51,3 +51,12 @@ TEST_F(NetworkTest, gpu_Network_dense_specified_order) {
   net.setOrder(false, "(A,(B,C))");
   EXPECT_TRUE(AreNearlyEqTensor(net.Launch().get_block(), utdnAns.get_block(), 1e-12));
 }
+TEST_F(NetworkTest, gpu_Network_dense_reuse) {
+  auto net = Network();
+  net.FromString({"A: a,b,c", "B: c,d", "C: d,e", "TOUT: a,b;e"});
+  net.PutUniTensors({"A", "B", "C"}, {utdnA, utdnB, utdnC});
+  net.setOrder(false, "(A,(B,C))");
+  EXPECT_TRUE(AreNearlyEqTensor(net.Launch().get_block(), utdnAns.get_block(), 1e-12));
+  net.PutUniTensors({"A", "B", "C"}, {utdnA, utdnC, utdnB});
+  EXPECT_TRUE(AreNearlyEqTensor(net.Launch().get_block(), utdnAns.get_block(), 1e-12));
+}

--- a/tests/gpu/linalg_test/linalg_test.h
+++ b/tests/gpu/linalg_test/linalg_test.h
@@ -63,7 +63,7 @@ class linalg_Test : public ::testing::Test {
     svd_T = svd_T.Load(data_dir + "Svd_truncate/Svd_truncate1.cytnx").to(cytnx::Device.cuda);
     svd_T.permute_({1, 0, 3, 2});
     svd_T.contiguous_();
-    svd_T.set_rowrank(2);
+    svd_T.set_rowrank_(2);
     svd_Sans = Tensor::Load(data_dir + "Svd_truncate/S_truncate1.cytn").to(cytnx::Device.cuda);
     svd_Sans = algo::Sort(svd_Sans);
     //==================== Lanczos_Gnd_Ut ===================

--- a/tests/gpu/ncon_test.cpp
+++ b/tests/gpu/ncon_test.cpp
@@ -3,16 +3,23 @@
 using namespace std;
 using namespace cytnx;
 
-TEST_F(NconTest, gpu_ncon) {
-  double dans;
-  ifstream fin("answer.txt");
-  UniTensor res = ncon(input.first, input.second, true).to(cytnx::Device.cuda);
-  res.reshape_({-1});
+TEST_F(NconTest, gpu_ncon_default_order) {
+  std::vector<UniTensor> tn_list = {utdnA, utdnB, utdnC};
+  std::vector<std::vector<cytnx_int64>> connect_list = {{-1, -2, 2}, {2, 1}, {1, -3}};
+  UniTensor res = ncon(tn_list, connect_list, true, false);
+  EXPECT_TRUE(AreNearlyEqTensor(res.get_block(), utdnAns.get_block(), 1e-12));
+}
 
-  for (int i = 0; i < res.shape()[0]; i++) {
-    fin >> dans;
-    double dres = *(((double*)res.get_block_().storage().data()) + i);
-    EXPECT_NEAR(dans, dres, 1e-8);  // We should consider change the epsilon since the resulting
-                                    // tensor may be very large in number
-  }
+TEST_F(NconTest, gpu_ncon_specified_order) {
+  std::vector<UniTensor> tn_list = {utdnA, utdnB, utdnC};
+  std::vector<std::vector<cytnx_int64>> connect_list = {{-1, -2, 2}, {2, 1}, {1, -3}};
+  UniTensor res = ncon(tn_list, connect_list, true, true, {2, 1});
+  EXPECT_TRUE(AreNearlyEqTensor(res.get_block(), utdnAns.get_block(), 1e-12));
+}
+
+TEST_F(NconTest, gpu_ncon_optimal_order) {
+  std::vector<UniTensor> tn_list = {utdnA, utdnB, utdnC};
+  std::vector<std::vector<cytnx_int64>> connect_list = {{-1, -2, 2}, {2, 1}, {1, -3}};
+  UniTensor res = ncon(tn_list, connect_list, true, true);
+  EXPECT_TRUE(AreNearlyEqTensor(res.get_block(), utdnAns.get_block(), 1e-12));
 }

--- a/tests/gpu/ncon_test.h
+++ b/tests/gpu/ncon_test.h
@@ -2,15 +2,37 @@
 #define _H_ncon_test
 
 #include "cytnx.hpp"
-#include "utils/getNconParameter.h"
 #include <gtest/gtest.h>
+#include "test_tools.h"
+
+using namespace cytnx;
+using namespace TestTools;
 
 class NconTest : public ::testing::Test {
  public:
-  std::pair<std::vector<cytnx::UniTensor>, std::vector<std::vector<cytnx::cytnx_int64>>> input;
+  // std::pair<std::vector<cytnx::UniTensor>, std::vector<std::vector<cytnx::cytnx_int64>>> input;
+  UniTensor utdnA =
+    UniTensor(arange(0, 8, 1, Type.ComplexDouble)).reshape({2, 2, 2}).to(cytnx::Device.cuda);
+  ;
+  UniTensor utdnB = UniTensor(ones({2, 2}, Type.ComplexDouble)).to(cytnx::Device.cuda);
+  ;
+  UniTensor utdnC = UniTensor(eye(2, Type.ComplexDouble)).to(cytnx::Device.cuda);
+  ;
+  UniTensor utdnAns = UniTensor(zeros({2, 2, 2}, Type.ComplexDouble)).to(cytnx::Device.cuda);
+  ;
 
  protected:
-  void SetUp() override { input = getNconParameter("output.txt"); }
+  void SetUp() override {
+    // input = getNconParameter("utils/output.txt");
+    utdnAns.at({0, 0, 0}) = 1;
+    utdnAns.at({0, 0, 1}) = 1;
+    utdnAns.at({0, 1, 0}) = 5;
+    utdnAns.at({0, 1, 1}) = 5;
+    utdnAns.at({1, 0, 0}) = 9;
+    utdnAns.at({1, 0, 1}) = 9;
+    utdnAns.at({1, 1, 0}) = 13;
+    utdnAns.at({1, 1, 1}) = 13;
+  }
   void TearDown() override {}
 };
 

--- a/tests/linalg_test/GeSvd_test.cpp
+++ b/tests/linalg_test/GeSvd_test.cpp
@@ -198,7 +198,7 @@ namespace GesvdTest {
     //  std::vector<UniTensor> GesvdsS = linalg::Gesvd(src_T, need_U = false, need_VT = false);
     //  EXPECT_EQ(GesvdsS.size(), 1) << "The number of the output of Gesvd not correct. Line:"
     //      << __LINE__ << std::endl;
-    std::vector<UniTensor> GesvdsS = linalg::Gesvd(src_T, compute_uv = false);
+    std::vector<UniTensor> GesvdsS = linalg::Gesvd(src_T, compute_uv = false, false);
     EXPECT_EQ(GesvdsS.size(), 1) << "The number of the output of Gesvd not correct. Line:"
                                  << __LINE__ << std::endl;
 

--- a/tests/linalg_test/linalg_test.h
+++ b/tests/linalg_test/linalg_test.h
@@ -61,7 +61,7 @@ class linalg_Test : public ::testing::Test {
     svd_T = svd_T.Load(data_dir + "Svd_truncate/Svd_truncate1.cytnx");
     svd_T.permute_({1, 0, 3, 2});
     svd_T.contiguous_();
-    svd_T.set_rowrank(2);
+    svd_T.set_rowrank_(2);
     svd_Sans = Tensor::Load(data_dir + "Svd_truncate/S_truncate1.cytn");
     svd_Sans = algo::Sort(svd_Sans);
     //==================== Lanczos_Gnd_Ut ===================

--- a/tests/ncon_test.cpp
+++ b/tests/ncon_test.cpp
@@ -3,16 +3,23 @@
 using namespace std;
 using namespace cytnx;
 
-TEST_F(NconTest, ncon) {
-  double dans;
-  ifstream fin("answer.txt");
-  UniTensor res = ncon(input.first, input.second, true);
-  res.reshape_({-1});
+TEST_F(NconTest, ncon_default_order) {
+  std::vector<UniTensor> tn_list = {utdnA, utdnB, utdnC};
+  std::vector<std::vector<cytnx_int64>> connect_list = {{-1, -2, 2}, {2, 1}, {1, -3}};
+  UniTensor res = ncon(tn_list, connect_list, true, false);
+  EXPECT_TRUE(AreNearlyEqTensor(res.get_block(), utdnAns.get_block(), 1e-12));
+}
 
-  for (int i = 0; i < res.shape()[0]; i++) {
-    fin >> dans;
-    double dres = *(((double*)res.get_block_().storage().data()) + i);
-    EXPECT_NEAR(dans, dres, 1e-8);  // We should consider change the epsilon since the resulting
-                                    // tensor may be very large in number
-  }
+TEST_F(NconTest, ncon_specified_order) {
+  std::vector<UniTensor> tn_list = {utdnA, utdnB, utdnC};
+  std::vector<std::vector<cytnx_int64>> connect_list = {{-1, -2, 2}, {2, 1}, {1, -3}};
+  UniTensor res = ncon(tn_list, connect_list, true, true, {2, 1});
+  EXPECT_TRUE(AreNearlyEqTensor(res.get_block(), utdnAns.get_block(), 1e-12));
+}
+
+TEST_F(NconTest, ncon_optimal_order) {
+  std::vector<UniTensor> tn_list = {utdnA, utdnB, utdnC};
+  std::vector<std::vector<cytnx_int64>> connect_list = {{-1, -2, 2}, {2, 1}, {1, -3}};
+  UniTensor res = ncon(tn_list, connect_list, true, true);
+  EXPECT_TRUE(AreNearlyEqTensor(res.get_block(), utdnAns.get_block(), 1e-12));
 }

--- a/tests/ncon_test.h
+++ b/tests/ncon_test.h
@@ -2,15 +2,32 @@
 #define _H_ncon_test
 
 #include "cytnx.hpp"
-#include "utils/getNconParameter.h"
 #include <gtest/gtest.h>
+#include "test_tools.h"
+
+using namespace cytnx;
+using namespace TestTools;
 
 class NconTest : public ::testing::Test {
  public:
-  std::pair<std::vector<cytnx::UniTensor>, std::vector<std::vector<cytnx::cytnx_int64>>> input;
+  // std::pair<std::vector<cytnx::UniTensor>, std::vector<std::vector<cytnx::cytnx_int64>>> input;
+  UniTensor utdnA = UniTensor(arange(0, 8, 1, Type.ComplexDouble)).reshape({2, 2, 2});
+  UniTensor utdnB = UniTensor(ones({2, 2}, Type.ComplexDouble));
+  UniTensor utdnC = UniTensor(eye(2, Type.ComplexDouble));
+  UniTensor utdnAns = UniTensor(zeros({2, 2, 2}, Type.ComplexDouble));
 
  protected:
-  void SetUp() override { input = getNconParameter("output.txt"); }
+  void SetUp() override {
+    // input = getNconParameter("utils/output.txt");
+    utdnAns.at({0, 0, 0}) = 1;
+    utdnAns.at({0, 0, 1}) = 1;
+    utdnAns.at({0, 1, 0}) = 5;
+    utdnAns.at({0, 1, 1}) = 5;
+    utdnAns.at({1, 0, 0}) = 9;
+    utdnAns.at({1, 0, 1}) = 9;
+    utdnAns.at({1, 1, 0}) = 13;
+    utdnAns.at({1, 1, 1}) = 13;
+  }
   void TearDown() override {}
 };
 


### PR DESCRIPTION
1. `ncon()` now utilizing the `Network.construct()` to pass the argument more directly.
2. Update `Network.construct()`.
3. Update ncon and tests.
4. Update network tests, add the reuse scenario.
5. Fix `BkUt_Svd_truncate1` and `Gesvd.none_isU_isVT` tests.