### PR TITLE
Cuda memcpy truncation

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 100%

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,7 @@ coverage:
       default:
         target: auto
         threshold: 100%
+    patch:
+      default:
+        target: auto
+        threshold: 100%

--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -19,6 +19,10 @@ namespace cytnx {
     std::vector<Tensor> Gesvd_truncate(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                        const double &err, const bool &is_U, const bool &is_vT,
                                        const unsigned int &return_err) {
+      cytnx_error_msg(Tin.shape().size() != 2,
+                      "[Gesvd_truncate] error, Gesvd_truncate can only operate on rank-2 Tensor.%s",
+                      "\n");
+
       if (Tin.device() == Device.cpu) {
         std::vector<Tensor> tmps = Gesvd(Tin, is_U, is_vT);
 
@@ -72,9 +76,6 @@ namespace cytnx {
       } else {
 #ifdef UNI_GPU
   #ifdef UNI_CUQUANTUM
-        cytnx_error_msg(
-          Tin.shape().size() != 2,
-          "[Gesvd_truncate] error, Gesvd_truncate can only operate on rank-2 Tensor.%s", "\n");
 
         Tensor in = Tin.contiguous();
 
@@ -88,10 +89,14 @@ namespace cytnx {
         U.Init({in.shape()[0], n_singlu}, in.dtype(), in.device());
         vT.Init({n_singlu, in.shape()[1]}, in.dtype(), in.device());
         terr.Init({1}, in.dtype(), in.device());
+
         cytnx::linalg_internal::lii.cuQuantumGeSvd_ii[in.dtype()](in, keepdim, err, return_err, U,
                                                                   S, vT, terr);
-        std::vector<Tensor> outT;
 
+        cytnx::linalg_internal::lii.cudaMemcpyTruncation_ii[in.dtype()](
+          U, vT, S, terr, keepdim, err, is_U, is_vT, return_err);
+
+        std::vector<Tensor> outT;
         outT.push_back(S);
         if (is_U) outT.push_back(U);
         if (is_vT) outT.push_back(vT);
@@ -100,9 +105,19 @@ namespace cytnx {
         return outT;
 
   #else
-        cytnx_error_msg(true, "[Gesvd_truncate] fatal error,%s",
-                        "try to call the cuquantum section without cuQunatum support.\n");
-        return std::vector<Tensor>();
+        std::vector<Tensor> tmps = Gesvd(Tin, is_U, is_vT);
+        Tensor terr({1}, Tin.dtype(), Tin.device());
+
+        cytnx::linalg_internal::lii.cudaMemcpyTruncation_ii[Tin.dtype()](
+          tmps[1], tmps[2], tmps[0], terr, keepdim, err, is_U, is_vT, return_err);
+
+        std::vector<Tensor> outT;
+        outT.push_back(tmps[0]);
+        if (is_U) outT.push_back(tmps[1]);
+        if (is_vT) outT.push_back(tmps[2]);
+        if (return_err) outT.push_back(terr);
+
+        return outT;
   #endif
 #else
         cytnx_error_msg(true, "[Gesvd_truncate] fatal error,%s",
@@ -118,83 +133,6 @@ namespace cytnx {
   namespace linalg {
     using namespace std;
     typedef Accessor ac;
-
-#ifdef UNI_GPU
-  #ifdef UNI_CUQUANTUM
-    void _cuquantum_gesvdj_truncate_Dense_UT(std::vector<UniTensor> &outCyT,
-                                             const cytnx::UniTensor &Tin,
-                                             const cytnx_uint64 &keepdim, const double &err,
-                                             const bool &is_U, const bool &is_vT,
-                                             const unsigned int &return_err) {
-      // Retrieve tensor from UniTensor
-      Tensor tmp;
-      if (Tin.is_contiguous())
-        tmp = Tin.get_block_();
-      else {
-        tmp = Tin.get_block();
-        tmp.contiguous_();
-      }
-
-      vector<cytnx_uint64> tmps = tmp.shape();
-      vector<cytnx_int64> oldshape(tmps.begin(), tmps.end());
-      tmps.clear();
-      vector<string> oldlabel = Tin.labels();
-
-      // collapse as Matrix:
-      cytnx_int64 rowdim = 1;
-      for (cytnx_uint64 i = 0; i < Tin.rowrank(); i++) rowdim *= Tin.shape()[i];
-
-      // pass to tensor API
-      vector<Tensor> outT = cytnx::linalg::Gesvd_truncate(tmp.reshape({rowdim, -1}), keepdim, err,
-                                                          is_U, is_vT, return_err);
-
-      // set output
-      int t = 0;
-      outCyT.resize(outT.size());
-      cytnx::UniTensor &Cy_S = outCyT[t];
-      cytnx::Bond newBond(outT[0].shape()[0]);
-      Cy_S.Init({newBond, newBond}, {string("_aux_L"), string("_aux_R")}, 1, Type.Double,
-                Tin.device(),
-                true);  // it is just reference so no hurt to alias ^^
-      Cy_S.put_block_(outT[t]);
-      t++;
-
-      if (is_U) {
-        cytnx::UniTensor &Cy_U = outCyT[t];
-        // shape
-        vector<cytnx_int64> shapeU = vec_clone(oldshape, Tin.rowrank());
-        shapeU.push_back(-1);
-
-        outT[t].reshape_(shapeU);
-
-        Cy_U.Init(outT[t], false, Tin.rowrank());
-        vector<string> labelU = vec_clone(oldlabel, Tin.rowrank());
-        labelU.push_back(Cy_S.labels()[0]);
-        Cy_U.set_labels(labelU);
-        t++;  // U
-      }
-
-      if (is_vT) {
-        cytnx::UniTensor &Cy_vT = outCyT[t];
-        // shape
-        vector<cytnx_int64> shapevT(Tin.rank() - Tin.rowrank() + 1);
-        shapevT[0] = -1;
-        memcpy(&shapevT[1], &oldshape[Tin.rowrank()], sizeof(cytnx_int64) * (shapevT.size() - 1));
-
-        outT[t].reshape_(shapevT);
-
-        Cy_vT.Init(outT[t], false, 1);
-        vector<string> labelvT(shapevT.size());
-        labelvT[0] = Cy_S.labels()[1];
-        std::copy(oldlabel.begin() + Tin.rowrank(), oldlabel.end(), labelvT.begin() + 1);
-        Cy_vT.set_labels(labelvT);
-        t++;  // vT
-      }
-
-      if (return_err) outCyT.back().Init(outT.back(), false, 0);
-    }
-  #endif
-#endif
 
     void _gesvd_truncate_Dense_UT(std::vector<UniTensor> &outCyT, const cytnx::UniTensor &Tin,
                                   const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
@@ -458,28 +396,9 @@ namespace cytnx {
 
       std::vector<UniTensor> outCyT;
       if (Tin.uten_type() == UTenType.Dense) {
-        if (Tin.device() == Device.cpu) {
-          _gesvd_truncate_Dense_UT(outCyT, Tin, keepdim, err, is_U, is_vT, return_err);
-        } else {
-#ifdef UNI_GPU
-  #ifdef UNI_CUQUANTUM
-          _cuquantum_gesvdj_truncate_Dense_UT(outCyT, Tin, keepdim, err, is_U, is_vT, return_err);
-  #else
-          cytnx_error_msg(true, "[cuQuantumSvd] fatal error,%s",
-                          "try to call the cuquantum section without cuQunatum support.\n");
-          return std::vector<cytnx::UniTensor>();
-  #endif
-
-#else
-          cytnx_error_msg(true, "[cuQuantumSvd] fatal error,%s",
-                          "try to call the gpu section without CUDA support.\n");
-          return std::vector<cytnx::UniTensor>();
-#endif
-        }
-
+        _gesvd_truncate_Dense_UT(outCyT, Tin, keepdim, err, is_U, is_vT, return_err);
       } else if (Tin.uten_type() == UTenType.Block) {
         _gesvd_truncate_Block_UT(outCyT, Tin, keepdim, err, is_U, is_vT, return_err);
-
       } else {
         cytnx_error_msg(true, "[ERROR] only support gesvd for Dense and Block UniTensor.%s", "\n");
       }

--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -25,7 +25,7 @@ namespace cytnx {
 
       if (Tin.device() == Device.cpu) {
         std::vector<Tensor> tmps = Gesvd(Tin, is_U, is_vT);
-        Tensor terr({1}, Tin.dtype());
+        Tensor terr({1}, Tin.dtype(), Tin.device());
 
         cytnx::linalg_internal::lii.memcpyTruncation_ii[Tin.dtype()](
           tmps[1], tmps[2], tmps[0], terr, keepdim, err, is_U, is_vT, return_err);

--- a/src/linalg/Svd_truncate.cpp
+++ b/src/linalg/Svd_truncate.cpp
@@ -4,6 +4,7 @@
 #include "Tensor.hpp"
 #include "UniTensor.hpp"
 #include "algo.hpp"
+#include "linalg_internal_interface.hpp"
 
 namespace cytnx {
   namespace linalg {
@@ -12,53 +13,77 @@ namespace cytnx {
                                      const double &err, const bool &is_UvT,
                                      const unsigned int &return_err) {
       cytnx_error_msg(return_err < 0, "[ERROR] return_err can only be positive int%s", "\n");
-      std::vector<Tensor> tmps = Svd(Tin, is_UvT);
+      if (Tin.device() == Device.cpu) {
+        std::vector<Tensor> tmps = Svd(Tin, is_UvT);
 
-      cytnx_uint64 id = 0;
-      cytnx_uint64 Kdim = keepdim;
+        cytnx_uint64 id = 0;
+        cytnx_uint64 Kdim = keepdim;
 
-      Storage ts = tmps[0].storage();
+        Storage ts = tmps[0].storage();
 
-      if (ts.size() < keepdim) {
-        Kdim = ts.size();
-      }
-
-      cytnx_uint64 truc_dim = Kdim;
-      for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
-        if (ts.at(i) < err) {
-          truc_dim--;
-        } else {
-          break;
+        if (ts.size() < keepdim) {
+          Kdim = ts.size();
         }
-      }
 
-      if (truc_dim == 0) {
-        truc_dim = 1;
-      }
-      /// std::cout << truc_dim << std::endl;
-      // cytnx_error_msg(tmps[0].shape()[0] < keepdim,"[ERROR] keepdim should be <= the valid # of
-      // singular value, %d!\n",tmps[0].shape()[0]);
-      Tensor terr({1}, Type.Double);
+        cytnx_uint64 truc_dim = Kdim;
+        for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
+          if (ts.at(i) < err) {
+            truc_dim--;
+          } else {
+            break;
+          }
+        }
 
-      if (truc_dim != ts.size()) {
-        if (return_err == 1)
-          terr = tmps[id](truc_dim);
-        else if (return_err)
-          terr = tmps[id].get({ac::tilend(truc_dim)});
+        if (truc_dim == 0) {
+          truc_dim = 1;
+        }
+        /// std::cout << truc_dim << std::endl;
+        // cytnx_error_msg(tmps[0].shape()[0] < keepdim,"[ERROR] keepdim should be <= the valid # of
+        // singular value, %d!\n",tmps[0].shape()[0]);
+        Tensor terr({1}, Type.Double);
 
-        tmps[id] = tmps[id].get({ac::range(0, truc_dim)});
+        if (truc_dim != ts.size()) {
+          if (return_err == 1)
+            terr = tmps[id](truc_dim);
+          else if (return_err)
+            terr = tmps[id].get({ac::tilend(truc_dim)});
 
+          tmps[id] = tmps[id].get({ac::range(0, truc_dim)});
+
+          if (is_UvT) {
+            id++;
+            tmps[id] = tmps[id].get({ac::all(), ac::range(0, truc_dim)});
+
+            id++;
+            tmps[id] = tmps[id].get({ac::range(0, truc_dim), ac::all()});
+          }
+        }
+        if (return_err) tmps.push_back(terr);
+
+        return tmps;
+      } else {
+#ifdef UNI_GPU
+        std::vector<Tensor> tmps = Svd(Tin, is_UvT);
+        Tensor terr({1}, Tin.dtype(), Tin.device());
+
+        cytnx::linalg_internal::lii.cudaMemcpyTruncation_ii[Tin.dtype()](
+          tmps[1], tmps[2], tmps[0], terr, keepdim, err, is_UvT, is_UvT, return_err);
+
+        std::vector<Tensor> outT;
+        outT.push_back(tmps[0]);
         if (is_UvT) {
-          id++;
-          tmps[id] = tmps[id].get({ac::all(), ac::range(0, truc_dim)});
-
-          id++;
-          tmps[id] = tmps[id].get({ac::range(0, truc_dim), ac::all()});
+          outT.push_back(tmps[1]);
+          outT.push_back(tmps[2]);
         }
-      }
-      if (return_err) tmps.push_back(terr);
+        if (return_err) outT.push_back(terr);
 
-      return tmps;
+        return outT;
+#else
+        cytnx_error_msg(true, "[Svd_truncate] fatal error,%s",
+                        "try to call the gpu section without CUDA support.\n");
+        return std::vector<Tensor>();
+#endif
+      }
     }
   }  // namespace linalg
 }  // namespace cytnx

--- a/src/linalg/Svd_truncate.cpp
+++ b/src/linalg/Svd_truncate.cpp
@@ -16,51 +16,20 @@ namespace cytnx {
       if (Tin.device() == Device.cpu) {
         std::vector<Tensor> tmps = Svd(Tin, is_UvT);
 
-        cytnx_uint64 id = 0;
-        cytnx_uint64 Kdim = keepdim;
+        Tensor terr({1}, Tin.dtype());
 
-        Storage ts = tmps[0].storage();
+        cytnx::linalg_internal::lii.memcpyTruncation_ii[Tin.dtype()](
+          tmps[1], tmps[2], tmps[0], terr, keepdim, err, is_UvT, is_UvT, return_err);
 
-        if (ts.size() < keepdim) {
-          Kdim = ts.size();
+        std::vector<Tensor> outT;
+        outT.push_back(tmps[0]);
+        if (is_UvT) {
+          outT.push_back(tmps[1]);
+          outT.push_back(tmps[2]);
         }
+        if (return_err) outT.push_back(terr);
 
-        cytnx_uint64 truc_dim = Kdim;
-        for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
-          if (ts.at(i) < err) {
-            truc_dim--;
-          } else {
-            break;
-          }
-        }
-
-        if (truc_dim == 0) {
-          truc_dim = 1;
-        }
-        /// std::cout << truc_dim << std::endl;
-        // cytnx_error_msg(tmps[0].shape()[0] < keepdim,"[ERROR] keepdim should be <= the valid # of
-        // singular value, %d!\n",tmps[0].shape()[0]);
-        Tensor terr({1}, Type.Double);
-
-        if (truc_dim != ts.size()) {
-          if (return_err == 1)
-            terr = tmps[id](truc_dim);
-          else if (return_err)
-            terr = tmps[id].get({ac::tilend(truc_dim)});
-
-          tmps[id] = tmps[id].get({ac::range(0, truc_dim)});
-
-          if (is_UvT) {
-            id++;
-            tmps[id] = tmps[id].get({ac::all(), ac::range(0, truc_dim)});
-
-            id++;
-            tmps[id] = tmps[id].get({ac::range(0, truc_dim), ac::all()});
-          }
-        }
-        if (return_err) tmps.push_back(terr);
-
-        return tmps;
+        return outT;
       } else {
 #ifdef UNI_GPU
         std::vector<Tensor> tmps = Svd(Tin, is_UvT);

--- a/src/linalg/Svd_truncate.cpp
+++ b/src/linalg/Svd_truncate.cpp
@@ -16,7 +16,7 @@ namespace cytnx {
       if (Tin.device() == Device.cpu) {
         std::vector<Tensor> tmps = Svd(Tin, is_UvT);
 
-        Tensor terr({1}, Tin.dtype());
+        Tensor terr({1}, Tin.dtype(), Tin.device());
 
         cytnx::linalg_internal::lii.memcpyTruncation_ii[Tin.dtype()](
           tmps[1], tmps[2], tmps[0], terr, keepdim, err, is_UvT, is_UvT, return_err);

--- a/src/linalg/linalg_internal_cpu/CMakeLists.txt
+++ b/src/linalg/linalg_internal_cpu/CMakeLists.txt
@@ -43,6 +43,8 @@ target_sources_local(cytnx
     Axpy_internal.hpp
     Ger_internal.hpp
 
+    memcpyTruncation.hpp
+
     Add_internal.cpp
     iAdd_internal.cpp
     Arithmetic_internal.cpp
@@ -85,4 +87,6 @@ target_sources_local(cytnx
 
     Axpy_internal.cpp
     Ger_internal.cpp
+
+    memcpyTruncation.cpp
 )

--- a/src/linalg/linalg_internal_cpu/memcpyTruncation.cpp
+++ b/src/linalg/linalg_internal_cpu/memcpyTruncation.cpp
@@ -30,12 +30,13 @@ namespace cytnx {
       }
       if (truc_dim != nums) {
         // perform the manual truncation
-        Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
-        Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+
         Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
         memcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
                (cytnx_double *)S._impl->storage()._impl->Mem, truc_dim * sizeof(cytnx_double));
         if (is_U) {
+          Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+
           int src = 0;
           int dest = 0;
           // copy with strides.
@@ -49,6 +50,7 @@ namespace cytnx {
           U = newU;
         }
         if (is_vT) {
+          Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
           // simply copy a new one dropping the tail.
           memcpy((cytnx_complex128 *)newvT._impl->storage()._impl->Mem,
                  (cytnx_complex128 *)vT._impl->storage()._impl->Mem,
@@ -94,12 +96,13 @@ namespace cytnx {
       }
       if (truc_dim != nums) {
         // perform the manual truncation
-        Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
-        Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+
         Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
         memcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
                (cytnx_double *)S._impl->storage()._impl->Mem, truc_dim * sizeof(cytnx_double));
         if (is_U) {
+          Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+
           int src = 0;
           int dest = 0;
           // copy with strides.
@@ -113,6 +116,7 @@ namespace cytnx {
           U = newU;
         }
         if (is_vT) {
+          Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
           // simply copy a new one dropping the tail.
           memcpy((cytnx_complex64 *)newvT._impl->storage()._impl->Mem,
                  (cytnx_complex64 *)vT._impl->storage()._impl->Mem,
@@ -158,12 +162,13 @@ namespace cytnx {
       }
       if (truc_dim != nums) {
         // perform the manual truncation
-        Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
-        Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+
         Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
         memcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
                (cytnx_double *)S._impl->storage()._impl->Mem, truc_dim * sizeof(cytnx_double));
         if (is_U) {
+          Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+
           int src = 0;
           int dest = 0;
           // copy with strides.
@@ -177,6 +182,7 @@ namespace cytnx {
           U = newU;
         }
         if (is_vT) {
+          Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
           // simply copy a new one dropping the tail.
           memcpy((cytnx_double *)newvT._impl->storage()._impl->Mem,
                  (cytnx_double *)vT._impl->storage()._impl->Mem,
@@ -222,12 +228,13 @@ namespace cytnx {
       }
       if (truc_dim != nums) {
         // perform the manual truncation
-        Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
-        Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+
         Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
         memcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
                (cytnx_double *)S._impl->storage()._impl->Mem, truc_dim * sizeof(cytnx_double));
         if (is_U) {
+          Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+
           int src = 0;
           int dest = 0;
           // copy with strides.
@@ -241,6 +248,7 @@ namespace cytnx {
           U = newU;
         }
         if (is_vT) {
+          Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
           // simply copy a new one dropping the tail.
           memcpy((cytnx_float *)newvT._impl->storage()._impl->Mem,
                  (cytnx_float *)vT._impl->storage()._impl->Mem,

--- a/src/linalg/linalg_internal_cpu/memcpyTruncation.cpp
+++ b/src/linalg/linalg_internal_cpu/memcpyTruncation.cpp
@@ -1,0 +1,268 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <vector>
+
+#include "memcpyTruncation.hpp"
+
+namespace cytnx {
+  namespace linalg_internal {
+
+    void memcpyTruncation_cd(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                             const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
+                             const bool &is_vT, const unsigned int &return_err) {
+      // determine the truc_dim
+      cytnx_uint64 Kdim = keepdim;
+      cytnx_uint64 nums = S.storage().size();
+      if (nums < keepdim) {
+        Kdim = nums;
+      }
+      cytnx_uint64 truc_dim = Kdim;
+      for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
+        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err) {
+          truc_dim--;
+        } else {
+          break;
+        }
+      }
+      if (truc_dim == 0) {
+        truc_dim = 1;
+      }
+      if (truc_dim != nums) {
+        // perform the manual truncation
+        Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+        Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+        Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
+        memcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
+               (cytnx_double *)S._impl->storage()._impl->Mem, truc_dim * sizeof(cytnx_double));
+        if (is_U) {
+          int src = 0;
+          int dest = 0;
+          // copy with strides.
+          for (int i = 0; i < U.shape()[0]; i++) {
+            memcpy((cytnx_complex128 *)newU._impl->storage()._impl->Mem + src,
+                   (cytnx_complex128 *)U._impl->storage()._impl->Mem + dest,
+                   truc_dim * sizeof(cytnx_complex128));
+            src += truc_dim;
+            dest += U.shape()[1];
+          }
+          U = newU;
+        }
+        if (is_vT) {
+          // simply copy a new one dropping the tail.
+          memcpy((cytnx_complex128 *)newvT._impl->storage()._impl->Mem,
+                 (cytnx_complex128 *)vT._impl->storage()._impl->Mem,
+                 vT.shape()[1] * truc_dim * sizeof(cytnx_complex128));
+          vT = newvT;
+        }
+        if (return_err == 1) {
+          Tensor newterr = Tensor({1}, S.dtype(), S.device());
+          ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
+            ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
+          terr = newterr;
+        } else if (return_err) {
+          cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
+          Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
+          memcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
+                 (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
+                 discared_dim * sizeof(cytnx_double));
+          terr = newterr;
+        }
+        S = newS;
+      }
+    }
+
+    void memcpyTruncation_cf(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                             const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
+                             const bool &is_vT, const unsigned int &return_err) {
+      // determine the truc_dim
+      cytnx_uint64 Kdim = keepdim;
+      cytnx_uint64 nums = S.storage().size();
+      if (nums < keepdim) {
+        Kdim = nums;
+      }
+      cytnx_uint64 truc_dim = Kdim;
+      for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
+        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err) {
+          truc_dim--;
+        } else {
+          break;
+        }
+      }
+      if (truc_dim == 0) {
+        truc_dim = 1;
+      }
+      if (truc_dim != nums) {
+        // perform the manual truncation
+        Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+        Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+        Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
+        memcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
+               (cytnx_double *)S._impl->storage()._impl->Mem, truc_dim * sizeof(cytnx_double));
+        if (is_U) {
+          int src = 0;
+          int dest = 0;
+          // copy with strides.
+          for (int i = 0; i < U.shape()[0]; i++) {
+            memcpy((cytnx_complex64 *)newU._impl->storage()._impl->Mem + src,
+                   (cytnx_complex64 *)U._impl->storage()._impl->Mem + dest,
+                   truc_dim * sizeof(cytnx_complex64));
+            src += truc_dim;
+            dest += U.shape()[1];
+          }
+          U = newU;
+        }
+        if (is_vT) {
+          // simply copy a new one dropping the tail.
+          memcpy((cytnx_complex64 *)newvT._impl->storage()._impl->Mem,
+                 (cytnx_complex64 *)vT._impl->storage()._impl->Mem,
+                 vT.shape()[1] * truc_dim * sizeof(cytnx_complex64));
+          vT = newvT;
+        }
+        if (return_err == 1) {
+          Tensor newterr = Tensor({1}, S.dtype(), S.device());
+          ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
+            ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
+          terr = newterr;
+        } else if (return_err) {
+          cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
+          Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
+          memcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
+                 (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
+                 discared_dim * sizeof(cytnx_double));
+          terr = newterr;
+        }
+        S = newS;
+      }
+    }
+
+    void memcpyTruncation_d(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                            const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
+                            const bool &is_vT, const unsigned int &return_err) {
+      // determine the truc_dim
+      cytnx_uint64 Kdim = keepdim;
+      cytnx_uint64 nums = S.storage().size();
+      if (nums < keepdim) {
+        Kdim = nums;
+      }
+      cytnx_uint64 truc_dim = Kdim;
+      for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
+        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err) {
+          truc_dim--;
+        } else {
+          break;
+        }
+      }
+      if (truc_dim == 0) {
+        truc_dim = 1;
+      }
+      if (truc_dim != nums) {
+        // perform the manual truncation
+        Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+        Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+        Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
+        memcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
+               (cytnx_double *)S._impl->storage()._impl->Mem, truc_dim * sizeof(cytnx_double));
+        if (is_U) {
+          int src = 0;
+          int dest = 0;
+          // copy with strides.
+          for (int i = 0; i < U.shape()[0]; i++) {
+            memcpy((cytnx_double *)newU._impl->storage()._impl->Mem + src,
+                   (cytnx_double *)U._impl->storage()._impl->Mem + dest,
+                   truc_dim * sizeof(cytnx_double));
+            src += truc_dim;
+            dest += U.shape()[1];
+          }
+          U = newU;
+        }
+        if (is_vT) {
+          // simply copy a new one dropping the tail.
+          memcpy((cytnx_double *)newvT._impl->storage()._impl->Mem,
+                 (cytnx_double *)vT._impl->storage()._impl->Mem,
+                 vT.shape()[1] * truc_dim * sizeof(cytnx_double));
+          vT = newvT;
+        }
+        if (return_err == 1) {
+          Tensor newterr = Tensor({1}, S.dtype(), S.device());
+          ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
+            ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
+          terr = newterr;
+        } else if (return_err) {
+          cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
+          Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
+          memcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
+                 (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
+                 discared_dim * sizeof(cytnx_double));
+          terr = newterr;
+        }
+        S = newS;
+      }
+    }
+
+    void memcpyTruncation_f(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                            const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
+                            const bool &is_vT, const unsigned int &return_err) {
+      // determine the truc_dim
+      cytnx_uint64 Kdim = keepdim;
+      cytnx_uint64 nums = S.storage().size();
+      if (nums < keepdim) {
+        Kdim = nums;
+      }
+      cytnx_uint64 truc_dim = Kdim;
+      for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
+        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err) {
+          truc_dim--;
+        } else {
+          break;
+        }
+      }
+      if (truc_dim == 0) {
+        truc_dim = 1;
+      }
+      if (truc_dim != nums) {
+        // perform the manual truncation
+        Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+        Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+        Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
+        memcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
+               (cytnx_double *)S._impl->storage()._impl->Mem, truc_dim * sizeof(cytnx_double));
+        if (is_U) {
+          int src = 0;
+          int dest = 0;
+          // copy with strides.
+          for (int i = 0; i < U.shape()[0]; i++) {
+            memcpy((cytnx_float *)newU._impl->storage()._impl->Mem + src,
+                   (cytnx_float *)U._impl->storage()._impl->Mem + dest,
+                   truc_dim * sizeof(cytnx_float));
+            src += truc_dim;
+            dest += U.shape()[1];
+          }
+          U = newU;
+        }
+        if (is_vT) {
+          // simply copy a new one dropping the tail.
+          memcpy((cytnx_float *)newvT._impl->storage()._impl->Mem,
+                 (cytnx_float *)vT._impl->storage()._impl->Mem,
+                 vT.shape()[1] * truc_dim * sizeof(cytnx_float));
+          vT = newvT;
+        }
+        if (return_err == 1) {
+          Tensor newterr = Tensor({1}, S.dtype(), S.device());
+          ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
+            ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
+          terr = newterr;
+        } else if (return_err) {
+          cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
+          Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
+          memcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
+                 (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
+                 discared_dim * sizeof(cytnx_double));
+          terr = newterr;
+        }
+        S = newS;
+      }
+    }
+
+  }  // namespace linalg_internal
+}  // namespace cytnx

--- a/src/linalg/linalg_internal_cpu/memcpyTruncation.hpp
+++ b/src/linalg/linalg_internal_cpu/memcpyTruncation.hpp
@@ -1,0 +1,29 @@
+#ifndef __memcpyTruncation_internal_H__
+#define __memcpyTruncation_internal_H__
+
+#include <iostream>
+#include <vector>
+#include "Type.hpp"
+#include "cytnx_error.hpp"
+#include "linalg/linalg_internal_interface.hpp"
+
+namespace cytnx {
+  namespace linalg_internal {
+
+    void memcpyTruncation_cd(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                             const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
+                             const bool &is_vT, const unsigned int &return_err);
+    void memcpyTruncation_cf(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                             const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
+                             const bool &is_vT, const unsigned int &return_err);
+    void memcpyTruncation_d(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                            const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
+                            const bool &is_vT, const unsigned int &return_err);
+    void memcpyTruncation_f(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                            const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
+                            const bool &is_vT, const unsigned int &return_err);
+
+  }  // namespace linalg_internal
+}  // namespace cytnx
+
+#endif

--- a/src/linalg/linalg_internal_gpu/CMakeLists.txt
+++ b/src/linalg/linalg_internal_gpu/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources_local(cytnx
     cuTensordot_internal.hpp
     cuQuantumGeSvd_internal.hpp
     cuQuantumQr_internal.hpp
+    cudaMemcpyTruncation.hpp
 
     cuAbs_internal.cu
     cuAdd_internal.cu
@@ -66,4 +67,5 @@ target_sources_local(cytnx
     cuTensordot_internal.cu
     cuQuantumGeSvd_internal.cu
     cuQuantumQr_internal.cu
+    cudaMemcpyTruncation.cu
 )

--- a/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.cu
+++ b/src/linalg/linalg_internal_gpu/cuQuantumGeSvd_internal.cu
@@ -1225,27 +1225,6 @@ namespace cytnx {
       if (devWork) cudaFree(devWork);
       if (hostWork) free(hostWork);
       // printf("Free resource and exit.\n");
-
-      // Manually truncation
-      cytnx_uint64 Kdim = keepdim;
-      cytnx_uint64 nums = S.storage().size();
-      if (nums < keepdim) {
-        Kdim = nums;
-      }
-      cytnx_uint64 truc_dim = Kdim;
-      for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
-        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err) {
-          truc_dim--;
-        } else {
-          break;
-        }
-      }
-      if (truc_dim == 0) {
-        truc_dim = 1;
-      }
-      if (truc_dim != nums) {
-        memcpy_truncation_f(U, vT, S, terr, truc_dim, true, true, return_err);
-      }
     }
 
   #endif

--- a/src/linalg/linalg_internal_gpu/cudaMemcpyTruncation.cu
+++ b/src/linalg/linalg_internal_gpu/cudaMemcpyTruncation.cu
@@ -30,193 +30,274 @@ namespace cytnx {
 
 #ifdef UNI_GPU
     void cudaMemcpyTruncation_cd(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
-                                 const cytnx_uint64 &truc_dim, const bool &is_U, const bool &is_vT,
-                                 const unsigned int &return_err) {
-      Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
-      Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
-      Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
-      HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
-                                   (cytnx_double *)S._impl->storage()._impl->Mem,
-                                   truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
-      if (is_U) {
-        int src = 0;
-        int dest = 0;
-        // copy with strides.
-        for (int i = 0; i < U.shape()[0]; i++) {
-          HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_complex128 *)newU._impl->storage()._impl->Mem + src,
-                                       (cytnx_complex128 *)U._impl->storage()._impl->Mem + dest,
-                                       truc_dim * sizeof(cytnx_complex128),
-                                       cudaMemcpyDeviceToDevice));
-          src += truc_dim;
-          dest += U.shape()[1];
+                                 const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
+                                 const bool &is_vT, const unsigned int &return_err) {
+      // determine the truc_dim
+      cytnx_uint64 Kdim = keepdim;
+      cytnx_uint64 nums = S.storage().size();
+      if (nums < keepdim) {
+        Kdim = nums;
+      }
+      cytnx_uint64 truc_dim = Kdim;
+      for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
+        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err) {
+          truc_dim--;
+        } else {
+          break;
         }
-        U = newU;
       }
-      if (is_vT) {
-        // simply copy a new one dropping the tail.
-        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_complex128 *)newvT._impl->storage()._impl->Mem,
-                                     (cytnx_complex128 *)vT._impl->storage()._impl->Mem,
-                                     vT.shape()[1] * truc_dim * sizeof(cytnx_complex128),
-                                     cudaMemcpyDeviceToDevice));
-        vT = newvT;
+      if (truc_dim == 0) {
+        truc_dim = 1;
       }
-      if (return_err == 1) {
-        Tensor newterr = Tensor({1}, S.dtype(), S.device());
-        ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
-          ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
-        terr = newterr;
-      } else if (return_err) {
-        cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
-        Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
-        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
-                                     (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
-                                     discared_dim * sizeof(cytnx_double),
-                                     cudaMemcpyDeviceToDevice));
-        terr = newterr;
+      if (truc_dim != nums) {
+        // perform the manual truncation
+        Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+        Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+        Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
+        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
+                                     (cytnx_double *)S._impl->storage()._impl->Mem,
+                                     truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
+        if (is_U) {
+          int src = 0;
+          int dest = 0;
+          // copy with strides.
+          for (int i = 0; i < U.shape()[0]; i++) {
+            HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_complex128 *)newU._impl->storage()._impl->Mem + src,
+                                         (cytnx_complex128 *)U._impl->storage()._impl->Mem + dest,
+                                         truc_dim * sizeof(cytnx_complex128),
+                                         cudaMemcpyDeviceToDevice));
+            src += truc_dim;
+            dest += U.shape()[1];
+          }
+          U = newU;
+        }
+        if (is_vT) {
+          // simply copy a new one dropping the tail.
+          HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_complex128 *)newvT._impl->storage()._impl->Mem,
+                                       (cytnx_complex128 *)vT._impl->storage()._impl->Mem,
+                                       vT.shape()[1] * truc_dim * sizeof(cytnx_complex128),
+                                       cudaMemcpyDeviceToDevice));
+          vT = newvT;
+        }
+        if (return_err == 1) {
+          Tensor newterr = Tensor({1}, S.dtype(), S.device());
+          ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
+            ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
+          terr = newterr;
+        } else if (return_err) {
+          cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
+          Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
+          HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
+                                       (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
+                                       discared_dim * sizeof(cytnx_double),
+                                       cudaMemcpyDeviceToDevice));
+          terr = newterr;
+        }
+        S = newS;
       }
-      S = newS;
     }
 
     void cudaMemcpyTruncation_cf(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
-                                 const cytnx_uint64 &truc_dim, const bool &is_U, const bool &is_vT,
-                                 const unsigned int &return_err) {
-      Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
-      Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
-      Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
-      HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
-                                   (cytnx_double *)S._impl->storage()._impl->Mem,
-                                   truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
-      if (is_U) {
-        int src = 0;
-        int dest = 0;
-        // copy with strides.
-        for (int i = 0; i < U.shape()[0]; i++) {
-          HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_complex64 *)newU._impl->storage()._impl->Mem + src,
-                                       (cytnx_complex64 *)U._impl->storage()._impl->Mem + dest,
-                                       truc_dim * sizeof(cytnx_complex64),
-                                       cudaMemcpyDeviceToDevice));
-          src += truc_dim;
-          dest += U.shape()[1];
+                                 const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
+                                 const bool &is_vT, const unsigned int &return_err) {
+      // determine the truc_dim
+      cytnx_uint64 Kdim = keepdim;
+      cytnx_uint64 nums = S.storage().size();
+      if (nums < keepdim) {
+        Kdim = nums;
+      }
+      cytnx_uint64 truc_dim = Kdim;
+      for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
+        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err) {
+          truc_dim--;
+        } else {
+          break;
         }
-        U = newU;
       }
-      if (is_vT) {
-        // simply copy a new one dropping the tail.
-        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_complex64 *)newvT._impl->storage()._impl->Mem,
-                                     (cytnx_complex64 *)vT._impl->storage()._impl->Mem,
-                                     vT.shape()[1] * truc_dim * sizeof(cytnx_complex64),
-                                     cudaMemcpyDeviceToDevice));
-        vT = newvT;
+      if (truc_dim == 0) {
+        truc_dim = 1;
       }
-      if (return_err == 1) {
-        Tensor newterr = Tensor({1}, S.dtype(), S.device());
-        ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
-          ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
-        terr = newterr;
-      } else if (return_err) {
-        cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
-        Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
-        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
-                                     (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
-                                     discared_dim * sizeof(cytnx_double),
-                                     cudaMemcpyDeviceToDevice));
-        terr = newterr;
+      if (truc_dim != nums) {
+        // perform the manual truncation
+        Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+        Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+        Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
+        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
+                                     (cytnx_double *)S._impl->storage()._impl->Mem,
+                                     truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
+        if (is_U) {
+          int src = 0;
+          int dest = 0;
+          // copy with strides.
+          for (int i = 0; i < U.shape()[0]; i++) {
+            HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_complex64 *)newU._impl->storage()._impl->Mem + src,
+                                         (cytnx_complex64 *)U._impl->storage()._impl->Mem + dest,
+                                         truc_dim * sizeof(cytnx_complex64),
+                                         cudaMemcpyDeviceToDevice));
+            src += truc_dim;
+            dest += U.shape()[1];
+          }
+          U = newU;
+        }
+        if (is_vT) {
+          // simply copy a new one dropping the tail.
+          HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_complex64 *)newvT._impl->storage()._impl->Mem,
+                                       (cytnx_complex64 *)vT._impl->storage()._impl->Mem,
+                                       vT.shape()[1] * truc_dim * sizeof(cytnx_complex64),
+                                       cudaMemcpyDeviceToDevice));
+          vT = newvT;
+        }
+        if (return_err == 1) {
+          Tensor newterr = Tensor({1}, S.dtype(), S.device());
+          ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
+            ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
+          terr = newterr;
+        } else if (return_err) {
+          cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
+          Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
+          HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
+                                       (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
+                                       discared_dim * sizeof(cytnx_double),
+                                       cudaMemcpyDeviceToDevice));
+          terr = newterr;
+        }
+        S = newS;
       }
