### PR TITLE
Add Scalar backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,37 @@ add_library(cytnx STATIC)
 set_property(TARGET cytnx PROPERTY C_VISIBILITY_PRESET hidden)
 set_property(TARGET cytnx PROPERTY VISIBILITY_INLINES_HIDDEN ON)
 
+if(BACKEND_TORCH)
+  message(STATUS "backend = pytorch")
+  target_compile_definitions(cytnx PUBLIC BACKEND_TORCH)
+
+  # let torch python expose where pytorch.cmake is installed
+  execute_process(
+    COMMAND bash -c "python -c 'import torch;print(torch.utils.cmake_prefix_path)'"
+    OUTPUT_VARIABLE TORCH_CMAKE_PATH_C
+  )
+  string(REGEX REPLACE "\n$" "" TORCH_CMAKE_PATH_C "${TORCH_CMAKE_PATH_C}")
+  set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${TORCH_CMAKE_PATH_C})
+  message(STATUS ${CMAKE_PREFIX_PATH})
+
+  find_package(Torch REQUIRED)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
+  message(STATUS "pytorch: ${TORCH_INSTALL_PREFIX}")
+  message(STATUS "pytorch libs: ${TORCH_LIBRARIES}")
+
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    target_link_libraries(cytnx PUBLIC ${TORCH_LIBRARIES} ${TORCH_INSTALL_PREFIX}/lib/libtorch_python.dylib)
+  else()
+    target_link_libraries(cytnx PUBLIC ${TORCH_LIBRARIES} ${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so)
+    target_link_libraries(cytnx PRIVATE ${TORCH_LIBRARIES} ${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so)
+    target_link_libraries(cytnx INTERFACE ${TORCH_LIBRARIES} ${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so)
+  endif()
+
+else()
+  message(STATUS "backend = cytnx")
+  include(CytnxBKNDCMakeLists.cmake)
+endif() # Backend torch
+
 target_include_directories(cytnx
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src
@@ -159,38 +190,6 @@ target_include_directories(cytnx SYSTEM
 )
 target_link_libraries(cytnx PUBLIC Boost::boost ${LAPACK_LIBRARIES})
 FILE(APPEND "${CMAKE_BINARY_DIR}/cxxflags.tmp" "-I${Boost_INCLUDE_DIRS}\n" "")
-
-# ###
-if(BACKEND_TORCH)
-  message(STATUS "backend = pytorch")
-  target_compile_definitions(cytnx PUBLIC BACKEND_TORCH)
-
-  # let torch python expose where pytorch.cmake is installed
-  execute_process(
-    COMMAND bash -c "python -c 'import torch;print(torch.utils.cmake_prefix_path)'"
-    OUTPUT_VARIABLE TORCH_CMAKE_PATH_C
-  )
-  string(REGEX REPLACE "\n$" "" TORCH_CMAKE_PATH_C "${TORCH_CMAKE_PATH_C}")
-  set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${TORCH_CMAKE_PATH_C})
-  message(STATUS ${CMAKE_PREFIX_PATH})
-
-  find_package(Torch REQUIRED)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
-  message(STATUS "pytorch: ${TORCH_INSTALL_PREFIX}")
-  message(STATUS "pytorch libs: ${TORCH_LIBRARIES}")
-
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    target_link_libraries(cytnx PUBLIC ${TORCH_LIBRARIES} ${TORCH_INSTALL_PREFIX}/lib/libtorch_python.dylib)
-  else()
-    target_link_libraries(cytnx PUBLIC ${TORCH_LIBRARIES} ${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so)
-    target_link_libraries(cytnx PRIVATE ${TORCH_LIBRARIES} ${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so)
-    target_link_libraries(cytnx INTERFACE ${TORCH_LIBRARIES} ${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so)
-  endif()
-
-else()
-  message(STATUS "backend = cytnx")
-  include(CytnxBKNDCMakeLists.cmake)
-endif() # Backend torch
 
 # #####################################################################
 # ## Get Gtest & benchmark

--- a/Install.sh
+++ b/Install.sh
@@ -179,7 +179,7 @@ FLAG="${FLAG} -DUSE_DEBUG=OFF "
 #-----------------------------------
 
 echo ${FLAG}
-rm -rf build
+# rm -rf build
 mkdir build
 cd build
 # cmake ../ ${FLAG} -DDEV_MODE=on

--- a/Install.sh
+++ b/Install.sh
@@ -179,11 +179,11 @@ FLAG="${FLAG} -DUSE_DEBUG=OFF "
 #-----------------------------------
 
 echo ${FLAG}
-# rm -rf build
+rm -rf build
 mkdir build
 cd build
 # cmake ../ ${FLAG} -DDEV_MODE=on
 cmake ../ ${FLAG}
-# make -j`nproc`
+make -j`nproc`
 # make install
 # ctest -j`nproc`

--- a/Install.sh
+++ b/Install.sh
@@ -182,8 +182,8 @@ echo ${FLAG}
 # rm -rf build
 mkdir build
 cd build
-# cmake ../ ${FLAG} -DDEV_MODE=on
-cmake ../ ${FLAG}
+cmake ../ ${FLAG} -DDEV_MODE=on
 make -j`nproc`
-# make install
-# ctest -j`nproc`
+make install
+ctest
+gcovr -r ../ . --html-details cov.html

--- a/Install.sh
+++ b/Install.sh
@@ -182,8 +182,8 @@ echo ${FLAG}
 # rm -rf build
 mkdir build
 cd build
-cmake ../ ${FLAG} -DDEV_MODE=on
-# cmake ../ ${FLAG}
-make -j`nproc`
+# cmake ../ ${FLAG} -DDEV_MODE=on
+cmake ../ ${FLAG}
+# make -j`nproc`
 # make install
 # ctest -j`nproc`

--- a/Install.sh
+++ b/Install.sh
@@ -184,6 +184,6 @@ mkdir build
 cd build
 # cmake ../ ${FLAG} -DDEV_MODE=on
 cmake ../ ${FLAG}
-make -j`nproc`
+# make -j`nproc`
 # make install
 # ctest -j`nproc`

--- a/Install.sh
+++ b/Install.sh
@@ -184,6 +184,6 @@ mkdir build
 cd build
 # cmake ../ ${FLAG} -DDEV_MODE=on
 cmake ../ ${FLAG}
-# make -j`nproc`
+make -j`nproc`
 # make install
 # ctest -j`nproc`

--- a/Install.sh
+++ b/Install.sh
@@ -183,7 +183,7 @@ echo ${FLAG}
 mkdir build
 cd build
 cmake ../ ${FLAG} -DDEV_MODE=on
-make -j`nproc`
+make -j4
 make install
 ctest
 gcovr -r ../ . --html-details cov.html

--- a/include/backend_torch/Scalar.hpp
+++ b/include/backend_torch/Scalar.hpp
@@ -4,22 +4,23 @@
 #include "Type.hpp"
 #ifdef BACKEND_TORCH
   #include <torch/torch.h>
-
 namespace cytnx {
   class Scalar : public c10::Scalar {
    public:
     int _dtype = Type.Void;
     ///@cond
     struct Sproxy {
-      c10::intrusive_ptr_target *_insimpl;
+      c10::intrusive_ptr<c10::StorageImpl> _insimpl;
       cytnx_uint64 _loc;
+      int _dtype = Type.Void;
       Sproxy() {}
-      Sproxy(c10::intrusive_ptr_target *_ptr, const cytnx_uint64 &idx)
-          : _insimpl(_ptr), _loc(idx) {}
+      Sproxy(c10::intrusive_ptr<c10::StorageImpl> _ptr, const cytnx_uint64 &idx)
+          : _insimpl(_ptr), _loc(idx), _dtype(Type.Void) {}
 
       Sproxy(const Sproxy &rhs) {
         this->_insimpl = rhs._insimpl;
         this->_loc = rhs._loc;
+        this->_dtype = rhs._dtype;
       }
 
       // When used to set elems:

--- a/include/backend_torch/Scalar.hpp
+++ b/include/backend_torch/Scalar.hpp
@@ -1,17 +1,20 @@
 #ifndef _H_Scalar_
 #define _H_Scalar_
+#include "cytnx_error.hpp"
+#include "Type.hpp"
 #ifdef BACKEND_TORCH
   #include <torch/torch.h>
 
 namespace cytnx {
   class Scalar : public c10::Scalar {
    public:
+    int _dtype = Type.Void;
     ///@cond
     struct Sproxy {
-      boost::intrusive_ptr<Storage_base> _insimpl;
+      c10::intrusive_ptr_target *_insimpl;
       cytnx_uint64 _loc;
       Sproxy() {}
-      Sproxy(boost::intrusive_ptr<Storage_base> _ptr, const cytnx_uint64 &idx)
+      Sproxy(c10::intrusive_ptr_target *_ptr, const cytnx_uint64 &idx)
           : _insimpl(_ptr), _loc(idx) {}
 
       Sproxy(const Sproxy &rhs) {
@@ -48,45 +51,75 @@ namespace cytnx {
       // operator Scalar() const;
     };
 
-    Scalar_base *_impl;
-    ///@endcond
-
     /// @brief default constructor
-    Scalar() : _impl(new Scalar_base()){};
+    Scalar(){};
 
     // init!!
     /// @brief init a Scalar with a cytnx::cytnx_complex128
-    Scalar(const cytnx_complex128 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_complex128 &in) { this->Init_by_number(in); }
 
     /// @brief init a Scalar with a cytnx::cytnx_complex64
-    Scalar(const cytnx_complex64 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_complex64 &in) { this->Init_by_number(in); }
 
     /// @brief init a Scalar with a cytnx::cytnx_double
-    Scalar(const cytnx_double &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_double &in) { this->Init_by_number(in); }
 
     /// @brief init a Scalar with a cytnx::cytnx_float
-    Scalar(const cytnx_float &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_float &in) { this->Init_by_number(in); }
 
     /// @brief init a Scalar with a cytnx::cytnx_uint64
-    Scalar(const cytnx_uint64 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_uint64 &in) {
+      cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+    }
 
     /// @brief init a Scalar with a cytnx::cytnx_int64
-    Scalar(const cytnx_int64 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_int64 &in) { this->Init_by_number(in); }
 
     /// @brief init a Scalar with a cytnx::cytnx_uint32
-    Scalar(const cytnx_uint32 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_uint32 &in) {
+      cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+    }
 
     /// @brief init a Scalar with a cytnx::cytnx_int32
-    Scalar(const cytnx_int32 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_int32 &in) { this->Init_by_number(in); }
 
     /// @brief init a Scalar with a cytnx::cytnx_uint16
-    Scalar(const cytnx_uint16 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_uint16 &in) {
+      cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+    }
 
     /// @brief init a Scalar with a cytnx::cytnx_int16
-    Scalar(const cytnx_int16 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_int16 &in) { this->Init_by_number(in); }
 
     /// @brief init a Scalar with a cytnx::cytnx_bool
-    Scalar(const cytnx_bool &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_bool &in) { this->Init_by_number(in); }
+
+    Scalar(c10::Scalar &rhs) : c10::Scalar(rhs) {
+      if (rhs.isComplex()) {
+        _dtype = Type.ComplexDouble;
+      } else if (rhs.isFloatingPoint()) {
+        _dtype = Type.Double;
+      } else if (rhs.isIntegral(/*includeBool=*/false)) {
+        _dtype = Type.Int64;
+      } else if (rhs.isBoolean()) {
+        _dtype = Type.Bool;
+      } else {
+        cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+      }
+    }
+    Scalar(c10::Scalar &&rhs) : c10::Scalar(rhs) {
+      if (rhs.isComplex()) {
+        _dtype = Type.ComplexDouble;
+      } else if (rhs.isFloatingPoint()) {
+        _dtype = Type.Double;
+      } else if (rhs.isIntegral(/*includeBool=*/false)) {
+        _dtype = Type.Int64;
+      } else if (rhs.isBoolean()) {
+        _dtype = Type.Bool;
+      } else {
+        cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+      }
+    }
 
     /**
      * @brief Get the max value of the Scalar with the given \p dtype.
@@ -98,8 +131,44 @@ namespace cytnx {
      */
     static Scalar maxval(const unsigned int &dtype) {
       Scalar out(0, dtype);
-      out._impl->set_maxval();
-      return out;
+      switch (dtype) {
+        case Type.ComplexDouble:
+          cytnx_error_msg(true, "[ERROR] maxval not supported for complex type%s", "\n");
+          break;
+        case Type.ComplexFloat:
+          cytnx_error_msg(true, "[ERROR] maxval not supported for complex type%s", "\n");
+          break;
+        case Type.Double:
+          return Scalar(std::numeric_limits<double>::max());
+          break;
+        case Type.Float:
+          return Scalar(std::numeric_limits<float>::max());
+          break;
+        case Type.Int64:
+          return Scalar(std::numeric_limits<int64_t>::max());
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          return Scalar(std::numeric_limits<int32_t>::max());
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          return Scalar(std::numeric_limits<int16_t>::max());
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          return Scalar(true);
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
+      }
     }
 
     /**
@@ -112,8 +181,44 @@ namespace cytnx {
      */
     static Scalar minval(const unsigned int &dtype) {
       Scalar out(0, dtype);
-      out._impl->set_minval();
-      return out;
+      switch (dtype) {
+        case Type.ComplexDouble:
+          cytnx_error_msg(true, "[ERROR] maxval not supported for complex type%s", "\n");
+          break;
+        case Type.ComplexFloat:
+          cytnx_error_msg(true, "[ERROR] maxval not supported for complex type%s", "\n");
+          break;
+        case Type.Double:
+          return Scalar(std::numeric_limits<double>::min());
+          break;
+        case Type.Float:
+          return Scalar(std::numeric_limits<float>::min());
+          break;
+        case Type.Int64:
+          return Scalar(std::numeric_limits<int64_t>::min());
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          return Scalar(std::numeric_limits<int32_t>::min());
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          return Scalar(std::numeric_limits<int16_t>::min());
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          return Scalar(false);
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
+      }
     }
 
     /**
@@ -126,80 +231,112 @@ namespace cytnx {
      * @note The \p dtype can be any of the cytnx::Type.
      */
     template <class T>
-    Scalar(const T &in, const unsigned int &dtype) : _impl(new Scalar_base()) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = __ScII.UScIInit[dtype]();
-      this->_impl->assign_selftype(in);
+    Scalar(const T &in, const unsigned int &dtype) {
+      destroy();
+      *this = Scalar(in);
+      switch (dtype) {
+        case Type.ComplexDouble:
+          *this = Scalar(toComplexDouble());
+          break;
+        case Type.ComplexFloat:
+          *this = Scalar(toComplexFloat());
+          break;
+        case Type.Double:
+          *this = Scalar(toDouble());
+          break;
+        case Type.Float:
+          *this = Scalar(toFloat());
+          break;
+        case Type.Int64:
+          *this = Scalar(toLong());
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          *this = Scalar(toInt());
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          *this = Scalar(toShort());
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          *this = Scalar(toBool());
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
+      }
     };
 
     /// @cond
     // move sproxy when use to get elements here.
     Scalar(const Sproxy &prox);
 
-    //[Internal!!]
-    Scalar(Scalar_base *in) { this->_impl = in; }
-    /// @endcond
-
     // specialization of init:
     ///@cond
     void Init_by_number(const cytnx_complex128 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new ComplexDoubleScalar(in);
+      destroy();
+      *this = c10::Scalar(c10::complex<double>(in));
+      this->_dtype = Type.ComplexDouble;
     };
     void Init_by_number(const cytnx_complex64 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new ComplexFloatScalar(in);
+      destroy();
+      *this = c10::Scalar(c10::complex<float>(in));
+      this->_dtype = Type.ComplexFloat;
     };
     void Init_by_number(const cytnx_double &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new DoubleScalar(in);
+      destroy();
+      *this = c10::Scalar(in);
+      this->_dtype = Type.Double;
     }
     void Init_by_number(const cytnx_float &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new FloatScalar(in);
+      destroy();
+      *this = c10::Scalar(in);
+      this->_dtype = Type.Float;
     }
     void Init_by_number(const cytnx_int64 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Int64Scalar(in);
+      destroy();
+      *this = c10::Scalar(in);
+      this->_dtype = Type.Int64;
     }
     void Init_by_number(const cytnx_uint64 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Uint64Scalar(in);
+      cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
     }
     void Init_by_number(const cytnx_int32 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Int32Scalar(in);
+      destroy();
+      *this = c10::Scalar(in);
+      this->_dtype = Type.Int32;
     }
     void Init_by_number(const cytnx_uint32 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Uint32Scalar(in);
+      cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
     }
     void Init_by_number(const cytnx_int16 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Int16Scalar(in);
+      destroy();
+      *this = c10::Scalar(in);
+      this->_dtype = Type.Int16;
     }
     void Init_by_number(const cytnx_uint16 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Uint16Scalar(in);
+      cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
     }
     void Init_by_number(const cytnx_bool &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new BoolScalar(in);
+      destroy();
+      *this = c10::Scalar(in);
+      this->_dtype = Type.Bool;
     }
 
     // The copy constructor
-    Scalar(const Scalar &rhs) : _impl(new Scalar_base()) {
-      if (this->_impl != nullptr) delete this->_impl;
-
-      this->_impl = rhs._impl->copy();
-    }
+    Scalar(const Scalar &rhs) { *this = c10::Scalar(rhs); }
     /// @endcond
 
     /// @brief The copy assignment of the Scalar class.
     Scalar &operator=(const Scalar &rhs) {
-      if (this->_impl != nullptr) delete this->_impl;
-
-      this->_impl = rhs._impl->copy();
+      *this = c10::Scalar(rhs);
       return *this;
     };
 
@@ -301,8 +438,45 @@ namespace cytnx {
      * part of the Scalar instead.
      */
     Scalar astype(const unsigned int &dtype) const {
-      Scalar out(this->_impl->astype(dtype));
-      return out;
+      Scalar out = *this;
+      switch (dtype) {
+        case Type.ComplexDouble:
+          out = Scalar(toComplexDouble());
+          break;
+        case Type.ComplexFloat:
+          out = Scalar(toComplexFloat());
+          break;
+        case Type.Double:
+          out = Scalar(toDouble());
+          break;
+        case Type.Float:
+          out = Scalar(toFloat());
+          break;
+        case Type.Int64:
+          out = Scalar(toLong());
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          out = Scalar(toInt());
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          out = Scalar(toShort());
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          out = Scalar(toBool());
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
+      }
     }
 
     /**
@@ -312,7 +486,7 @@ namespace cytnx {
      */
     Scalar conj() const {
       Scalar out = *this;
-      out._impl->conj_();
+      out = out.c10::Scalar::conj();
       return out;
     }
 
@@ -321,115 +495,484 @@ namespace cytnx {
      * the Scalar is \f$ c \f$.
      * @return The imaginary part of the Scalar.
      */
-    Scalar imag() const { return Scalar(this->_impl->get_imag()); }
+    Scalar imag() const {
+      if (!isComplex()) {
+        cytnx_error_msg(true, "[ERROR] cannot get imaginary part of a real Scalar.%s", "\n");
+      } else {
+        if (this->dtype() == Type.ComplexDouble) {
+          return Scalar(toComplexDouble().imag());
+        } else if (this->dtype() == Type.ComplexFloat) {
+          return Scalar(toComplexFloat().imag());
+        } else {
+          cytnx_error_msg(true, "[ERROR] This should not happen %s", "\n");
+        }
+      }
+    }
 
     /**
      * @brief Get the real part of the Scalar. That means return \f$ \Re(c) \f$ if
      * the Scalar is \f$ c \f$.
      * @return The real part of the Scalar.
      */
-    Scalar real() const { return Scalar(this->_impl->get_real()); }
+    Scalar real() const {
+      if (!isComplex()) {
+        return *this;
+      } else {
+        if (this->dtype() == Type.ComplexDouble) {
+          return c10::Scalar(toComplexDouble().real());
+        } else if (this->dtype() == Type.ComplexFloat) {
+          return c10::Scalar(toComplexFloat().real());
+        } else {
+          cytnx_error_msg(true, "[ERROR] This should not happen %s", "\n");
+        }
+      }
+    }
     // Scalar& set_imag(const Scalar &in){   return *this;}
     // Scalar& set_real(const Scalar &in){   return *this;}
 
     /**
      * @brief Get the dtype of the Scalar (see cytnx::Type for more details).
      */
-    int dtype() const { return this->_impl->_dtype; }
+    int dtype() const { return this->_dtype; }
 
     // print()
     /**
      * @brief Print the Scalar to the standard output.
      */
     void print() const {
-      this->_impl->print(std::cout);
-      std::cout << std::string(" Scalar dtype: [") << Type.getname(this->_impl->_dtype)
-                << std::string("]") << std::endl;
+      switch (_dtype) {
+        case Type.ComplexDouble:
+          std::cout << "< " << toComplexDouble() << " >";
+          break;
+        case Type.ComplexFloat:
+          std::cout << "< " << toComplexFloat() << " >";
+          break;
+        case Type.Double:
+          std::cout << "< " << toDouble() << " >";
+          break;
+        case Type.Float:
+          std::cout << "< " << toFloat() << " >";
+          break;
+        case Type.Int64:
+          std::cout << "< " << toLong() << " >";
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          std::cout << "< " << toInt() << " >";
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          std::cout << "< " << toShort() << " >";
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          std::cout << "< " << toBool() << " >";
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
+      }
+      std::cout << std::string(" Scalar dtype: [") << Type.getname(this->_dtype) << std::string("]")
+                << std::endl;
     }
 
     // casting
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_double.
-    explicit operator cytnx_double() const { return this->_impl->to_cytnx_double(); }
+    explicit operator cytnx_double() const { return toDouble(); }
 
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_float
-    explicit operator cytnx_float() const { return this->_impl->to_cytnx_float(); }
+    explicit operator cytnx_float() const { return toFloat(); }
 
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_uint64.
-    explicit operator cytnx_uint64() const { return this->_impl->to_cytnx_uint64(); }
+    explicit operator cytnx_uint64() const {
+      cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+    }
 
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_int64.
-    explicit operator cytnx_int64() const { return this->_impl->to_cytnx_int64(); }
+    explicit operator cytnx_int64() const { return toLong(); }
 
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_uint32.
-    explicit operator cytnx_uint32() const { return this->_impl->to_cytnx_uint32(); }
+    explicit operator cytnx_uint32() const {
+      cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+    }
 
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_int32.
-    explicit operator cytnx_int32() const { return this->_impl->to_cytnx_int32(); }
+    explicit operator cytnx_int32() const { return toInt(); }
 
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_uint16.
-    explicit operator cytnx_uint16() const { return this->_impl->to_cytnx_uint16(); }
+    explicit operator cytnx_uint16() const {
+      cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+    }
 
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_int16.
-    explicit operator cytnx_int16() const { return this->_impl->to_cytnx_int16(); }
+    explicit operator cytnx_int16() const { return toShort(); }
 
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_bool.
-    explicit operator cytnx_bool() const { return this->_impl->to_cytnx_bool(); }
+    explicit operator cytnx_bool() const { return toBool(); }
 
     /// @cond
     // destructor
-    ~Scalar() {
-      if (this->_impl != nullptr) delete this->_impl;
-    };
+    ~Scalar(){};
     /// @endcond
 
     // arithmetic:
     ///@brief The addition assignment operator of the Scalar class with a given number (template).
     template <class T>
     void operator+=(const T &rc) {
-      this->_impl->iadd(rc);
+      switch (_dtype) {
+        case Type.ComplexDouble:
+          *this = Scalar(toComplexDouble() + rc);
+          break;
+        case Type.ComplexFloat:
+          *this = Scalar(toComplexFloat() + rc);
+          break;
+        case Type.Double:
+          *this = Scalar(toDouble() + rc);
+          break;
+        case Type.Float:
+          *this = Scalar(toFloat() + rc);
+          break;
+        case Type.Int64:
+          *this = Scalar(toLong() + rc);
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          *this = Scalar(toInt() + rc);
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          *this = Scalar(toShort() + rc);
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          *this = Scalar(toBool() + rc);
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
+      }
     }
 
     ///@brief The addition assignment operator of the Scalar class with a given Scalar.
-    void operator+=(const Scalar &rhs) { this->_impl->iadd(rhs._impl); }
+    void operator+=(const Scalar &rhs) {
+      switch (_dtype) {
+        case Type.ComplexDouble:
+          *this = Scalar(toComplexDouble() + rhs.toComplexDouble());
+          break;
+        case Type.ComplexFloat:
+          *this = Scalar(toComplexFloat() + rhs.toComplexFloat());
+          break;
+        case Type.Double:
+          *this = Scalar(toDouble() + rhs.toDouble());
+          break;
+        case Type.Float:
+          *this = Scalar(toFloat() + rhs.toFloat());
+          break;
+        case Type.Int64:
+          *this = Scalar(toLong() + rhs.toLong());
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          *this = Scalar(toInt() + rhs.toInt());
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          *this = Scalar(toShort() + rhs.toShort());
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          *this = Scalar(toBool() + rhs.toBool());
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
+      }
+    }
 
     ///@brief The subtraction assignment operator of the Scalar class with a given number
     ///(template).
     template <class T>
     void operator-=(const T &rc) {
-      this->_impl->isub(rc);
+      switch (_dtype) {
+        case Type.ComplexDouble:
+          *this = Scalar(toComplexDouble() - rc);
+          break;
+        case Type.ComplexFloat:
+          *this = Scalar(toComplexFloat() - rc);
+          break;
+        case Type.Double:
+          *this = Scalar(toDouble() - rc);
+          break;
+        case Type.Float:
+          *this = Scalar(toFloat() - rc);
+          break;
+        case Type.Int64:
+          *this = Scalar(toLong() - rc);
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          *this = Scalar(toInt() - rc);
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          *this = Scalar(toShort() - rc);
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          *this = Scalar(toBool() - rc);
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
+      }
     }
 
     ///@brief The subtraction assignment operator of the Scalar class with a given Scalar.
-    void operator-=(const Scalar &rhs) { this->_impl->isub(rhs._impl); }
+    void operator-=(const Scalar &rhs) {
+      switch (_dtype) {
+        case Type.ComplexDouble:
+          *this = Scalar(toComplexDouble() - rhs.toComplexDouble());
+          break;
+        case Type.ComplexFloat:
+          *this = Scalar(toComplexFloat() - rhs.toComplexFloat());
+          break;
+        case Type.Double:
+          *this = Scalar(toDouble() - rhs.toDouble());
+          break;
+        case Type.Float:
+          *this = Scalar(toFloat() - rhs.toFloat());
+          break;
+        case Type.Int64:
+          *this = Scalar(toLong() - rhs.toLong());
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          *this = Scalar(toInt() - rhs.toInt());
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          *this = Scalar(toShort() - rhs.toShort());
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          *this = Scalar(toBool() - rhs.toBool());
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
+      }
+    }
     template <class T>
 
     ///@brief The multiplication assignment operator of the Scalar class with a given number
     ///(template).
     void operator*=(const T &rc) {
-      this->_impl->imul(rc);
+      switch (_dtype) {
+        case Type.ComplexDouble:
+          *this = Scalar(toComplexDouble() * rc);
+          break;
+        case Type.ComplexFloat:
+          *this = Scalar(toComplexFloat() * rc);
+          break;
+        case Type.Double:
+          *this = Scalar(toDouble() * rc);
+          break;
+        case Type.Float:
+          *this = Scalar(toFloat() * rc);
+          break;
+        case Type.Int64:
+          *this = Scalar(toLong() * rc);
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          *this = Scalar(toInt() * rc);
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          *this = Scalar(toShort() * rc);
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          *this = Scalar(toBool() * rc);
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
+      }
     }
 
     ///@brief The multiplication assignment operator of the Scalar class with a given Scalar.
-    void operator*=(const Scalar &rhs) { this->_impl->imul(rhs._impl); }
+    void operator*=(const Scalar &rhs) {
+      switch (_dtype) {
+        case Type.ComplexDouble:
+          *this = Scalar(toComplexDouble() * rhs.toComplexDouble());
+          break;
+        case Type.ComplexFloat:
+          *this = Scalar(toComplexFloat() * rhs.toComplexFloat());
+          break;
+        case Type.Double:
+          *this = Scalar(toDouble() * rhs.toDouble());
+          break;
+        case Type.Float:
+          *this = Scalar(toFloat() * rhs.toFloat());
+          break;
+        case Type.Int64:
+          *this = Scalar(toLong() * rhs.toLong());
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          *this = Scalar(toInt() * rhs.toInt());
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          *this = Scalar(toShort() * rhs.toShort());
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          *this = Scalar(toBool() * rhs.toBool());
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
+      }
+    }
     template <class T>
 
     /**
      * @brief The division assignment operator of the Scalar class with a given number (template).
      */
     void operator/=(const T &rc) {
-      this->_impl->idiv(rc);
+      switch (_dtype) {
+        case Type.ComplexDouble:
+          *this = Scalar(toComplexDouble() / rc);
+          break;
+        case Type.ComplexFloat:
+          *this = Scalar(toComplexFloat() / rc);
+          break;
+        case Type.Double:
+          *this = Scalar(toDouble() / rc);
+          break;
+        case Type.Float:
+          *this = Scalar(toFloat() / rc);
+          break;
+        case Type.Int64:
+          *this = Scalar(toLong() / rc);
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          *this = Scalar(toInt() / rc);
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          *this = Scalar(toShort() / rc);
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          *this = Scalar(toBool() / rc);
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
+      }
     }
 
     /**
      * @brief The division assignment operator of the Scalar class with a given Scalar.
      */
-    void operator/=(const Scalar &rhs) { this->_impl->idiv(rhs._impl); }
+    void operator/=(const Scalar &rhs) {
+      switch (_dtype) {
+        case Type.ComplexDouble:
+          *this = Scalar(toComplexDouble() / rhs.toComplexDouble());
+          break;
+        case Type.ComplexFloat:
+          *this = Scalar(toComplexFloat() / rhs.toComplexFloat());
+          break;
+        case Type.Double:
+          *this = Scalar(toDouble() / rhs.toDouble());
+          break;
+        case Type.Float:
+          *this = Scalar(toFloat() / rhs.toFloat());
+          break;
+        case Type.Int64:
+          *this = Scalar(toLong() / rhs.toLong());
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          *this = Scalar(toInt() / rhs.toInt());
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          *this = Scalar(toShort() / rhs.toShort());
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          *this = Scalar(toBool() / rhs.toBool());
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
+      }
+    }
 
     /// @brief Set the Scalar to absolute value. (inplace)
-    void iabs() { this->_impl->iabs(); }
+    void iabs() { *this = this->abs(); }
 
     /// @brief Set the Scalar to square root. (inplace)
-    void isqrt() { this->_impl->isqrt(); }
+    void isqrt() { *this = this->sqrt(); }
 
     /**
      * @brief The member function to get the absolute value of the Scalar.
@@ -439,8 +982,45 @@ namespace cytnx {
      */
     Scalar abs() const {
       Scalar out = *this;
-      out._impl->iabs();
-      return out.real();
+      switch (_dtype) {
+        case Type.ComplexDouble:
+          out = Scalar(std::abs(toComplexDouble()));
+          break;
+        case Type.ComplexFloat:
+          out = Scalar(std::abs(toComplexFloat()));
+          break;
+        case Type.Double:
+          out = Scalar(std::abs(toDouble()));
+          break;
+        case Type.Float:
+          out = Scalar(std::abs(toFloat()));
+          break;
+        case Type.Int64:
+          out = Scalar(std::abs(toLong()));
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          out = Scalar(std::abs(toInt()));
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          out = Scalar(std::abs(toShort()));
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          out = Scalar(std::abs(toBool()));
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
+      }
+      return out;
     }
 
     /**

--- a/include/backend_torch/Scalar.hpp
+++ b/include/backend_torch/Scalar.hpp
@@ -535,49 +535,57 @@ namespace cytnx {
      */
     int dtype() const { return this->_dtype; }
 
-    // print()
-    /**
-     * @brief Print the Scalar to the standard output.
+    /// @cond
+    /*
+     * @brief On the pytorch-side only. Not documented.
      */
-    void print() const {
+    void print_elem(std::ostream &os) const {
       switch (_dtype) {
         case Type.ComplexDouble:
-          std::cout << "< " << toComplexDouble() << " >";
+          os << "< " << toComplexDouble() << " >";
           break;
         case Type.ComplexFloat:
-          std::cout << "< " << toComplexFloat() << " >";
+          os << "< " << toComplexFloat() << " >";
           break;
         case Type.Double:
-          std::cout << "< " << toDouble() << " >";
+          os << "< " << toDouble() << " >";
           break;
         case Type.Float:
-          std::cout << "< " << toFloat() << " >";
+          os << "< " << toFloat() << " >";
           break;
         case Type.Int64:
-          std::cout << "< " << toLong() << " >";
+          os << "< " << toLong() << " >";
           break;
         case Type.Uint64:
           cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
           break;
         case Type.Int32:
-          std::cout << "< " << toInt() << " >";
+          os << "< " << toInt() << " >";
           break;
         case Type.Uint32:
           cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
           break;
         case Type.Int16:
-          std::cout << "< " << toShort() << " >";
+          os << "< " << toShort() << " >";
           break;
         case Type.Uint16:
           cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
           break;
         case Type.Bool:
-          std::cout << "< " << toBool() << " >";
+          os << "< " << toBool() << " >";
           break;
         default:
           cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
           break;
       }
+    }
+    /// @endcond
+
+    /**
+     * @brief Print the Scalar to the standard output.
+     */
+    void print() const {
+      print_elem(std::cout);
       std::cout << std::string(" Scalar dtype: [") << Type.getname(this->_dtype) << std::string("]")
                 << std::endl;
     }

--- a/include/backend_torch/Scalar.hpp
+++ b/include/backend_torch/Scalar.hpp
@@ -4,7 +4,847 @@
   #include <torch/torch.h>
 
 namespace cytnx {
-  class Scalar : public torch::Scalar {};
+  class Scalar : public c10::Scalar {
+   public:
+    ///@cond
+    struct Sproxy {
+      boost::intrusive_ptr<Storage_base> _insimpl;
+      cytnx_uint64 _loc;
+      Sproxy() {}
+      Sproxy(boost::intrusive_ptr<Storage_base> _ptr, const cytnx_uint64 &idx)
+          : _insimpl(_ptr), _loc(idx) {}
+
+      Sproxy(const Sproxy &rhs) {
+        this->_insimpl = rhs._insimpl;
+        this->_loc = rhs._loc;
+      }
+
+      // When used to set elems:
+      Sproxy &operator=(const Scalar &rc);
+      Sproxy &operator=(const cytnx_complex128 &rc);
+      Sproxy &operator=(const cytnx_complex64 &rc);
+      Sproxy &operator=(const cytnx_double &rc);
+      Sproxy &operator=(const cytnx_float &rc);
+      Sproxy &operator=(const cytnx_uint64 &rc);
+      Sproxy &operator=(const cytnx_int64 &rc);
+      Sproxy &operator=(const cytnx_uint32 &rc);
+      Sproxy &operator=(const cytnx_int32 &rc);
+      Sproxy &operator=(const cytnx_uint16 &rc);
+      Sproxy &operator=(const cytnx_int16 &rc);
+      Sproxy &operator=(const cytnx_bool &rc);
+
+      Sproxy &operator=(const Sproxy &rc);
+
+      Sproxy copy() const {
+        Sproxy out = *this;
+        return out;
+      }
+
+      Scalar real();
+      Scalar imag();
+      bool exists() const;
+
+      // When used to get elements:
+      // operator Scalar() const;
+    };
+
+    Scalar_base *_impl;
+    ///@endcond
+
+    /// @brief default constructor
+    Scalar() : _impl(new Scalar_base()){};
+
+    // init!!
+    /// @brief init a Scalar with a cytnx::cytnx_complex128
+    Scalar(const cytnx_complex128 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+
+    /// @brief init a Scalar with a cytnx::cytnx_complex64
+    Scalar(const cytnx_complex64 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+
+    /// @brief init a Scalar with a cytnx::cytnx_double
+    Scalar(const cytnx_double &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+
+    /// @brief init a Scalar with a cytnx::cytnx_float
+    Scalar(const cytnx_float &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+
+    /// @brief init a Scalar with a cytnx::cytnx_uint64
+    Scalar(const cytnx_uint64 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+
+    /// @brief init a Scalar with a cytnx::cytnx_int64
+    Scalar(const cytnx_int64 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+
+    /// @brief init a Scalar with a cytnx::cytnx_uint32
+    Scalar(const cytnx_uint32 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+
+    /// @brief init a Scalar with a cytnx::cytnx_int32
+    Scalar(const cytnx_int32 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+
+    /// @brief init a Scalar with a cytnx::cytnx_uint16
+    Scalar(const cytnx_uint16 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+
+    /// @brief init a Scalar with a cytnx::cytnx_int16
+    Scalar(const cytnx_int16 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+
+    /// @brief init a Scalar with a cytnx::cytnx_bool
+    Scalar(const cytnx_bool &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+
+    /**
+     * @brief Get the max value of the Scalar with the given \p dtype.
+     * @details This function is used to get the max value of the Scalar with the given \p dtype.
+     * That is, for example, if you want to get the max value of a Scalar with
+     * \p dtype = cytnx::Type.Int16, then you will get the max value of a 16-bit integer 32767.
+     * @param[in] dtype The data type of the Scalar.
+     * @return The max value of the Scalar with the given \p dtype.
+     */
+    static Scalar maxval(const unsigned int &dtype) {
+      Scalar out(0, dtype);
+      out._impl->set_maxval();
+      return out;
+    }
+
+    /**
+     * @brief Get the min value of the Scalar with the given \p dtype.
+     * @details This function is used to get the min value of the Scalar with the given \p dtype.
+     * That is, for example, if you want to get the min value of a Scalar with
+     * \p dtype = cytnx::Type.Int16, then you will get the min value of a 16-bit integer -32768.
+     * @param[in] dtype The data type of the Scalar.
+     * @return The min value of the Scalar with the given \p dtype.
+     */
+    static Scalar minval(const unsigned int &dtype) {
+      Scalar out(0, dtype);
+      out._impl->set_minval();
+      return out;
+    }
+
+    /**
+     * @brief The constructor of the Scalar class.
+     * @details This constructor is used to init a Scalar with a given template value
+     *  \p in and \p dtype (see cytnx::Type).
+     * @param[in] in The value of the Scalar.
+     * @param[in] dtype The data type of the Scalar.
+     * @return A Scalar object.
+     * @note The \p dtype can be any of the cytnx::Type.
+     */
+    template <class T>
+    Scalar(const T &in, const unsigned int &dtype) : _impl(new Scalar_base()) {
+      if (this->_impl != nullptr) delete this->_impl;
+      this->_impl = __ScII.UScIInit[dtype]();
+      this->_impl->assign_selftype(in);
+    };
+
+    /// @cond
+    // move sproxy when use to get elements here.
+    Scalar(const Sproxy &prox);
+
+    //[Internal!!]
+    Scalar(Scalar_base *in) { this->_impl = in; }
+    /// @endcond
+
+    // specialization of init:
+    ///@cond
+    void Init_by_number(const cytnx_complex128 &in) {
+      if (this->_impl != nullptr) delete this->_impl;
+      this->_impl = new ComplexDoubleScalar(in);
+    };
+    void Init_by_number(const cytnx_complex64 &in) {
+      if (this->_impl != nullptr) delete this->_impl;
+      this->_impl = new ComplexFloatScalar(in);
+    };
+    void Init_by_number(const cytnx_double &in) {
+      if (this->_impl != nullptr) delete this->_impl;
+      this->_impl = new DoubleScalar(in);
+    }
+    void Init_by_number(const cytnx_float &in) {
+      if (this->_impl != nullptr) delete this->_impl;
+      this->_impl = new FloatScalar(in);
+    }
+    void Init_by_number(const cytnx_int64 &in) {
+      if (this->_impl != nullptr) delete this->_impl;
+      this->_impl = new Int64Scalar(in);
+    }
+    void Init_by_number(const cytnx_uint64 &in) {
+      if (this->_impl != nullptr) delete this->_impl;
+      this->_impl = new Uint64Scalar(in);
+    }
+    void Init_by_number(const cytnx_int32 &in) {
+      if (this->_impl != nullptr) delete this->_impl;
+      this->_impl = new Int32Scalar(in);
+    }
+    void Init_by_number(const cytnx_uint32 &in) {
+      if (this->_impl != nullptr) delete this->_impl;
+      this->_impl = new Uint32Scalar(in);
+    }
+    void Init_by_number(const cytnx_int16 &in) {
+      if (this->_impl != nullptr) delete this->_impl;
+      this->_impl = new Int16Scalar(in);
+    }
+    void Init_by_number(const cytnx_uint16 &in) {
+      if (this->_impl != nullptr) delete this->_impl;
+      this->_impl = new Uint16Scalar(in);
+    }
+    void Init_by_number(const cytnx_bool &in) {
+      if (this->_impl != nullptr) delete this->_impl;
+      this->_impl = new BoolScalar(in);
+    }
+
+    // The copy constructor
+    Scalar(const Scalar &rhs) : _impl(new Scalar_base()) {
+      if (this->_impl != nullptr) delete this->_impl;
+
+      this->_impl = rhs._impl->copy();
+    }
+    /// @endcond
+
+    /// @brief The copy assignment of the Scalar class.
+    Scalar &operator=(const Scalar &rhs) {
+      if (this->_impl != nullptr) delete this->_impl;
+
+      this->_impl = rhs._impl->copy();
+      return *this;
+    };
+
+    // copy assignment [Number]:
+    /** @brief The copy assignment operator of the Scalar class with a given number
+     * cytnx::cytnx_complex128 \p rhs.
+     */
+    Scalar &operator=(const cytnx_complex128 &rhs) {
+      this->Init_by_number(rhs);
+      return *this;
+    }
+
+    /** @brief The copy assignment operator of the Scalar class with a given number
+     * cytnx::cytnx_complex64 \p rhs.
+     */
+    Scalar &operator=(const cytnx_complex64 &rhs) {
+      this->Init_by_number(rhs);
+      return *this;
+    }
+
+    /** @brief The copy assignment operator of the Scalar class with a given number
+     * cytnx::cytnx_double \p rhs.
+     */
+    Scalar &operator=(const cytnx_double &rhs) {
+      this->Init_by_number(rhs);
+      return *this;
+    }
+
+    /** @brief The copy assignment operator of the Scalar class with a given number
+     * cytnx::cytnx_float \p rhs.
+     */
+    Scalar &operator=(const cytnx_float &rhs) {
+      this->Init_by_number(rhs);
+      return *this;
+    }
+
+    /** @brief The copy assignment operator of the Scalar class with a given number
+     * cytnx::cytnx_uint64 \p rhs.
+     */
+    Scalar &operator=(const cytnx_uint64 &rhs) {
+      this->Init_by_number(rhs);
+      return *this;
+    }
+
+    /** @brief The copy assignment operator of the Scalar class with a given number
+     * cytnx::cytnx_int64 \p rhs.
+     */
+    Scalar &operator=(const cytnx_int64 &rhs) {
+      this->Init_by_number(rhs);
+      return *this;
+    }
+
+    /** @brief The copy assignment operator of the Scalar class with a given number
+     * cytnx::cytnx_uint32 \p rhs.
+     */
+    Scalar &operator=(const cytnx_uint32 &rhs) {
+      this->Init_by_number(rhs);
+      return *this;
+    }
+
+    /** @brief The copy assignment operator of the Scalar class with a given number
+     * cytnx::cytnx_int32 \p rhs.
+     */
+    Scalar &operator=(const cytnx_int32 &rhs) {
+      this->Init_by_number(rhs);
+      return *this;
+    }
+
+    /** @brief The copy assignment operator of the Scalar class with a given number
+     * cytnx::cytnx_uint16 \p rhs.
+     */
+    Scalar &operator=(const cytnx_uint16 &rhs) {
+      this->Init_by_number(rhs);
+      return *this;
+    }
+
+    /** @brief The copy assignment operator of the Scalar class with a given number
+     * cytnx::cytnx_int16 \p rhs.
+     */
+    Scalar &operator=(const cytnx_int16 &rhs) {
+      this->Init_by_number(rhs);
+      return *this;
+    }
+
+    /** @brief The copy assignment operator of the Scalar class with a given number
+     * cytnx::cytnx_bool \p rhs.
+     */
+    Scalar &operator=(const cytnx_bool &rhs) {
+      this->Init_by_number(rhs);
+      return *this;
+    }
+
+    /**
+     * @brief Type conversion function.
+     * @param[in] dtype The type of the output Scalar (see cytnx::Type for more details).
+     * @return The converted Scalar.
+     * @attention The function cannot convert from complex to real, please use
+     * cytnx::Scalar::real() or cytnx::Scalar::imag() to get the real or imaginary
+     * part of the Scalar instead.
+     */
+    Scalar astype(const unsigned int &dtype) const {
+      Scalar out(this->_impl->astype(dtype));
+      return out;
+    }
+
+    /**
+     * @brief Get the conjugate of the Scalar. That means return \f$ c^* \f$ if
+     * the Scalar is \f$ c \f$.
+     * @return The conjugate of the Scalar.
+     */
+    Scalar conj() const {
+      Scalar out = *this;
+      out._impl->conj_();
+      return out;
+    }
+
+    /**
+     * @brief Get the imaginary part of the Scalar. That means return \f$ \Im(c) \f$ if
+     * the Scalar is \f$ c \f$.
+     * @return The imaginary part of the Scalar.
+     */
+    Scalar imag() const { return Scalar(this->_impl->get_imag()); }
+
+    /**
+     * @brief Get the real part of the Scalar. That means return \f$ \Re(c) \f$ if
+     * the Scalar is \f$ c \f$.
+     * @return The real part of the Scalar.
+     */
+    Scalar real() const { return Scalar(this->_impl->get_real()); }
+    // Scalar& set_imag(const Scalar &in){   return *this;}
+    // Scalar& set_real(const Scalar &in){   return *this;}
+
+    /**
+     * @brief Get the dtype of the Scalar (see cytnx::Type for more details).
+     */
+    int dtype() const { return this->_impl->_dtype; }
+
+    // print()
+    /**
+     * @brief Print the Scalar to the standard output.
+     */
+    void print() const {
+      this->_impl->print(std::cout);
+      std::cout << std::string(" Scalar dtype: [") << Type.getname(this->_impl->_dtype)
+                << std::string("]") << std::endl;
+    }
+
+    // casting
+    /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_double.
+    explicit operator cytnx_double() const { return this->_impl->to_cytnx_double(); }
+
+    /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_float
+    explicit operator cytnx_float() const { return this->_impl->to_cytnx_float(); }
+
+    /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_uint64.
+    explicit operator cytnx_uint64() const { return this->_impl->to_cytnx_uint64(); }
+
+    /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_int64.
+    explicit operator cytnx_int64() const { return this->_impl->to_cytnx_int64(); }
+
+    /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_uint32.
+    explicit operator cytnx_uint32() const { return this->_impl->to_cytnx_uint32(); }
+
+    /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_int32.
+    explicit operator cytnx_int32() const { return this->_impl->to_cytnx_int32(); }
+
+    /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_uint16.
+    explicit operator cytnx_uint16() const { return this->_impl->to_cytnx_uint16(); }
+
+    /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_int16.
+    explicit operator cytnx_int16() const { return this->_impl->to_cytnx_int16(); }
+
+    /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_bool.
+    explicit operator cytnx_bool() const { return this->_impl->to_cytnx_bool(); }
+
+    /// @cond
+    // destructor
+    ~Scalar() {
+      if (this->_impl != nullptr) delete this->_impl;
+    };
+    /// @endcond
+
+    // arithmetic:
+    ///@brief The addition assignment operator of the Scalar class with a given number (template).
+    template <class T>
+    void operator+=(const T &rc) {
+      this->_impl->iadd(rc);
+    }
+
+    ///@brief The addition assignment operator of the Scalar class with a given Scalar.
+    void operator+=(const Scalar &rhs) { this->_impl->iadd(rhs._impl); }
+
+    ///@brief The subtraction assignment operator of the Scalar class with a given number
+    ///(template).
+    template <class T>
+    void operator-=(const T &rc) {
+      this->_impl->isub(rc);
+    }
+
+    ///@brief The subtraction assignment operator of the Scalar class with a given Scalar.
+    void operator-=(const Scalar &rhs) { this->_impl->isub(rhs._impl); }
+    template <class T>
+
+    ///@brief The multiplication assignment operator of the Scalar class with a given number
+    ///(template).
+    void operator*=(const T &rc) {
+      this->_impl->imul(rc);
+    }
+
+    ///@brief The multiplication assignment operator of the Scalar class with a given Scalar.
+    void operator*=(const Scalar &rhs) { this->_impl->imul(rhs._impl); }
+    template <class T>
+
+    /**
+     * @brief The division assignment operator of the Scalar class with a given number (template).
+     */
+    void operator/=(const T &rc) {
+      this->_impl->idiv(rc);
+    }
+
+    /**
+     * @brief The division assignment operator of the Scalar class with a given Scalar.
+     */
+    void operator/=(const Scalar &rhs) { this->_impl->idiv(rhs._impl); }
+
+    /// @brief Set the Scalar to absolute value. (inplace)
+    void iabs() { this->_impl->iabs(); }
+
+    /// @brief Set the Scalar to square root. (inplace)
+    void isqrt() { this->_impl->isqrt(); }
+
+    /**
+     * @brief The member function to get the absolute value of the Scalar.
+     * @note Compare to the iabs() function, this function will return a new Scalar object.
+     * @return The absolute value of the Scalar.
+     * @see iabs()
+     */
+    Scalar abs() const {
+      Scalar out = *this;
+      out._impl->iabs();
+      return out.real();
+    }
+
+    /**
+     * @brief The member function to get the square root of the Scalar.
+     * @note Compare to the isqrt() function, this function will return a new Scalar object.
+     * @return The square root of the Scalar.
+     * @see isqrt()
+     */
+    Scalar sqrt() const {
+      Scalar out = *this;
+      out._impl->isqrt();
+      return out;
+    }
+
+    // comparison <
+    /**
+     * @brief Return whether the current Scalar is less than a given template number \p rc.
+     * @details That is, whether \f$ s < r \f$, where \f$ s \f$ is the current Scalar
+     * itself and \f$ r \f$ is the given number \p rc.
+     * @see operator<(const Scalar &lhs, const Scalar &rhs)
+     */
+    template <class T>
+    bool less(const T &rc) const {
+      Scalar tmp;
+      int rid = Type.cy_typeid(rc);
+      if (rid < this->dtype()) {
+        tmp = this->astype(rid);
+        return tmp._impl->less(rc);
+      } else {
+        return this->_impl->less(rc);
+      }
+    }
+
+    /**
+     * @brief Return whether the current Scalar is less than a given Scalar \p rhs.
+     * @details That is, whether \f$ s < r \f$, where \f$ s \f$ is the current Scalar
+     * itself and \f$ r \f$ is the given Scalar \p rhs.
+     * @see operator<(const Scalar &lhs, const Scalar &rhs)
+     */
+    bool less(const Scalar &rhs) const {
+      Scalar tmp;
+      if (rhs.dtype() < this->dtype()) {
+        tmp = this->astype(rhs.dtype());
+        return tmp._impl->less(rhs._impl);
+      } else {
+        return this->_impl->less(rhs._impl);
+      }
+    }
+
+    // comparison <=
+
+    /**
+     * @brief Return whether the current Scalar is less than or equal to a given template number \p
+     * rc.
+     * @details That is, whether \f$ s \leq r \f$, where \f$ s \f$ is the current Scalar
+     * itself and \f$ r \f$ is the given number \p rc.
+     * @see operator<=(const Scalar &lhs, const Scalar &rhs)
+     */
+    template <class T>
+    bool leq(const T &rc) const {
+      Scalar tmp;
+      int rid = Type.cy_typeid(rc);
+      if (rid < this->dtype()) {
+        tmp = this->astype(rid);
+        return !(tmp._impl->greater(rc));
+      } else {
+        return !(this->_impl->greater(rc));
+      }
+    }
+
+    /**
+     * @brief Return whether the current Scalar is less than or equal to a given Scalar \p rhs.
+     * @details That is, whether \f$ s \leq r \f$, where \f$ s \f$ is the current Scalar
+     * itself and \f$ r \f$ is the given Scalar \p rhs.
+     * @see operator<=(const Scalar &lhs, const Scalar &rhs)
+     */
+    bool leq(const Scalar &rhs) const {
+      Scalar tmp;
+      if (rhs.dtype() < this->dtype()) {
+        tmp = this->astype(rhs.dtype());
+        return !(tmp._impl->greater(rhs._impl));
+      } else {
+        return !(this->_impl->greater(rhs._impl));
+      }
+    }
+
+    // comparison >
+    /**
+     * @brief Return whether the current Scalar is greater than a given template number \p rc.
+     * @details That is, whether \f$ s > r \f$, where \f$ s \f$ is the current Scalar
+     * itself and \f$ r \f$ is the given number \p rc.
+     * @see operator>(const Scalar &lhs, const Scalar &rhs)
+     */
+    template <class T>
+    bool greater(const T &rc) const {
+      Scalar tmp;
+      int rid = Type.cy_typeid(rc);
+      if (rid < this->dtype()) {
+        tmp = this->astype(rid);
+        return tmp._impl->greater(rc);
+      } else {
+        return this->_impl->greater(rc);
+      }
+    }
+
+    /**
+     * @brief Return whether the current Scalar is greater than a given Scalar \p rhs.
+     * @details That is, whether \f$ s > r \f$, where \f$ s \f$ is the current Scalar
+     * itself and \f$ r \f$ is the given Scalar \p rhs.
+     * @see operator>(const Scalar &lhs, const Scalar &rhs)
+     */
+    bool greater(const Scalar &rhs) const {
+      Scalar tmp;
+      if (rhs.dtype() < this->dtype()) {
+        tmp = this->astype(rhs.dtype());
+        return tmp._impl->greater(rhs._impl);
+      } else {
+        return this->_impl->greater(rhs._impl);
+      }
+    }
+
+    // comparison >=
+
+    /**
+     * @brief Return whether the current Scalar is greater than or equal to a given template number
+     * \p rc.
+     * @details That is, whether \f$ s \geq r \f$, where \f$ s \f$ is the current Scalar
+     * itself and \f$ r \f$ is the given number \p rc.
+     * @see operator>=(const Scalar &lhs, const Scalar &rhs)
+     */
+    template <class T>
+    bool geq(const T &rc) const {
+      Scalar tmp;
+      int rid = Type.cy_typeid(rc);
+      if (rid < this->dtype()) {
+        tmp = this->astype(rid);
+        return !(tmp._impl->less(rc));
+      } else {
+        return !(this->_impl->less(rc));
+      }
+    }
+
+    /**
+     * @brief Return whether the current Scalar is greater than or equal to a given Scalar \p rhs.
+     * @details That is, whether \f$ s \geq r \f$, where \f$ s \f$ is the current Scalar
+     * itself and \f$ r \f$ is the given Scalar \p rhs.
+     * @see operator>=(const Scalar &lhs, const Scalar &rhs)
+     */
+    bool geq(const Scalar &rhs) const {
+      Scalar tmp;
+      if (rhs.dtype() < this->dtype()) {
+        tmp = this->astype(rhs.dtype());
+        return !(tmp._impl->less(rhs._impl));
+      } else {
+        return !(this->_impl->less(rhs._impl));
+      }
+    }
+
+    // comparison ==
+
+    /**
+     * @brief Return whether the current Scalar is equal to a given template number \p rc.
+     * @details That is, whether \f$ s = r \f$, where \f$ s \f$ is the current Scalar
+     * itself and \f$ r \f$ is the given number \p rc.
+     * @see operator==(const Scalar &lhs, const Scalar &rhs)
+     */
+    template <class T>
+    bool eq(const T &rc) const {
+      Scalar tmp;
+      int rid = Type.cy_typeid(rc);
+      if (rid < this->dtype()) {
+        tmp = this->astype(rid);
+        return tmp._impl->eq(rc);
+      } else {
+        return this->_impl->eq(rc);
+      }
+    }
+    // /**
+    //  * @brief Return whether the current Scalar is approximately equal to a given template number
+    //  \p
+    //  * rc.
+    //  * @details That is, whether \f$ abs(s-r)<tol \f$, where \f$ s \f$ is the current Scalar
+    //  * itself, \f$ r \f$ is the given number \p rc and \p tol is the tolerance value.
+    //  */
+    // template <class T>
+    // bool approx_eq(const T &rc, cytnx_double tol = 1e-8) const {
+    //   Scalar tmp;
+    //   int rid = Type.cy_typeid(rc);
+    //   if (rid < this->dtype()) {
+    //     tmp = this->astype(rid);
+    //     return tmp._impl->approx_eq(rc, tol);
+    //   } else {
+    //     return this->_impl->approx_eq(rc, tol);
+    //   }
+    // }
+
+    /**
+     * @brief Return whether the current Scalar is equal to a given Scalar \p rhs.
+     * @details That is, whether \f$ s = r \f$, where \f$ s \f$ is the current Scalar
+     * itself and \f$ r \f$ is the given Scalar \p rhs.
+     * @see operator==(const Scalar &lhs, const Scalar &rhs)
+     */
+    bool eq(const Scalar &rhs) const {
+      Scalar tmp;
+      if (rhs.dtype() < this->dtype()) {
+        tmp = this->astype(rhs.dtype());
+        return tmp._impl->eq(rhs._impl);
+      } else {
+        return this->_impl->eq(rhs._impl);
+      }
+    }
+    // /**
+    //  * @brief Return whether the current Scalar is approximately equal to a given Scalar \p rhs.
+    //  * @details That is, whether \f$ abs(s-r)<tol \f$, where \f$ s \f$ is the current Scalar
+    //  * itself, \f$ r \f$ is the given Scalar \p rhs and \p tol is the tolerance value.
+    //  */
+    // bool approx_eq(const Scalar &rhs, cytnx_double tol = 1e-8) const {
+    //   Scalar tmp;
+    //   if (rhs.dtype() < this->dtype()) {
+    //     tmp = this->astype(rhs.dtype());
+    //     return tmp._impl->approx_eq(rhs._impl, tol);
+    //   } else {
+    //     return this->_impl->approx_eq(rhs._impl, tol);
+    //   }
+    // }
+
+    // radd: Scalar + c
+
+    /**
+     * @brief Return the addition of the current Scalar and a given template number \p rc.
+     * @see operator+(const Scalar &lhs, const Scalar &rhs)
+     */
+    template <class T>
+    Scalar radd(const T &rc) const {
+      Scalar out;
+      int rid = Type.cy_typeid(rc);
+      if (this->dtype() < rid) {
+        out = *this;
+      } else {
+        out = this->astype(rid);
+      }
+      out._impl->iadd(rc);
+      return out;
+    }
+
+    /**
+     * @brief Return the addition of the current Scalar and a given Scalar \p rhs.
+     * @see operator+(const Scalar &lhs, const Scalar &rhs)
+     */
+    Scalar radd(const Scalar &rhs) const {
+      Scalar out;
+      if (this->dtype() < rhs.dtype()) {
+        out = *this;
+      } else {
+        out = this->astype(rhs.dtype());
+      }
+      out._impl->iadd(rhs._impl);
+      return out;
+    }
+
+    // rmul: Scalar * c
+
+    /**
+     * @brief Return the multiplication of the current Scalar and a given template number \p rc.
+     * @see operator*(const Scalar &lhs, const Scalar &rhs)
+     */
+    template <class T>
+    Scalar rmul(const T &rc) const {
+      Scalar out;
+      int rid = Type.cy_typeid(rc);
+      if (this->dtype() < rid) {
+        out = *this;
+      } else {
+        out = this->astype(rid);
+      }
+      out._impl->imul(rc);
+      return out;
+    }
+
+    /**
+     * @brief Return the multiplication of the current Scalar and a given Scalar \p rhs.
+     * @see operator*(const Scalar &lhs, const Scalar &rhs)
+     */
+    Scalar rmul(const Scalar &rhs) const {
+      Scalar out;
+      if (this->dtype() < rhs.dtype()) {
+        out = *this;
+      } else {
+        out = this->astype(rhs.dtype());
+      }
+      out._impl->imul(rhs._impl);
+      return out;
+    }
+
+    // rsub: Scalar - c
+
+    /**
+     * @brief Return the subtraction of the current Scalar and a given template number \p rc.
+     * @see operator-(const Scalar &lhs, const Scalar &rhs)
+     */
+    template <class T>
+    Scalar rsub(const T &rc) const {
+      Scalar out;
+      int rid = Type.cy_typeid(rc);
+      if (this->dtype() < rid) {
+        out = *this;
+      } else {
+        out = this->astype(rid);
+      }
+      out._impl->isub(rc);
+      return out;
+    }
+
+    /**
+     * @brief Return the subtraction of the current Scalar and a given Scalar \p rhs.
+     * @see operator-(const Scalar &lhs, const Scalar &rhs)
+     */
+    Scalar rsub(const Scalar &rhs) const {
+      Scalar out;
+      if (this->dtype() < rhs.dtype()) {
+        out = *this;
+      } else {
+        out = this->astype(rhs.dtype());
+      }
+      out._impl->isub(rhs._impl);
+      return out;
+    }
+
+    // rdiv: Scalar / c
+
+    /**
+     * @brief Return the division of the current Scalar and a given template number \p rc.
+     * @see operator/(const Scalar &lhs, const Scalar &rhs)
+     */
+    template <class T>
+    Scalar rdiv(const T &rc) const {
+      Scalar out;
+      int rid = Type.cy_typeid(rc);
+      if (this->dtype() < rid) {
+        out = *this;
+      } else {
+        out = this->astype(rid);
+      }
+      out._impl->idiv(rc);
+      return out;
+    }
+
+    /**
+     * @brief Return the division of the current Scalar and a given Scalar \p rhs.
+     * @see operator/(const Scalar &lhs, const Scalar &rhs)
+     */
+    Scalar rdiv(const Scalar &rhs) const {
+      Scalar out;
+      if (this->dtype() < rhs.dtype()) {
+        out = *this;
+      } else {
+        out = this->astype(rhs.dtype());
+      }
+      out._impl->idiv(rhs._impl);
+      return out;
+    }
+
+    /*
+    //operator:
+    template<class T>
+    Scalar operator+(const T &rc){
+        return this->radd(rc);
+    }
+    template<class T>
+    Scalar operator*(const T &rc){
+        return this->rmul(rc);
+    }
+    template<class T>
+    Scalar operator-(const T &rc){
+        return this->rsub(rc);
+    }
+    template<class T>
+    Scalar operator/(const T &rc){
+        return this->rdiv(rc);
+    }
+
+    template<class T>
+    bool operator<(const T &rc){
+        return this->less(rc);
+    }
+
+    template<class T>
+    bool operator>(const T &rc){
+        return this->greater(rc);
+    }
+
+
+    template<class T>
+    bool operator<=(const T &rc){
+        return this->leq(rc);
+    }
+
+    template<class T>
+    bool operator>=(const T &rc){
+        return this->geq(rc);
+    }
+    */
+  };
+};
 }  // namespace cytnx
 #endif
 #endif

--- a/include/backend_torch/Scalar.hpp
+++ b/include/backend_torch/Scalar.hpp
@@ -1031,7 +1031,44 @@ namespace cytnx {
      */
     Scalar sqrt() const {
       Scalar out = *this;
-      out._impl->isqrt();
+      switch (_dtype) {
+        case Type.ComplexDouble:
+          out = Scalar(std::sqrt(toComplexDouble()));
+          break;
+        case Type.ComplexFloat:
+          out = Scalar(std::sqrt(toComplexFloat()));
+          break;
+        case Type.Double:
+          out = Scalar(std::sqrt(toDouble()));
+          break;
+        case Type.Float:
+          out = Scalar(std::sqrt(toFloat()));
+          break;
+        case Type.Int64:
+          out = Scalar(std::sqrt(toLong()));
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          out = Scalar(std::sqrt(toInt()));
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          out = Scalar(std::sqrt(toShort()));
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          out = Scalar(std::sqrt(toBool()));
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
+      }
       return out;
     }
 
@@ -1048,9 +1085,46 @@ namespace cytnx {
       int rid = Type.cy_typeid(rc);
       if (rid < this->dtype()) {
         tmp = this->astype(rid);
-        return tmp._impl->less(rc);
       } else {
-        return this->_impl->less(rc);
+        tmp = *this;
+      }
+      switch (tmp.dtype()) {
+        case Type.ComplexDouble:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.ComplexFloat:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.Double:
+          return tmp.toDouble() < rc;
+          break;
+        case Type.Float:
+          return tmp.toFloat() < rc;
+          break;
+        case Type.Int64:
+          return tmp.toLong() < rc;
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          return tmp.toInt() < rc;
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          return tmp.toShort() < rc;
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          return tmp.toBool() < rc;
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
       }
     }
 
@@ -1064,16 +1138,54 @@ namespace cytnx {
       Scalar tmp;
       if (rhs.dtype() < this->dtype()) {
         tmp = this->astype(rhs.dtype());
-        return tmp._impl->less(rhs._impl);
       } else {
-        return this->_impl->less(rhs._impl);
+        tmp = *this;
+      }
+      switch (tmp.dtype()) {
+        case Type.ComplexDouble:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.ComplexFloat:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.Double:
+          return tmp.toDouble() < rhs.toDouble();
+          break;
+        case Type.Float:
+          return tmp.toFloat() < rhs.toFloat();
+          break;
+        case Type.Int64:
+          return tmp.toLong() < rhs.toLong();
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          return tmp.toInt() < rhs.toInt();
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          return tmp.toShort() < rhs.toShort();
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          return tmp.toBool() < rhs.toBool();
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
       }
     }
 
     // comparison <=
 
     /**
-     * @brief Return whether the current Scalar is less than or equal to a given template number \p
+     * @brief Return whether the current Scalar is less than or equal to a given template number
+     \p
      * rc.
      * @details That is, whether \f$ s \leq r \f$, where \f$ s \f$ is the current Scalar
      * itself and \f$ r \f$ is the given number \p rc.
@@ -1085,9 +1197,46 @@ namespace cytnx {
       int rid = Type.cy_typeid(rc);
       if (rid < this->dtype()) {
         tmp = this->astype(rid);
-        return !(tmp._impl->greater(rc));
       } else {
-        return !(this->_impl->greater(rc));
+        tmp = *this;
+      }
+      switch (tmp.dtype()) {
+        case Type.ComplexDouble:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.ComplexFloat:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.Double:
+          return tmp.toDouble() <= rc;
+          break;
+        case Type.Float:
+          return tmp.toFloat() <= rc;
+          break;
+        case Type.Int64:
+          return tmp.toLong() <= rc;
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          return tmp.toInt() <= rc;
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          return tmp.toShort() <= rc;
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          return tmp.toBool() <= rc;
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
       }
     }
 
@@ -1101,9 +1250,46 @@ namespace cytnx {
       Scalar tmp;
       if (rhs.dtype() < this->dtype()) {
         tmp = this->astype(rhs.dtype());
-        return !(tmp._impl->greater(rhs._impl));
       } else {
-        return !(this->_impl->greater(rhs._impl));
+        tmp = *this;
+      }
+      switch (tmp.dtype()) {
+        case Type.ComplexDouble:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.ComplexFloat:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.Double:
+          return tmp.toDouble() <= rhs.toDouble();
+          break;
+        case Type.Float:
+          return tmp.toFloat() <= rhs.toFloat();
+          break;
+        case Type.Int64:
+          return tmp.toLong() <= rhs.toLong();
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          return tmp.toInt() <= rhs.toInt();
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          return tmp.toShort() <= rhs.toShort();
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          return tmp.toBool() <= rhs.toBool();
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
       }
     }
 
@@ -1120,9 +1306,46 @@ namespace cytnx {
       int rid = Type.cy_typeid(rc);
       if (rid < this->dtype()) {
         tmp = this->astype(rid);
-        return tmp._impl->greater(rc);
       } else {
-        return this->_impl->greater(rc);
+        tmp = *this;
+      }
+      switch (tmp.dtype()) {
+        case Type.ComplexDouble:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.ComplexFloat:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.Double:
+          return tmp.toDouble() > rc;
+          break;
+        case Type.Float:
+          return tmp.toFloat() > rc;
+          break;
+        case Type.Int64:
+          return tmp.toLong() > rc;
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          return tmp.toInt() > rc;
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          return tmp.toShort() > rc;
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          return tmp.toBool() > rc;
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
       }
     }
 
@@ -1136,16 +1359,54 @@ namespace cytnx {
       Scalar tmp;
       if (rhs.dtype() < this->dtype()) {
         tmp = this->astype(rhs.dtype());
-        return tmp._impl->greater(rhs._impl);
       } else {
-        return this->_impl->greater(rhs._impl);
+        tmp = *this;
+      }
+      switch (tmp.dtype()) {
+        case Type.ComplexDouble:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.ComplexFloat:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.Double:
+          return tmp.toDouble() > rhs.toDouble();
+          break;
+        case Type.Float:
+          return tmp.toFloat() > rhs.toFloat();
+          break;
+        case Type.Int64:
+          return tmp.toLong() > rhs.toLong();
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          return tmp.toInt() > rhs.toInt();
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          return tmp.toShort() > rhs.toShort();
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          return tmp.toBool() > rhs.toBool();
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
       }
     }
 
     // comparison >=
 
     /**
-     * @brief Return whether the current Scalar is greater than or equal to a given template number
+     * @brief Return whether the current Scalar is greater than or equal to a given template
+     number
      * \p rc.
      * @details That is, whether \f$ s \geq r \f$, where \f$ s \f$ is the current Scalar
      * itself and \f$ r \f$ is the given number \p rc.
@@ -1157,14 +1418,52 @@ namespace cytnx {
       int rid = Type.cy_typeid(rc);
       if (rid < this->dtype()) {
         tmp = this->astype(rid);
-        return !(tmp._impl->less(rc));
       } else {
-        return !(this->_impl->less(rc));
+        tmp = *this;
+      }
+      switch (tmp.dtype()) {
+        case Type.ComplexDouble:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.ComplexFloat:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.Double:
+          return tmp.toDouble() >= rc;
+          break;
+        case Type.Float:
+          return tmp.toFloat() >= rc;
+          break;
+        case Type.Int64:
+          return tmp.toLong() >= rc;
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          return tmp.toInt() >= rc;
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          return tmp.toShort() >= rc;
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          return tmp.toBool() >= rc;
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
       }
     }
 
     /**
-     * @brief Return whether the current Scalar is greater than or equal to a given Scalar \p rhs.
+     * @brief Return whether the current Scalar is greater than or equal to a given Scalar \p
+     rhs.
      * @details That is, whether \f$ s \geq r \f$, where \f$ s \f$ is the current Scalar
      * itself and \f$ r \f$ is the given Scalar \p rhs.
      * @see operator>=(const Scalar &lhs, const Scalar &rhs)
@@ -1173,9 +1472,46 @@ namespace cytnx {
       Scalar tmp;
       if (rhs.dtype() < this->dtype()) {
         tmp = this->astype(rhs.dtype());
-        return !(tmp._impl->less(rhs._impl));
       } else {
-        return !(this->_impl->less(rhs._impl));
+        tmp = *this;
+      }
+      switch (tmp.dtype()) {
+        case Type.ComplexDouble:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.ComplexFloat:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.Double:
+          return tmp.toDouble() >= rhs.toDouble();
+          break;
+        case Type.Float:
+          return tmp.toFloat() >= rhs.toFloat();
+          break;
+        case Type.Int64:
+          return tmp.toLong() >= rhs.toLong();
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          return tmp.toInt() >= rhs.toInt();
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          return tmp.toShort() >= rhs.toShort();
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          return tmp.toBool() >= rhs.toBool();
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
       }
     }
 
@@ -1193,9 +1529,46 @@ namespace cytnx {
       int rid = Type.cy_typeid(rc);
       if (rid < this->dtype()) {
         tmp = this->astype(rid);
-        return tmp._impl->eq(rc);
       } else {
-        return this->_impl->eq(rc);
+        tmp = *this;
+      }
+      switch (tmp.dtype()) {
+        case Type.ComplexDouble:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.ComplexFloat:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.Double:
+          return tmp.toDouble() == rc;
+          break;
+        case Type.Float:
+          return tmp.toFloat() == rc;
+          break;
+        case Type.Int64:
+          return tmp.toLong() == rc;
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          return tmp.toInt() == rc;
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          return tmp.toShort() == rc;
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          return tmp.toBool() == rc;
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
       }
     }
     // /**
@@ -1227,9 +1600,46 @@ namespace cytnx {
       Scalar tmp;
       if (rhs.dtype() < this->dtype()) {
         tmp = this->astype(rhs.dtype());
-        return tmp._impl->eq(rhs._impl);
       } else {
-        return this->_impl->eq(rhs._impl);
+        tmp = *this;
+      }
+      switch (tmp.dtype()) {
+        case Type.ComplexDouble:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.ComplexFloat:
+          cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
+          break;
+        case Type.Double:
+          return tmp.toDouble() == rhs.toDouble();
+          break;
+        case Type.Float:
+          return tmp.toFloat() == rhs.toFloat();
+          break;
+        case Type.Int64:
+          return tmp.toLong() == rhs.toLong();
+          break;
+        case Type.Uint64:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int32:
+          return tmp.toInt() == rhs.toInt();
+          break;
+        case Type.Uint32:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Int16:
+          return tmp.toShort() == rhs.toShort();
+          break;
+        case Type.Uint16:
+          cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+          break;
+        case Type.Bool:
+          return tmp.toBool() == rhs.toBool();
+          break;
+        default:
+          cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+          break;
       }
     }
     // /**
@@ -1262,7 +1672,7 @@ namespace cytnx {
       } else {
         out = this->astype(rid);
       }
-      out._impl->iadd(rc);
+      out += rc;
       return out;
     }
 
@@ -1277,7 +1687,7 @@ namespace cytnx {
       } else {
         out = this->astype(rhs.dtype());
       }
-      out._impl->iadd(rhs._impl);
+      out += rhs;
       return out;
     }
 
@@ -1296,7 +1706,7 @@ namespace cytnx {
       } else {
         out = this->astype(rid);
       }
-      out._impl->imul(rc);
+      out *= rc;
       return out;
     }
 
@@ -1311,7 +1721,7 @@ namespace cytnx {
       } else {
         out = this->astype(rhs.dtype());
       }
-      out._impl->imul(rhs._impl);
+      out *= rhs;
       return out;
     }
 
@@ -1330,7 +1740,7 @@ namespace cytnx {
       } else {
         out = this->astype(rid);
       }
-      out._impl->isub(rc);
+      out -= rc;
       return out;
     }
 
@@ -1345,7 +1755,7 @@ namespace cytnx {
       } else {
         out = this->astype(rhs.dtype());
       }
-      out._impl->isub(rhs._impl);
+      out -= rhs;
       return out;
     }
 
@@ -1364,7 +1774,7 @@ namespace cytnx {
       } else {
         out = this->astype(rid);
       }
-      out._impl->idiv(rc);
+      out /= rc;
       return out;
     }
 
@@ -1379,7 +1789,7 @@ namespace cytnx {
       } else {
         out = this->astype(rhs.dtype());
       }
-      out._impl->idiv(rhs._impl);
+      out /= rhs;
       return out;
     }
 
@@ -1412,7 +1822,6 @@ namespace cytnx {
         return this->greater(rc);
     }
 
-
     template<class T>
     bool operator<=(const T &rc){
         return this->leq(rc);
@@ -1424,7 +1833,6 @@ namespace cytnx {
     }
     */
   };
-};
-}  // namespace cytnx
+};  // namespace cytnx
 #endif
 #endif

--- a/src/backend_torch/CMakeLists.txt
+++ b/src/backend_torch/CMakeLists.txt
@@ -5,4 +5,5 @@
 target_sources_local(cytnx
     PRIVATE
     Type_convert.cpp
+    Scalar.cpp
 )

--- a/src/backend_torch/Scalar.cpp
+++ b/src/backend_torch/Scalar.cpp
@@ -1,0 +1,6 @@
+#include "backend_torch/Scalar.hpp"
+#include "cytnx_error.hpp"
+#include "Type.hpp"
+
+using namespace std;
+namespace cytnx {}  // namespace cytnx

--- a/src/backend_torch/Scalar.cpp
+++ b/src/backend_torch/Scalar.cpp
@@ -1,6 +1,202 @@
 #include "backend_torch/Scalar.hpp"
-#include "cytnx_error.hpp"
-#include "Type.hpp"
 
 using namespace std;
-namespace cytnx {}  // namespace cytnx
+namespace cytnx {
+  cytnx_complex128 complex128(const Scalar& in) { return complex<double>(in.toComplexDouble()); }
+
+  cytnx_complex64 complex64(const Scalar& in) { return complex<float>(in.toComplexFloat()); }
+
+  std::ostream& operator<<(std::ostream& os, const Scalar& in) {
+    in.print_elem(os);
+    os << std::string(" dtype: [") << Type.getname(in._dtype) << std::string("]");
+    return os;
+  }
+
+  // ladd: c + Scalar:
+  Scalar operator+(const Scalar& lc, const Scalar& rs) { return rs.radd(lc); };
+
+  // lmul c * Scalar;
+  Scalar operator*(const Scalar& lc, const Scalar& rs) { return rs.rmul(lc); };
+
+  // lsub c - Scalar;
+  Scalar operator-(const Scalar& lc, const Scalar& rs) { return lc.rsub(rs); };
+
+  // ldiv c / Scalar;
+  Scalar operator/(const Scalar& lc, const Scalar& rs) { return lc.rdiv(rs); };
+
+  // lless c < Scalar;
+  bool operator<(const Scalar& lc, const Scalar& rs) { return lc.less(rs); };
+
+  // lless c > Scalar;
+  bool operator>(const Scalar& lc, const Scalar& rs) { return lc.greater(rs); };
+
+  // lless c <= Scalar;
+  bool operator<=(const Scalar& lc, const Scalar& rs) { return lc.leq(rs); };
+
+  // lless c >= Scalar;
+  bool operator>=(const Scalar& lc, const Scalar& rs) { return lc.geq(rs); };
+
+  // eq c == Scalar;
+  bool operator==(const Scalar& lc, const Scalar& rs) {
+    // if (lc.dtype() < rs.dtype())
+    //   return lc.geq(rs);
+    // else
+    //   return rs.geq(lc);
+    return lc.eq(rs);
+  };
+
+  Scalar abs(const Scalar& c) { return c.abs(); };
+
+  Scalar sqrt(const Scalar& c) { return c.sqrt(); };
+
+  // Scalar proxy:
+  // Sproxy
+  Scalar::Sproxy& Scalar::Sproxy::operator=(const Scalar::Sproxy& rc) {
+    // std::cout << "entry !!" << std::endl;
+    if (this->_insimpl.get() == 0) {
+      // std::cout << "entry cpcon, not init!!" << std::endl;
+      // std::cout << std::flush;
+      //  not init:
+      this->_insimpl = rc._insimpl;
+      this->_loc = rc._loc;
+      return *this;
+    } else {
+      if ((rc._insimpl == this->_insimpl) && (rc._loc == this->_loc)) {
+        // std::cout << "entry same!!" << std::endl;
+        std::cout << std::flush;
+        return *this;
+      } else {
+        // std::cout << "entry wrn !!" << std::endl;
+        std::cout << std::flush;
+        Scalar tmp = rc._insimpl->get_item(rc._loc);
+        this->_insimpl->set_item(this->_loc, tmp);
+        return *this;
+      }
+    }
+  }
+  Scalar::Sproxy& Scalar::Sproxy::operator=(const Scalar& rc) {
+    this->_insimpl->set_item(this->_loc, rc);
+    return *this;
+  }
+  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_complex128& rc) {
+    this->_insimpl->set_item(this->_loc, rc);
+    return *this;
+  }
+  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_complex64& rc) {
+    this->_insimpl->set_item(this->_loc, rc);
+    return *this;
+  }
+  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_double& rc) {
+    this->_insimpl->set_item(this->_loc, rc);
+    return *this;
+  }
+  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_float& rc) {
+    this->_insimpl->set_item(this->_loc, rc);
+    return *this;
+  }
+  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_uint64& rc) {
+    this->_insimpl->set_item(this->_loc, rc);
+    return *this;
+  }
+  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_int64& rc) {
+    this->_insimpl->set_item(this->_loc, rc);
+    return *this;
+  }
+  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_uint32& rc) {
+    this->_insimpl->set_item(this->_loc, rc);
+    return *this;
+  }
+  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_int32& rc) {
+    this->_insimpl->set_item(this->_loc, rc);
+    return *this;
+  }
+  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_uint16& rc) {
+    this->_insimpl->set_item(this->_loc, rc);
+    return *this;
+  }
+  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_int16& rc) {
+    this->_insimpl->set_item(this->_loc, rc);
+    return *this;
+  }
+  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_bool& rc) {
+    this->_insimpl->set_item(this->_loc, rc);
+    return *this;
+  }
+
+  bool Scalar::Sproxy::exists() const { return this->_insimpl->dtype != Type.Void; };
+
+  Scalar Scalar::Sproxy::real() { return Scalar(*this).real(); }
+  Scalar Scalar::Sproxy::imag() { return Scalar(*this).imag(); }
+
+  Scalar::Scalar(const Sproxy& prox) : _impl(new Scalar_base()) {
+    if (this->_impl != nullptr) {
+      delete this->_impl;
+    }
+    this->_impl = prox._insimpl->get_item(prox._loc)._impl->copy();
+  }
+
+  //   // Storage Init interface.
+  //   //=============================
+  //   inline Scalar_base* ScIInit_cd() {
+  //     Scalar_base* out = new ComplexDoubleScalar();
+  //     return out;
+  //   }
+  //   inline Scalar_base* ScIInit_cf() {
+  //     Scalar_base* out = new ComplexFloatScalar();
+  //     return out;
+  //   }
+  //   inline Scalar_base* ScIInit_d() {
+  //     Scalar_base* out = new DoubleScalar();
+  //     return out;
+  //   }
+  //   inline Scalar_base* ScIInit_f() {
+  //     Scalar_base* out = new FloatScalar();
+  //     return out;
+  //   }
+  //   inline Scalar_base* ScIInit_u64() {
+  //     Scalar_base* out = new Uint64Scalar();
+  //     return out;
+  //   }
+  //   inline Scalar_base* ScIInit_i64() {
+  //     Scalar_base* out = new Int64Scalar();
+  //     return out;
+  //   }
+  //   inline Scalar_base* ScIInit_u32() {
+  //     Scalar_base* out = new Uint32Scalar();
+  //     return out;
+  //   }
+  //   inline Scalar_base* ScIInit_i32() {
+  //     Scalar_base* out = new Int32Scalar();
+  //     return out;
+  //   }
+  //   inline Scalar_base* ScIInit_u16() {
+  //     Scalar_base* out = new Uint16Scalar();
+  //     return out;
+  //   }
+  //   inline Scalar_base* ScIInit_i16() {
+  //     Scalar_base* out = new Int16Scalar();
+  //     return out;
+  //   }
+  //   inline Scalar_base* ScIInit_b() {
+  //     Scalar_base* out = new BoolScalar();
+  //     return out;
+  //   }
+  //   Scalar_init_interface::Scalar_init_interface() {
+  //     if (!inited) {
+  //       UScIInit[this->Double] = ScIInit_d;
+  //       UScIInit[this->Float] = ScIInit_f;
+  //       UScIInit[this->ComplexDouble] = ScIInit_cd;
+  //       UScIInit[this->ComplexFloat] = ScIInit_cf;
+  //       UScIInit[this->Uint64] = ScIInit_u64;
+  //       UScIInit[this->Int64] = ScIInit_i64;
+  //       UScIInit[this->Uint32] = ScIInit_u32;
+  //       UScIInit[this->Int32] = ScIInit_i32;
+  //       UScIInit[this->Uint16] = ScIInit_u16;
+  //       UScIInit[this->Int16] = ScIInit_i16;
+  //       UScIInit[this->Bool] = ScIInit_b;
+  //       inited = true;
+  //     }
+  //   }
+
+  //   Scalar_init_interface __ScII;
+}  // namespace cytnx

--- a/src/backend_torch/Scalar.cpp
+++ b/src/backend_torch/Scalar.cpp
@@ -49,90 +49,188 @@ namespace cytnx {
 
   Scalar sqrt(const Scalar& c) { return c.sqrt(); };
 
+  at::Tensor StorageImpl2Tensor(const c10::intrusive_ptr<c10::StorageImpl>& impl, int dtype) {
+    c10::Storage sto = c10::Storage(impl);
+
+    if (dtype == Type.Bool) {
+      at::TensorImpl tnimpl =
+        at::TensorImpl(std::move(sto), c10::DispatchKeySet::FULL, caffe2::TypeMeta::Make<bool>());
+      return at::Tensor(
+        c10::intrusive_ptr<c10::TensorImpl, c10::UndefinedTensorImpl>::reclaim(&tnimpl));
+    } else if (dtype == Type.ComplexDouble) {
+      at::TensorImpl tnimpl = at::TensorImpl(std::move(sto), c10::DispatchKeySet::FULL,
+                                             caffe2::TypeMeta::Make<c10::complex<double>>());
+      return at::Tensor(
+        c10::intrusive_ptr<c10::TensorImpl, c10::UndefinedTensorImpl>::reclaim(&tnimpl));
+    } else if (dtype == Type.ComplexFloat) {
+      at::TensorImpl tnimpl = at::TensorImpl(std::move(sto), c10::DispatchKeySet::FULL,
+                                             caffe2::TypeMeta::Make<c10::complex<float>>());
+      return at::Tensor(
+        c10::intrusive_ptr<c10::TensorImpl, c10::UndefinedTensorImpl>::reclaim(&tnimpl));
+    } else if (dtype == Type.Int64) {
+      at::TensorImpl tnimpl = at::TensorImpl(std::move(sto), c10::DispatchKeySet::FULL,
+                                             caffe2::TypeMeta::Make<int64_t>());
+      return at::Tensor(
+        c10::intrusive_ptr<c10::TensorImpl, c10::UndefinedTensorImpl>::reclaim(&tnimpl));
+    } else if (dtype == Type.Int32) {
+      at::TensorImpl tnimpl = at::TensorImpl(std::move(sto), c10::DispatchKeySet::FULL,
+                                             caffe2::TypeMeta::Make<int32_t>());
+      return at::Tensor(
+        c10::intrusive_ptr<c10::TensorImpl, c10::UndefinedTensorImpl>::reclaim(&tnimpl));
+    } else if (dtype == Type.Int16) {
+      at::TensorImpl tnimpl = at::TensorImpl(std::move(sto), c10::DispatchKeySet::FULL,
+                                             caffe2::TypeMeta::Make<int16_t>());
+      return at::Tensor(
+        c10::intrusive_ptr<c10::TensorImpl, c10::UndefinedTensorImpl>::reclaim(&tnimpl));
+    } else if (dtype == Type.Double) {
+      at::TensorImpl tnimpl =
+        at::TensorImpl(std::move(sto), c10::DispatchKeySet::FULL, caffe2::TypeMeta::Make<double>());
+      return at::Tensor(
+        c10::intrusive_ptr<c10::TensorImpl, c10::UndefinedTensorImpl>::reclaim(&tnimpl));
+    } else if (dtype == Type.Float) {
+      at::TensorImpl tnimpl =
+        at::TensorImpl(std::move(sto), c10::DispatchKeySet::FULL, caffe2::TypeMeta::Make<float>());
+      return at::Tensor(
+        c10::intrusive_ptr<c10::TensorImpl, c10::UndefinedTensorImpl>::reclaim(&tnimpl));
+    } else if (dtype == Type.Float) {
+      at::TensorImpl tnimpl =
+        at::TensorImpl(std::move(sto), c10::DispatchKeySet::FULL, caffe2::TypeMeta::Make<float>());
+      return at::Tensor(
+        c10::intrusive_ptr<c10::TensorImpl, c10::UndefinedTensorImpl>::reclaim(&tnimpl));
+    }
+    cytnx_error_msg(true, "[ERROR] StorageImpl2Tensor: unsupported dtype%s", "\n");
+    return at::Tensor();
+  }
+
   // Scalar proxy:
   // Sproxy
   Scalar::Sproxy& Scalar::Sproxy::operator=(const Scalar::Sproxy& rc) {
-    // std::cout << "entry !!" << std::endl;
     if (this->_insimpl.get() == 0) {
-      // std::cout << "entry cpcon, not init!!" << std::endl;
-      // std::cout << std::flush;
-      //  not init:
       this->_insimpl = rc._insimpl;
       this->_loc = rc._loc;
       return *this;
     } else {
       if ((rc._insimpl == this->_insimpl) && (rc._loc == this->_loc)) {
-        // std::cout << "entry same!!" << std::endl;
-        std::cout << std::flush;
         return *this;
       } else {
-        // std::cout << "entry wrn !!" << std::endl;
-        std::cout << std::flush;
-        Scalar tmp = rc._insimpl->get_item(rc._loc);
-        this->_insimpl->set_item(this->_loc, tmp);
+        at::Tensor tnthis = StorageImpl2Tensor(this->_insimpl, this->_dtype);
+        at::Tensor tnrc = StorageImpl2Tensor(rc._insimpl, rc._dtype);
+        tnthis[this->_loc] = tnrc[rc._loc];
         return *this;
       }
     }
   }
   Scalar::Sproxy& Scalar::Sproxy::operator=(const Scalar& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
+    at::Tensor tnthis = StorageImpl2Tensor(this->_insimpl, this->_dtype);
+    tnthis[this->_loc] = rc;
     return *this;
   }
   Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_complex128& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
+    at::Tensor tnthis = StorageImpl2Tensor(this->_insimpl, this->_dtype);
+    tnthis[this->_loc] = c10::complex<double>(rc);
     return *this;
   }
   Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_complex64& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
+    at::Tensor tnthis = StorageImpl2Tensor(this->_insimpl, this->_dtype);
+    tnthis[this->_loc] = c10::complex<float>(rc);
     return *this;
   }
   Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_double& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
+    at::Tensor tnthis = StorageImpl2Tensor(this->_insimpl, this->_dtype);
+    tnthis[this->_loc] = rc;
     return *this;
   }
   Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_float& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
+    at::Tensor tnthis = StorageImpl2Tensor(this->_insimpl, this->_dtype);
+    tnthis[this->_loc] = rc;
     return *this;
   }
   Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_uint64& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
+    cytnx_error_msg(true,
+                    "[ERROR] invalid dtype for scalar operator=, pytorch backend doesn't support "
+                    "unsigned type %s",
+                    "\n");
     return *this;
   }
   Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_int64& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
+    at::Tensor tnthis = StorageImpl2Tensor(this->_insimpl, this->_dtype);
+    tnthis[this->_loc] = rc;
     return *this;
   }
   Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_uint32& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
+    cytnx_error_msg(true,
+                    "[ERROR] invalid dtype for scalar operator=, pytorch backend doesn't support "
+                    "unsigned type %s",
+                    "\n");
     return *this;
   }
   Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_int32& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
+    at::Tensor tnthis = StorageImpl2Tensor(this->_insimpl, this->_dtype);
+    tnthis[this->_loc] = rc;
     return *this;
   }
   Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_uint16& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
+    cytnx_error_msg(true,
+                    "[ERROR] invalid dtype for scalar operator=, pytorch backend doesn't support "
+                    "unsigned type %s",
+                    "\n");
     return *this;
   }
   Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_int16& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
+    at::Tensor tnthis = StorageImpl2Tensor(this->_insimpl, this->_dtype);
+    tnthis[this->_loc] = rc;
     return *this;
   }
   Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_bool& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
+    at::Tensor tnthis = StorageImpl2Tensor(this->_insimpl, this->_dtype);
+    tnthis[this->_loc] = rc;
     return *this;
   }
 
-  bool Scalar::Sproxy::exists() const { return this->_insimpl->dtype != Type.Void; };
+  bool Scalar::Sproxy::exists() const { return this->_dtype != Type.Void; };
 
   Scalar Scalar::Sproxy::real() { return Scalar(*this).real(); }
   Scalar Scalar::Sproxy::imag() { return Scalar(*this).imag(); }
 
-  Scalar::Scalar(const Sproxy& prox) : _impl(new Scalar_base()) {
-    if (this->_impl != nullptr) {
-      delete this->_impl;
+  Scalar::Scalar(const Sproxy& prox) {
+    switch (prox._dtype) {
+      case Type.ComplexDouble:
+        *this = StorageImpl2Tensor(prox._insimpl, prox._dtype)[prox._loc].item();
+        break;
+      case Type.ComplexFloat:
+        *this = StorageImpl2Tensor(prox._insimpl, prox._dtype)[prox._loc].item();
+        break;
+      case Type.Double:
+        *this = StorageImpl2Tensor(prox._insimpl, prox._dtype)[prox._loc].item();
+        break;
+      case Type.Float:
+        *this = StorageImpl2Tensor(prox._insimpl, prox._dtype)[prox._loc].item();
+        break;
+      case Type.Int64:
+        *this = StorageImpl2Tensor(prox._insimpl, prox._dtype)[prox._loc].item();
+        break;
+      case Type.Uint64:
+        cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+        break;
+      case Type.Int32:
+        *this = StorageImpl2Tensor(prox._insimpl, prox._dtype)[prox._loc].item();
+        break;
+      case Type.Uint32:
+        cytnx_error_msg(true, "[ERROR] no support for unsigned dtype for torch backend %s", "\n");
+        break;
+      case Type.Int16:
+        *this = StorageImpl2Tensor(prox._insimpl, prox._dtype)[prox._loc].item();
+        break;
+      case Type.Uint16:
+        *this = StorageImpl2Tensor(prox._insimpl, prox._dtype)[prox._loc].item();
+        break;
+      case Type.Bool:
+        *this = StorageImpl2Tensor(prox._insimpl, prox._dtype)[prox._loc].item();
+        break;
+      default:
+        cytnx_error_msg(true, "[ERROR] invalid dtype for torch backend %s", "\n");
+        break;
     }
-    this->_impl = prox._insimpl->get_item(prox._loc)._impl->copy();
   }
 
   //   // Storage Init interface.


### PR DESCRIPTION
Not fully tested, at least compile passed.

It's important to review SProxy, since we're not using straightforward way to write into memory.
Instead, we first convert memory to at::Tensor, then use `tn[loc] = elem; `