### PR TITLE
Migrate cuTENSOR APIs to 2.x

### DIFF
--- a/src/backend/linalg_internal_gpu/cuTensordot_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTensordot_internal.cu
@@ -14,14 +14,25 @@
       }                                                                          \
     };
 
+  #define HANDLE_CUDA_ERROR(x)                           \
+    {                                                    \
+      const auto err = x;                                \
+      if (err != cudaSuccess) {                          \
+        printf("Error in line %d: %s\n", __LINE__, err); \
+        exit(-1);                                        \
+      }                                                  \
+    };
+
 namespace cytnx {
 
   namespace linalg_internal {
 
     inline void _cuTensordot_internal(Tensor &out, const Tensor &Lin, const Tensor &Rin,
                                       const std::vector<cytnx_uint64> &idxl,
-                                      const std::vector<cytnx_uint64> &idxr, cudaDataType_t type,
-                                      cutensorComputeType_t typeCompute, void *alpha, void *beta) {
+                                      const std::vector<cytnx_uint64> &idxr,
+                                      cutensorDataType_t type,
+                                      cutensorComputeDescriptor_t descCompute, void *alpha,
+                                      void *beta) {
       // hostType alpha = (hostType){1.f, 0.f};
       // hostType beta = (hostType){0.f, 0.f};
 
@@ -90,94 +101,89 @@ namespace cytnx {
        * cuTENSOR
        *************************/
 
-      cutensorHandle_t *handle;
+      cutensorHandle_t handle;
       HANDLE_ERROR(cutensorCreate(&handle));
 
       /**********************
        * Create Tensor Descriptors
        **********************/
 
+      // This is the default alignment of cudaMalloc() and may also be the default alignment of
+      // cudaMallocManaged()
+      cytnx_uint64 defaultAlignment = 256;
       cutensorTensorDescriptor_t descL;
-      HANDLE_ERROR(cutensorInitTensorDescriptor(handle, &descL, nlabelL, extentL.data(),
-                                                NULL, /*stride*/
-                                                type, CUTENSOR_OP_IDENTITY));
+      HANDLE_ERROR(cutensorCreateTensorDescriptor(handle, &descL, nlabelL, extentL.data(),
+                                                  NULL, /*stride*/
+                                                  type, defaultAlignment));
 
       cutensorTensorDescriptor_t descR;
-      HANDLE_ERROR(cutensorInitTensorDescriptor(handle, &descR, nlabelR, extentR.data(),
-                                                NULL, /*stride*/
-                                                type, CUTENSOR_OP_IDENTITY));
+      HANDLE_ERROR(cutensorCreateTensorDescriptor(handle, &descR, nlabelR, extentR.data(),
+                                                  NULL, /*stride*/
+                                                  type, defaultAlignment));
 
       cutensorTensorDescriptor_t descOut;
-      HANDLE_ERROR(cutensorInitTensorDescriptor(handle, &descOut, nlabelOut, extentOut.data(),
-                                                NULL, /*stride*/
-                                                type, CUTENSOR_OP_IDENTITY));
-
-      /**********************************************
-       * Retrieve the memory alignment for each tensor
-       **********************************************/
-
-      uint32_t alignmentRequirementL;
-      HANDLE_ERROR(cutensorGetAlignmentRequirement(handle, lPtr, &descL, &alignmentRequirementL));
-
-      uint32_t alignmentRequirementR;
-      HANDLE_ERROR(cutensorGetAlignmentRequirement(handle, rPtr, &descR, &alignmentRequirementR));
-
-      uint32_t alignmentRequirementOut;
-      HANDLE_ERROR(
-        cutensorGetAlignmentRequirement(handle, outPtr, &descOut, &alignmentRequirementOut));
+      HANDLE_ERROR(cutensorCreateTensorDescriptor(handle, &descOut, nlabelOut, extentOut.data(),
+                                                  NULL, /*stride*/
+                                                  type, defaultAlignment));
 
       /*******************************
        * Create Contraction Descriptor
        *******************************/
 
-      cutensorContractionDescriptor_t desc;
-      HANDLE_ERROR(cutensorInitContractionDescriptor(
-        handle, &desc, &descL, labelL.data(), alignmentRequirementL, &descR, labelR.data(),
-        alignmentRequirementR, &descOut, labelOut.data(), alignmentRequirementOut, &descOut,
-        labelOut.data(), alignmentRequirementOut, typeCompute));
+      cutensorOperationDescriptor_t desc;
+      HANDLE_ERROR(
+        cutensorCreateContraction(handle, &desc, descL, labelL.data(), CUTENSOR_OP_IDENTITY, descR,
+                                  labelR.data(), CUTENSOR_OP_IDENTITY, descOut, labelOut.data(),
+                                  CUTENSOR_OP_IDENTITY, descOut, labelOut.data(), descCompute));
 
       /**************************
        * Set the algorithm to use
        ***************************/
 
-      cutensorContractionFind_t find;
-      HANDLE_ERROR(cutensorInitContractionFind(handle, &find, CUTENSOR_ALGO_DEFAULT));
+      cutensorPlanPreference_t planPref;
+      cutensorCreatePlanPreference(handle, &planPref, CUTENSOR_ALGO_DEFAULT,
+                                   CUTENSOR_JIT_MODE_NONE);
 
       /**********************
        * Query workspace
        **********************/
 
-      uint64_t worksize = 0;
-      HANDLE_ERROR(cutensorContractionGetWorkspaceSize(handle, &desc, &find,
-                                                       CUTENSOR_WORKSPACE_RECOMMENDED, &worksize));
-
-      void *work = nullptr;
-      if (worksize > 0) {
-        if (cudaSuccess != cudaMalloc(&work, worksize)) {
-          work = nullptr;
-          worksize = 0;
-        }
-      }
+      uint64_t workspaceSizeEstimate = 0;
+      cutensorEstimateWorkspaceSize(handle, desc, planPref, CUTENSOR_WORKSPACE_DEFAULT,
+                                    &workspaceSizeEstimate);
 
       /**************************
        * Create Contraction Plan
        **************************/
 
-      cutensorContractionPlan_t plan;
-      HANDLE_ERROR(cutensorInitContractionPlan(handle, &plan, &desc, &find, worksize));
+      cutensorPlan_t plan;
+      cutensorCreatePlan(handle, &plan, desc, planPref, workspaceSizeEstimate);
+
+      uint64_t actualWorkspaceSize = 0;
+      cutensorPlanGetAttribute(handle, plan, CUTENSOR_PLAN_REQUIRED_WORKSPACE, &actualWorkspaceSize,
+                               sizeof(actualWorkspaceSize));
+
+      void *work = nullptr;
+      if (actualWorkspaceSize > 0) HANDLE_CUDA_ERROR(cudaMalloc(&work, actualWorkspaceSize));
 
       /**********************
        * Run
        **********************/
 
-      HANDLE_ERROR(cutensorContraction(handle, &plan, alpha, lPtr, rPtr, beta, outPtr, outPtr, work,
-                                       worksize, 0 /* stream */));
+      cutensorContract(handle, plan, (void *)alpha, lPtr, rPtr, (void *)beta, outPtr, outPtr, work,
+                       actualWorkspaceSize, /* stream */ 0);
 
       /*************************/
 
       cudaDeviceSynchronize();
 
       if (work) checkCudaErrors(cudaFree(work));
+      // XXX: Can the OperationDescriptor be destories before running?
+      HANDLE_ERROR(cutensorDestroyTensorDescriptor(descL));
+      HANDLE_ERROR(cutensorDestroyTensorDescriptor(descR));
+      HANDLE_ERROR(cutensorDestroyTensorDescriptor(descOut));
+      HANDLE_ERROR(cutensorDestroyPlanPreference(planPref));
+      HANDLE_ERROR(cutensorDestroyPlan(plan));
       HANDLE_ERROR(cutensorDestroy(handle));
     }
 
@@ -185,52 +191,52 @@ namespace cytnx {
                                  const std::vector<cytnx_uint64> &idxl,
                                  const std::vector<cytnx_uint64> &idxr) {
       typedef cuDoubleComplex hostType;
-      cudaDataType_t type = CUDA_C_64F;
-      cutensorComputeType_t typeCompute = CUTENSOR_COMPUTE_64F;
+      cutensorDataType_t type = CUTENSOR_C_64F;
+      cutensorComputeDescriptor_t descCompute = CUTENSOR_COMPUTE_DESC_64F;
 
       hostType alpha = {1., 0.};
       hostType beta = {0., 0.};
 
-      _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, typeCompute, &alpha, &beta);
+      _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, descCompute, &alpha, &beta);
     }
 
     void cuTensordot_internal_cf(Tensor &out, const Tensor &Lin, const Tensor &Rin,
                                  const std::vector<cytnx_uint64> &idxl,
                                  const std::vector<cytnx_uint64> &idxr) {
       typedef cuFloatComplex hostType;
-      cudaDataType_t type = CUDA_C_32F;
-      cutensorComputeType_t typeCompute = CUTENSOR_COMPUTE_32F;
+      cutensorDataType_t type = CUTENSOR_C_32F;
+      cutensorComputeDescriptor_t descCompute = CUTENSOR_COMPUTE_DESC_32F;
 
       hostType alpha = {1.f, 0.f};
       hostType beta = {0.f, 0.f};
 
-      _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, typeCompute, &alpha, &beta);
+      _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, descCompute, &alpha, &beta);
     }
 
     void cuTensordot_internal_d(Tensor &out, const Tensor &Lin, const Tensor &Rin,
                                 const std::vector<cytnx_uint64> &idxl,
                                 const std::vector<cytnx_uint64> &idxr) {
       typedef double hostType;
-      cudaDataType_t type = CUDA_R_64F;
-      cutensorComputeType_t typeCompute = CUTENSOR_COMPUTE_64F;
+      cutensorDataType_t type = CUTENSOR_R_64F;
+      cutensorComputeDescriptor_t descCompute = CUTENSOR_COMPUTE_DESC_64F;
 
       hostType alpha = 1.f;
       hostType beta = 0.f;
 
-      _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, typeCompute, &alpha, &beta);
+      _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, descCompute, &alpha, &beta);
     }
 
     void cuTensordot_internal_f(Tensor &out, const Tensor &Lin, const Tensor &Rin,
                                 const std::vector<cytnx_uint64> &idxl,
                                 const std::vector<cytnx_uint64> &idxr) {
       typedef float hostType;
-      cudaDataType_t type = CUDA_R_32F;
-      cutensorComputeType_t typeCompute = CUTENSOR_COMPUTE_32F;
+      cutensorDataType_t type = CUTENSOR_R_32F;
+      cutensorComputeDescriptor_t descCompute = CUTENSOR_COMPUTE_DESC_32F;
 
       hostType alpha = 1.f;
       hostType beta = 0.f;
 
-      _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, typeCompute, &alpha, &beta);
+      _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, descCompute, &alpha, &beta);
     }
 
   }  // namespace linalg_internal