-      S = newS;
     }
 
     void cudaMemcpyTruncation_d(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
-                                const cytnx_uint64 &truc_dim, const bool &is_U, const bool &is_vT,
-                                const unsigned int &return_err) {
-      Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
-      Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
-      Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
-      HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
-                                   (cytnx_double *)S._impl->storage()._impl->Mem,
-                                   truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
-      if (is_U) {
-        int src = 0;
-        int dest = 0;
-        // copy with strides.
-        for (int i = 0; i < U.shape()[0]; i++) {
-          HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newU._impl->storage()._impl->Mem + src,
-                                       (cytnx_double *)U._impl->storage()._impl->Mem + dest,
-                                       truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
-          src += truc_dim;
-          dest += U.shape()[1];
+                                const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
+                                const bool &is_vT, const unsigned int &return_err) {
+      // determine the truc_dim
+      cytnx_uint64 Kdim = keepdim;
+      cytnx_uint64 nums = S.storage().size();
+      if (nums < keepdim) {
+        Kdim = nums;
+      }
+      cytnx_uint64 truc_dim = Kdim;
+      for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
+        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err) {
+          truc_dim--;
+        } else {
+          break;
         }
-        U = newU;
       }
-      if (is_vT) {
-        // simply copy a new one dropping the tail.
-        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newvT._impl->storage()._impl->Mem,
-                                     (cytnx_double *)vT._impl->storage()._impl->Mem,
-                                     vT.shape()[1] * truc_dim * sizeof(cytnx_double),
-                                     cudaMemcpyDeviceToDevice));
-        vT = newvT;
+      if (truc_dim == 0) {
+        truc_dim = 1;
       }
