### PR TITLE
make TOUT colon optional

### DIFF
--- a/src/RegularNetwork.cpp
+++ b/src/RegularNetwork.cpp
@@ -44,7 +44,8 @@ namespace cytnx {
     // cytnx_error_msg(tmp.size() != 2, "[ERROR][Network][Fromfile] line:%d %s\n", line_num,
     //                 "Invalid TOUT line");
     if (tmp.size() != 2) {
-      tmp.push_back("");
+      // tmp.push_back("");
+      tmp.insert(tmp.begin(), "");
     }
 
     // handle col-space lbl

--- a/src/RegularNetwork.cpp
+++ b/src/RegularNetwork.cpp
@@ -39,9 +39,13 @@ namespace cytnx {
   void _parse_TOUT_line_(vector<string> &lbls, cytnx_uint64 &TOUT_iBondNum, const string &line,
                          const cytnx_uint64 &line_num) {
     lbls.clear();
+
     vector<string> tmp = str_split(line, false, ";");
-    cytnx_error_msg(tmp.size() != 2, "[ERROR][Network][Fromfile] line:%d %s\n", line_num,
-                    "Invalid TOUT line");
+    // cytnx_error_msg(tmp.size() != 2, "[ERROR][Network][Fromfile] line:%d %s\n", line_num,
+    //                 "Invalid TOUT line");
+    if (tmp.size() != 2) {
+      tmp.push_back("");
+    }
 
     // handle col-space lbl
     vector<string> ket_lbls = str_split(tmp[0], false, ",");

--- a/tests/Network_test.cpp
+++ b/tests/Network_test.cpp
@@ -70,5 +70,5 @@ TEST_F(NetworkTest, Network_dense_TOUT_no_colon) {
   net.PutUniTensors({"A", "B", "C"}, {utdnA, utdnB, utdnC});
   auto res = net.Launch();
   EXPECT_TRUE(AreNearlyEqTensor(res.get_block(), utdnAns.get_block(), 1e-12));
-  EXPECT_EQ(res.rowrank(), 3);
+  EXPECT_EQ(res.rowrank(), 0);
 }

--- a/tests/Network_test.cpp
+++ b/tests/Network_test.cpp
@@ -59,6 +59,16 @@ TEST_F(NetworkTest, Network_dense_reuse) {
   net.PutUniTensors({"A", "B", "C"}, {utdnA, utdnB, utdnC});
   net.setOrder(false, "(A,(B,C))");
   EXPECT_TRUE(AreNearlyEqTensor(net.Launch().get_block(), utdnAns.get_block(), 1e-12));
+  // EXPECT_TRUE(AreNearlyEqTensor(net.Launch().get_block(), utdnAns.get_block(), 1e-12));
   net.PutUniTensors({"A", "B", "C"}, {utdnA, utdnC, utdnB});
   EXPECT_TRUE(AreNearlyEqTensor(net.Launch().get_block(), utdnAns.get_block(), 1e-12));
+}
+
+TEST_F(NetworkTest, Network_dense_TOUT_no_colon) {
+  auto net = Network();
+  net.FromString({"A: a,b,c", "B: c,d", "C: d,e", "TOUT: a,b,e"});
+  net.PutUniTensors({"A", "B", "C"}, {utdnA, utdnB, utdnC});
+  auto res = net.Launch();
+  EXPECT_TRUE(AreNearlyEqTensor(res.get_block(), utdnAns.get_block(), 1e-12));
+  EXPECT_EQ(res.rowrank(), 3);
 }


### PR DESCRIPTION
This PR address https://github.com/Cytnx-dev/Cytnx/issues/288.
Now if users don't specify the colons in TOUT, all labels will be put in colspace (rowrank = 0).