--- a/src/backend/linalg_internal_gpu/cuTensordot_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTensordot_internal.cu
@@ -233,34 +233,6 @@ namespace cytnx {
       _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, typeCompute, &alpha, &beta);
     }
 
-    void cuTensordot_internal_u32(Tensor &out, const Tensor &Lin, const Tensor &Rin,
-                                  const std::vector<cytnx_uint64> &idxl,
-                                  const std::vector<cytnx_uint64> &idxr) {
-      typedef cytnx_uint32 hostType;
-      cudaDataType_t type = CUDA_R_32U;
-
-      cutensorComputeType_t typeCompute = CUTENSOR_COMPUTE_32U;
-
-      hostType alpha = 1;
-      hostType beta = 0;
-
-      _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, typeCompute, &alpha, &beta);
-    }
-
-    void cuTensordot_internal_i32(Tensor &out, const Tensor &Lin, const Tensor &Rin,
-                                  const std::vector<cytnx_uint64> &idxl,
-                                  const std::vector<cytnx_uint64> &idxr) {
-      typedef cytnx_int32 hostType;
-      cudaDataType_t type = CUDA_R_32I;
-
-      cutensorComputeType_t typeCompute = CUTENSOR_COMPUTE_32I;
-
-      hostType alpha = 1;
-      hostType beta = 0;
-
-      _cuTensordot_internal(out, Lin, Rin, idxl, idxr, type, typeCompute, &alpha, &beta);
-    }
-
   }  // namespace linalg_internal
 
 }  // namespace cytnx

