### PR TITLE
Fixed a static casting issue from uint to int for Intel oneAPI compilers

### DIFF
--- a/tests/BlockUniTensor_test.h
+++ b/tests/BlockUniTensor_test.h
@@ -160,7 +160,7 @@ class BlockUniTensorTest : public ::testing::Test {
     using namespace std::complex_literals;
     for (size_t i = 0; i < UT_diag_cplx.bonds()[0].qnums().size(); i++) {
       cytnx_uint64 deg = UT_diag_cplx.bonds()[0]._impl->_degs[i];
-      UT_diag_cplx.get_block_(i).fill(std::complex<double>{i + 1, i + 1});
+      UT_diag_cplx.get_block_(i).fill(std::complex<double>{static_cast<double>(i + 1), static_cast<double>(i + 1)});
     }
   }
   void TearDown() override {}

--- a/tests/BlockUniTensor_test.h
+++ b/tests/BlockUniTensor_test.h
@@ -160,7 +160,8 @@ class BlockUniTensorTest : public ::testing::Test {
     using namespace std::complex_literals;
     for (size_t i = 0; i < UT_diag_cplx.bonds()[0].qnums().size(); i++) {
       cytnx_uint64 deg = UT_diag_cplx.bonds()[0]._impl->_degs[i];
-      UT_diag_cplx.get_block_(i).fill(std::complex<double>{static_cast<double>(i + 1), static_cast<double>(i + 1)});
+      UT_diag_cplx.get_block_(i).fill(
+        std::complex<double>{static_cast<double>(i + 1), static_cast<double>(i + 1)});
     }
   }
   void TearDown() override {}


### PR DESCRIPTION
This PR fixed a static casting issue that causes the compiler failure for Intel oneAPI compilers