-      if (return_err == 1) {
-        Tensor newterr = Tensor({1}, S.dtype(), S.device());
-        ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
-          ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
-        terr = newterr;
-      } else if (return_err) {
-        cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
-        Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
-        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
-                                     (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
-                                     discared_dim * sizeof(cytnx_double),
-                                     cudaMemcpyDeviceToDevice));
-        terr = newterr;
+      if (truc_dim != nums) {
+        // perform the manual truncation
+        Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+        Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+        Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
+        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
+                                     (cytnx_double *)S._impl->storage()._impl->Mem,
+                                     truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
+        if (is_U) {
+          int src = 0;
+          int dest = 0;
+          // copy with strides.
+          for (int i = 0; i < U.shape()[0]; i++) {
+            HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newU._impl->storage()._impl->Mem + src,
+                                         (cytnx_double *)U._impl->storage()._impl->Mem + dest,
+                                         truc_dim * sizeof(cytnx_double),
+                                         cudaMemcpyDeviceToDevice));
+            src += truc_dim;
+            dest += U.shape()[1];
+          }
+          U = newU;
+        }
+        if (is_vT) {
+          // simply copy a new one dropping the tail.
+          HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newvT._impl->storage()._impl->Mem,
+                                       (cytnx_double *)vT._impl->storage()._impl->Mem,
+                                       vT.shape()[1] * truc_dim * sizeof(cytnx_double),
+                                       cudaMemcpyDeviceToDevice));
+          vT = newvT;
+        }
+        if (return_err == 1) {
+          Tensor newterr = Tensor({1}, S.dtype(), S.device());
+          ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
+            ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
+          terr = newterr;
+        } else if (return_err) {
+          cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
+          Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
+          HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
+                                       (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
+                                       discared_dim * sizeof(cytnx_double),
+                                       cudaMemcpyDeviceToDevice));
+          terr = newterr;
+        }
+        S = newS;
       }