--- a/src/backend/linalg_internal_gpu/cuTensordot_internal.hpp
+++ b/src/backend/linalg_internal_gpu/cuTensordot_internal.hpp
@@ -30,14 +30,6 @@ namespace cytnx {
                                 const std::vector<cytnx_uint64> &idxl,
                                 const std::vector<cytnx_uint64> &idxr);
 
-    void cuTensordot_internal_u32(Tensor &out, const Tensor &Lin, const Tensor &Rin,
-                                  const std::vector<cytnx_uint64> &idxl,
-                                  const std::vector<cytnx_uint64> &idxr);
-
-    void cuTensordot_internal_i32(Tensor &out, const Tensor &Lin, const Tensor &Rin,
-                                  const std::vector<cytnx_uint64> &idxl,
-                                  const std::vector<cytnx_uint64> &idxr);
-
   }  // namespace linalg_internal
 }  // namespace cytnx
 

--- a/src/backend/linalg_internal_interface.cpp
+++ b/src/backend/linalg_internal_interface.cpp
@@ -1403,8 +1403,6 @@ namespace cytnx {
       cuTensordot_ii[Type.ComplexFloat] = cuTensordot_internal_cf;
       cuTensordot_ii[Type.Double] = cuTensordot_internal_d;
       cuTensordot_ii[Type.Float] = cuTensordot_internal_f;
-      cuTensordot_ii[Type.Int32] = cuTensordot_internal_i32;
-      cuTensordot_ii[Type.Uint32] = cuTensordot_internal_u32;
   #endif
 #endif
     }

