### PR TITLE
Adding denseUt linalg::InvM_/InvM

### DIFF
--- a/include/linalg.hpp
+++ b/include/linalg.hpp
@@ -1791,6 +1791,7 @@ namespace cytnx {
     @pre \p Tin should be a rank-2 Tensor.
     */
     Tensor InvM(const Tensor &Tin);
+    UniTensor InvM(const UniTensor &Tin);
     /**
     @brief inplace matrix inverse.
     @details This function will perform matrix inverse on the input matrix \p Tin, inplacely.

--- a/include/linalg.hpp
+++ b/include/linalg.hpp
@@ -1799,7 +1799,6 @@ namespace cytnx {
     @pre the Tin should be a rank-2 Tensor.
     */
     void InvM_(Tensor &Tin);
-    void InvM_(UniTensor &Tin);
 
     // Inv:
     //==================================================

--- a/include/linalg.hpp
+++ b/include/linalg.hpp
@@ -1439,6 +1439,19 @@ namespace cytnx {
     */
     Tensor Norm(const Tensor &Tl);
 
+    // Norm:
+    //=================================================
+    /**
+    @brief Calculate the norm of an UniTensor.
+    @details This function will calculate the norm of an UniTensor. If the input UniTensor is
+    rank-1, then the frobenius norm will be calculated. If the input UniTensor is rank-N with N>=2,
+    then the blocks will be flatten (see @ref Tensor::flatten() const "flatten()") to 1d first, and
+    then calculate the frobenius norm.
+    @param[in] uTl input UniTensor
+    @return Tensor
+    */
+    Tensor Norm(const UniTensor &uTl);
+
     // Det:
     //=================================================
     /**

--- a/include/linalg.hpp
+++ b/include/linalg.hpp
@@ -1799,7 +1799,7 @@ namespace cytnx {
     @pre the Tin should be a rank-2 Tensor.
     */
     void InvM_(Tensor &Tin);
-
+    void InvM_(UniTensor &Tin);
     // Inv:
     //==================================================
     /**

--- a/include/linalg.hpp
+++ b/include/linalg.hpp
@@ -1799,6 +1799,7 @@ namespace cytnx {
     @pre the Tin should be a rank-2 Tensor.
     */
     void InvM_(Tensor &Tin);
+    void InvM_(UniTensor &Tin);
 
     // Inv:
     //==================================================

--- a/include/linalg.hpp
+++ b/include/linalg.hpp
@@ -1685,6 +1685,9 @@ namespace cytnx {
     */
     std::vector<Tensor> Eigh(const Tensor &Tin, const bool &is_V = true, const bool &row_v = false);
 
+    std::vector<UniTensor> Eigh(const UniTensor &Tin, const bool &is_V = true,
+                                const bool &row_v = false);
+
     // Eig:
     //==================================================
     /**
@@ -1707,6 +1710,9 @@ namespace cytnx {
     @pre the \p Tin should be a square matrix.
     */
     std::vector<Tensor> Eig(const Tensor &Tin, const bool &is_V = true, const bool &row_v = false);
+
+    std::vector<UniTensor> Eig(const UniTensor &Tin, const bool &is_V = true,
+                               const bool &row_v = false);
 
     // Trace:
     //==================================================

--- a/pybind/linalg_py.cpp
+++ b/pybind/linalg_py.cpp
@@ -389,7 +389,14 @@ void linalg_binding(py::module &m) {
                py::arg("is_conj") = false);
   m_linalg.def("Tridiag", &cytnx::linalg::Tridiag, py::arg("A"), py::arg("B"),
                py::arg("is_V") = true, py::arg("is_row") = false, py::arg("throw_excp") = false);
-  m_linalg.def("Norm", &cytnx::linalg::Norm, py::arg("T1"));
+
+  // m_linalg.def("Norm", &cytnx::linalg::Norm, py::arg("T1") = cytnx::Tensor());
+  // m_linalg.def("Norm", &cytnx::linalg::Norm, py::arg("T1") = cytnx::UniTensor());
+  m_linalg.def(
+    "Norm", [](cytnx::UniTensor &T1) { return cytnx::linalg::Norm(T1); }, py::arg("T1"));
+  m_linalg.def(
+    "Norm", [](cytnx::Tensor &T1) { return cytnx::linalg::Norm(T1); }, py::arg("T1"));
+
   m_linalg.def("Dot", &cytnx::linalg::Dot, py::arg("T1"), py::arg("T2"));
   m_linalg.def(
     "Axpy", [](const Scalar &a, const Tensor &x) { return cytnx::linalg::Axpy(a, x); },

--- a/pybind/linalg_py.cpp
+++ b/pybind/linalg_py.cpp
@@ -383,7 +383,14 @@ void linalg_binding(py::module &m) {
     py::arg("Tio"), py::arg("is_tau") = false);
 
   m_linalg.def("InvM", &cytnx::linalg::InvM, py::arg("Tin"));
-  m_linalg.def("InvM_", &cytnx::linalg::InvM_, py::arg("Tio"));
+
+  // m_linalg.def("InvM_", &cytnx::linalg::InvM_, py::arg("Tio"));
+
+  m_linalg.def(
+    "InvM_", [](cytnx::UniTensor &Tin) { cytnx::linalg::InvM_(Tin); }, py::arg("Tin"));
+  m_linalg.def(
+    "InvM_", [](cytnx::Tensor &Tin) { cytnx::linalg::InvM_(Tin); }, py::arg("Tin"));
+
   m_linalg.def("Inv_", &cytnx::linalg::Inv_, py::arg("Tio"), py::arg("clip"));
   m_linalg.def("Inv", &cytnx::linalg::Inv, py::arg("Tio"), py::arg("clip"));
 

--- a/pybind/linalg_py.cpp
+++ b/pybind/linalg_py.cpp
@@ -383,7 +383,13 @@ void linalg_binding(py::module &m) {
     py::arg("Tio"), py::arg("is_tau") = false);
 
   m_linalg.def("InvM", &cytnx::linalg::InvM, py::arg("Tin"));
-  m_linalg.def("InvM_", &cytnx::linalg::InvM_, py::arg("Tio"));
+
+  // m_linalg.def("InvM_", &cytnx::linalg::InvM_, py::arg("Tio"));
+  m_linalg.def(
+    "InvM_", [](cytnx::UniTensor &Tio) { cytnx::linalg::InvM_(Tio); }, py::arg("Tio"));
+  m_linalg.def(
+    "InvM_", [](cytnx::Tensor &Tio) { cytnx::linalg::InvM_(Tio); }, py::arg("Tio"));
+
   m_linalg.def("Inv_", &cytnx::linalg::Inv_, py::arg("Tio"), py::arg("clip"));
   m_linalg.def("Inv", &cytnx::linalg::Inv, py::arg("Tio"), py::arg("clip"));
 

--- a/pybind/linalg_py.cpp
+++ b/pybind/linalg_py.cpp
@@ -382,13 +382,18 @@ void linalg_binding(py::module &m) {
     [](const cytnx::Tensor &Tin, const bool &is_tau) { return cytnx::linalg::Qdr(Tin, is_tau); },
     py::arg("Tio"), py::arg("is_tau") = false);
 
-  m_linalg.def("InvM", &cytnx::linalg::InvM, py::arg("Tin"));
+  // m_linalg.def("InvM", &cytnx::linalg::InvM, py::arg("Tin"));
 
   // m_linalg.def("InvM_", &cytnx::linalg::InvM_, py::arg("Tio"));
   m_linalg.def(
     "InvM_", [](cytnx::UniTensor &Tio) { cytnx::linalg::InvM_(Tio); }, py::arg("Tio"));
   m_linalg.def(
     "InvM_", [](cytnx::Tensor &Tio) { cytnx::linalg::InvM_(Tio); }, py::arg("Tio"));
+
+  m_linalg.def(
+    "InvM", [](cytnx::UniTensor &Tin) { return cytnx::linalg::InvM(Tin); }, py::arg("Tin"));
+  m_linalg.def(
+    "InvM", [](cytnx::Tensor &Tin) { return cytnx::linalg::InvM(Tin); }, py::arg("Tin"));
 
   m_linalg.def("Inv_", &cytnx::linalg::Inv_, py::arg("Tio"), py::arg("clip"));
   m_linalg.def("Inv", &cytnx::linalg::Inv, py::arg("Tio"), py::arg("clip"));

--- a/pybind/linalg_py.cpp
+++ b/pybind/linalg_py.cpp
@@ -383,14 +383,7 @@ void linalg_binding(py::module &m) {
     py::arg("Tio"), py::arg("is_tau") = false);
 
   m_linalg.def("InvM", &cytnx::linalg::InvM, py::arg("Tin"));
-
-  // m_linalg.def("InvM_", &cytnx::linalg::InvM_, py::arg("Tio"));
-
-  m_linalg.def(
-    "InvM_", [](cytnx::UniTensor &Tin) { cytnx::linalg::InvM_(Tin); }, py::arg("Tin"));
-  m_linalg.def(
-    "InvM_", [](cytnx::Tensor &Tin) { cytnx::linalg::InvM_(Tin); }, py::arg("Tin"));
-
+  m_linalg.def("InvM_", &cytnx::linalg::InvM_, py::arg("Tio"));
   m_linalg.def("Inv_", &cytnx::linalg::Inv_, py::arg("Tio"), py::arg("clip"));
   m_linalg.def("Inv", &cytnx::linalg::Inv, py::arg("Tio"), py::arg("clip"));
 

--- a/pybind/linalg_py.cpp
+++ b/pybind/linalg_py.cpp
@@ -80,10 +80,36 @@ void linalg_binding(py::module &m) {
     py::arg("Tin"), py::arg("keepdim"), py::arg("err") = 0, py::arg("is_UvT") = true,
     py::arg("return_err") = (unsigned int)(0));
 
-  m_linalg.def("Eigh", &cytnx::linalg::Eigh, py::arg("Tin"), py::arg("is_V") = true,
-               py::arg("row_v") = false);
-  m_linalg.def("Eig", &cytnx::linalg::Eig, py::arg("Tin"), py::arg("is_V") = true,
-               py::arg("row_v") = false);
+  // m_linalg.def("Eigh", &cytnx::linalg::Eigh, py::arg("Tin"), py::arg("is_V") = true,
+  //              py::arg("row_v") = false);
+  //  m_linalg.def("Eig", &cytnx::linalg::Eig, py::arg("Tin"), py::arg("is_V") = true,
+  //                py::arg("row_v") = false);
+  m_linalg.def(
+    "Eigh",
+    [](const Tensor &Tin, const bool &is_V, const bool &row_v) {
+      return cytnx::linalg::Eigh(Tin, is_V, row_v);
+    },
+    py::arg("Tin"), py::arg("is_V") = true, py::arg("row_v") = false);
+  m_linalg.def(
+    "Eigh",
+    [](const UniTensor &Tin, const bool &is_V, const bool &row_v) {
+      return cytnx::linalg::Eigh(Tin, is_V, row_v);
+    },
+    py::arg("Tin"), py::arg("is_V") = true, py::arg("row_v") = false);
+
+  m_linalg.def(
+    "Eig",
+    [](const Tensor &Tin, const bool &is_V, const bool &row_v) {
+      return cytnx::linalg::Eig(Tin, is_V, row_v);
+    },
+    py::arg("Tin"), py::arg("is_V") = true, py::arg("row_v") = false);
+  m_linalg.def(
+    "Eig",
+    [](const UniTensor &Tin, const bool &is_V, const bool &row_v) {
+      return cytnx::linalg::Eig(Tin, is_V, row_v);
+    },
+    py::arg("Tin"), py::arg("is_V") = true, py::arg("row_v") = false);
+
   m_linalg.def("Exp", &cytnx::linalg::Exp, py::arg("Tin"));
   m_linalg.def("Exp_", &cytnx::linalg::Exp_, py::arg("Tio"));
   m_linalg.def("Expf_", &cytnx::linalg::Expf_, py::arg("Tio"));

--- a/src/linalg/Eig.cpp
+++ b/src/linalg/Eig.cpp
@@ -132,13 +132,14 @@ namespace cytnx {
       cytnx::UniTensor &Cy_S = outCyT[t];
       cytnx::Bond newBond(outT[t].shape()[0]);
 
-      Cy_S.Init({newBond, newBond}, {std::string("_aux_L"), std::string("_aux_R")}, 1, Type.Double,
-                Device.cpu, true);  // it is just reference so no hurt to alias ^^
+      Cy_S.Init({newBond, newBond}, {std::string("0"), std::string("1")}, 1, Type.ComplexDouble,
+                Device.cpu, true);  // it is just reference so no hurt to alias ^^. Eigvals are
+                                    // complex for general case so ComplexDouble.
 
       // cout << "[AFTER INIT]" << endl;
       Cy_S.put_block_(outT[t]);
+      if (Tin.is_tag()) Cy_S.tag();
       t++;
-
       if (is_V) {
         cytnx::UniTensor &Cy_U = outCyT[t];
         vector<cytnx_int64> shapeU = vec_clone(oldshape, Tin.rowrank());
@@ -146,25 +147,20 @@ namespace cytnx {
         outT[t].reshape_(shapeU);
         Cy_U.Init(outT[t], false, Tin.rowrank());
         vector<string> labelU = vec_clone(oldlabel, Tin.rowrank());
-        labelU.push_back(Cy_S.labels()[0]);
-        Cy_U.set_labels(labelU);
-        t++;  // U
-      }
-      // if tag, then update  the tagging informations
-      if (Tin.is_tag()) {
-        Cy_S.tag();
-        t = 1;
-        if (is_V) {
-          cytnx::UniTensor &Cy_U = outCyT[t];
+        // labelU.push_back(Cy_S.labels()[0]);
+        // Cy_U.set_labels(labelU);
+
+        // if tag, then update  the tagging informations
+        if (Tin.is_tag()) {
           Cy_U._impl->_is_tag = true;
           for (int i = 0; i < Cy_U.rowrank(); i++) {
             Cy_U.bonds()[i].set_type(Tin.bonds()[i].type());
           }
           Cy_U.bonds().back().set_type(cytnx::BD_BRA);
           Cy_U._impl->_is_braket_form = Cy_U._impl->_update_braket();
-          t++;
-        }
-      }  // if tag
+          // t++;
+        }  // if tag
+      }  // V
     }
 
     std::vector<cytnx::UniTensor> Eig(const UniTensor &Tin, const bool &is_V, const bool &row_v) {
@@ -186,8 +182,7 @@ namespace cytnx {
                         "[ERROR] Eig, unsupported type of UniTensor only support (Dense). "
                         "something wrong internal%s",
                         "\n");
-
-      }  // is block form ?
+      }  // ut type
 
       return outCyT;
 

--- a/src/linalg/Eig.cpp
+++ b/src/linalg/Eig.cpp
@@ -132,34 +132,15 @@ namespace cytnx {
       cytnx::UniTensor &Cy_S = outCyT[t];
       cytnx::Bond newBond(outT[t].shape()[0]);
 
-      Cy_S.Init({newBond, newBond}, {std::string("0"), std::string("1")}, 1, Type.ComplexDouble,
-                Device.cpu, true);  // it is just reference so no hurt to alias ^^. Eigvals are
-                                    // complex for general case so ComplexDouble.
+      Cy_S.Init({newBond, newBond}, {std::string("0"), std::string("1")}, 1, Type.Double,
+                Device.cpu, true);  // it is just reference so no hurt to alias ^^. All eigvals are
+                                    // real for eigh so Type.Double.
 
-      // cout << "[AFTER INIT]" << endl;
       Cy_S.put_block_(outT[t]);
-      if (Tin.is_tag()) Cy_S.tag();
       t++;
       if (is_V) {
         cytnx::UniTensor &Cy_U = outCyT[t];
-        vector<cytnx_int64> shapeU = vec_clone(oldshape, Tin.rowrank());
-        shapeU.push_back(-1);
-        outT[t].reshape_(shapeU);
-        Cy_U.Init(outT[t], false, Tin.rowrank());
-        vector<string> labelU = vec_clone(oldlabel, Tin.rowrank());
-        // labelU.push_back(Cy_S.labels()[0]);
-        // Cy_U.set_labels(labelU);
-
-        // if tag, then update  the tagging informations
-        if (Tin.is_tag()) {
-          Cy_U._impl->_is_tag = true;
-          for (int i = 0; i < Cy_U.rowrank(); i++) {
-            Cy_U.bonds()[i].set_type(Tin.bonds()[i].type());
-          }
-          Cy_U.bonds().back().set_type(cytnx::BD_BRA);
-          Cy_U._impl->_is_braket_form = Cy_U._impl->_update_braket();
-          // t++;
-        }  // if tag
+        Cy_U.Init(outT[t], false, 1);  // Tin is a rowrank = 1 square UniTensor.
       }  // V
     }
 

--- a/src/linalg/Eigh.cpp
+++ b/src/linalg/Eigh.cpp
@@ -129,30 +129,11 @@ namespace cytnx {
                 Device.cpu, true);  // it is just reference so no hurt to alias ^^. All eigvals are
                                     // real for eigh so Type.Double.
 
-      // cout << "[AFTER INIT]" << endl;
       Cy_S.put_block_(outT[t]);
-      if (Tin.is_tag()) Cy_S.tag();
       t++;
       if (is_V) {
         cytnx::UniTensor &Cy_U = outCyT[t];
-        vector<cytnx_int64> shapeU = vec_clone(oldshape, Tin.rowrank());
-        shapeU.push_back(-1);
-        outT[t].reshape_(shapeU);
-        Cy_U.Init(outT[t], false, Tin.rowrank());
-        vector<string> labelU = vec_clone(oldlabel, Tin.rowrank());
-        // labelU.push_back(Cy_S.labels()[0]);
-        // Cy_U.set_labels(labelU);
-
-        // if tag, then update  the tagging informations
-        if (Tin.is_tag()) {
-          Cy_U._impl->_is_tag = true;
-          for (int i = 0; i < Cy_U.rowrank(); i++) {
-            Cy_U.bonds()[i].set_type(Tin.bonds()[i].type());
-          }
-          Cy_U.bonds().back().set_type(cytnx::BD_BRA);
-          Cy_U._impl->_is_braket_form = Cy_U._impl->_update_braket();
-          // t++;
-        }  // if tag
+        Cy_U.Init(outT[t], false, 1);  // Tin is a rowrank = 1 square UniTensor.
       }  // V
     }  //_Eigh_Dense_UT
 

--- a/src/linalg/Eigh.cpp
+++ b/src/linalg/Eigh.cpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include "Tensor.hpp"
+using namespace std;
 
 #ifdef BACKEND_TORCH
 #else
@@ -81,6 +82,109 @@ namespace cytnx {
   #endif
       }
     }
+
+  }  // namespace linalg
+}  // namespace cytnx
+
+namespace cytnx {
+  namespace linalg {
+
+    // actual impls:
+    void _Eigh_Dense_UT(std::vector<cytnx::UniTensor> &outCyT, const UniTensor &Tin,
+                        const bool &is_V, const bool &row_v) {
+      //[Note] outCyT must be empty!
+
+      // DenseUniTensor:
+      // cout << "entry Dense UT" << endl;
+
+      Tensor tmp;
+      if (Tin.is_contiguous())
+        tmp = Tin.get_block_();
+      else {
+        tmp = Tin.get_block();
+        tmp.contiguous_();
+      }
+
+      vector<cytnx_uint64> tmps = tmp.shape();
+      vector<cytnx_int64> oldshape(tmps.begin(), tmps.end());
+      tmps.clear();
+      vector<string> oldlabel = Tin.labels();
+
+      // collapse as Matrix:
+      cytnx_int64 rowdim = 1;
+      for (cytnx_uint64 i = 0; i < Tin.rowrank(); i++) rowdim *= tmp.shape()[i];
+      tmp.reshape_({rowdim, -1});
+
+      vector<Tensor> outT = cytnx::linalg::Eig(tmp, is_V, row_v);
+      if (Tin.is_contiguous()) tmp.reshape_(oldshape);
+
+      int t = 0;
+      outCyT.resize(outT.size());
+
+      // s
+      cytnx::UniTensor &Cy_S = outCyT[t];
+      cytnx::Bond newBond(outT[t].shape()[0]);
+
+      Cy_S.Init({newBond, newBond}, {std::string("_aux_L"), std::string("_aux_R")}, 1, Type.Double,
+                Device.cpu, true);  // it is just reference so no hurt to alias ^^
+
+      // cout << "[AFTER INIT]" << endl;
+      Cy_S.put_block_(outT[t]);
+      t++;
+
+      if (is_V) {
+        cytnx::UniTensor &Cy_U = outCyT[t];
+        vector<cytnx_int64> shapeU = vec_clone(oldshape, Tin.rowrank());
+        shapeU.push_back(-1);
+        outT[t].reshape_(shapeU);
+        Cy_U.Init(outT[t], false, Tin.rowrank());
+        vector<string> labelU = vec_clone(oldlabel, Tin.rowrank());
+        labelU.push_back(Cy_S.labels()[0]);
+        Cy_U.set_labels(labelU);
+        t++;  // U
+      }
+      // if tag, then update  the tagging informations
+      if (Tin.is_tag()) {
+        Cy_S.tag();
+        t = 1;
+        if (is_V) {
+          cytnx::UniTensor &Cy_U = outCyT[t];
+          Cy_U._impl->_is_tag = true;
+          for (int i = 0; i < Cy_U.rowrank(); i++) {
+            Cy_U.bonds()[i].set_type(Tin.bonds()[i].type());
+          }
+          Cy_U.bonds().back().set_type(cytnx::BD_BRA);
+          Cy_U._impl->_is_braket_form = Cy_U._impl->_update_braket();
+          t++;
+        }
+      }  // if tag
+    }
+
+    std::vector<cytnx::UniTensor> Eigh(const UniTensor &Tin, const bool &is_V, const bool &row_v) {
+      // using rowrank to split the bond to form a matrix.
+      cytnx_error_msg(Tin.rowrank() < 1 || Tin.rank() == 1,
+                      "[Eigh][ERROR] Eigh for UniTensor should have rank>1 and rowrank>0%s", "\n");
+
+      cytnx_error_msg(Tin.is_diag(),
+                      "[Eigh][ERROR] Eigh for diagonal UniTensor is trivial and currently not "
+                      "support. Use other manipulation.%s",
+                      "\n");
+
+      std::vector<UniTensor> outCyT;
+      if (Tin.uten_type() == UTenType.Dense) {
+        _Eigh_Dense_UT(outCyT, Tin, is_V, row_v);
+
+      } else {
+        cytnx_error_msg(true,
+                        "[ERROR] Eig, unsupported type of UniTensor only support (Dense). "
+                        "something wrong internal%s",
+                        "\n");
+
+      }  // is block form ?
+
+      return outCyT;
+
+    };  // Eig
 
   }  // namespace linalg
 }  // namespace cytnx