-      S = newS;
     }
 
     void cudaMemcpyTruncation_f(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
-                                const cytnx_uint64 &truc_dim, const bool &is_U, const bool &is_vT,
-                                const unsigned int &return_err) {
-      Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
-      Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
-      Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
-      HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
-                                   (cytnx_double *)S._impl->storage()._impl->Mem,
-                                   truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
-      if (is_U) {
-        int src = 0;
-        int dest = 0;
-        // copy with strides.
-        for (int i = 0; i < U.shape()[0]; i++) {
-          HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_float *)newU._impl->storage()._impl->Mem + src,
-                                       (cytnx_float *)U._impl->storage()._impl->Mem + dest,
-                                       truc_dim * sizeof(cytnx_float), cudaMemcpyDeviceToDevice));
-          src += truc_dim;
-          dest += U.shape()[1];
+                                const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
+                                const bool &is_vT, const unsigned int &return_err) {
+      // determine the truc_dim
+      cytnx_uint64 Kdim = keepdim;
+      cytnx_uint64 nums = S.storage().size();
+      if (nums < keepdim) {
+        Kdim = nums;
+      }
+      cytnx_uint64 truc_dim = Kdim;
+      for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
+        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err) {
+          truc_dim--;
+        } else {
+          break;
         }
-        U = newU;
       }