--- a/src/linalg/Tensordot.cpp
+++ b/src/linalg/Tensordot.cpp
@@ -98,8 +98,8 @@ namespace cytnx {
                          const std::vector<cytnx_uint64> &idxr, const bool &cacheL,
                          const bool &cacheR) {
       unsigned int t = Tl.dtype();
-      if (t == Type.Uint64 || t == Type.Int64 || t == Type.Uint16 || t == Type.Int16 ||
-          t == Type.Bool) {
+      if (t == Type.Uint64 || t == Type.Int64 || t == Type.Uint32 || t == Type.Int32 ||
+          t == Type.Uint16 || t == Type.Int16 || t == Type.Bool) {
         cytnx_warning_msg(true, "Unsupported data type in cuTensor: %s, use default implementation",
                           Type.Typeinfos[Tl.dtype()].name);
         return _Tensordot_generic(out, Tl, Tr, idxl, idxr, cacheL, cacheR);


### PR DESCRIPTION
Because cuQuantum 23.x requires cuTENSOR v1.6.1+ (and < 2.0.0) which is not compatible with cuTENSOR 2.x, the oldest supported cuQuantum will be 24.x after this commit. Currently, there is no place to indicate the required version of cuTENSOR and cuQuantum.

Some tests failed when cuTENSOR and cuQuantum were enabled. It's not clear if those tests have been broken before this PR. #272 may be related. Below are the failed tests:

- 653 - BlockUniTensorTest.gpu_Trace (Failed)
- 706 - DenseUniTensorTest.gpu_Trace (Failed)
- 785 - ExpM.gpu_ExpM_test (Failed)
- 787 - Lanczos_Gnd.gpu_Bk_Lanczos_Gnd_test (Failed)
- 788 - Arnoldi.gpu_which_LM_test (Failed)
- 789 - Arnoldi.gpu_which_LR_test (Failed)
- 790 - Arnoldi.gpu_which_LI_test (Failed)
- 791 - Arnoldi.gpu_which_SM_test (Failed)
- 792 - Arnoldi.gpu_which_SR_test (Failed)
- 793 - Arnoldi.gpu_which_SI_test (Failed)
- 794 - Arnoldi.gpu_mat_type_real_test (Failed)
- 795 - Arnoldi.gpu_k1_test (Failed)
- 796 - Arnoldi.gpu_k_max (Failed)
- 797 - Arnoldi.gpu_smallest_dim (Failed)
- 803 - Svd.gpu_dense_one_elem (Failed)
- 804 - Svd.gpu_dense_nondiag_test (Failed)
- 809 - Svd.gpu_U1_zeros_test (Failed)
- 816 - Gesvd.gpu_dense_one_elem (Failed)
- 817 - Gesvd.gpu_dense_nondiag_test (Failed)
- 831 - linalg_Test.gpu_BkUt_Svd_truncate3 (Failed)
- 834 - linalg_Test.gpu_BkUt_expM (Failed)
- 835 - linalg_Test.gpu_DenseUt_Gesvd_truncate (Failed)
- 836 - linalg_Test.gpu_DenseUt_Svd_truncate (Failed)