--- a/src/linalg/InvM.cpp
+++ b/src/linalg/InvM.cpp
@@ -1,6 +1,7 @@
 #include "linalg.hpp"
 
 #include "Tensor.hpp"
+using namespace std;
 
 #ifdef BACKEND_TORCH
 #else
@@ -47,4 +48,58 @@ namespace cytnx {
 
   }  // namespace linalg
 }  // namespace cytnx
+
+namespace cytnx {
+  namespace linalg {
+    void _InvM_Dense_UT(UniTensor &outCyT, const UniTensor &Tin) {
+      Tensor tmp;
+
+      if (Tin.is_contiguous()) {
+        tmp = Tin.get_block_();
+      } else {
+        tmp = Tin.get_block();
+        tmp.contiguous_();
+      }
+
+      vector<cytnx_uint64> tmps = tmp.shape();
+      vector<cytnx_int64> oldshape(tmps.begin(), tmps.end());
+      tmps.clear();
+      vector<string> oldlabel = Tin.labels();
+
+      // collapse as Matrix:
+      cytnx_int64 rowdim = 1;
+      for (cytnx_uint64 i = 0; i < Tin.rowrank(); i++) rowdim *= tmp.shape()[i];
+      tmp.reshape_({rowdim, -1});
+
+      Tensor outT = cytnx::linalg::InvM(tmp);
+
+      if (Tin.is_contiguous()) tmp.reshape_(oldshape);
+
+      outCyT = UniTensor(outT, false, 1);
+    }
+
+    UniTensor InvM(const UniTensor &Tin) {
+      cytnx_error_msg(Tin.rowrank() < 1 || Tin.rank() == 1,
+                      "[InvM_][ERROR] InvM for UniTensor should have rank>1 and rowrank>0%s", "\n");
+
+      cytnx_error_msg(Tin.is_diag(),
+                      "[InvM_[ERROR] InvM for diagonal UniTensor is trivial and currently not "
+                      "support. Use other manipulation.%s",
+                      "\n");
+      UniTensor outCyT;
+      if (Tin.uten_type() == UTenType.Dense) {
+        _InvM_Dense_UT(outCyT, Tin);
+        return outCyT;
+      } else {
+        cytnx_error_msg(true,
+                        "[ERROR] InvM, unsupported type of UniTensor only support (Dense). "
+                        "something wrong internal%s",
+                        "\n");
+        return UniTensor();
+      }
+    }
+
+  }  // namespace linalg
+}  // namespace cytnx
+
 #endif  // BACKEND_TORCH