-      if (is_vT) {
-        // simply copy a new one dropping the tail.
-        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_float *)newvT._impl->storage()._impl->Mem,
-                                     (cytnx_float *)vT._impl->storage()._impl->Mem,
-                                     vT.shape()[1] * truc_dim * sizeof(cytnx_float),
-                                     cudaMemcpyDeviceToDevice));
-        vT = newvT;
+      if (truc_dim == 0) {
+        truc_dim = 1;
       }
-      if (return_err == 1) {
-        Tensor newterr = Tensor({1}, S.dtype(), S.device());
-        ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
-          ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
-        terr = newterr;
-      } else if (return_err) {
-        cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
-        Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
-        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
-                                     (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
-                                     discared_dim * sizeof(cytnx_double),
-                                     cudaMemcpyDeviceToDevice));
-        terr = newterr;
+      if (truc_dim != nums) {
+        // perform the manual truncation
+        Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+        Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+        Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
+        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
+                                     (cytnx_double *)S._impl->storage()._impl->Mem,
+                                     truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
+        if (is_U) {
+          int src = 0;
+          int dest = 0;
+          // copy with strides.
+          for (int i = 0; i < U.shape()[0]; i++) {
+            HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_float *)newU._impl->storage()._impl->Mem + src,
+                                         (cytnx_float *)U._impl->storage()._impl->Mem + dest,
+                                         truc_dim * sizeof(cytnx_float), cudaMemcpyDeviceToDevice));
+            src += truc_dim;
+            dest += U.shape()[1];
+          }
+          U = newU;
+        }
+        if (is_vT) {
+          // simply copy a new one dropping the tail.
+          HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_float *)newvT._impl->storage()._impl->Mem,
+                                       (cytnx_float *)vT._impl->storage()._impl->Mem,
+                                       vT.shape()[1] * truc_dim * sizeof(cytnx_float),
+                                       cudaMemcpyDeviceToDevice));
+          vT = newvT;
+        }
+        if (return_err == 1) {
+          Tensor newterr = Tensor({1}, S.dtype(), S.device());
+          ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
+            ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
+          terr = newterr;
+        } else if (return_err) {
+          cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
+          Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
+          HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
+                                       (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
+                                       discared_dim * sizeof(cytnx_double),
+                                       cudaMemcpyDeviceToDevice));
+          terr = newterr;
+        }
+        S = newS;
       }
-      S = newS;
     }
 #endif
   }  // namespace linalg_internal

