### PR TITLE
- fixed wrong argument name in UniTensor_base::relabel(const std::str…

### DIFF
--- a/include/Network.hpp
+++ b/include/Network.hpp
@@ -132,8 +132,8 @@ namespace cytnx {
     virtual UniTensor Launch();
 
     virtual void construct(const std::vector<std::string> &alias,
-                           const std::vector<std::vector<std::string>> &lbls,
-                           const std::vector<std::string> &outlbl, const cytnx_int64 &outrk,
+                           const std::vector<std::vector<std::string>> &labels,
+                           const std::vector<std::string> &outlabel, const cytnx_int64 &outrk,
                            const std::string &order, const bool optim);
     virtual void PrintNet(std::ostream &os);
     virtual boost::intrusive_ptr<Network_base> clone();
@@ -178,8 +178,8 @@ namespace cytnx {
     UniTensor Launch();
 
     void construct(const std::vector<std::string> &alias,
-                   const std::vector<std::vector<std::string>> &lbls,
-                   const std::vector<std::string> &outlbl, const cytnx_int64 &outrk,
+                   const std::vector<std::vector<std::string>> &labels,
+                   const std::vector<std::string> &outlabel, const cytnx_int64 &outrk,
                    const std::string &order, const bool optim);
     boost::intrusive_ptr<Network_base> clone() {
       RegularNetwork *tmp = new RegularNetwork();
@@ -384,17 +384,17 @@ namespace cytnx {
     void RmUniTensor(const cytnx_uint64 &idx) { this->_impl->RmUniTensor(idx); }
     void RmUniTensors(const std::vector<std::string> &names) { this->_impl->RmUniTensors(names); }
     void PutUniTensor(const std::string &name, const UniTensor &utensor,
-                      const std::vector<std::string> &lbl_order = {}) {
-      if (lbl_order.size()) {
-        auto tmpu = utensor.permute(lbl_order);
+                      const std::vector<std::string> &label_order = {}) {
+      if (label_order.size()) {
+        auto tmpu = utensor.permute(label_order);
         this->_impl->PutUniTensor(name, tmpu);
       } else
         this->_impl->PutUniTensor(name, utensor);
     }
     void PutUniTensor(const cytnx_uint64 &idx, const UniTensor &utensor,
-                      const std::vector<std::string> &lbl_order = {}) {
-      if (lbl_order.size()) {
-        auto tmpu = utensor.permute(lbl_order);
+                      const std::vector<std::string> &label_order = {}) {
+      if (label_order.size()) {
+        auto tmpu = utensor.permute(label_order);
         this->_impl->PutUniTensor(idx, tmpu);
       } else
         this->_impl->PutUniTensor(idx, utensor);
@@ -427,8 +427,8 @@ namespace cytnx {
     }
 
     void construct(const std::vector<std::string> &alias,
-                   const std::vector<std::vector<std::string>> &lbls,
-                   const std::vector<std::string> &outlbl = std::vector<std::string>(),
+                   const std::vector<std::vector<std::string>> &labels,
+                   const std::vector<std::string> &outlabel = std::vector<std::string>(),
                    const cytnx_int64 &outrk = 0, const std::string &order = "",
                    const bool optim = false, const int &network_type = NtType.Regular) {
       if (network_type == NtType.Regular) {
@@ -437,7 +437,7 @@ namespace cytnx {
       } else {
         cytnx_error_msg(true, "[Developing] currently only support regular type network.%s", "\n");
       }
-      this->_impl->construct(alias, lbls, outlbl, outrk, order, optim);
+      this->_impl->construct(alias, labels, outlabel, outrk, order, optim);
     }
 
     void clear() {

--- a/include/UniTensor.hpp
+++ b/include/UniTensor.hpp
@@ -111,13 +111,13 @@ namespace cytnx {
     /**
      * @brief Get the index of an desired label string
      *
-     * @param lbl Label you want to find
+     * @param label Label you want to find
      * @return The index of the label. If not found, return -1
      */
-    cytnx_int64 get_index(std::string lbl) const {
-      std::vector<std::string> lbls = this->_labels;
-      for (cytnx_uint64 i = 0; i < lbls.size(); i++) {
-        if (lbls[i] == lbl) return i;
+    cytnx_int64 get_index(std::string label) const {
+      std::vector<std::string> labels = this->_labels;
+      for (cytnx_uint64 i = 0; i < labels.size(); i++) {
+        if (labels[i] == label) return i;
       }
       return -1;
     }
@@ -130,9 +130,9 @@ namespace cytnx {
       return this->_bonds[idx];
     }
 
-    Bond &bond_(const std::string &lbl) {
-      auto res = std::find(this->_labels.begin(), this->_labels.end(), lbl);
-      cytnx_error_msg(res == this->_labels.end(), "[ERROR] label %s not exists.\n", lbl.c_str());
+    Bond &bond_(const std::string &label) {
+      auto res = std::find(this->_labels.begin(), this->_labels.end(), label);
+      cytnx_error_msg(res == this->_labels.end(), "[ERROR] label %s not exists.\n", label.c_str());
       cytnx_uint64 idx = std::distance(this->_labels.begin(), res);
 
       return this->bond_(idx);
@@ -145,17 +145,17 @@ namespace cytnx {
     /**
      * @brief Set the label object
      * @details Replace the old label by new label.
-     * @param[in] oldlbl The old label you want to replace.
+     * @param[in] oldlabel The old label you want to replace.
      * @param[in] new_lable The label you want to replace with.
      * @pre
-     * 1. \p oldlbl should be exist in this UniTensor.
+     * 1. \p oldlabel should be exist in this UniTensor.
      * 2. The new label \p new_label cannot set as others exit labels (cannot be duplicated.)
      * @see set_label(const cytnx_int64 &inx, const std::string &new_label)
      */
-    void set_label(const std::string &oldlbl, const std::string &new_label) {
+    void set_label(const std::string &oldlabel, const std::string &new_label) {
       cytnx_int64 idx;
-      auto res = std::find(this->_labels.begin(), this->_labels.end(), oldlbl);
-      cytnx_error_msg(res == this->_labels.end(), "[ERROR] label %s not exists.\n", oldlbl.c_str());
+      auto res = std::find(this->_labels.begin(), this->_labels.end(), oldlabel);
+      cytnx_error_msg(res == this->_labels.end(), "[ERROR] label %s not exists.\n", oldlabel.c_str());
       idx = std::distance(this->_labels.begin(), res);
 
       cytnx_error_msg(idx >= this->_labels.size(), "[ERROR] index exceed the rank of UniTensor%s",
@@ -309,7 +309,7 @@ namespace cytnx {
     virtual boost::intrusive_ptr<UniTensor_base> relabels(
       const std::vector<std::string> &old_labels, const std::vector<std::string> &new_labels);
 
-    virtual boost::intrusive_ptr<UniTensor_base> relabel(const std::string &inx,
+    virtual boost::intrusive_ptr<UniTensor_base> relabel(const std::string &old_label,
                                                          const std::string &new_label);
 
     virtual boost::intrusive_ptr<UniTensor_base> relabel(const cytnx_int64 &inx,
@@ -1974,8 +1974,8 @@ namespace cytnx {
     }
 
     /*
-    UniTensor& change_label(const cytnx_int64 &old_lbl, const cytnx_int64 &new_label){
-        this->_impl->change_label(old_lbl,new_label);
+    UniTensor& change_label(const cytnx_int64 &old_label, const cytnx_int64 &new_label){
+        this->_impl->change_label(old_label,new_label);
         return *this;
     }
     */
@@ -2155,10 +2155,10 @@ namespace cytnx {
     /**
      * @brief Get the index of an desired label string
      *
-     * @param lbl Label you want to find
+     * @param label Label you want to find
      * @return The index of the label. If not found, return -1
      */
-    cytnx_int64 get_index(std::string lbl) const { return this->_impl->get_index(lbl); }
+    cytnx_int64 get_index(std::string label) const { return this->_impl->get_index(label); }
 
     /**
     @brief Get the bonds of the UniTensor.
@@ -2174,11 +2174,11 @@ namespace cytnx {
     const Bond &bond_(const cytnx_uint64 &idx) const { return this->_impl->bond_(idx); }
     Bond &bond_(const cytnx_uint64 &idx) { return this->_impl->bond_(idx); }
 
-    const Bond &bond_(const std::string &lbl) const { return this->_impl->bond_(lbl); }
-    Bond &bond_(const std::string &lbl) { return this->_impl->bond_(lbl); }
+    const Bond &bond_(const std::string &label) const { return this->_impl->bond_(label); }
+    Bond &bond_(const std::string &label) { return this->_impl->bond_(label); }
 
     Bond bond(const cytnx_uint64 &idx) const { return this->_impl->bond_(idx).clone(); }
-    Bond bond(const std::string &lbl) const { return this->_impl->bond_(lbl).clone(); }
+    Bond bond(const std::string &label) const { return this->_impl->bond_(label).clone(); }
 
     /**
     @brief Get the shape of the UniTensor.
@@ -2260,10 +2260,10 @@ namespace cytnx {
     /**
     @see relabels(const std::vector<std::string> &new_labels) const
      */
-    UniTensor relabels(const std::initializer_list<char *> &new_lbls) const {
-      std::vector<char *> new_labels(new_lbls);
-      std::vector<std::string> vs(new_labels.size());
-      transform(new_labels.begin(), new_labels.end(), vs.begin(),
+    UniTensor relabels(const std::initializer_list<char *> &new_labels) const {
+      std::vector<char *> new_lbls(new_labels);
+      std::vector<std::string> vs(new_lbls.size());
+      transform(new_lbls.begin(), new_lbls.end(), vs.begin(),
                 [](char *x) -> std::string { return std::string(x); });
 
       UniTensor out;
@@ -2273,10 +2273,10 @@ namespace cytnx {
     /**
     @see relabels_(const std::vector<std::string> &new_labels)
      */
-    UniTensor &relabels_(const std::initializer_list<char *> &new_lbls) {
-      std::vector<char *> new_labels(new_lbls);
-      std::vector<std::string> vs(new_labels.size());
-      transform(new_labels.begin(), new_labels.end(), vs.begin(),
+    UniTensor &relabels_(const std::initializer_list<char *> &new_labels) {
+      std::vector<char *> new_lbls(new_labels);
+      std::vector<std::string> vs(new_lbls.size());
+      transform(new_lbls.begin(), new_lbls.end(), vs.begin(),
                 [](char *x) -> std::string { return std::string(x); });
 
       this->_impl->relabels_(vs);
@@ -2322,16 +2322,16 @@ namespace cytnx {
     @see relabels(const std::vector<std::string> &old_labels, const std::vector<std::string>
     &new_labels) const
      */
-    UniTensor relabels(const std::initializer_list<char *> &old_lbls,
-                       const std::initializer_list<char *> &new_lbls) const {
-      std::vector<char *> new_labels(new_lbls);
-      std::vector<std::string> vs(new_labels.size());
-      transform(new_labels.begin(), new_labels.end(), vs.begin(),
+    UniTensor relabels(const std::initializer_list<char *> &old_labels,
+                       const std::initializer_list<char *> &new_labels) const {
+      std::vector<char *> new_lbls(new_labels);
+      std::vector<std::string> vs(new_lbls.size());
+      transform(new_lbls.begin(), new_lbls.end(), vs.begin(),
                 [](char *x) -> std::string { return std::string(x); });
 
-      std::vector<char *> old_labels(old_lbls);
-      std::vector<std::string> vs_old(old_labels.size());
-      transform(old_labels.begin(), old_labels.end(), vs_old.begin(),
+      std::vector<char *> old_lbls(old_labels);
+      std::vector<std::string> vs_old(old_lbls.size());
+      transform(old_lbls.begin(), old_lbls.end(), vs_old.begin(),
                 [](char *x) -> std::string { return std::string(x); });
 
       return this->relabels(vs_old, vs);
@@ -2341,16 +2341,16 @@ namespace cytnx {
     @see relabels_(const std::vector<std::string> &old_labels, const std::vector<std::string>
     &new_labels)
      */
-    UniTensor &relabels_(const std::initializer_list<char *> &old_lbls,
-                         const std::initializer_list<char *> &new_lbls) {
-      std::vector<char *> new_labels(new_lbls);
-      std::vector<std::string> vs(new_labels.size());
-      transform(new_labels.begin(), new_labels.end(), vs.begin(),
+    UniTensor &relabels_(const std::initializer_list<char *> &old_labels,
+                         const std::initializer_list<char *> &new_labels) {
+      std::vector<char *> new_lbls(new_labels);
+      std::vector<std::string> vs(new_lbls.size());
+      transform(new_lbls.begin(), new_lbls.end(), vs.begin(),
                 [](char *x) -> std::string { return std::string(x); });
 
-      std::vector<char *> old_labels(old_lbls);
-      std::vector<std::string> vs_old(old_labels.size());
-      transform(old_labels.begin(), old_labels.end(), vs_old.begin(),
+      std::vector<char *> old_lbls(old_labels);
+      std::vector<std::string> vs_old(old_lbls.size());
+      transform(old_lbls.begin(), old_lbls.end(), vs_old.begin(),
                 [](char *x) -> std::string { return std::string(x); });
 
       this->relabels_(vs_old, vs);
@@ -2618,41 +2618,41 @@ namespace cytnx {
     }
 
     template <class T>
-    const T &at(const std::vector<std::string> &lbls,
+    const T &at(const std::vector<std::string> &labels,
                 const std::vector<cytnx_uint64> &locator) const {
       // giving label <-> locator one to one corresponding, return the element:
-      cytnx_error_msg(locator.size() != lbls.size(),
+      cytnx_error_msg(locator.size() != labels.size(),
                       "[ERROR][at] length of list should be the same for label and locator.%s",
                       "\n");
       cytnx_error_msg(
-        lbls.size() != this->rank(),
+        labels.size() != this->rank(),
         "[ERROR][at] length of lists must be the same as UniTensor.rank (# of legs)%s", "\n");
       std::vector<cytnx_uint64> new_locator(this->rank());
       cytnx_uint64 new_loc;
-      for (int i = 0; i < lbls.size(); i++) {
-        auto res = std::find(this->_impl->_labels.begin(), this->_impl->_labels.end(), lbls[i]);
+      for (int i = 0; i < labels.size(); i++) {
+        auto res = std::find(this->_impl->_labels.begin(), this->_impl->_labels.end(), labels[i]);
         cytnx_error_msg(res == this->_impl->_labels.end(),
-                        "[ERROR] lbl:%s does not exist in current UniTensor.\n", lbls[i].c_str());
+                        "[ERROR] label:%s does not exist in current UniTensor.\n", labels[i].c_str());
         new_loc = std::distance(this->_impl->_labels.begin(), res);
         new_locator[new_loc] = locator[i];
       }
       return this->at<T>(new_locator);
     }
     template <class T>
-    T &at(const std::vector<std::string> &lbls, const std::vector<cytnx_uint64> &locator) {
+    T &at(const std::vector<std::string> &labels, const std::vector<cytnx_uint64> &locator) {
       // giving label <-> locator one to one corresponding, return the element:
-      cytnx_error_msg(locator.size() != lbls.size(),
+      cytnx_error_msg(locator.size() != labels.size(),
                       "[ERROR][at] length of list should be the same for label and locator.%s",
                       "\n");
       cytnx_error_msg(
-        lbls.size() != this->rank(),
+        labels.size() != this->rank(),
         "[ERROR][at] length of lists must be the same as UniTensor.rank (# of legs)%s", "\n");
       std::vector<cytnx_uint64> new_locator(this->rank());
       cytnx_uint64 new_loc;
-      for (int i = 0; i < lbls.size(); i++) {
-        auto res = std::find(this->_impl->_labels.begin(), this->_impl->_labels.end(), lbls[i]);
+      for (int i = 0; i < labels.size(); i++) {
+        auto res = std::find(this->_impl->_labels.begin(), this->_impl->_labels.end(), labels[i]);
         cytnx_error_msg(res == this->_impl->_labels.end(),
-                        "[ERROR] lbl:%s does not exist in current UniTensor.\n", lbls[i].c_str());
+                        "[ERROR] label:%s does not exist in current UniTensor.\n", labels[i].c_str());
         new_loc = std::distance(this->_impl->_labels.begin(), res);
         new_locator[new_loc] = locator[i];
       }
@@ -2697,42 +2697,42 @@ namespace cytnx {
       }
     }
 
-    Scalar::Sproxy at(const std::vector<std::string> &lbls,
+    Scalar::Sproxy at(const std::vector<std::string> &labels,
                       const std::vector<cytnx_uint64> &locator) {
       // giving label <-> locator one to one corresponding, return the element:
-      cytnx_error_msg(locator.size() != lbls.size(),
+      cytnx_error_msg(locator.size() != labels.size(),
                       "[ERROR][at] length of list should be the same for label and locator.%s",
                       "\n");
       cytnx_error_msg(
-        lbls.size() != this->rank(),
+        labels.size() != this->rank(),
         "[ERROR][at] length of lists must be the same as UniTensor.rank (# of legs)%s", "\n");
       std::vector<cytnx_uint64> new_locator(this->rank());
       cytnx_uint64 new_loc;
-      for (int i = 0; i < lbls.size(); i++) {
-        auto res = std::find(this->_impl->_labels.begin(), this->_impl->_labels.end(), lbls[i]);
+      for (int i = 0; i < labels.size(); i++) {
+        auto res = std::find(this->_impl->_labels.begin(), this->_impl->_labels.end(), labels[i]);
         cytnx_error_msg(res == this->_impl->_labels.end(),
-                        "[ERROR] lbl:%s does not exist in current UniTensor.\n", lbls[i].c_str());
+                        "[ERROR] label:%s does not exist in current UniTensor.\n", labels[i].c_str());
         new_loc = std::distance(this->_impl->_labels.begin(), res);
         new_locator[new_loc] = locator[i];
       }
       return this->at(new_locator);
     }
 
-    const Scalar::Sproxy at(const std::vector<std::string> &lbls,
+    const Scalar::Sproxy at(const std::vector<std::string> &labels,
                             const std::vector<cytnx_uint64> &locator) const {
       // giving label <-> locator one to one corresponding, return the element:
-      cytnx_error_msg(locator.size() != lbls.size(),
+      cytnx_error_msg(locator.size() != labels.size(),
                       "[ERROR][at] length of list should be the same for label and locator.%s",
                       "\n");
       cytnx_error_msg(
-        lbls.size() != this->rank(),
+        labels.size() != this->rank(),
         "[ERROR][at] length of lists must be the same as UniTensor.rank (# of legs)%s", "\n");
       std::vector<cytnx_uint64> new_locator(this->rank());
       cytnx_uint64 new_loc;
-      for (int i = 0; i < lbls.size(); i++) {
-        auto res = std::find(this->_impl->_labels.begin(), this->_impl->_labels.end(), lbls[i]);
+      for (int i = 0; i < labels.size(); i++) {
+        auto res = std::find(this->_impl->_labels.begin(), this->_impl->_labels.end(), labels[i]);
         cytnx_error_msg(res == this->_impl->_labels.end(),
-                        "[ERROR] lbl:%s does not exist in current UniTensor.\n", lbls[i].c_str());
+                        "[ERROR] label:%s does not exist in current UniTensor.\n", labels[i].c_str());
         new_loc = std::distance(this->_impl->_labels.begin(), res);
         new_locator[new_loc] = locator[i];
       }
@@ -2760,12 +2760,12 @@ namespace cytnx {
       return this->_impl->get_block(qidx, force);
     }
 
-    Tensor get_block(const std::vector<std::string> &lbls, const std::vector<cytnx_int64> &qidx,
+    Tensor get_block(const std::vector<std::string> &labels, const std::vector<cytnx_int64> &qidx,
                      const bool &force = false) const {
       cytnx_error_msg(
-        lbls.size() != qidx.size(),
+        labels.size() != qidx.size(),
         "[ERROR][get_block] length of lists must be the same for both lables and qnidices%s", "\n");
-      cytnx_error_msg(lbls.size() != this->rank(),
+      cytnx_error_msg(labels.size() != this->rank(),
                       "[ERROR][get_block] length of lists must be the rank (# of legs)%s", "\n");
 
       std::vector<cytnx_int64> loc_id(this->rank());
@@ -2773,11 +2773,11 @@ namespace cytnx {
 
       cytnx_uint64 new_loc;
       std::vector<cytnx_uint64> new_order(this->rank());
-      for (int i = 0; i < lbls.size(); i++) {
-        auto res = std::find(this->_impl->_labels.begin(), this->_impl->_labels.end(), lbls[i]);
+      for (int i = 0; i < labels.size(); i++) {
+        auto res = std::find(this->_impl->_labels.begin(), this->_impl->_labels.end(), labels[i]);
         cytnx_error_msg(res == this->_impl->_labels.end(),
                         "[ERROR][get_block] label:%s does not exists in current Tensor.\n",
-                        lbls[i].c_str());
+                        labels[i].c_str());
         new_loc = std::distance(this->_impl->_labels.begin(), res);
         new_qidx[new_loc] = qidx[i];
         new_order[i] = new_loc;
@@ -2806,10 +2806,10 @@ namespace cytnx {
       return this->_impl->get_block(iqnum, force);
     }
 
-    Tensor get_block(const std::vector<std::string> &lbls, const std::vector<cytnx_uint64> &qidx,
+    Tensor get_block(const std::vector<std::string> &labels, const std::vector<cytnx_uint64> &qidx,
                      const bool &force = false) const {
       std::vector<cytnx_int64> iqnum(qidx.begin(), qidx.end());
-      return this->get_block(lbls, iqnum, force);
+      return this->get_block(labels, iqnum, force);
     }
 
     /**
@@ -2841,25 +2841,25 @@ namespace cytnx {
 
     /**
     @brief Get the shared (data) view of block for the given quantum indices on given labels
-        @param[in] lbls the labels of the bonds.
+        @param[in] labels the labels of the bonds.
         @param[in] qidx input the quantum indices you want to get the corresponding block.
         @param[in] force If force is true, it will return the tensor anyway (Even the
             corresponding block is empty, it will return void type tensor if \p force is
                 set as true. Otherwise, it will trow the exception.)
         @return Tensor&
 
-        @note lbls and qidx forming one to one pairs. e.g. it means get `qidx[i]` qnum at Bond
-    `lbls[i]`. Also note that the return Tensor will have axes in the same order specified by lbls.
+        @note labels and qidx forming one to one pairs. e.g. it means get `qidx[i]` qnum at Bond
+    `labels[i]`. Also note that the return Tensor will have axes in the same order specified by labels.
 
     */
     // developer note: Tensor is not the same object (Thus Tensor instead of Tensor& ),
     //                 since we permute! but they have shared data memory.
-    Tensor get_block_(const std::vector<std::string> &lbls, const std::vector<cytnx_int64> &qidx,
+    Tensor get_block_(const std::vector<std::string> &labels, const std::vector<cytnx_int64> &qidx,
                       const bool &force = false) {
       cytnx_error_msg(
-        lbls.size() != qidx.size(),
+        labels.size() != qidx.size(),
         "[ERROR][get_block] length of lists must be the same for both lables and qnidices%s", "\n");
-      cytnx_error_msg(lbls.size() != this->rank(),
+      cytnx_error_msg(labels.size() != this->rank(),
                       "[ERROR][get_block] length of lists must be the rank (# of legs)%s", "\n");
 
       std::vector<cytnx_int64> loc_id(this->rank());
@@ -2867,11 +2867,11 @@ namespace cytnx {
 
       cytnx_uint64 new_loc;
       std::vector<cytnx_uint64> new_order(this->rank());
-      for (int i = 0; i < lbls.size(); i++) {
-        auto res = std::find(this->_impl->_labels.begin(), this->_impl->_labels.end(), lbls[i]);
+      for (int i = 0; i < labels.size(); i++) {
+        auto res = std::find(this->_impl->_labels.begin(), this->_impl->_labels.end(), labels[i]);
         cytnx_error_msg(res == this->_impl->_labels.end(),
                         "[ERROR][get_block] label:%s does not exists in current Tensor.\n",
-                        lbls[i].c_str());
+                        labels[i].c_str());
         new_loc = std::distance(this->_impl->_labels.begin(), res);
         new_qidx[new_loc] = qidx[i];
         new_order[i] = new_loc;
@@ -2899,10 +2899,10 @@ namespace cytnx {
       return get_block_(iqidx, force);
     }
 
-    Tensor get_block_(const std::vector<std::string> &lbls, const std::vector<cytnx_uint64> &qidx,
+    Tensor get_block_(const std::vector<std::string> &labels, const std::vector<cytnx_uint64> &qidx,
                       const bool &force = false) {
       std::vector<cytnx_int64> iqidx(qidx.begin(), qidx.end());
-      return get_block_(lbls, iqidx, force);
+      return get_block_(labels, iqidx, force);
     }
     //================================
 

--- a/include/UniTensor.hpp
+++ b/include/UniTensor.hpp
@@ -155,7 +155,8 @@ namespace cytnx {
     void set_label(const std::string &oldlabel, const std::string &new_label) {
       cytnx_int64 idx;
       auto res = std::find(this->_labels.begin(), this->_labels.end(), oldlabel);
-      cytnx_error_msg(res == this->_labels.end(), "[ERROR] label %s not exists.\n", oldlabel.c_str());
+      cytnx_error_msg(res == this->_labels.end(), "[ERROR] label %s not exists.\n",
+                      oldlabel.c_str());
       idx = std::distance(this->_labels.begin(), res);
 
       cytnx_error_msg(idx >= this->_labels.size(), "[ERROR] index exceed the rank of UniTensor%s",
@@ -2632,7 +2633,8 @@ namespace cytnx {
       for (int i = 0; i < labels.size(); i++) {
         auto res = std::find(this->_impl->_labels.begin(), this->_impl->_labels.end(), labels[i]);
         cytnx_error_msg(res == this->_impl->_labels.end(),
-                        "[ERROR] label:%s does not exist in current UniTensor.\n", labels[i].c_str());
+                        "[ERROR] label:%s does not exist in current UniTensor.\n",
+                        labels[i].c_str());
         new_loc = std::distance(this->_impl->_labels.begin(), res);
         new_locator[new_loc] = locator[i];
       }
@@ -2652,7 +2654,8 @@ namespace cytnx {
       for (int i = 0; i < labels.size(); i++) {
         auto res = std::find(this->_impl->_labels.begin(), this->_impl->_labels.end(), labels[i]);
         cytnx_error_msg(res == this->_impl->_labels.end(),
-                        "[ERROR] label:%s does not exist in current UniTensor.\n", labels[i].c_str());
+                        "[ERROR] label:%s does not exist in current UniTensor.\n",
+                        labels[i].c_str());
         new_loc = std::distance(this->_impl->_labels.begin(), res);
         new_locator[new_loc] = locator[i];
       }
@@ -2711,7 +2714,8 @@ namespace cytnx {
       for (int i = 0; i < labels.size(); i++) {
         auto res = std::find(this->_impl->_labels.begin(), this->_impl->_labels.end(), labels[i]);
         cytnx_error_msg(res == this->_impl->_labels.end(),
-                        "[ERROR] label:%s does not exist in current UniTensor.\n", labels[i].c_str());
+                        "[ERROR] label:%s does not exist in current UniTensor.\n",
+                        labels[i].c_str());
         new_loc = std::distance(this->_impl->_labels.begin(), res);
         new_locator[new_loc] = locator[i];
       }
@@ -2732,7 +2736,8 @@ namespace cytnx {
       for (int i = 0; i < labels.size(); i++) {
         auto res = std::find(this->_impl->_labels.begin(), this->_impl->_labels.end(), labels[i]);
         cytnx_error_msg(res == this->_impl->_labels.end(),
-                        "[ERROR] label:%s does not exist in current UniTensor.\n", labels[i].c_str());
+                        "[ERROR] label:%s does not exist in current UniTensor.\n",
+                        labels[i].c_str());
         new_loc = std::distance(this->_impl->_labels.begin(), res);
         new_locator[new_loc] = locator[i];
       }
@@ -2849,7 +2854,8 @@ namespace cytnx {
         @return Tensor&
 
         @note labels and qidx forming one to one pairs. e.g. it means get `qidx[i]` qnum at Bond
-    `labels[i]`. Also note that the return Tensor will have axes in the same order specified by labels.
+    `labels[i]`. Also note that the return Tensor will have axes in the same order specified by
+    labels.
 
     */
     // developer note: Tensor is not the same object (Thus Tensor instead of Tensor& ),

--- a/pybind/network_py.cpp
+++ b/pybind/network_py.cpp
@@ -61,7 +61,9 @@ void network_binding(py::module &m) {
     .def(
       "PutUniTensor",
       [](Network &self, const cytnx_uint64 &idx, const UniTensor &utensor,
-         const std::vector<std::string> &label_order) { self.PutUniTensor(idx, utensor, label_order); },
+         const std::vector<std::string> &label_order) {
+        self.PutUniTensor(idx, utensor, label_order);
+      },
       py::arg("idx"), py::arg("utensor"), py::arg("label_order") = std::vector<std::string>())
     .def(
       "PutUniTensors",

--- a/pybind/network_py.cpp
+++ b/pybind/network_py.cpp
@@ -54,15 +54,15 @@ void network_binding(py::module &m) {
     .def(
       "PutUniTensor",
       [](Network &self, const std::string &name, const UniTensor &utensor,
-         const std::vector<std::string> &lbl_order) {
-        self.PutUniTensor(name, utensor, lbl_order);
+         const std::vector<std::string> &label_order) {
+        self.PutUniTensor(name, utensor, label_order);
       },
-      py::arg("name"), py::arg("utensor"), py::arg("lbl_order") = std::vector<std::string>())
+      py::arg("name"), py::arg("utensor"), py::arg("label_order") = std::vector<std::string>())
     .def(
       "PutUniTensor",
       [](Network &self, const cytnx_uint64 &idx, const UniTensor &utensor,
-         const std::vector<std::string> &lbl_order) { self.PutUniTensor(idx, utensor, lbl_order); },
-      py::arg("idx"), py::arg("utensor"), py::arg("lbl_order") = std::vector<std::string>())
+         const std::vector<std::string> &label_order) { self.PutUniTensor(idx, utensor, label_order); },
+      py::arg("idx"), py::arg("utensor"), py::arg("label_order") = std::vector<std::string>())
     .def(
       "PutUniTensors",
       [](Network &self, const std::vector<std::string> &names,
@@ -97,8 +97,8 @@ void network_binding(py::module &m) {
     // .def("getOrder", &Network::getOrder)
     .def("Launch", &Network::Launch, py::arg("network_type") = (int)NtType.Regular)
 
-    .def("construct", &Network::construct, py::arg("alias"), py::arg("lbls"),
-         py::arg("outlbl") = std::vector<std::string>(), py::arg("outrk"), py::arg("order") = "",
+    .def("construct", &Network::construct, py::arg("alias"), py::arg("labels"),
+         py::arg("outlabel") = std::vector<std::string>(), py::arg("outrk"), py::arg("order") = "",
          py::arg("optim") = false, py::arg("network_type") = (int)NtType.Regular)
 
     .def("clear", &Network::clear)

--- a/pybind/unitensor_py.cpp
+++ b/pybind/unitensor_py.cpp
@@ -287,8 +287,8 @@ void unitensor_binding(py::module &m) {
                },py::arg("locator"))
 
 
-    .def("c_at",[](UniTensor &self, const std::vector<std::string> &lbls, const std::vector<cytnx_uint64> &locator){
-                  Scalar::Sproxy tmp = self.at(lbls,locator);
+    .def("c_at",[](UniTensor &self, const std::vector<std::string> &labels, const std::vector<cytnx_uint64> &locator){
+                  Scalar::Sproxy tmp = self.at(labels,locator);
                   //std::cout << "ok" << std::endl;
                   return cHclass(tmp);
                },py::arg("labels"), py::arg("locator"))
@@ -532,14 +532,14 @@ void unitensor_binding(py::module &m) {
 
     .def(
       "get_block",
-      [](const UniTensor &self, const std::vector<std::string> &lbl, const std::vector<cytnx_int64> &qnum, const bool &force) {
-        return self.get_block(lbl, qnum, force);
+      [](const UniTensor &self, const std::vector<std::string> &label, const std::vector<cytnx_int64> &qnum, const bool &force) {
+        return self.get_block(label, qnum, force);
       },
       py::arg("labels"), py::arg("qnum"), py::arg("force") = false)
     .def(
       "get_block",
-      [](const UniTensor &self, const std::vector<std::string> &lbl, const std::vector<cytnx_uint64> &qnum, const bool &force) {
-        return self.get_block(lbl,qnum, force);
+      [](const UniTensor &self, const std::vector<std::string> &label, const std::vector<cytnx_uint64> &qnum, const bool &force) {
+        return self.get_block(label,qnum, force);
       },
       py::arg("labels"), py::arg("qnum"), py::arg("force") = false)
     .def(
@@ -557,14 +557,14 @@ void unitensor_binding(py::module &m) {
 
     .def(
       "get_block_",
-      [](UniTensor &self, const std::vector<std::string> &lbls, const std::vector<cytnx_int64> &qnum, const bool &force) {
-        return self.get_block_(lbls, qnum, force);
+      [](UniTensor &self, const std::vector<std::string> &labels, const std::vector<cytnx_int64> &qnum, const bool &force) {
+        return self.get_block_(labels, qnum, force);
       },
       py::arg("labels"), py::arg("qnum"), py::arg("force") = false)
     .def(
       "get_block_",
-      [](UniTensor &self, const std::vector<std::string> &lbls, const std::vector<cytnx_uint64> &qnum, const bool &force) {
-        return self.get_block_(lbls,qnum, force);
+      [](UniTensor &self, const std::vector<std::string> &labels, const std::vector<cytnx_uint64> &qnum, const bool &force) {
+        return self.get_block_(labels,qnum, force);
       },
       py::arg("labels"), py::arg("qnum"), py::arg("force") = false)
 

--- a/src/DenseUniTensor.cpp
+++ b/src/DenseUniTensor.cpp
@@ -1179,11 +1179,11 @@ namespace cytnx {
   void DenseUniTensor::_save_dispatch(std::fstream &f) const { this->_block._Save(f); }
   void DenseUniTensor::_load_dispatch(std::fstream &f) { this->_block._Load(f); }
 
-  void DenseUniTensor::truncate_(const std::string &bond_lbl, const cytnx_uint64 &dim) {
+  void DenseUniTensor::truncate_(const std::string &bond_label, const cytnx_uint64 &dim) {
     // if it is diagonal tensor, truncate will be done on both index!
     cytnx_error_msg(dim < 1, "[ERROR][DenseUniTensor][truncate] dim should be >0.%s", "\n");
     cytnx_uint64 idx;
-    auto it = std::find(this->_labels.begin(), this->_labels.end(), bond_lbl);
+    auto it = std::find(this->_labels.begin(), this->_labels.end(), bond_label);
     cytnx_error_msg(it == this->_labels.end(),
                     "[ERROR][DenseUniTensor][truncate] Error, bond label does not exist in the "
                     "current label list.%s",

--- a/src/Network_base.cpp
+++ b/src/Network_base.cpp
@@ -68,8 +68,8 @@ namespace cytnx {
   }
 
   void Network_base::construct(const std::vector<std::string> &alias,
-                               const std::vector<std::vector<std::string>> &lbls,
-                               const std::vector<std::string> &outlbl, const cytnx_int64 &outrk,
+                               const std::vector<std::vector<std::string>> &labels,
+                               const std::vector<std::string> &outlabel, const cytnx_int64 &outrk,
                                const std::string &order, const bool optim) {
     cytnx_error_msg(true, "[ERROR][Network][construct] call from uninitialize network.%s", "\n");
   }

--- a/src/RegularNetwork.cpp
+++ b/src/RegularNetwork.cpp
@@ -36,9 +36,9 @@ namespace cytnx {
                     line_num, "\n");
   }
 
-  void _parse_TOUT_line_(vector<string> &lbls, cytnx_uint64 &TOUT_iBondNum, const string &line,
+  void _parse_TOUT_line_(vector<string> &labels, cytnx_uint64 &TOUT_iBondNum, const string &line,
                          const cytnx_uint64 &line_num) {
-    lbls.clear();
+    labels.clear();
 
     vector<string> tmp = str_split(line, false, ";");
     // cytnx_error_msg(tmp.size() != 2, "[ERROR][Network][Fromfile] line:%d %s\n", line_num,
@@ -48,35 +48,35 @@ namespace cytnx {
       tmp.insert(tmp.begin(), "");
     }
 
-    // handle col-space lbl
-    vector<string> ket_lbls = str_split(tmp[0], false, ",");
-    if (ket_lbls.size() == 1)
-      if (ket_lbls[0].length() == 0) ket_lbls.clear();
-    for (cytnx_uint64 i = 0; i < ket_lbls.size(); i++) {
-      string tmp = str_strip(ket_lbls[i]);
+    // handle col-space label
+    vector<string> ket_labels = str_split(tmp[0], false, ",");
+    if (ket_labels.size() == 1)
+      if (ket_labels[0].length() == 0) ket_labels.clear();
+    for (cytnx_uint64 i = 0; i < ket_labels.size(); i++) {
+      string tmp = str_strip(ket_labels[i]);
       cytnx_error_msg(tmp.length() == 0,
                       "[ERROR][Network][Fromfile] line:%d Invalid labels for TOUT line.%s",
                       line_num, "\n");
       // cytnx_error_msg((tmp.find_first_not_of("0123456789-") != string::npos),
       //                 "[ERROR][Network][Fromfile] line:%d %s\n", line_num,
       //                 "Invalid TOUT line. label contain non integer.");
-      lbls.push_back(tmp);
+      labels.push_back(tmp);
     }
-    TOUT_iBondNum = lbls.size();
+    TOUT_iBondNum = labels.size();
 
-    // handle row-space lbl
-    vector<string> bra_lbls = str_split(tmp[1], false, ",");
-    if (bra_lbls.size() == 1)
-      if (bra_lbls[0].length() == 0) bra_lbls.clear();
-    for (cytnx_uint64 i = 0; i < bra_lbls.size(); i++) {
-      string tmp = str_strip(bra_lbls[i]);
+    // handle row-space label
+    vector<string> bra_labels = str_split(tmp[1], false, ",");
+    if (bra_labels.size() == 1)
+      if (bra_labels[0].length() == 0) bra_labels.clear();
+    for (cytnx_uint64 i = 0; i < bra_labels.size(); i++) {
+      string tmp = str_strip(bra_labels[i]);
       cytnx_error_msg(tmp.length() == 0,
                       "[ERROR][Network][Fromfile] line:%d Invalid labels for TOUT line.%s",
                       line_num, "\n");
       // cytnx_error_msg((tmp.find_first_not_of("0123456789-") != string::npos),
       //                 "[ERROR][Network][Fromfile] line:%d %s\n", line_num,
       //                 "Invalid TOUT line. label contain non integer.");
-      lbls.push_back(tmp);
+      labels.push_back(tmp);
     }
   }
 
@@ -113,21 +113,21 @@ namespace cytnx {
     }
   }
 
-  void _parse_TN_line_(vector<string> &lbls, cytnx_uint64 &TN_iBondNum, const string &line,
+  void _parse_TN_line_(vector<string> &labels, cytnx_uint64 &TN_iBondNum, const string &line,
                        const cytnx_uint64 &line_num) {
-    lbls.clear();
+    labels.clear();
     // vector<string> tmp = str_split(line, false, ";");
     // cytnx_error_msg(tmp.size() != 2, "[ERROR][Network][Fromfile] line:%d %s\n", line_num,
     //                 "Invalid TN line. A \';\' should be used to indicate the rowrank.\nexample1>
     //                 "
     //                 "\'Tn: 0, 1; 2, 3\'\nexample2> \'Tn: ; -1, 2, 3\'");
 
-    // // handle col-space lbl
-    // vector<string> ket_lbls = str_split(tmp[0], false, ",");
-    // if (ket_lbls.size() == 1)
-    //   if (ket_lbls[0].length() == 0) ket_lbls.clear();
-    // for (cytnx_uint64 i = 0; i < ket_lbls.size(); i++) {
-    //   string tmp = str_strip(ket_lbls[i]);
+    // // handle col-space label
+    // vector<string> ket_labels = str_split(tmp[0], false, ",");
+    // if (ket_labels.size() == 1)
+    //   if (ket_labels[0].length() == 0) ket_labels.clear();
+    // for (cytnx_uint64 i = 0; i < ket_labels.size(); i++) {
+    //   string tmp = str_strip(ket_labels[i]);
     //   cytnx_error_msg(tmp.length() == 0,
     //                   "[ERROR][Network][Fromfile] line:%d Invalid labels for TN line.%s",
     //                   line_num,
@@ -135,16 +135,16 @@ namespace cytnx {
     //   cytnx_error_msg((tmp.find_first_not_of("0123456789-") != string::npos),
     //                   "[ERROR][Network][Fromfile] line:%d %s\n", line_num,
     //                   "Invalid TN line. label contain non integer.");
-    //   lbls.push_back(tmp);
+    //   labels.push_back(tmp);
     // }
-    // TN_iBondNum = lbls.size();
+    // TN_iBondNum = labels.size();
 
-    // // handle row-space lbl
-    // vector<string> bra_lbls = str_split(tmp[1], false, ",");
-    // if (bra_lbls.size() == 1)
-    //   if (bra_lbls[0].length() == 0) bra_lbls.clear();
-    // for (cytnx_uint64 i = 0; i < bra_lbls.size(); i++) {
-    //   string tmp = str_strip(bra_lbls[i]);
+    // // handle row-space label
+    // vector<string> bra_labels = str_split(tmp[1], false, ",");
+    // if (bra_labels.size() == 1)
+    //   if (bra_labels[0].length() == 0) bra_labels.clear();
+    // for (cytnx_uint64 i = 0; i < bra_labels.size(); i++) {
+    //   string tmp = str_strip(bra_labels[i]);
     //   cytnx_error_msg(tmp.length() == 0,
     //                   "[ERROR][Network][Fromfile] line:%d Invalid labels for TOUT line.%s",
     //                   line_num, "\n");
@@ -156,26 +156,26 @@ namespace cytnx {
     //   cytnx_error_msg((tmp.find_first_not_of("0123456789-") != string::npos),
     //                   "[ERROR][Network][Fromfile] line:%d %s\n", line_num,
     //                   "Invalid TN line. label contain non integer.");
-    //   lbls.push_back(tmp);
+    //   labels.push_back(tmp);
     // }
 
-    vector<string> alllbls = str_split(line, false, ",");
-    if (alllbls.size() == 1)
-      if (alllbls[0].length() == 0) alllbls.clear();
-    for (cytnx_uint64 i = 0; i < alllbls.size(); i++) {
-      string tmp = str_strip(alllbls[i]);
+    vector<string> alllabels = str_split(line, false, ",");
+    if (alllabels.size() == 1)
+      if (alllabels[0].length() == 0) alllabels.clear();
+    for (cytnx_uint64 i = 0; i < alllabels.size(); i++) {
+      string tmp = str_strip(alllabels[i]);
       cytnx_error_msg(tmp.length() == 0,
                       "[ERROR][Network][Fromfile] line:%d Invalid labels for TN line.%s", line_num,
                       "\n");
       // cytnx_error_msg((tmp.find_first_not_of("0123456789-") != string::npos),
       //                 "[ERROR][Network][Fromfile] line:%d %s\n", line_num,
       //                 "Invalid TN line. label contain non integer.");
-      lbls.push_back(tmp);
+      labels.push_back(tmp);
     }
 
-    TN_iBondNum = lbls.size();
+    TN_iBondNum = labels.size();
 
-    cytnx_error_msg(lbls.size() == 0, "[ERROR][Network][Fromfile] line:%d %s\n", line_num,
+    cytnx_error_msg(labels.size() == 0, "[ERROR][Network][Fromfile] line:%d %s\n", line_num,
                     "Invalid TN line. no label present in this line, which is invalid.%s", "\n");
   }
 
@@ -387,17 +387,17 @@ namespace cytnx {
     }  // check all RN.
 
     // checking label matching:
-    map<string, cytnx_int64> lblcnt;
+    map<string, cytnx_int64> labelcnt;
     for (int i = 0; i < this->names.size(); i++) {
       for (int j = 0; j < this->label_arr[i].size(); j++) {
-        if (lblcnt.find(this->label_arr[i][j]) == lblcnt.end())
-          lblcnt[this->label_arr[i][j]] = 1;
+        if (labelcnt.find(this->label_arr[i][j]) == labelcnt.end())
+          labelcnt[this->label_arr[i][j]] = 1;
         else
-          lblcnt[this->label_arr[i][j]] += 1;
+          labelcnt[this->label_arr[i][j]] += 1;
       }
     }
     vector<string> expected_TOUT;
-    for (map<string, cytnx_int64>::iterator it = lblcnt.begin(); it != lblcnt.end(); ++it) {
+    for (map<string, cytnx_int64>::iterator it = labelcnt.begin(); it != labelcnt.end(); ++it) {
       if (it->second == 1) expected_TOUT.push_back(it->first);
     }
     bool err = false;
@@ -542,17 +542,17 @@ namespace cytnx {
     }  // check all RN.
 
     // checking label matching:
-    map<string, cytnx_int64> lblcnt;
+    map<string, cytnx_int64> labelcnt;
     for (int i = 0; i < this->names.size(); i++) {
       for (int j = 0; j < this->label_arr[i].size(); j++) {
-        if (lblcnt.find(this->label_arr[i][j]) == lblcnt.end())
-          lblcnt[this->label_arr[i][j]] = 1;
+        if (labelcnt.find(this->label_arr[i][j]) == labelcnt.end())
+          labelcnt[this->label_arr[i][j]] = 1;
         else
-          lblcnt[this->label_arr[i][j]] += 1;
+          labelcnt[this->label_arr[i][j]] += 1;
       }
     }
     vector<string> expected_TOUT;
-    for (map<string, cytnx_int64>::iterator it = lblcnt.begin(); it != lblcnt.end(); ++it) {
+    for (map<string, cytnx_int64>::iterator it = labelcnt.begin(); it != labelcnt.end(); ++it) {
       if (it->second == 1) expected_TOUT.push_back(it->first);
     }
     bool err = false;
@@ -590,20 +590,20 @@ namespace cytnx {
     }
 
     // get int_label
-    std::map<std::string, cytnx_int64> lblmap = std::map<std::string, cytnx_int64>();
+    std::map<std::string, cytnx_int64> labelmap = std::map<std::string, cytnx_int64>();
     this->int_modes = std::vector<std::vector<cytnx_int64>>(this->label_arr.size());
     this->int_out_mode = std::vector<cytnx_int64>(this->TOUT_labels.size());
-    cytnx_int64 lbl_int = 0;
+    cytnx_int64 label_int = 0;
     for (size_t i = 0; i < this->label_arr.size(); i++) {
       this->int_modes[i] = std::vector<cytnx_int64>(this->label_arr[i].size());
       for (size_t j = 0; j < this->label_arr[i].size(); j++) {
-        lblmap.insert(std::pair<std::string, cytnx_int64>(this->label_arr[i][j], lbl_int));
-        this->int_modes[i][j] = lblmap[this->label_arr[i][j]];
-        lbl_int += 1;
+        labelmap.insert(std::pair<std::string, cytnx_int64>(this->label_arr[i][j], label_int));
+        this->int_modes[i][j] = labelmap[this->label_arr[i][j]];
+        label_int += 1;
       }
     }
     for (size_t i = 0; i < TOUT_labels.size(); i++) {
-      this->int_out_mode[i] = lblmap[this->TOUT_labels[i]];
+      this->int_out_mode[i] = labelmap[this->TOUT_labels[i]];
     }
 
   #ifdef UNI_GPU
@@ -1132,20 +1132,20 @@ namespace cytnx {
     }
   }
 
-  void RegularNetwork::construct(const vector<string> &alias, const vector<vector<string>> &lbls,
-                                 const vector<string> &outlbl, const cytnx_int64 &outrk,
+  void RegularNetwork::construct(const vector<string> &alias, const vector<vector<string>> &labels,
+                                 const vector<string> &outlabel, const cytnx_int64 &outrk,
                                  const string &order, const bool optim) {
     this->clear();
     for (int i = 0; i < alias.size(); i++) {
       this->names.push_back(alias[i]);
       this->name2pos[alias[i]] = names.size() - 1;  // register
-      cytnx_uint64 tmp_iBN = lbls[i].size();
+      cytnx_uint64 tmp_iBN = labels[i].size();
       // this is an internal function that is defined in this cpp file.
-      this->label_arr.push_back(lbls[i]);
+      this->label_arr.push_back(labels[i]);
       this->iBondNums.push_back(tmp_iBN);
     }
-    this->TOUT_labels = outlbl;
-    this->TOUT_iBondNum = outlbl.size() - outrk;
+    this->TOUT_labels = outlabel;
+    this->TOUT_iBondNum = outlabel.size() - outrk;
 
     if (order.length()) {
       this->order_line = order;
@@ -1179,18 +1179,18 @@ namespace cytnx {
     this->CtTree.base_nodes.resize(this->names.size());
 
     // checking label matching:
-    map<string, cytnx_int64> lblcnt;
+    map<string, cytnx_int64> labelcnt;
     for (int i = 0; i < this->names.size(); i++) {
       for (int j = 0; j < this->label_arr[i].size(); j++) {
-        if (lblcnt.find(this->label_arr[i][j]) == lblcnt.end())
-          lblcnt[this->label_arr[i][j]] = 1;
+        if (labelcnt.find(this->label_arr[i][j]) == labelcnt.end())
+          labelcnt[this->label_arr[i][j]] = 1;
         else
-          lblcnt[this->label_arr[i][j]] += 1;
+          labelcnt[this->label_arr[i][j]] += 1;
       }
     }
     vector<string> expected_TOUT;
 
-    for (map<string, cytnx_int64>::iterator it = lblcnt.begin(); it != lblcnt.end(); ++it) {
+    for (map<string, cytnx_int64>::iterator it = labelcnt.begin(); it != labelcnt.end(); ++it) {
       if (it->second == 1) expected_TOUT.push_back(it->first);
     }
     // cout<<this->TOUT_labels.size();
@@ -1232,20 +1232,20 @@ namespace cytnx {
     }
 
     // get int_label
-    std::map<std::string, cytnx_int64> lblmap = std::map<std::string, cytnx_int64>();
+    std::map<std::string, cytnx_int64> labelmap = std::map<std::string, cytnx_int64>();
     this->int_modes = std::vector<std::vector<cytnx_int64>>(this->label_arr.size());
     this->int_out_mode = std::vector<cytnx_int64>(this->TOUT_labels.size());
-    cytnx_int64 lbl_int = 0;
+    cytnx_int64 label_int = 0;
     for (size_t i = 0; i < this->label_arr.size(); i++) {
       this->int_modes[i] = std::vector<cytnx_int64>(this->label_arr[i].size());
       for (size_t j = 0; j < this->label_arr[i].size(); j++) {
-        lblmap.insert(std::pair<std::string, cytnx_int64>(this->label_arr[i][j], lbl_int));
-        this->int_modes[i][j] = lblmap[this->label_arr[i][j]];
-        lbl_int += 1;
+        labelmap.insert(std::pair<std::string, cytnx_int64>(this->label_arr[i][j], label_int));
+        this->int_modes[i][j] = labelmap[this->label_arr[i][j]];
+        label_int += 1;
       }
     }
     for (size_t i = 0; i < TOUT_labels.size(); i++) {
-      this->int_out_mode[i] = lblmap[this->TOUT_labels[i]];
+      this->int_out_mode[i] = labelmap[this->TOUT_labels[i]];
     }
 
   #ifdef UNI_GPU

--- a/src/UniTensor_base.cpp
+++ b/src/UniTensor_base.cpp
@@ -324,7 +324,7 @@ namespace cytnx {
     return nullptr;
   }
 
-  boost::intrusive_ptr<UniTensor_base> UniTensor_base::relabel(const std::string &inx,
+  boost::intrusive_ptr<UniTensor_base> UniTensor_base::relabel(const std::string &old_label,
                                                                const std::string &new_label) {
     cytnx_error_msg(true, "[ERROR] fatal internal, cannot call on a un-initialize UniTensor_base%s",
                     "\n");

--- a/src/ncon.cpp
+++ b/src/ncon.cpp
@@ -12,17 +12,17 @@ namespace cytnx {
                  std::vector<cytnx_int64> cont_order /*= std::vector<cytnx_int64>()*/,
                  const std::vector<std::string> &out_labels /*= std::vector<std::string>()*/) {
     vector<string> alias;
-    vector<vector<string>> lbls;
+    vector<vector<string>> labels;
     map<cytnx_int64, vector<cytnx_uint64>> posbond2tensor;
     for (cytnx_uint64 i = 0; i < tensor_list_in.size(); i++) {
       string name = "t" + to_string(i);
       alias.push_back(name);
 
-      vector<string> lbl;
+      vector<string> label;
       for (cytnx_uint64 j = 0; j < connect_list_in[i].size(); j++) {
-        lbl.push_back(to_string(connect_list_in[i][j]));
+        label.push_back(to_string(connect_list_in[i][j]));
       }
-      lbls.push_back(lbl);
+      labels.push_back(label);
     }
     vector<cytnx_int64> positive;
     for (cytnx_uint64 i = 0; i < connect_list_in.size(); i++) {
@@ -85,7 +85,7 @@ namespace cytnx {
     std::cout << str_order << std::endl;
     UniTensor out;
     Network N;
-    N.construct(alias, lbls, out_labels, 1, str_order, optimize);
+    N.construct(alias, labels, out_labels, 1, str_order, optimize);
     for (cytnx_uint64 i = 0; i < tensor_list_in.size(); i++) {
       N.PutUniTensor(i, tensor_list_in[i]);
     }


### PR DESCRIPTION
- fixed wrong argument name in UniTensor_base::relabel(const std::string &inx, const std::string &new_label)
- changed argument names in many functions from lbl(s) to label(s), to be consistent with old_label(s)/new_label(s) and allow for a more intuitive call when argument names are specifically used in python