### PR TITLE
CMake gtest/benchmark deps refactor + CI deps change

### DIFF
--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -35,7 +35,7 @@ jobs:
       shell: bash -l {0}
       run: |
         mamba install _openmp_mutex=*=*_llvm cmake make boost git compilers numpy mkl mkl-include mkl-service pybind11 libblas=*=*mkl
-        mamba install gcovr
+        mamba install gcovr gtest
 
 
     - name: Configure CMake

--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         # Specify python version your environment will have. Remember to quote this, or
         # YAML will think you want python 3.1 not 3.10
-        python-version: "3.10"
+        python-version: "3.11"
         # This uses *miniforge*, rather than *minicond*. The primary difference is that
         # the defaults channel is not enabled at all
         miniforge-version: latest

--- a/.github/workflows/conda_build_linux.yml
+++ b/.github/workflows/conda_build_linux.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         # Specify python version your environment will have. Remember to quote this, or
         # YAML will think you want python 3.1 not 3.10
-        python-version: "3.10"
+        python-version: "3.11"
         # This uses *miniforge*, rather than *minicond*. The primary difference is that
         # the defaults channel is not enabled at all
         miniforge-version: latest

--- a/.github/workflows/conda_build_linux_release.yml
+++ b/.github/workflows/conda_build_linux_release.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         # Specify python version your environment will have. Remember to quote this, or
         # YAML will think you want python 3.1 not 3.10
-        python-version: "3.10"
+        python-version: "3.11"
         # This uses *miniforge*, rather than *minicond*. The primary difference is that
         # the defaults channel is not enabled at all
         miniforge-version: latest

--- a/.github/workflows/conda_build_macos.yml
+++ b/.github/workflows/conda_build_macos.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         # Specify python version your environment will have. Remember to quote this, or
         # YAML will think you want python 3.1 not 3.10
-        python-version: "3.10"
+        python-version: "3.11"
         # This uses *miniforge*, rather than *minicond*. The primary difference is that
         # the defaults channel is not enabled at all
         miniforge-version: latest

--- a/.github/workflows/conda_build_macos_release.yml
+++ b/.github/workflows/conda_build_macos_release.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         # Specify python version your environment will have. Remember to quote this, or
         # YAML will think you want python 3.1 not 3.10
-        python-version: "3.10"
+        python-version: "3.11"
         # This uses *miniforge*, rather than *minicond*. The primary difference is that
         # the defaults channel is not enabled at all
         miniforge-version: latest

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}
       run: |
-        mamba install _openmp_mutex=*=*_llvm cmake make boost git compilers numpy mkl mkl-include mkl-service pybind11 libblas=*=*mkl
+        mamba install _openmp_mutex=*=*_llvm cmake make boost git compilers numpy mkl mkl-include mkl-service pybind11 libblas=*=*mkl gtest
 
         cmake -S ${{github.workspace}} -B ${{github.workspace}}/build -DCMAKE_INSTALL_PREFIX=/home/runner/works/Cytnx_lib -DUSE_MKL=on -DUSE_HPTT=on -DHPTT_ENABLE_FINE_TUNE=on -DHPTT_ENABLE_AVX=on -DBUILD_PYTHON=on -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DRUN_TESTS=on
 

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         # Specify python version your environment will have. Remember to quote this, or
         # YAML will think you want python 3.1 not 3.10