--- a/src/linalg/linalg_internal_gpu/cudaMemcpyTruncation.cu
+++ b/src/linalg/linalg_internal_gpu/cudaMemcpyTruncation.cu
@@ -51,13 +51,14 @@ namespace cytnx {
       }
       if (truc_dim != nums) {
         // perform the manual truncation
-        Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
-        Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+
         Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
         HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
                                      (cytnx_double *)S._impl->storage()._impl->Mem,
                                      truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
         if (is_U) {
+          Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+
           int src = 0;
           int dest = 0;
           // copy with strides.
@@ -72,6 +73,7 @@ namespace cytnx {
           U = newU;
         }
         if (is_vT) {
+          Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
           // simply copy a new one dropping the tail.
           HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_complex128 *)newvT._impl->storage()._impl->Mem,
                                        (cytnx_complex128 *)vT._impl->storage()._impl->Mem,
@@ -119,13 +121,14 @@ namespace cytnx {
       }
       if (truc_dim != nums) {
         // perform the manual truncation
-        Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
-        Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+
         Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
         HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
                                      (cytnx_double *)S._impl->storage()._impl->Mem,
                                      truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
         if (is_U) {
+          Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+
           int src = 0;
           int dest = 0;
           // copy with strides.
@@ -140,6 +143,7 @@ namespace cytnx {
           U = newU;
         }
         if (is_vT) {
+          Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
           // simply copy a new one dropping the tail.
           HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_complex64 *)newvT._impl->storage()._impl->Mem,
                                        (cytnx_complex64 *)vT._impl->storage()._impl->Mem,
@@ -187,13 +191,14 @@ namespace cytnx {
       }
       if (truc_dim != nums) {
         // perform the manual truncation
-        Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
-        Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+
         Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
         HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
                                      (cytnx_double *)S._impl->storage()._impl->Mem,
                                      truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
         if (is_U) {
+          Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+
           int src = 0;
           int dest = 0;
           // copy with strides.
@@ -208,6 +213,7 @@ namespace cytnx {
           U = newU;
         }
         if (is_vT) {
+          Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
           // simply copy a new one dropping the tail.
           HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newvT._impl->storage()._impl->Mem,
                                        (cytnx_double *)vT._impl->storage()._impl->Mem,
@@ -255,13 +261,14 @@ namespace cytnx {
       }
       if (truc_dim != nums) {
         // perform the manual truncation
-        Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
-        Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+
         Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
         HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
                                      (cytnx_double *)S._impl->storage()._impl->Mem,
                                      truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
         if (is_U) {
+          Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+
           int src = 0;
           int dest = 0;
           // copy with strides.
@@ -275,6 +282,7 @@ namespace cytnx {
           U = newU;
         }
         if (is_vT) {
+          Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
           // simply copy a new one dropping the tail.
           HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_float *)newvT._impl->storage()._impl->Mem,
                                        (cytnx_float *)vT._impl->storage()._impl->Mem,

--- a/src/linalg/linalg_internal_gpu/cudaMemcpyTruncation.cu
+++ b/src/linalg/linalg_internal_gpu/cudaMemcpyTruncation.cu
@@ -1,0 +1,223 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <vector>
+
+#include "cudaMemcpyTruncation.hpp"
+
+#ifdef UNI_GPU
+  #define HANDLE_ERROR(x)                                                           \
+    {                                                                               \
+      const auto err = x;                                                           \
+      if (err != CUTENSORNET_STATUS_SUCCESS) {                                      \
+        printf("Error: %s in line %d\n", cutensornetGetErrorString(err), __LINE__); \
+        fflush(stdout);                                                             \
+      }                                                                             \
+    };
+
+  #define HANDLE_CUDA_ERROR(x)                                                    \
+    {                                                                             \
+      const auto err = x;                                                         \
+      if (err != cudaSuccess) {                                                   \
+        printf("CUDA Error: %s in line %d\n", cudaGetErrorString(err), __LINE__); \
+        fflush(stdout);                                                           \
+      }                                                                           \
+    };
+#endif
+
+namespace cytnx {
+  namespace linalg_internal {
+
+#ifdef UNI_GPU
+    void cudaMemcpyTruncation_cd(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                                 const cytnx_uint64 &truc_dim, const bool &is_U, const bool &is_vT,
+                                 const unsigned int &return_err) {
+      Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+      Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+      Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
+      HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
+                                   (cytnx_double *)S._impl->storage()._impl->Mem,
+                                   truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
+      if (is_U) {
+        int src = 0;
+        int dest = 0;
+        // copy with strides.
+        for (int i = 0; i < U.shape()[0]; i++) {
+          HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_complex128 *)newU._impl->storage()._impl->Mem + src,
+                                       (cytnx_complex128 *)U._impl->storage()._impl->Mem + dest,
+                                       truc_dim * sizeof(cytnx_complex128),
+                                       cudaMemcpyDeviceToDevice));
+          src += truc_dim;
+          dest += U.shape()[1];
+        }
+        U = newU;
+      }
+      if (is_vT) {
+        // simply copy a new one dropping the tail.
+        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_complex128 *)newvT._impl->storage()._impl->Mem,
+                                     (cytnx_complex128 *)vT._impl->storage()._impl->Mem,
+                                     vT.shape()[1] * truc_dim * sizeof(cytnx_complex128),
+                                     cudaMemcpyDeviceToDevice));
+        vT = newvT;
+      }
+      if (return_err == 1) {
+        Tensor newterr = Tensor({1}, S.dtype(), S.device());
+        ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
+          ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
+        terr = newterr;
+      } else if (return_err) {
+        cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
+        Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
+        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
+                                     (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
+                                     discared_dim * sizeof(cytnx_double),
+                                     cudaMemcpyDeviceToDevice));
+        terr = newterr;
+      }
+      S = newS;
+    }
+
+    void cudaMemcpyTruncation_cf(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                                 const cytnx_uint64 &truc_dim, const bool &is_U, const bool &is_vT,
+                                 const unsigned int &return_err) {
+      Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+      Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+      Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
+      HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
+                                   (cytnx_double *)S._impl->storage()._impl->Mem,
+                                   truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
+      if (is_U) {
+        int src = 0;
+        int dest = 0;
+        // copy with strides.
+        for (int i = 0; i < U.shape()[0]; i++) {
+          HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_complex64 *)newU._impl->storage()._impl->Mem + src,
+                                       (cytnx_complex64 *)U._impl->storage()._impl->Mem + dest,
+                                       truc_dim * sizeof(cytnx_complex64),
+                                       cudaMemcpyDeviceToDevice));
+          src += truc_dim;
+          dest += U.shape()[1];
+        }
+        U = newU;
+      }
+      if (is_vT) {
+        // simply copy a new one dropping the tail.
+        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_complex64 *)newvT._impl->storage()._impl->Mem,
+                                     (cytnx_complex64 *)vT._impl->storage()._impl->Mem,
+                                     vT.shape()[1] * truc_dim * sizeof(cytnx_complex64),
+                                     cudaMemcpyDeviceToDevice));
+        vT = newvT;
+      }
+      if (return_err == 1) {
+        Tensor newterr = Tensor({1}, S.dtype(), S.device());
+        ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
+          ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
+        terr = newterr;
+      } else if (return_err) {
+        cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
+        Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
+        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
+                                     (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
+                                     discared_dim * sizeof(cytnx_double),
+                                     cudaMemcpyDeviceToDevice));
+        terr = newterr;
+      }
+      S = newS;
+    }
+
+    void cudaMemcpyTruncation_d(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                                const cytnx_uint64 &truc_dim, const bool &is_U, const bool &is_vT,
+                                const unsigned int &return_err) {
+      Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+      Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+      Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
+      HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
+                                   (cytnx_double *)S._impl->storage()._impl->Mem,
+                                   truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
+      if (is_U) {
+        int src = 0;
+        int dest = 0;
+        // copy with strides.
+        for (int i = 0; i < U.shape()[0]; i++) {
+          HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newU._impl->storage()._impl->Mem + src,
+                                       (cytnx_double *)U._impl->storage()._impl->Mem + dest,
+                                       truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
+          src += truc_dim;
+          dest += U.shape()[1];
+        }
+        U = newU;
+      }
+      if (is_vT) {
+        // simply copy a new one dropping the tail.
+        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newvT._impl->storage()._impl->Mem,
+                                     (cytnx_double *)vT._impl->storage()._impl->Mem,
+                                     vT.shape()[1] * truc_dim * sizeof(cytnx_double),
+                                     cudaMemcpyDeviceToDevice));
+        vT = newvT;
+      }
+      if (return_err == 1) {
+        Tensor newterr = Tensor({1}, S.dtype(), S.device());
+        ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
+          ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
+        terr = newterr;
+      } else if (return_err) {
+        cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
+        Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
+        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
+                                     (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
+                                     discared_dim * sizeof(cytnx_double),
+                                     cudaMemcpyDeviceToDevice));
+        terr = newterr;
+      }
+      S = newS;
+    }
+
+    void cudaMemcpyTruncation_f(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                                const cytnx_uint64 &truc_dim, const bool &is_U, const bool &is_vT,
+                                const unsigned int &return_err) {
+      Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+      Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+      Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
+      HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
+                                   (cytnx_double *)S._impl->storage()._impl->Mem,
+                                   truc_dim * sizeof(cytnx_double), cudaMemcpyDeviceToDevice));
+      if (is_U) {
+        int src = 0;
+        int dest = 0;
+        // copy with strides.
+        for (int i = 0; i < U.shape()[0]; i++) {
+          HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_float *)newU._impl->storage()._impl->Mem + src,
+                                       (cytnx_float *)U._impl->storage()._impl->Mem + dest,
+                                       truc_dim * sizeof(cytnx_float), cudaMemcpyDeviceToDevice));
+          src += truc_dim;
+          dest += U.shape()[1];
+        }
+        U = newU;
+      }
+      if (is_vT) {
+        // simply copy a new one dropping the tail.
+        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_float *)newvT._impl->storage()._impl->Mem,
+                                     (cytnx_float *)vT._impl->storage()._impl->Mem,
+                                     vT.shape()[1] * truc_dim * sizeof(cytnx_float),
+                                     cudaMemcpyDeviceToDevice));
+        vT = newvT;
+      }
+      if (return_err == 1) {
+        Tensor newterr = Tensor({1}, S.dtype(), S.device());
+        ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
+          ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
+        terr = newterr;
+      } else if (return_err) {
+        cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
+        Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
+        HANDLE_CUDA_ERROR(cudaMemcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
+                                     (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
+                                     discared_dim * sizeof(cytnx_double),
+                                     cudaMemcpyDeviceToDevice));
+        terr = newterr;
+      }
+      S = newS;
+    }
+#endif
+  }  // namespace linalg_internal
+}  // namespace cytnx

--- a/src/linalg/linalg_internal_gpu/cudaMemcpyTruncation.hpp
+++ b/src/linalg/linalg_internal_gpu/cudaMemcpyTruncation.hpp
@@ -13,17 +13,17 @@ namespace cytnx {
 #ifdef UNI_GPU
     /// cuSvd
     void cudaMemcpyTruncation_cd(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
-                                 const cytnx_uint64 &truc_dim, const bool &is_U, const bool &is_vT,
-                                 const unsigned int &return_err);
+                                 const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
+                                 const bool &is_vT, const unsigned int &return_err);
     void cudaMemcpyTruncation_cf(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
-                                 const cytnx_uint64 &truc_dim, const bool &is_U, const bool &is_vT,
-                                 const unsigned int &return_err);
+                                 const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
+                                 const bool &is_vT, const unsigned int &return_err);
     void cudaMemcpyTruncation_d(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
-                                const cytnx_uint64 &truc_dim, const bool &is_U, const bool &is_vT,
-                                const unsigned int &return_err);
+                                const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
+                                const bool &is_vT, const unsigned int &return_err);
     void cudaMemcpyTruncation_f(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
-                                const cytnx_uint64 &truc_dim, const bool &is_U, const bool &is_vT,
-                                const unsigned int &return_err);
+                                const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
+                                const bool &is_vT, const unsigned int &return_err);
 #endif
 
   }  // namespace linalg_internal

--- a/src/linalg/linalg_internal_gpu/cudaMemcpyTruncation.hpp
+++ b/src/linalg/linalg_internal_gpu/cudaMemcpyTruncation.hpp
@@ -1,0 +1,32 @@
+#ifndef __cudaMemcpyTruncation_internal_H__
+#define __cudaMemcpyTruncation_internal_H__
+
+#include <iostream>
+#include <vector>
+#include "Type.hpp"
+#include "cytnx_error.hpp"
+#include "linalg/linalg_internal_interface.hpp"
+
+namespace cytnx {
+  namespace linalg_internal {
+
+#ifdef UNI_GPU
+    /// cuSvd
+    void cudaMemcpyTruncation_cd(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                                 const cytnx_uint64 &truc_dim, const bool &is_U, const bool &is_vT,
+                                 const unsigned int &return_err);
+    void cudaMemcpyTruncation_cf(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                                 const cytnx_uint64 &truc_dim, const bool &is_U, const bool &is_vT,
+                                 const unsigned int &return_err);
+    void cudaMemcpyTruncation_d(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                                const cytnx_uint64 &truc_dim, const bool &is_U, const bool &is_vT,
+                                const unsigned int &return_err);
+    void cudaMemcpyTruncation_f(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                                const cytnx_uint64 &truc_dim, const bool &is_U, const bool &is_vT,
+                                const unsigned int &return_err);
+#endif
+
+  }  // namespace linalg_internal
+}  // namespace cytnx
+
+#endif