--- a/src/linalg/InvM_.cpp
+++ b/src/linalg/InvM_.cpp
@@ -1,7 +1,6 @@
 #include "linalg.hpp"
 
 #include "Tensor.hpp"
-using namespace std;
 
 #ifdef BACKEND_TORCH
 #else
@@ -34,54 +33,6 @@ namespace cytnx {
         cytnx_error_msg(true, "[InvM] fatal error,%s",
                         "try to call the gpu section without CUDA support.\n");
   #endif
-      }
-    }
-
-  }  // namespace linalg
-}  // namespace cytnx
-
-namespace cytnx {
-  namespace linalg {
-    void _InvM_inplace_Dense_UT(UniTensor &Tin) {
-      Tensor tmp = Tin.get_block_();
-
-      // if (Tin.is_contiguous())
-      //   tmp = Tin.get_block_();
-      // else {
-      //   tmp = Tin.get_block();
-      //   tmp.contiguous_();
-      // }
-
-      vector<cytnx_uint64> tmps = tmp.shape();
-      vector<cytnx_int64> oldshape(tmps.begin(), tmps.end());
-      tmps.clear();
-      vector<string> oldlabel = Tin.labels();
-
-      // collapse as Matrix:
-      cytnx_int64 rowdim = 1;
-      for (cytnx_uint64 i = 0; i < Tin.rowrank(); i++) rowdim *= tmp.shape()[i];
-      tmp.reshape_({rowdim, -1});
-
-      cytnx::linalg::InvM_(tmp);
-      tmp.reshape_(oldshape);
-    }
-    void InvM_(UniTensor &Tin) {
-      cytnx_error_msg(Tin.rowrank() < 1 || Tin.rank() == 1,
-                      "[InvM_][ERROR] InvM_ for UniTensor should have rank>1 and rowrank>0%s",
-                      "\n");
-
-      cytnx_error_msg(Tin.is_diag(),
-                      "[InvM_[ERROR] InvM_ for diagonal UniTensor is trivial and currently not "
-                      "support. Use other manipulation.%s",
-                      "\n");
-      if (Tin.uten_type() == UTenType.Dense) {
-        _InvM_inplace_Dense_UT(Tin);
-
-      } else {
-        cytnx_error_msg(true,
-                        "[ERROR] InvM, unsupported type of UniTensor only support (Dense). "
-                        "something wrong internal%s",
-                        "\n");
       }
     }
 

--- a/src/linalg/InvM_.cpp
+++ b/src/linalg/InvM_.cpp
@@ -1,7 +1,7 @@
 #include "linalg.hpp"
 
 #include "Tensor.hpp"
-
+using namespace std;
 #ifdef BACKEND_TORCH
 #else
   #include "../backend/linalg_internal_interface.hpp"
@@ -33,6 +33,54 @@ namespace cytnx {
         cytnx_error_msg(true, "[InvM] fatal error,%s",
                         "try to call the gpu section without CUDA support.\n");
   #endif
+      }
+    }
+
+  }  // namespace linalg
+}  // namespace cytnx
+
+namespace cytnx {
+  namespace linalg {
+    void _InvM_inplace_Dense_UT(UniTensor &Tin) {
+      Tensor tmp = Tin.get_block_();
+
+      // if (Tin.is_contiguous())
+      //   tmp = Tin.get_block_();
+      // else {
+      //   tmp = Tin.get_block();
+      //   tmp.contiguous_();
+      // }
+
+      vector<cytnx_uint64> tmps = tmp.shape();
+      vector<cytnx_int64> oldshape(tmps.begin(), tmps.end());
+      tmps.clear();
+      vector<string> oldlabel = Tin.labels();
+
+      // collapse as Matrix:
+      cytnx_int64 rowdim = 1;
+      for (cytnx_uint64 i = 0; i < Tin.rowrank(); i++) rowdim *= tmp.shape()[i];
+      tmp.reshape_({rowdim, -1});
+
+      cytnx::linalg::InvM_(tmp);
+      tmp.reshape_(oldshape);
+    }
+    void InvM_(UniTensor &Tin) {
+      cytnx_error_msg(Tin.rowrank() < 1 || Tin.rank() == 1,
+                      "[InvM_][ERROR] InvM_ for UniTensor should have rank>1 and rowrank>0%s",
+                      "\n");
+
+      cytnx_error_msg(Tin.is_diag(),
+                      "[InvM_[ERROR] InvM_ for diagonal UniTensor is trivial and currently not "
+                      "support. Use other manipulation.%s",
+                      "\n");
+      if (Tin.uten_type() == UTenType.Dense) {
+        _InvM_inplace_Dense_UT(Tin);
+
+      } else {
+        cytnx_error_msg(true,
+                        "[ERROR] InvM, unsupported type of UniTensor only support (Dense). "
+                        "something wrong internal%s",
+                        "\n");
       }
     }
 

--- a/src/linalg/InvM_.cpp
+++ b/src/linalg/InvM_.cpp
@@ -42,14 +42,14 @@ namespace cytnx {
 namespace cytnx {
   namespace linalg {
     void _InvM_inplace_Dense_UT(UniTensor &Tin) {
-      Tensor tmp = Tin.get_block_();
+      Tensor tmp;
 
-      // if (Tin.is_contiguous())
-      //   tmp = Tin.get_block_();
-      // else {
-      //   tmp = Tin.get_block();
-      //   tmp.contiguous_();
-      // }
+      if (Tin.is_contiguous())
+        tmp = Tin.get_block_();
+      else {
+        tmp = Tin.get_block();
+        tmp.contiguous_();
+      }
 
       vector<cytnx_uint64> tmps = tmp.shape();
       vector<cytnx_int64> oldshape(tmps.begin(), tmps.end());
@@ -62,7 +62,8 @@ namespace cytnx {
       tmp.reshape_({rowdim, -1});
 
       cytnx::linalg::InvM_(tmp);
-      tmp.reshape_(oldshape);
+
+      if (Tin.is_contiguous()) tmp.reshape_(oldshape);
     }
     void InvM_(UniTensor &Tin) {
       cytnx_error_msg(Tin.rowrank() < 1 || Tin.rank() == 1,
@@ -78,7 +79,7 @@ namespace cytnx {
 
       } else {
         cytnx_error_msg(true,
-                        "[ERROR] InvM, unsupported type of UniTensor only support (Dense). "
+                        "[ERROR] InvM_, unsupported type of UniTensor only support (Dense). "
                         "something wrong internal%s",
                         "\n");
       }

--- a/src/linalg/InvM_.cpp
+++ b/src/linalg/InvM_.cpp
@@ -1,6 +1,7 @@
 #include "linalg.hpp"
 
 #include "Tensor.hpp"
+using namespace std;
 
 #ifdef BACKEND_TORCH
 #else
@@ -33,6 +34,54 @@ namespace cytnx {
         cytnx_error_msg(true, "[InvM] fatal error,%s",
                         "try to call the gpu section without CUDA support.\n");
   #endif
+      }
+    }
+
+  }  // namespace linalg
+}  // namespace cytnx
+
+namespace cytnx {
+  namespace linalg {
+    void _InvM_inplace_Dense_UT(UniTensor &Tin) {
+      Tensor tmp = Tin.get_block_();
+
+      // if (Tin.is_contiguous())
+      //   tmp = Tin.get_block_();
+      // else {
+      //   tmp = Tin.get_block();
+      //   tmp.contiguous_();
+      // }
+
+      vector<cytnx_uint64> tmps = tmp.shape();
+      vector<cytnx_int64> oldshape(tmps.begin(), tmps.end());
+      tmps.clear();
+      vector<string> oldlabel = Tin.labels();
+
+      // collapse as Matrix:
+      cytnx_int64 rowdim = 1;
+      for (cytnx_uint64 i = 0; i < Tin.rowrank(); i++) rowdim *= tmp.shape()[i];
+      tmp.reshape_({rowdim, -1});
+
+      cytnx::linalg::InvM_(tmp);
+      tmp.reshape_(oldshape);
+    }
+    void InvM_(UniTensor &Tin) {
+      cytnx_error_msg(Tin.rowrank() < 1 || Tin.rank() == 1,
+                      "[InvM_][ERROR] InvM_ for UniTensor should have rank>1 and rowrank>0%s",
+                      "\n");
+
+      cytnx_error_msg(Tin.is_diag(),
+                      "[InvM_[ERROR] InvM_ for diagonal UniTensor is trivial and currently not "
+                      "support. Use other manipulation.%s",
+                      "\n");
+      if (Tin.uten_type() == UTenType.Dense) {
+        _InvM_inplace_Dense_UT(Tin);
+
+      } else {
+        cytnx_error_msg(true,
+                        "[ERROR] InvM, unsupported type of UniTensor only support (Dense). "
+                        "something wrong internal%s",
+                        "\n");
       }
     }
 

--- a/src/linalg/Norm.cpp
+++ b/src/linalg/Norm.cpp
@@ -1,7 +1,7 @@
 #include "linalg.hpp"
 #include <iostream>
 #include "Tensor.hpp"
-
+#include "cytnx.hpp"
 #ifdef BACKEND_TORCH
 #else
   #include "../backend/linalg_internal_interface.hpp"
@@ -58,6 +58,17 @@ namespace cytnx {
       cytnx_error_msg(uTl.uten_type() != UTenType.Dense,
                       "[Error][Norm] Can only use Norm on DenseUniTensor or Tensor%s", "\n");
       return Norm(uTl.get_block_());
+      // if(uTl.uten_type() == UTenType.Dense){
+      //   // return Norm(uTl.get_block_());
+      // }else{
+
+      // std::vector<Tensor> bks = uTl.get_blocks_();
+      // Tensor res = Norm(bks[0]);
+      // for(int i = 1; i < bks.size(); i++){
+      //   res+=Norm(bks[i]);
+      // }
+      // return res;
+      // }
     }
 
   }  // namespace linalg

--- a/src/linalg/Norm.cpp
+++ b/src/linalg/Norm.cpp
@@ -55,20 +55,19 @@ namespace cytnx {
     }
 
     Tensor Norm(const UniTensor& uTl) {
-      cytnx_error_msg(uTl.uten_type() != UTenType.Dense,
-                      "[Error][Norm] Can only use Norm on DenseUniTensor or Tensor%s", "\n");
-      return Norm(uTl.get_block_());
-      // if(uTl.uten_type() == UTenType.Dense){
-      //   // return Norm(uTl.get_block_());
-      // }else{
-
-      // std::vector<Tensor> bks = uTl.get_blocks_();
-      // Tensor res = Norm(bks[0]);
-      // for(int i = 1; i < bks.size(); i++){
-      //   res+=Norm(bks[i]);
-      // }
-      // return res;
-      // }
+      // cytnx_error_msg(uTl.uten_type() != UTenType.Dense,
+      //                 "[Error][Norm] Can only use Norm on DenseUniTensor or Tensor%s", "\n");
+      // return Norm(uTl.get_block_());
+      if (uTl.uten_type() == UTenType.Dense) {
+        return Norm(uTl.get_block_());
+      } else {
+        std::vector<Tensor> bks = uTl.get_blocks_();
+        Tensor res = Norm(bks[0]).Pow(2);
+        for (int i = 1; i < bks.size(); i++) {
+          res += Norm(bks[i]).Pow(2);
+        }
+        return res.Pow(0.5);
+      }
     }
 
   }  // namespace linalg

--- a/src/linalg/Norm.cpp
+++ b/src/linalg/Norm.cpp
@@ -55,18 +55,17 @@ namespace cytnx {
     }
 
     Tensor Norm(const UniTensor& uTl) {
-      // cytnx_error_msg(uTl.uten_type() != UTenType.Dense,
-      //                 "[Error][Norm] Can only use Norm on DenseUniTensor or Tensor%s", "\n");
-      // return Norm(uTl.get_block_());
       if (uTl.uten_type() == UTenType.Dense) {
         return Norm(uTl.get_block_());
       } else {
         std::vector<Tensor> bks = uTl.get_blocks_();
-        Tensor res = Norm(bks[0]).Pow(2);
-        for (int i = 1; i < bks.size(); i++) {
-          res += Norm(bks[i]).Pow(2);
+        Tensor res = zeros(1);
+        for (int i = 0; i < bks.size(); i++) {
+          Tensor tmp = Norm(bks[i]);
+          res.at({0}) = res.at({0}) + tmp.at({0}) * tmp.at({0});
         }
-        return res.Pow(0.5);
+        res.at({0}) = sqrt(res.at({0}));
+        return res;
       }
     }
 

--- a/src/linalg/Norm.cpp
+++ b/src/linalg/Norm.cpp
@@ -57,7 +57,7 @@ namespace cytnx {
     Tensor Norm(const UniTensor& uTl) {
       if (uTl.uten_type() == UTenType.Dense) {
         return Norm(uTl.get_block_());
-      } else {
+      } else if (uTl.uten_type() == UTenType.Block) {
         std::vector<Tensor> bks = uTl.get_blocks_();
         Tensor res = zeros(1);
         for (int i = 0; i < bks.size(); i++) {
@@ -66,6 +66,12 @@ namespace cytnx {
         }
         res.at({0}) = sqrt(res.at({0}));
         return res;
+      } else {
+        cytnx_error_msg(
+          true,
+          "[ERROR] Norm, unsupported type of UniTensor, only support Dense and Block. "
+          "something wrong internal%s",
+          "\n");
       }
     }
 

--- a/tests/linalg_test/linalg_test.cpp
+++ b/tests/linalg_test/linalg_test.cpp
@@ -409,7 +409,11 @@ TEST_F(linalg_Test, Tensor_InvM_) {
   EXPECT_TRUE((linalg::Tensordot(invertable3x3cd, inv, {1}, {0}) - eye3x3cd).Norm().item() < 1e-13);
 }
 
-TEST_F(linalg_Test, DenseUt_InvM) {}
+TEST_F(linalg_Test, DenseUt_InvM) {
+  auto inv = linalg::InvM(invertable3x3cd_ut);
+  inv.set_labels({"1", "2"});  // invertable3x3cd_ut is labeled "0","1".
+  EXPECT_TRUE((invertable3x3cd_ut.contract(inv) - UniTensor(eye3x3cd)).Norm().item() < 1e-13);
+}
 
 TEST_F(linalg_Test, DenseUt_InvM_) {
   auto inv = invertable3x3cd_ut.clone();

--- a/tests/linalg_test/linalg_test.cpp
+++ b/tests/linalg_test/linalg_test.cpp
@@ -311,7 +311,7 @@ TEST_F(linalg_Test, Tensor_Gemm_) {
 
 TEST_F(linalg_Test, Tensor_Norm) {
   cytnx_double ans = 0;
-  for (int i = 0; i < 9; i++) {
+  for (cytnx_uint64 i = 0; i < 9; i++) {
     ans += i * i * 2;
   }
   ans = sqrt(ans);
@@ -320,7 +320,7 @@ TEST_F(linalg_Test, Tensor_Norm) {
 
 TEST_F(linalg_Test, DenseUt_Norm) {
   cytnx_double ans = 0;
-  for (int i = 0; i < 9; i++) {
+  for (cytnx_uint64 i = 0; i < 9; i++) {
     ans += i * i * 2;
   }
   ans = sqrt(ans);
@@ -329,7 +329,7 @@ TEST_F(linalg_Test, DenseUt_Norm) {
 
 // TEST_F(linalg_Test, BkUt_Norm) {
 //   cytnx_double ans=0;
-//   for(int i = 0; i<9;i++){
+//   for(cytnx_uint64 i = 0; i<9;i++){
 //     ans+=i*i*2;
 //   }
 //   ans+=9;

--- a/tests/linalg_test/linalg_test.cpp
+++ b/tests/linalg_test/linalg_test.cpp
@@ -309,6 +309,54 @@ TEST_F(linalg_Test, Tensor_Gemm_) {
     }
 }
 
+TEST_F(linalg_Test, Tensor_Norm) {
+  cytnx_double ans = 0;
+  for (int i = 0; i < 9; i++) {
+    ans += i * i * 2;
+  }
+  ans = sqrt(ans);
+  EXPECT_EQ(linalg::Norm(arange3x3cd).item(), ans);
+}
+
+TEST_F(linalg_Test, DenseUt_Norm) {
+  cytnx_double ans = 0;
+  for (int i = 0; i < 9; i++) {
+    ans += i * i * 2;
+  }
+  ans = sqrt(ans);
+  EXPECT_EQ(linalg::Norm(arange3x3cd_ut).item(), ans);
+}
+
+// TEST_F(linalg_Test, BkUt_Norm) {
+//   cytnx_double ans=0;
+//   for(int i = 0; i<9;i++){
+//     ans+=i*i*2;
+//   }
+//   ans+=9;
+//   ans = sqrt(ans);
+//   Bond I = Bond(BD_IN, {Qs(-1), Qs(1)}, {3, 3});
+//   Bond J = Bond(BD_OUT, {Qs(-1), Qs(1)}, {3, 3});
+//   UniTensor in = UniTensor({I, J});
+//   in.put_block_(arange3x3cd, 0);
+//   in.put_block_(ones3x3cd, 1);
+//   EXPECT_EQ(linalg::Norm(in).item(), ans);
+// }
+
+TEST_F(linalg_Test, Tensor_Eig) { EXPECT_TRUE(false); }
+
+TEST_F(linalg_Test, Tensor_Eigh) { EXPECT_TRUE(false); }
+
+TEST_F(linalg_Test, DenseUt_Eig) { EXPECT_TRUE(false); }
+
+TEST_F(linalg_Test, DenseUt_Eigh) { EXPECT_TRUE(false); }
+
+TEST_F(linalg_Test, Tensor_Inv) { EXPECT_TRUE(false); }
+
+TEST_F(linalg_Test, Tensor_Inv_) { EXPECT_TRUE(false); }
+
+TEST_F(linalg_Test, DenseUt_Inv) { EXPECT_TRUE(false); }
+
+TEST_F(linalg_Test, DenseUt_Inv_) { EXPECT_TRUE(false); }
 // TEST_F(linalg_Test, DenseUt_Mod_UtUt){
 //     UniTensor At = UniTensor(A);
 //     UniTensor Bt = UniTensor(B);

--- a/tests/linalg_test/linalg_test.cpp
+++ b/tests/linalg_test/linalg_test.cpp
@@ -339,7 +339,9 @@ TEST_F(linalg_Test, BkUt_Norm) {
   UniTensor in = UniTensor({I, J});
   in.put_block_(arange3x3cd, 0);
   in.put_block_(ones3x3cd, 1);
-  EXPECT_EQ(linalg::Norm(in).item(), ans);
+  // EXPECT_EQ(cytnx_double(linalg::Norm(in).item().real()), ans);
+  EXPECT_TRUE(abs(cytnx_double(linalg::Norm(in).item().real()) - ans) <
+              1e-13);  // not sure why some precision lost.
 }
 
 TEST_F(linalg_Test, Tensor_Eig) {

--- a/tests/linalg_test/linalg_test.cpp
+++ b/tests/linalg_test/linalg_test.cpp
@@ -399,26 +399,23 @@ TEST_F(linalg_Test, DenseUt_Eigh) {
 // TEST_F(linalg_Test, DenseUt_Inv_) { EXPECT_TRUE(false); }
 
 TEST_F(linalg_Test, Tensor_InvM) {
-  auto her = arange3x3cd + arange3x3cd.Conj().permute({1, 0});
-  auto inv = linalg::InvM(her);
-  // std::cout<< (linalg::Tensordot(arange3x3cd, inv, {1},{0})- eye3x3cd).Norm().item();
-  EXPECT_TRUE((linalg::Tensordot(her, inv, {1}, {0}) - eye3x3cd).Norm().item() < 1e-13);
+  auto inv = linalg::InvM(invertable3x3cd);
+  EXPECT_TRUE((linalg::Tensordot(invertable3x3cd, inv, {1}, {0}) - eye3x3cd).Norm().item() < 1e-13);
 }
 
 TEST_F(linalg_Test, Tensor_InvM_) {
-  auto inv = arange3x3cd.clone();
+  auto inv = invertable3x3cd.clone();
   linalg::InvM_(inv);
-  // std::cout<< (linalg::Tensordot(arange3x3cd, inv, {1},{0})- eye3x3cd).Norm().item();
-  EXPECT_TRUE((linalg::Tensordot(arange3x3cd, inv, {1}, {0}) - eye3x3cd).Norm().item() < 1e-13);
+  EXPECT_TRUE((linalg::Tensordot(invertable3x3cd, inv, {1}, {0}) - eye3x3cd).Norm().item() < 1e-13);
 }
 
 TEST_F(linalg_Test, DenseUt_InvM) {}
 
 TEST_F(linalg_Test, DenseUt_InvM_) {
-  auto inv = arange3x3cd_ut.clone();
-  inv.set_labels({"2", "3"});
+  auto inv = invertable3x3cd_ut.clone();
+  inv.set_labels({"1", "2"});  // invertable3x3cd_ut is labeled "0","1".
   linalg::InvM_(inv);
-  EXPECT_TRUE((arange3x3cd_ut.contract(inv) - UniTensor(eye3x3cd)).Norm().item() < 1e-13);
+  EXPECT_TRUE((invertable3x3cd_ut.contract(inv) - UniTensor(eye3x3cd)).Norm().item() < 1e-13);
 }
 
 // TEST_F(linalg_Test, DenseUt_Mod_UtUt){

--- a/tests/linalg_test/linalg_test.cpp
+++ b/tests/linalg_test/linalg_test.cpp
@@ -342,13 +342,51 @@ TEST_F(linalg_Test, DenseUt_Norm) {
 //   EXPECT_EQ(linalg::Norm(in).item(), ans);
 // }
 
-TEST_F(linalg_Test, Tensor_Eig) { EXPECT_TRUE(false); }
+TEST_F(linalg_Test, Tensor_Eig) {
+  auto res = linalg::Eig(arange3x3cd);
+  auto e = UniTensor(res[0], true);
+  e.set_labels({"a", "b"});
+  auto v = UniTensor(res[1]);
+  v.set_labels({"i", "a"});
+  auto vt = UniTensor(linalg::InvM(v.get_block()));
+  vt.set_labels({"b", "j"});
+  EXPECT_TRUE((UniTensor(arange3x3cd) - Contract(Contract(e, v), vt)).Norm().item() < 1e-13);
+}
 
-TEST_F(linalg_Test, Tensor_Eigh) { EXPECT_TRUE(false); }
+TEST_F(linalg_Test, Tensor_Eigh) {
+  auto her = arange3x3cd + arange3x3cd.Conj().permute({1, 0});
+  auto res = linalg::Eigh(her);
+  auto e = UniTensor(res[0], true);
+  e.set_labels({"a", "b"});
+  auto v = UniTensor(res[1]);
+  v.set_labels({"i", "a"});
+  auto vt = UniTensor(linalg::InvM(v.get_block()));
+  vt.set_labels({"b", "j"});
+  EXPECT_TRUE((UniTensor(her) - Contract(Contract(e, v), vt)).Norm().item() < 1e-13);
+}
 
-TEST_F(linalg_Test, DenseUt_Eig) { EXPECT_TRUE(false); }
+TEST_F(linalg_Test, DenseUt_Eig) {
+  auto res = linalg::Eig(arange3x3cd_ut);
+  auto e = res[0];
+  e.set_labels({"a", "b"});
+  auto v = res[1];
+  v.set_labels({"i", "a"});
+  auto vt = UniTensor(linalg::InvM(v.get_block()));
+  vt.set_labels({"b", "j"});
+  EXPECT_TRUE((UniTensor(arange3x3cd) - Contract(Contract(e, v), vt)).Norm().item() < 1e-13);
+}
 
-TEST_F(linalg_Test, DenseUt_Eigh) { EXPECT_TRUE(false); }
+TEST_F(linalg_Test, DenseUt_Eigh) {
+  auto her = arange3x3cd + arange3x3cd.Conj().permute({1, 0});
+  auto res = linalg::Eigh(UniTensor(her));
+  auto e = res[0];
+  e.set_labels({"a", "b"});
+  auto v = res[1];
+  v.set_labels({"i", "a"});
+  auto vt = UniTensor(linalg::InvM(v.get_block()));
+  vt.set_labels({"b", "j"});
+  EXPECT_TRUE((UniTensor(her) - Contract(Contract(e, v), vt)).Norm().item() < 1e-13);
+}
 
 TEST_F(linalg_Test, Tensor_Inv) { EXPECT_TRUE(false); }
 

--- a/tests/linalg_test/linalg_test.cpp
+++ b/tests/linalg_test/linalg_test.cpp
@@ -398,6 +398,29 @@ TEST_F(linalg_Test, DenseUt_Eigh) {
 
 // TEST_F(linalg_Test, DenseUt_Inv_) { EXPECT_TRUE(false); }
 
+TEST_F(linalg_Test, Tensor_InvM) {
+  auto her = arange3x3cd + arange3x3cd.Conj().permute({1, 0});
+  auto inv = linalg::InvM(her);
+  // std::cout<< (linalg::Tensordot(arange3x3cd, inv, {1},{0})- eye3x3cd).Norm().item();
+  EXPECT_TRUE((linalg::Tensordot(her, inv, {1}, {0}) - eye3x3cd).Norm().item() < 1e-13);
+}
+
+TEST_F(linalg_Test, Tensor_InvM_) {
+  auto inv = arange3x3cd.clone();
+  linalg::InvM_(inv);
+  // std::cout<< (linalg::Tensordot(arange3x3cd, inv, {1},{0})- eye3x3cd).Norm().item();
+  EXPECT_TRUE((linalg::Tensordot(arange3x3cd, inv, {1}, {0}) - eye3x3cd).Norm().item() < 1e-13);
+}
+
+TEST_F(linalg_Test, DenseUt_InvM) {}
+
+TEST_F(linalg_Test, DenseUt_InvM_) {
+  auto inv = arange3x3cd_ut.clone();
+  inv.set_labels({"2", "3"});
+  linalg::InvM_(inv);
+  EXPECT_TRUE((arange3x3cd_ut.contract(inv) - UniTensor(eye3x3cd)).Norm().item() < 1e-13);
+}
+
 // TEST_F(linalg_Test, DenseUt_Mod_UtUt){
 //     UniTensor At = UniTensor(A);
 //     UniTensor Bt = UniTensor(B);

--- a/tests/linalg_test/linalg_test.cpp
+++ b/tests/linalg_test/linalg_test.cpp
@@ -327,20 +327,20 @@ TEST_F(linalg_Test, DenseUt_Norm) {
   EXPECT_EQ(linalg::Norm(arange3x3cd_ut).item(), ans);
 }
 
-// TEST_F(linalg_Test, BkUt_Norm) {
-//   cytnx_double ans=0;
-//   for(cytnx_uint64 i = 0; i<9;i++){
-//     ans+=i*i*2;
-//   }
-//   ans+=9;
-//   ans = sqrt(ans);
-//   Bond I = Bond(BD_IN, {Qs(-1), Qs(1)}, {3, 3});
-//   Bond J = Bond(BD_OUT, {Qs(-1), Qs(1)}, {3, 3});
-//   UniTensor in = UniTensor({I, J});
-//   in.put_block_(arange3x3cd, 0);
-//   in.put_block_(ones3x3cd, 1);
-//   EXPECT_EQ(linalg::Norm(in).item(), ans);
-// }
+TEST_F(linalg_Test, BkUt_Norm) {
+  cytnx_double ans = 0;
+  for (cytnx_uint64 i = 0; i < 9; i++) {
+    ans += i * i * 2;
+  }
+  ans += 9;
+  ans = sqrt(ans);
+  Bond I = Bond(BD_IN, {Qs(-1), Qs(1)}, {3, 3});
+  Bond J = Bond(BD_OUT, {Qs(-1), Qs(1)}, {3, 3});
+  UniTensor in = UniTensor({I, J});
+  in.put_block_(arange3x3cd, 0);
+  in.put_block_(ones3x3cd, 1);
+  EXPECT_EQ(linalg::Norm(in).item(), ans);
+}
 
 TEST_F(linalg_Test, Tensor_Eig) {
   auto res = linalg::Eig(arange3x3cd);

--- a/tests/linalg_test/linalg_test.cpp
+++ b/tests/linalg_test/linalg_test.cpp
@@ -388,36 +388,13 @@ TEST_F(linalg_Test, DenseUt_Eigh) {
   EXPECT_TRUE((UniTensor(her) - Contract(Contract(e, v), vt)).Norm().item() < 1e-13);
 }
 
-TEST_F(linalg_Test, Tensor_Inv) {}
+TEST_F(linalg_Test, Tensor_Inv) { EXPECT_TRUE(false); }
 
-TEST_F(linalg_Test, Tensor_Inv_) {}
+TEST_F(linalg_Test, Tensor_Inv_) { EXPECT_TRUE(false); }
 
-TEST_F(linalg_Test, DenseUt_Inv) {}
+TEST_F(linalg_Test, DenseUt_Inv) { EXPECT_TRUE(false); }
 
-TEST_F(linalg_Test, DenseUt_Inv_) {}
-
-TEST_F(linalg_Test, Tensor_InvM) {
-  auto her = arange3x3cd + arange3x3cd.Conj().permute({1, 0});
-  auto inv = linalg::InvM(her);
-  // std::cout<< (linalg::Tensordot(arange3x3cd, inv, {1},{0})- eye3x3cd).Norm().item();
-  EXPECT_TRUE((linalg::Tensordot(her, inv, {1}, {0}) - eye3x3cd).Norm().item() < 1e-13);
-}
-
-TEST_F(linalg_Test, Tensor_InvM_) {
-  auto inv = arange3x3cd.clone();
-  linalg::InvM_(inv);
-  // std::cout<< (linalg::Tensordot(arange3x3cd, inv, {1},{0})- eye3x3cd).Norm().item();
-  EXPECT_TRUE((linalg::Tensordot(arange3x3cd, inv, {1}, {0}) - eye3x3cd).Norm().item() < 1e-13);
-}
-
-TEST_F(linalg_Test, DenseUt_InvM) {}
-
-TEST_F(linalg_Test, DenseUt_InvM_) {
-  auto inv = arange3x3cd_ut.clone();
-  inv.set_labels({"2", "3"});
-  linalg::InvM_(inv);
-  EXPECT_TRUE((arange3x3cd_ut.contract(inv) - UniTensor(eye3x3cd)).Norm().item() < 1e-13);
-}
+TEST_F(linalg_Test, DenseUt_Inv_) { EXPECT_TRUE(false); }
 // TEST_F(linalg_Test, DenseUt_Mod_UtUt){
 //     UniTensor At = UniTensor(A);
 //     UniTensor Bt = UniTensor(B);

--- a/tests/linalg_test/linalg_test.cpp
+++ b/tests/linalg_test/linalg_test.cpp
@@ -388,13 +388,36 @@ TEST_F(linalg_Test, DenseUt_Eigh) {
   EXPECT_TRUE((UniTensor(her) - Contract(Contract(e, v), vt)).Norm().item() < 1e-13);
 }
 
-TEST_F(linalg_Test, Tensor_Inv) { EXPECT_TRUE(false); }
+TEST_F(linalg_Test, Tensor_Inv) {}
 
-TEST_F(linalg_Test, Tensor_Inv_) { EXPECT_TRUE(false); }
+TEST_F(linalg_Test, Tensor_Inv_) {}
 
-TEST_F(linalg_Test, DenseUt_Inv) { EXPECT_TRUE(false); }
+TEST_F(linalg_Test, DenseUt_Inv) {}
 
-TEST_F(linalg_Test, DenseUt_Inv_) { EXPECT_TRUE(false); }
+TEST_F(linalg_Test, DenseUt_Inv_) {}
+
+TEST_F(linalg_Test, Tensor_InvM) {
+  auto her = arange3x3cd + arange3x3cd.Conj().permute({1, 0});
+  auto inv = linalg::InvM(her);
+  // std::cout<< (linalg::Tensordot(arange3x3cd, inv, {1},{0})- eye3x3cd).Norm().item();
+  EXPECT_TRUE((linalg::Tensordot(her, inv, {1}, {0}) - eye3x3cd).Norm().item() < 1e-13);
+}
+
+TEST_F(linalg_Test, Tensor_InvM_) {
+  auto inv = arange3x3cd.clone();
+  linalg::InvM_(inv);
+  // std::cout<< (linalg::Tensordot(arange3x3cd, inv, {1},{0})- eye3x3cd).Norm().item();
+  EXPECT_TRUE((linalg::Tensordot(arange3x3cd, inv, {1}, {0}) - eye3x3cd).Norm().item() < 1e-13);
+}
+
+TEST_F(linalg_Test, DenseUt_InvM) {}
+
+TEST_F(linalg_Test, DenseUt_InvM_) {
+  auto inv = arange3x3cd_ut.clone();
+  inv.set_labels({"2", "3"});
+  linalg::InvM_(inv);
+  EXPECT_TRUE((arange3x3cd_ut.contract(inv) - UniTensor(eye3x3cd)).Norm().item() < 1e-13);
+}
 // TEST_F(linalg_Test, DenseUt_Mod_UtUt){
 //     UniTensor At = UniTensor(A);
 //     UniTensor Bt = UniTensor(B);

--- a/tests/linalg_test/linalg_test.cpp
+++ b/tests/linalg_test/linalg_test.cpp
@@ -388,13 +388,14 @@ TEST_F(linalg_Test, DenseUt_Eigh) {
   EXPECT_TRUE((UniTensor(her) - Contract(Contract(e, v), vt)).Norm().item() < 1e-13);
 }
 
-TEST_F(linalg_Test, Tensor_Inv) { EXPECT_TRUE(false); }
+// TEST_F(linalg_Test, Tensor_Inv) { EXPECT_TRUE(false); }
 
-TEST_F(linalg_Test, Tensor_Inv_) { EXPECT_TRUE(false); }
+// TEST_F(linalg_Test, Tensor_Inv_) { EXPECT_TRUE(false); }
 
-TEST_F(linalg_Test, DenseUt_Inv) { EXPECT_TRUE(false); }
+// TEST_F(linalg_Test, DenseUt_Inv) { EXPECT_TRUE(false); }
 
-TEST_F(linalg_Test, DenseUt_Inv_) { EXPECT_TRUE(false); }
+// TEST_F(linalg_Test, DenseUt_Inv_) { EXPECT_TRUE(false); }
+
 // TEST_F(linalg_Test, DenseUt_Mod_UtUt){
 //     UniTensor At = UniTensor(A);
 //     UniTensor Bt = UniTensor(B);

--- a/tests/linalg_test/linalg_test.h
+++ b/tests/linalg_test/linalg_test.h
@@ -21,8 +21,11 @@ class linalg_Test : public ::testing::Test {
   Tensor eye3x3cd = eye(3, Type.ComplexDouble);
   Tensor zeros3x3cd = zeros(9, Type.ComplexDouble).reshape(3, 3);
 
+  Tensor invertable3x3cd = arange(1, 10, 1, Type.ComplexDouble).reshape(3, 3);
+
   UniTensor arange3x3cd_ut = UniTensor(arange3x3cd, false, -1);
   UniTensor ones3x3cd_ut = UniTensor(ones3x3cd, false, -1);
+  UniTensor invertable3x3cd_ut = UniTensor(invertable3x3cd, false, -1);
 
   std::string data_dir = "../../tests/test_data_base/linalg/";
   // ==================== svd_truncate ===================
@@ -63,7 +66,6 @@ class linalg_Test : public ::testing::Test {
  protected:
   void SetUp() override {
     //================ svd truncate =======================
-
     svd_T = svd_T.Load(data_dir + "Svd_truncate/Svd_truncate1.cytnx");
     svd_T.permute_({1, 0, 3, 2});
     svd_T.contiguous_();
@@ -75,6 +77,9 @@ class linalg_Test : public ::testing::Test {
     H.put_block(B, 1);
     H.put_block(C, 2);
     H.set_labels({"a", "b"});
+
+    invertable3x3cd.at({0, 0}) = 2;  // just to make it invertable.
+    invertable3x3cd_ut.at({0, 0}) = 2;  // just to make it invertable.
   }
   void TearDown() override {}
 };

--- a/tests/linalg_test/linalg_test.h
+++ b/tests/linalg_test/linalg_test.h
@@ -21,6 +21,9 @@ class linalg_Test : public ::testing::Test {
   Tensor eye3x3cd = eye(3, Type.ComplexDouble);
   Tensor zeros3x3cd = zeros(9, Type.ComplexDouble).reshape(3, 3);
 
+  UniTensor arange3x3cd_ut = UniTensor(arange3x3cd, false, -1);
+  UniTensor ones3x3cd_ut = UniTensor(ones3x3cd, false, -1);
+
   std::string data_dir = "../../tests/test_data_base/linalg/";
   // ==================== svd_truncate ===================
   Bond svd_I = Bond(BD_OUT, {Qs(1), Qs(-1)}, {1, 1});


### PR DESCRIPTION
Issue https://github.com/Cytnx-dev/Cytnx/issues/311.

Currently` InvM_` return the block inverse inplacely, and the ut metas(label,shape,tag..) remains the same, while `invM` returns a new square ut without any meta infos of input, I'm not sure if this is a good behavior.

Note that this PR depends on https://github.com/Cytnx-dev/Cytnx/pull/312.