-        python-version: "3.10"
+        python-version: "3.11"
         # This uses *miniforge*, rather than *minicond*. The primary difference is that
         # the defaults channel is not enabled at all
         miniforge-version: latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ if(RUN_TESTS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fprofile-arcs -ftest-coverage")
   target_link_libraries(cytnx PUBLIC "-lgcov --coverage")
   add_subdirectory(tests)
-  add_subdirectory(bm_tests)
+  #add_subdirectory(bm_tests)
 endif()
 
 include(GNUInstallDirs)
@@ -196,24 +196,28 @@ endif() # Backend torch
 # ## Get Gtest & benchmark
 # #####################################################################
 if(RUN_TESTS)
-  include(FetchContent)
-  FetchContent_Declare(
-    googletest
-    URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
-  )
+  find_package(GTest REQUIRED)
+  #find_package(benchmark REQUIRED)
+
+
+  #include(FetchContent)
+  #FetchContent_Declare(
+  #  googletest
+  #  URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+  #)
 
   # For Windows: Prevent overriding the parent project's compiler/linker settings
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-  FetchContent_Declare(
-    googlebenchmark
-    GIT_REPOSITORY https://github.com/google/benchmark.git
-    GIT_TAG v1.7.1) # need master for benchmark::benchmark
-  set(BENCHMARK_ENABLE_TESTING off) # to suppress benchmark internal tests
+  #FetchContent_Declare(
+  #  googlebenchmark
+  #  GIT_REPOSITORY https://github.com/google/benchmark.git
+  #  GIT_TAG v1.7.1) # need master for benchmark::benchmark
+  #set(BENCHMARK_ENABLE_TESTING off) # to suppress benchmark internal tests
 
-  FetchContent_MakeAvailable(
-    googletest
-    googlebenchmark)
+  #FetchContent_MakeAvailable(
+  #  googletest
+  #  googlebenchmark)
 endif()
 
 # #######

--- a/Install.sh
+++ b/Install.sh
@@ -183,7 +183,7 @@ rm -rf build
 mkdir build
 cd build
 cmake ../ ${FLAG} #-DDEV_MODE=on
-make -j`nproc`
+make -j4
 make install
 ctest
 gcovr -r ../ . --html-details cov.html

--- a/conda_build/conda_gen/conda_build_config.yaml
+++ b/conda_build/conda_gen/conda_build_config.yaml
@@ -1,6 +1,6 @@
 python:
-    - 3.8
     - 3.9
     - 3.10
+    - 3.11
 pin_run_as_build:
     python: x.x

--- a/conda_build/conda_gen/meta.yaml
+++ b/conda_build/conda_gen/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - "graphviz"
     - "blas * mkl"
     - "beartype"
+    - "gtest"
     - '{{ compiler("c")}}'
     - '{{ compiler("cxx")}}'
 
@@ -47,6 +48,7 @@ requirements:
     - "graphviz"
     - "blas * mkl"
     - "beartype"
+    - "gtest"
     - '{{ compiler("c")}}'
     - '{{ compiler("cxx")}}'
 
@@ -67,6 +69,7 @@ requirements:
     - "cmake"
     - "make"
     - "pybind11"
+    - "gtest"
     - '{{ compiler("c")}}'
     - '{{ compiler("cxx")}}'
 

--- a/conda_build/conda_gen_mac/conda_build_config.yaml
+++ b/conda_build/conda_gen_mac/conda_build_config.yaml
@@ -1,6 +1,7 @@
 python:
-    - 3.7
-    - 3.8
+    - 3.9
+    - 3.10
+    - 3.11
 pin_run_as_build:
     python: x.x
 # Please consult conda-forge/core before doing this

--- a/conda_build/conda_gen_mac/meta.yaml
+++ b/conda_build/conda_gen_mac/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - "graphviz"
     - "blas * mkl"
     - "beartype"
+    - "gtest"
     - '{{ compiler("c")}}'
     - '{{ compiler("cxx")}}'
 
@@ -47,6 +48,7 @@ requirements:
     - "graphviz"
     - "blas * mkl"
     - "beartype"
+    - "gtest"
     - '{{ compiler("c")}}'
     - '{{ compiler("cxx")}}'
 
@@ -64,6 +66,7 @@ requirements:
     - "graphviz"
     - "blas * mkl"
     - "beartype"
+    - "gtest"
     - "cmake"
     - "make"
     - "pybind11"


### PR DESCRIPTION
1. remove google-benchmark
2. change gtest to access from deps instead of build from scrach 
3. change support python version to 3.9/.10/.11 for both linux and mac (#281)
4. change all ci running python to 3.11