--- a/src/linalg/linalg_internal_interface.cpp
+++ b/src/linalg/linalg_internal_interface.cpp
@@ -1367,6 +1367,14 @@ namespace cytnx {
       cuOuter_ii[Type.Bool][Type.Int16] = cuOuter_internal_bti16;
       cuOuter_ii[Type.Bool][Type.Bool] = cuOuter_internal_btb;
 
+      //========Helper function for svd_truncate on cuda========
+      cudaMemcpyTruncation_ii = vector<cudaMemcpyTruncation_oii>(N_Type);
+
+      cudaMemcpyTruncation_ii[Type.ComplexDouble] = cudaMemcpyTruncation_cd;
+      cudaMemcpyTruncation_ii[Type.ComplexFloat] = cudaMemcpyTruncation_cf;
+      cudaMemcpyTruncation_ii[Type.Double] = cudaMemcpyTruncation_d;
+      cudaMemcpyTruncation_ii[Type.Float] = cudaMemcpyTruncation_f;
+
   #ifdef UNI_CUQUANTUM
       cuQuantumGeSvd_ii = vector<cuQuantumGeSvd_oii>(N_Type);
       cuQuantumGeSvd_ii[Type.ComplexDouble] = cuQuantumGeSvd_internal_cd;

--- a/src/linalg/linalg_internal_interface.cpp
+++ b/src/linalg/linalg_internal_interface.cpp
@@ -782,6 +782,14 @@ namespace cytnx {
       Gemm_Batch_ii[Type.Double] = Gemm_Batch_internal_d;
       Gemm_Batch_ii[Type.Float] = Gemm_Batch_internal_f;
 
+      //========Helper function for svd_truncate on cuda========
+      memcpyTruncation_ii = vector<memcpyTruncation_oii>(N_Type);
+
+      memcpyTruncation_ii[Type.ComplexDouble] = memcpyTruncation_cd;
+      memcpyTruncation_ii[Type.ComplexFloat] = memcpyTruncation_cf;
+      memcpyTruncation_ii[Type.Double] = memcpyTruncation_d;
+      memcpyTruncation_ii[Type.Float] = memcpyTruncation_f;
+
 #ifdef UNI_GPU
       cuAri_ii = vector<vector<Arithmeticfunc_oii>>(N_Type, vector<Arithmeticfunc_oii>(N_Type));
 

--- a/src/linalg/linalg_internal_interface.hpp
+++ b/src/linalg/linalg_internal_interface.hpp
@@ -38,6 +38,8 @@
 #include "linalg/linalg_internal_cpu/Gemm_Batch_internal.hpp"
 #include "linalg/linalg_internal_cpu/Trace_internal.hpp"
 
+#include "linalg/linalg_internal_cpu/memcpyTruncation.hpp"
+
 #ifdef UNI_GPU
   #include "linalg/linalg_internal_gpu/cuArithmetic_internal.hpp"
   #include "linalg/linalg_internal_gpu/cuAbs_internal.hpp"
@@ -187,6 +189,12 @@ namespace cytnx {
     typedef void (*Tensordotfunc_oii)(Tensor &out, const Tensor &Lin, const Tensor &Rin,
                                       const std::vector<cytnx_uint64> &idxl,
                                       const std::vector<cytnx_uint64> &idxr);
+
+    typedef void (*memcpyTruncation_oii)(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                                         const cytnx_uint64 &keepdim, const double &err,
+                                         const bool &is_U, const bool &is_vT,
+                                         const unsigned int &return_err);
+
 #ifdef UNI_GPU
 
     typedef void (*cudaMemcpyTruncation_oii)(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
@@ -241,6 +249,9 @@ namespace cytnx {
 
       std::vector<axpy_oii> axpy_ii;
       std::vector<ger_oii> ger_ii;
+
+      std::vector<memcpyTruncation_oii> memcpyTruncation_ii;
+
       int mkl_code;
 
 #ifdef UNI_GPU

--- a/src/linalg/linalg_internal_interface.hpp
+++ b/src/linalg/linalg_internal_interface.hpp
@@ -190,8 +190,9 @@ namespace cytnx {
 #ifdef UNI_GPU
 
     typedef void (*cudaMemcpyTruncation_oii)(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
-                                             const cytnx_uint64 &truc_dim, const bool &is_U,
-                                             const bool &is_vT, const unsigned int &return_err);
+                                             const cytnx_uint64 &keepdim, const double &err,
+                                             const bool &is_U, const bool &is_vT,
+                                             const unsigned int &return_err);
 
   #ifdef UNI_CUQUANTUM
     typedef void (*cuQuantumGeSvd_oii)(const Tensor &Tin, const cytnx_uint64 &keepdim,

--- a/src/linalg/linalg_internal_interface.hpp
+++ b/src/linalg/linalg_internal_interface.hpp
@@ -63,6 +63,9 @@
   #include "linalg/linalg_internal_gpu/cuSum_internal.hpp"
   #include "linalg/linalg_internal_gpu/cuMaxMin_internal.hpp"
   #include "linalg/linalg_internal_gpu/cuKron_internal.hpp"
+
+  #include "linalg/linalg_internal_gpu/cudaMemcpyTruncation.hpp"
+
   #ifdef UNI_CUTENSOR
     #include "linalg/linalg_internal_gpu/cuTensordot_internal.hpp"
   #endif
@@ -185,6 +188,11 @@ namespace cytnx {
                                       const std::vector<cytnx_uint64> &idxl,
                                       const std::vector<cytnx_uint64> &idxr);
 #ifdef UNI_GPU
+
+    typedef void (*cudaMemcpyTruncation_oii)(Tensor &U, Tensor &vT, Tensor &S, Tensor &terr,
+                                             const cytnx_uint64 &truc_dim, const bool &is_U,
+                                             const bool &is_vT, const unsigned int &return_err);
+
   #ifdef UNI_CUQUANTUM
     typedef void (*cuQuantumGeSvd_oii)(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                        const double &err, const unsigned int &return_err, Tensor &U,
@@ -260,6 +268,8 @@ namespace cytnx {
       std::vector<MaxMinfunc_oii> cuSum_ii;
       std::vector<std::vector<Kronfunc_oii>> cuKron_ii;
       std::vector<Tensordotfunc_oii> cuTensordot_ii;
+
+      std::vector<cudaMemcpyTruncation_oii> cudaMemcpyTruncation_ii;
 
   #ifdef UNI_CUQUANTUM
       std::vector<cuQuantumGeSvd_oii> cuQuantumGeSvd_ii;

--- a/tests/gpu/linalg_test/linalg_test.cpp
+++ b/tests/gpu/linalg_test/linalg_test.cpp
@@ -94,6 +94,148 @@ TEST_F(linalg_Test, gpu_BkUt_expM) {
     }
 }
 
+TEST_F(linalg_Test, gpu_DenseUt_Gesvd_truncate) {
+  std::vector<UniTensor> full = linalg::Gesvd_truncate(svd_T_dense, 999, 0, true, true, 999);
+  EXPECT_EQ(full[0].shape()[0], 11);
+
+  EXPECT_EQ(full[1].shape()[0], 11);
+  EXPECT_EQ(full[1].shape()[1], 11);
+
+  EXPECT_EQ(full[2].shape()[0], 11);
+  EXPECT_EQ(full[2].shape()[1], 13);
+
+  std::vector<UniTensor> truc1 = linalg::Gesvd_truncate(svd_T_dense, 5, 0, true, true, 999);
+
+  EXPECT_EQ(truc1[0].shape()[0], 5);
+
+  EXPECT_EQ(truc1[1].shape()[0], 11);
+  EXPECT_EQ(truc1[1].shape()[1], 5);
+
+  EXPECT_EQ(truc1[2].shape()[0], 5);
+  EXPECT_EQ(truc1[2].shape()[1], 13);
+
+  EXPECT_EQ(truc1[3].shape()[0], 6);
+
+  for (size_t i = 0; i < 5; i++) {
+    EXPECT_EQ(full[0].at({i}), truc1[0].at({i}));
+  }
+  for (size_t i = 0; i < 6; i++) {
+    EXPECT_EQ(full[0].at({i + 5}), truc1[3].at({i}));
+  }
+
+  for (size_t i = 0; i < 11; i++) {
+    for (size_t j = 0; j < 5; j++) {
+      EXPECT_EQ(full[1].at({i, j}), truc1[1].at({i, j}));
+    }
+  }
+  for (size_t i = 0; i < 5; i++) {
+    for (size_t j = 0; j < 13; j++) {
+      EXPECT_EQ(full[2].at({i, j}), truc1[2].at({i, j}));
+    }
+  }
+
+  std::vector<UniTensor> truc2 = linalg::Gesvd_truncate(svd_T_dense, 5, 1e-12, true, true, 999);
+
+  EXPECT_EQ(truc2[0].shape()[0], 2);
+
+  EXPECT_EQ(truc2[1].shape()[0], 11);
+  EXPECT_EQ(truc2[1].shape()[1], 2);
+
+  EXPECT_EQ(truc2[2].shape()[0], 2);
+  EXPECT_EQ(truc2[2].shape()[1], 13);
+
+  EXPECT_EQ(truc2[3].shape()[0], 9);
+
+  for (size_t i = 0; i < 2; i++) {
+    EXPECT_EQ(full[0].at({i}), truc2[0].at({i}));
+  }
+  for (size_t i = 0; i < 9; i++) {
+    EXPECT_EQ(full[0].at({i + 2}), truc2[3].at({i}));
+  }
+
+  for (size_t i = 0; i < 11; i++) {
+    for (size_t j = 0; j < 2; j++) {
+      EXPECT_EQ(full[1].at({i, j}), truc2[1].at({i, j}));
+    }
+  }
+  for (size_t i = 0; i < 2; i++) {
+    for (size_t j = 0; j < 13; j++) {
+      EXPECT_EQ(full[2].at({i, j}), truc2[2].at({i, j}));
+    }
+  }
+}
+
+TEST_F(linalg_Test, gpu_DenseUt_Svd_truncate) {
+  std::vector<UniTensor> full = linalg::Svd_truncate(svd_T_dense, 999, 0, true, 999);
+  EXPECT_EQ(full[0].shape()[0], 11);
+
+  EXPECT_EQ(full[1].shape()[0], 11);
+  EXPECT_EQ(full[1].shape()[1], 11);
+
+  EXPECT_EQ(full[2].shape()[0], 11);
+  EXPECT_EQ(full[2].shape()[1], 13);
+
+  std::vector<UniTensor> truc1 = linalg::Svd_truncate(svd_T_dense, 5, 0, true, 999);
+
+  EXPECT_EQ(truc1[0].shape()[0], 5);
+
+  EXPECT_EQ(truc1[1].shape()[0], 11);
+  EXPECT_EQ(truc1[1].shape()[1], 5);
+
+  EXPECT_EQ(truc1[2].shape()[0], 5);
+  EXPECT_EQ(truc1[2].shape()[1], 13);
+
+  EXPECT_EQ(truc1[3].shape()[0], 6);
+
+  for (size_t i = 0; i < 5; i++) {
+    EXPECT_EQ(full[0].at({i}), truc1[0].at({i}));
+  }
+  for (size_t i = 0; i < 6; i++) {
+    EXPECT_EQ(full[0].at({i + 5}), truc1[3].at({i}));
+  }
+
+  for (size_t i = 0; i < 11; i++) {
+    for (size_t j = 0; j < 5; j++) {
+      EXPECT_EQ(full[1].at({i, j}), truc1[1].at({i, j}));
+    }
+  }
+  for (size_t i = 0; i < 5; i++) {
+    for (size_t j = 0; j < 13; j++) {
+      EXPECT_EQ(full[2].at({i, j}), truc1[2].at({i, j}));
+    }
+  }
+
+  std::vector<UniTensor> truc2 = linalg::Svd_truncate(svd_T_dense, 5, 1e-9, true, 999);
+
+  EXPECT_EQ(truc2[0].shape()[0], 2);
+
+  EXPECT_EQ(truc2[1].shape()[0], 11);
+  EXPECT_EQ(truc2[1].shape()[1], 2);
+
+  EXPECT_EQ(truc2[2].shape()[0], 2);
+  EXPECT_EQ(truc2[2].shape()[1], 13);
+
+  EXPECT_EQ(truc2[3].shape()[0], 9);
+
+  for (size_t i = 0; i < 2; i++) {
+    EXPECT_EQ(full[0].at({i}), truc2[0].at({i}));
+  }
+  for (size_t i = 0; i < 9; i++) {
+    EXPECT_EQ(full[0].at({i + 2}), truc2[3].at({i}));
+  }
+
+  for (size_t i = 0; i < 11; i++) {
+    for (size_t j = 0; j < 2; j++) {
+      EXPECT_EQ(full[1].at({i, j}), truc2[1].at({i, j}));
+    }
+  }
+  for (size_t i = 0; i < 2; i++) {
+    for (size_t j = 0; j < 13; j++) {
+      EXPECT_EQ(full[2].at({i, j}), truc2[2].at({i, j}));
+    }
+  }
+}
+
 TEST_F(linalg_Test, gpu_DenseUt_Pow) {
   UniTensor Ht = UniTensor(A);
   auto res = linalg::Pow(Ht, 3);

--- a/tests/gpu/linalg_test/linalg_test.h
+++ b/tests/gpu/linalg_test/linalg_test.h
@@ -33,6 +33,10 @@ class linalg_Test : public ::testing::Test {
   UniTensor svd_T = UniTensor({svd_I, svd_J, svd_K, svd_L}, {"a", "b", "c", "d"}, 1, Type.Double,
                               Device.cuda, false)
                       .to(cytnx::Device.cuda);
+
+  UniTensor svd_T_dense =
+    UniTensor(arange(0, 11 * 13, 1).reshape(11, 13)).astype(Type.ComplexDouble).to(Device.cuda);
+
   Tensor svd_Sans;
   //==================== Lanczos_Gnd_Ut ===================
   Tensor A = Tensor::Load(data_dir + "Lanczos_Gnd/lan_block_A.cytn").to(cytnx::Device.cuda);

--- a/tests/linalg_test/linalg_test.cpp
+++ b/tests/linalg_test/linalg_test.cpp
@@ -90,6 +90,148 @@ TEST_F(linalg_Test, BkUt_expM) {
     }
 }
 
+TEST_F(linalg_Test, DenseUt_Gesvd_truncate) {
+  std::vector<UniTensor> full = linalg::Gesvd_truncate(svd_T_dense, 999, 0, true, true, 999);
+  EXPECT_EQ(full[0].shape()[0], 11);
+
+  EXPECT_EQ(full[1].shape()[0], 11);
+  EXPECT_EQ(full[1].shape()[1], 11);
+
+  EXPECT_EQ(full[2].shape()[0], 11);
+  EXPECT_EQ(full[2].shape()[1], 13);
+
+  std::vector<UniTensor> truc1 = linalg::Gesvd_truncate(svd_T_dense, 5, 0, true, true, 999);
+
+  EXPECT_EQ(truc1[0].shape()[0], 5);
+
+  EXPECT_EQ(truc1[1].shape()[0], 11);
+  EXPECT_EQ(truc1[1].shape()[1], 5);
+
+  EXPECT_EQ(truc1[2].shape()[0], 5);
+  EXPECT_EQ(truc1[2].shape()[1], 13);
+
+  EXPECT_EQ(truc1[3].shape()[0], 6);
+
+  for (size_t i = 0; i < 5; i++) {
+    EXPECT_EQ(full[0].at({i}), truc1[0].at({i}));
+  }
+  for (size_t i = 0; i < 6; i++) {
+    EXPECT_EQ(full[0].at({i + 5}), truc1[3].at({i}));
+  }
+
+  for (size_t i = 0; i < 11; i++) {
+    for (size_t j = 0; j < 5; j++) {
+      EXPECT_EQ(full[1].at({i, j}), truc1[1].at({i, j}));
+    }
+  }
+  for (size_t i = 0; i < 5; i++) {
+    for (size_t j = 0; j < 13; j++) {
+      EXPECT_EQ(full[2].at({i, j}), truc1[2].at({i, j}));
+    }
+  }
+
+  std::vector<UniTensor> truc2 = linalg::Gesvd_truncate(svd_T_dense, 5, 1e-12, true, true, 999);
+
+  EXPECT_EQ(truc2[0].shape()[0], 2);
+
+  EXPECT_EQ(truc2[1].shape()[0], 11);
+  EXPECT_EQ(truc2[1].shape()[1], 2);
+
+  EXPECT_EQ(truc2[2].shape()[0], 2);
+  EXPECT_EQ(truc2[2].shape()[1], 13);
+
+  EXPECT_EQ(truc2[3].shape()[0], 9);
+
+  for (size_t i = 0; i < 2; i++) {
+    EXPECT_EQ(full[0].at({i}), truc2[0].at({i}));
+  }
+  for (size_t i = 0; i < 9; i++) {
+    EXPECT_EQ(full[0].at({i + 2}), truc2[3].at({i}));
+  }
+
+  for (size_t i = 0; i < 11; i++) {
+    for (size_t j = 0; j < 2; j++) {
+      EXPECT_EQ(full[1].at({i, j}), truc2[1].at({i, j}));
+    }
+  }
+  for (size_t i = 0; i < 2; i++) {
+    for (size_t j = 0; j < 13; j++) {
+      EXPECT_EQ(full[2].at({i, j}), truc2[2].at({i, j}));
+    }
+  }
+}
+
+TEST_F(linalg_Test, DenseUt_Svd_truncate) {
+  std::vector<UniTensor> full = linalg::Svd_truncate(svd_T_dense, 999, 0, true, 999);
+  EXPECT_EQ(full[0].shape()[0], 11);
+
+  EXPECT_EQ(full[1].shape()[0], 11);
+  EXPECT_EQ(full[1].shape()[1], 11);
+
+  EXPECT_EQ(full[2].shape()[0], 11);
+  EXPECT_EQ(full[2].shape()[1], 13);
+
+  std::vector<UniTensor> truc1 = linalg::Svd_truncate(svd_T_dense, 5, 0, true, 999);
+
+  EXPECT_EQ(truc1[0].shape()[0], 5);
+
+  EXPECT_EQ(truc1[1].shape()[0], 11);
+  EXPECT_EQ(truc1[1].shape()[1], 5);
+
+  EXPECT_EQ(truc1[2].shape()[0], 5);
+  EXPECT_EQ(truc1[2].shape()[1], 13);
+
+  EXPECT_EQ(truc1[3].shape()[0], 6);
+
+  for (size_t i = 0; i < 5; i++) {
+    EXPECT_EQ(full[0].at({i}), truc1[0].at({i}));
+  }
+  for (size_t i = 0; i < 6; i++) {
+    EXPECT_EQ(full[0].at({i + 5}), truc1[3].at({i}));
+  }
+
+  for (size_t i = 0; i < 11; i++) {
+    for (size_t j = 0; j < 5; j++) {
+      EXPECT_EQ(full[1].at({i, j}), truc1[1].at({i, j}));
+    }
+  }
+  for (size_t i = 0; i < 5; i++) {
+    for (size_t j = 0; j < 13; j++) {
+      EXPECT_EQ(full[2].at({i, j}), truc1[2].at({i, j}));
+    }
+  }
+
+  std::vector<UniTensor> truc2 = linalg::Svd_truncate(svd_T_dense, 5, 1e-12, true, 999);
+
+  EXPECT_EQ(truc2[0].shape()[0], 2);
+
+  EXPECT_EQ(truc2[1].shape()[0], 11);
+  EXPECT_EQ(truc2[1].shape()[1], 2);
+
+  EXPECT_EQ(truc2[2].shape()[0], 2);
+  EXPECT_EQ(truc2[2].shape()[1], 13);
+
+  EXPECT_EQ(truc2[3].shape()[0], 9);
+
+  for (size_t i = 0; i < 2; i++) {
+    EXPECT_EQ(full[0].at({i}), truc2[0].at({i}));
+  }
+  for (size_t i = 0; i < 9; i++) {
+    EXPECT_EQ(full[0].at({i + 2}), truc2[3].at({i}));
+  }
+
+  for (size_t i = 0; i < 11; i++) {
+    for (size_t j = 0; j < 2; j++) {
+      EXPECT_EQ(full[1].at({i, j}), truc2[1].at({i, j}));
+    }
+  }
+  for (size_t i = 0; i < 2; i++) {
+    for (size_t j = 0; j < 13; j++) {
+      EXPECT_EQ(full[2].at({i, j}), truc2[2].at({i, j}));
+    }
+  }
+}
+
 TEST_F(linalg_Test, DenseUt_Pow) {
   UniTensor Ht = UniTensor(A);
   auto res = linalg::Pow(Ht, 3);

--- a/tests/linalg_test/linalg_test.h
+++ b/tests/linalg_test/linalg_test.h
@@ -31,6 +31,9 @@ class linalg_Test : public ::testing::Test {
   Bond svd_L = Bond(BD_OUT, {Qs(1), Qs(-1)}, {1, 1});
   UniTensor svd_T = UniTensor({svd_I, svd_J, svd_K, svd_L}, {"a", "b", "c", "d"}, 1, Type.Double,
                               Device.cpu, false);
+
+  UniTensor svd_T_dense =
+    UniTensor(arange(0, 11 * 13, 1).reshape(11, 13)).astype(Type.ComplexDouble).to(Device.cpu);
   Tensor svd_Sans;
   //==================== Lanczos_Gnd_Ut ===================
   Tensor A = Tensor::Load(data_dir + "Lanczos_Gnd/lan_block_A.cytn");


### PR DESCRIPTION
Unified the cuda svd truncation step into `cytnx::linalg_internal::cudaMemcpyTruncation_X()`, since several svd functions share the same behavior( `cuQuantumGeSvd`, cuSolver version of `Gesvd_truncate` and `Svd_truncate`.).

Also part of this PR address https://github.com/Cytnx-dev/Cytnx/issues/245.