### PR TITLE
Change the CTest working directory to `tests/`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,9 @@ if(USE_DEBUG)
 endif()
 
 if(RUN_TESTS)
-  enable_testing()
+  # Include CTest explicitly to suppress the error that DartConfiguration.tcl
+  # is not found
+  include(CTest)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fprofile-arcs -ftest-coverage")
   target_link_libraries(cytnx PUBLIC "-lgcov --coverage")
   add_subdirectory(tests)

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -50,6 +50,10 @@ namespace cytnx {
   //-----------------
   Tensor arange(const cytnx_double &start, const cytnx_double &end, const cytnx_double &step,
                 const unsigned int &dtype, const int &device) {
+    cytnx_error_msg((end - start) / step <= 0,
+                    "[ERROR] arange(start=%f,end=%f,step=%f) "
+                    "No values in the sspecified range.\n",
+                    start, end, step);
     cytnx_uint64 Nelem;
     Tensor out;
     if (start < end) {

--- a/src/RegularNetwork.cpp
+++ b/src/RegularNetwork.cpp
@@ -261,7 +261,6 @@ namespace cytnx {
             tns.erase(tns.begin() + id2);
           else
             tns.erase(tns.begin() + id2 - 1);
-          // tns.push_back(root->name);
           tns.push_back("(" + root->left->name + "," + root->right->name + ")");
           root->name = "(" + root->left->name + "," + root->right->name + ")";
           path.push_back(std::pair<cytnx_int64, cytnx_int64>(id1, id2));

--- a/src/RegularNetwork.cpp
+++ b/src/RegularNetwork.cpp
@@ -261,6 +261,7 @@ namespace cytnx {
             tns.erase(tns.begin() + id2);
           else
             tns.erase(tns.begin() + id2 - 1);
+          // tns.push_back(root->name);
           tns.push_back("(" + root->left->name + "," + root->right->name + ")");
           root->name = "(" + root->left->name + "," + root->right->name + ")";
           path.push_back(std::pair<cytnx_int64, cytnx_int64>(id1, id2));

--- a/tests/BlockUniTensor_test.h
+++ b/tests/BlockUniTensor_test.h
@@ -9,7 +9,7 @@ using namespace cytnx;
 using namespace TestTools;
 class BlockUniTensorTest : public ::testing::Test {
  public:
-  std::string data_dir = "../../tests/test_data_base/common/BlockUniTensor/";
+  std::string data_dir = "./test_data_base/common/BlockUniTensor/";
 
   Bond B1 = Bond(BD_IN, {Qs(0) >> 1, Qs(1) >> 2});
   Bond B2 = Bond(BD_IN, {Qs(0), Qs(1)}, {3, 4});

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,7 +50,6 @@ target_link_libraries(test_main cytnx)
 #target_link_libraries(test_main PUBLIC "-lgcov --coverage")
 include(GoogleTest)
 gtest_discover_tests(test_main
-                     PROPERTIES TEST_DISCOVERY_TIMEOUT 600
                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/testNet.net"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,7 +49,9 @@ target_link_libraries(
 target_link_libraries(test_main cytnx)
 #target_link_libraries(test_main PUBLIC "-lgcov --coverage")
 include(GoogleTest)
-gtest_discover_tests(test_main PROPERTIES TEST_DISCOVERY_TIMEOUT 600)
+gtest_discover_tests(test_main
+                     PROPERTIES TEST_DISCOVERY_TIMEOUT 600
+                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/testNet.net"
       DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/DenseUniTensor_test.cpp
+++ b/tests/DenseUniTensor_test.cpp
@@ -3,6 +3,8 @@ using namespace std;
 using namespace cytnx;
 using namespace std::complex_literals;
 
+#include <cstdio>
+#include <filesystem>
 #include "test_tools.h"
 
 #define FAIL_CASE_OPEN 0
@@ -4533,15 +4535,14 @@ TEST_F(DenseUniTensorTest, elem_exists_uninit) { EXPECT_ANY_THROW(ut_uninit.elem
 describe:test Save and Load by string
 ====================*/
 TEST_F(DenseUniTensorTest, Save) {
-  const std::string fileName = "SaveUniTestUniTensor";
   auto row_rank = 1u;
   std::vector<Bond> bonds = {Bond(3), Bond(2)};
   std::vector<std::string> labels = {"a", "b"};
   auto seed = 0;
   auto ut = UniTensor(bonds, labels, row_rank);
   random::uniform_(ut, 0.0, 5.0, seed);
-  ut.Save(fileName);
-  UniTensor ut_load = UniTensor::Load(fileName + ".cytnx");
+  ut.Save(temp_file_path);
+  UniTensor ut_load = UniTensor::Load(temp_file_path + ".cytnx");
   EXPECT_TRUE(AreEqUniTensor(ut_load, ut));
 }
 
@@ -4549,15 +4550,14 @@ TEST_F(DenseUniTensorTest, Save) {
 describe:test Save and Load by charPtr
 ====================*/
 TEST_F(DenseUniTensorTest, Save_chr) {
-  const std::string fileName = "SaveUniTestUniTensor_chr";
   auto row_rank = 1u;
   std::vector<Bond> bonds = {Bond(3), Bond(2)};
   std::vector<std::string> labels = {"a", "b"};
   auto seed = 0;
   auto ut = UniTensor(bonds, labels, row_rank);
   random::uniform_(ut, 0.0, 5.0, seed);
-  ut.Save(fileName.c_str());
-  UniTensor ut_load = UniTensor::Load((fileName + ".cytnx").c_str());
+  ut.Save(temp_file_path.c_str());
+  UniTensor ut_load = UniTensor::Load((temp_file_path + ".cytnx").c_str());
   EXPECT_TRUE(AreEqUniTensor(ut_load, ut));
 }
 
@@ -4565,24 +4565,25 @@ TEST_F(DenseUniTensorTest, Save_chr) {
 describe:test Save Load not exist file
 ====================*/
 TEST_F(DenseUniTensorTest, Save_path_incorrect) {
-  const std::string fileName = "./NotExistFolder/SaveUniTestUniTensor";
+  std::filesystem::path file_path_under_non_existent_folder = std::tmpnam(nullptr);
+  std::filesystem::path temp_filename = std::tmpnam(nullptr);
+  // std::tmpnam(nullptr) returns full temp file path, like /tmp/fileRandSuffix
+  file_path_under_non_existent_folder /= temp_filename.filename();
   auto row_rank = 1u;
   std::vector<Bond> bonds = {Bond(3), Bond(2)};
   std::vector<std::string> labels = {"a", "b"};
   auto seed = 0;
   auto ut = UniTensor(bonds, labels, row_rank);
   random::uniform_(ut, 0.0, 5.0, seed);
-  EXPECT_THROW(ut.Save(fileName), std::logic_error);
-  EXPECT_THROW(UniTensor::Load(fileName + ".cytnx"), std::logic_error);
+  EXPECT_THROW(ut.Save(file_path_under_non_existent_folder), std::logic_error);
+  EXPECT_THROW(UniTensor::Load(file_path_under_non_existent_folder.string() + ".cytnx"),
+               std::logic_error);
 }
 
 /*=====test info=====
 describe:test Save uninitialized UniTensor
 ====================*/
-TEST_F(DenseUniTensorTest, Save_uninit) {
-  const std::string fileName = "SaveUniTestUniTensor_uninit";
-  EXPECT_ANY_THROW(ut_uninit.Save(fileName));
-}
+TEST_F(DenseUniTensorTest, Save_uninit) { EXPECT_ANY_THROW(ut_uninit.Save(temp_file_path)); }
 
 /*=====test info=====
 describe:test truncate by label

--- a/tests/DenseUniTensor_test.h
+++ b/tests/DenseUniTensor_test.h
@@ -12,7 +12,7 @@ using namespace std;
 using namespace TestTools;
 class DenseUniTensorTest : public ::testing::Test {
  public:
-  std::string data_dir = "../../tests/test_data_base/common/DenseUniTensor/";
+  const std::string data_dir = "./test_data_base/common/DenseUniTensor/";
   const std::string temp_file_path = std::tmpnam(nullptr);
 
   UniTensor ut_uninit;

--- a/tests/DenseUniTensor_test.h
+++ b/tests/DenseUniTensor_test.h
@@ -1,8 +1,10 @@
 #ifndef _H_DENSEUNITENSOR_TEST
 #define _H_DENSEUNITENSOR_TEST
 
-#include "cytnx.hpp"
+#include <cstdio>
+#include <filesystem>
 #include <gtest/gtest.h>
+#include "cytnx.hpp"
 #include "test_tools.h"
 
 using namespace cytnx;
@@ -11,6 +13,7 @@ using namespace TestTools;
 class DenseUniTensorTest : public ::testing::Test {
  public:
   std::string data_dir = "../../tests/test_data_base/common/DenseUniTensor/";
+  const std::string temp_file_path = std::tmpnam(nullptr);
 
   UniTensor ut_uninit;
   UniTensor utzero345;
@@ -39,6 +42,14 @@ class DenseUniTensorTest : public ::testing::Test {
 
   UniTensor ut1, ut2, contres1, contres2, contres3, dense4trtensor, densetr;
   UniTensor ut3, ut4, permu1, permu2;
+
+  ~DenseUniTensorTest() {
+    try {
+      std::filesystem::remove(temp_file_path);
+    } catch (const std::filesystem::filesystem_error& error) {
+      // Do nothing. The system cleans the temp files periodically.
+    }
+  }
 
  protected:
   void SetUp() override {

--- a/tests/Tensor_test.cpp
+++ b/tests/Tensor_test.cpp
@@ -25,7 +25,7 @@ TEST_F(TensorTest, Constructor) {
   EXPECT_EQ(C.shape()[1], 4);
   EXPECT_EQ(C.shape()[2], 5);
   EXPECT_EQ(C.is_contiguous(), true);
-#ifdef USE_CUDA
+#ifdef UNI_GPU
   Tensor D({3, 4, 5}, Type.Double, Device.cuda);
   EXPECT_EQ(D.dtype(), Type.Double);
   EXPECT_EQ(D.device(), Device.cuda);
@@ -56,7 +56,7 @@ TEST_F(TensorTest, Constructor) {
 }
 
 TEST_F(TensorTest, CopyConstructor) {
-#ifdef USE_CUDA
+#ifdef UNI_GPU
   Tensor A({3, 4, 5}, Type.Double, Device.cuda, false);
   Tensor B(A);
   EXPECT_EQ(B.dtype(), Type.Double);

--- a/tests/Tensor_test.h
+++ b/tests/Tensor_test.h
@@ -8,7 +8,7 @@ using namespace cytnx;
 using namespace std;
 class TensorTest : public ::testing::Test {
  public:
-  std::string data_dir = "../../tests/test_data_base/common/Tensor/";
+  std::string data_dir = "./test_data_base/common/Tensor/";
 
   Tensor tzero345;
   Tensor tone345;

--- a/tests/common_data_generator.cpp
+++ b/tests/common_data_generator.cpp
@@ -18,7 +18,7 @@ using namespace TestTools;
 
 namespace CommonDataGen {
 
-  std::string dataRoot = "../../tests/test_data_base/common/";
+  std::string dataRoot = "./test_data_base/common/";
   static std::vector<unsigned int> dtype_list1 = {
     Type.ComplexDouble,
     Type.Double,

--- a/tests/gpu/BlockUniTensor_test.h
+++ b/tests/gpu/BlockUniTensor_test.h
@@ -10,7 +10,7 @@ using namespace TestTools;
 
 class BlockUniTensorTest : public ::testing::Test {
  public:
-  std::string data_dir = "../../../tests/test_data_base/common/BlockUniTensor/";
+  std::string data_dir = "./test_data_base/common/BlockUniTensor/";
 
   Bond B1 = Bond(BD_IN, {Qs(0) >> 1, Qs(1) >> 2});
   Bond B2 = Bond(BD_IN, {Qs(0), Qs(1)}, {3, 4});

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -39,7 +39,6 @@ target_link_libraries(gpu_test_main cytnx)
 include(GoogleTest)
 cmake_path(APPEND CMAKE_CURRENT_SOURCE_DIR ".." OUTPUT_VARIABLE test_dir)
 gtest_discover_tests(gpu_test_main
-                     PROPERTIES TEST_DISCOVERY_TIMEOUT 600
                      WORKING_DIRECTORY ${test_dir})
 
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/testNet.net"

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -37,7 +37,10 @@ target_link_libraries(
 target_link_libraries(gpu_test_main cytnx)
 #target_link_libraries(test_main PUBLIC "-lgcov --coverage")
 include(GoogleTest)
-gtest_discover_tests(gpu_test_main PROPERTIES TEST_DISCOVERY_TIMEOUT 600)
+cmake_path(APPEND CMAKE_CURRENT_SOURCE_DIR ".." OUTPUT_VARIABLE test_dir)
+gtest_discover_tests(gpu_test_main
+                     PROPERTIES TEST_DISCOVERY_TIMEOUT 600
+                     WORKING_DIRECTORY ${test_dir})
 
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/testNet.net"
       DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/gpu/DenseUniTensor_test.h
+++ b/tests/gpu/DenseUniTensor_test.h
@@ -10,7 +10,7 @@ using namespace std;
 using namespace TestTools;
 class DenseUniTensorTest : public ::testing::Test {
  public:
-  std::string data_dir = "../../../tests/test_data_base/common/DenseUniTensor/";
+  std::string data_dir = "./test_data_base/common/DenseUniTensor/";
 
   UniTensor utzero345;
   UniTensor utone345;

--- a/tests/gpu/Tensor_test.h
+++ b/tests/gpu/Tensor_test.h
@@ -8,7 +8,7 @@ using namespace cytnx;
 using namespace std;
 class TensorTest : public ::testing::Test {
  public:
-  std::string data_dir = "../../../tests/test_data_base/common/Tensor/";
+  std::string data_dir = "./test_data_base/common/Tensor/";
 
   Tensor tzero345;
   Tensor tone345;

--- a/tests/gpu/common_data_generator.cpp
+++ b/tests/gpu/common_data_generator.cpp
@@ -18,7 +18,7 @@ using namespace TestTools;
 
 namespace CommonDataGen {
 
-  std::string dataRoot = "../../tests/test_data_base/common/";
+  std::string dataRoot = "./test_data_base/common/";
   static std::vector<unsigned int> dtype_list1 = {
     Type.ComplexDouble,
     Type.Double,

--- a/tests/gpu/linalg_test/GeSvd_test.cpp
+++ b/tests/gpu/linalg_test/GeSvd_test.cpp
@@ -14,7 +14,7 @@ namespace GesvdTest {
   bool ReComposeCheck(const UniTensor& Tin, const std::vector<UniTensor>& Tout);
   bool CheckLabels(const UniTensor& Tin, const std::vector<UniTensor>& Tout);
   bool SingularValsCorrect(const UniTensor& res, const UniTensor& ans);
-  std::string data_root = "../../../tests/test_data_base/";
+  std::string data_root = "./test_data_base/";
   std::string src_data_root = data_root + "common/";
   std::string ans_data_root = data_root + "linalg/Gesvd/";
   // normal test

--- a/tests/gpu/linalg_test/Lanczos_Gnd_test.cpp
+++ b/tests/gpu/linalg_test/Lanczos_Gnd_test.cpp
@@ -19,12 +19,12 @@ class MyOp2 : public LinOp {
  public:
   UniTensor H;
   MyOp2(int dim) : LinOp("mv", dim) {
-    Tensor A = Tensor::Load("../../../tests/test_data_base/linalg/Lanczos_Gnd/lan_block_A.cytn")
-                 .to(cytnx::Device.cuda);
-    Tensor B = Tensor::Load("../../../tests/test_data_base/linalg/Lanczos_Gnd/lan_block_B.cytn")
-                 .to(cytnx::Device.cuda);
-    Tensor C = Tensor::Load("../../../tests/test_data_base/linalg/Lanczos_Gnd/lan_block_C.cytn")
-                 .to(cytnx::Device.cuda);
+    Tensor A =
+      Tensor::Load("./test_data_base/linalg/Lanczos_Gnd/lan_block_A.cytn").to(cytnx::Device.cuda);
+    Tensor B =
+      Tensor::Load("./test_data_base/linalg/Lanczos_Gnd/lan_block_B.cytn").to(cytnx::Device.cuda);
+    Tensor C =
+      Tensor::Load("./test_data_base/linalg/Lanczos_Gnd/lan_block_C.cytn").to(cytnx::Device.cuda);
     Bond lan_I = Bond(BD_IN, {Qs(-1), Qs(0), Qs(1)}, {9, 9, 9});
     Bond lan_J = Bond(BD_OUT, {Qs(-1), Qs(0), Qs(1)}, {9, 9, 9});
     H = UniTensor({lan_I, lan_J});

--- a/tests/gpu/linalg_test/Svd_test.cpp
+++ b/tests/gpu/linalg_test/Svd_test.cpp
@@ -14,7 +14,7 @@ namespace SvdTest {
   bool ReComposeCheck(const UniTensor& Tin, const std::vector<UniTensor>& Tout);
   bool CheckLabels(const UniTensor& Tin, const std::vector<UniTensor>& Tout);
   bool SingularValsCorrect(const UniTensor& res, const UniTensor& ans);
-  std::string data_root = "../../../tests/test_data_base/";
+  std::string data_root = "./test_data_base/";
   std::string src_data_root = data_root + "common/";
   std::string ans_data_root = data_root + "linalg/Svd/";
   // normal test

--- a/tests/gpu/linalg_test/linalg_test.h
+++ b/tests/gpu/linalg_test/linalg_test.h
@@ -22,7 +22,7 @@ class linalg_Test : public ::testing::Test {
   Tensor eye3x3cd = eye(3, Type.ComplexDouble).to(cytnx::Device.cuda);
   Tensor zeros3x3cd = zeros(9, Type.ComplexDouble).reshape(3, 3).to(cytnx::Device.cuda);
 
-  std::string data_dir = "../../../tests/test_data_base/linalg/";
+  std::string data_dir = "./test_data_base/linalg/";
   // ==================== svd_truncate ===================
   Bond svd_I = Bond(BD_OUT, {Qs(1), Qs(-1)}, {1, 1});
   Bond svd_J =

--- a/tests/linalg_test/GeSvd_test.cpp
+++ b/tests/linalg_test/GeSvd_test.cpp
@@ -14,7 +14,7 @@ namespace GesvdTest {
   bool ReComposeCheck(const UniTensor& Tin, const std::vector<UniTensor>& Tout);
   bool CheckLabels(const UniTensor& Tin, const std::vector<UniTensor>& Tout);
   bool SingularValsCorrect(const UniTensor& res, const UniTensor& ans);
-  std::string data_root = "../../tests/test_data_base/";
+  std::string data_root = "./test_data_base/";
   std::string src_data_root = data_root + "common/";
   std::string ans_data_root = data_root + "linalg/Gesvd/";
   // normal test

--- a/tests/linalg_test/Lanczos_Gnd_test.cpp
+++ b/tests/linalg_test/Lanczos_Gnd_test.cpp
@@ -17,9 +17,9 @@ class MyOp2 : public LinOp {
  public:
   UniTensor H;
   MyOp2(int dim) : LinOp("mv", dim) {
-    Tensor A = Tensor::Load("../../tests/test_data_base/linalg/Lanczos_Gnd/lan_block_A.cytn");
-    Tensor B = Tensor::Load("../../tests/test_data_base/linalg/Lanczos_Gnd/lan_block_B.cytn");
-    Tensor C = Tensor::Load("../../tests/test_data_base/linalg/Lanczos_Gnd/lan_block_C.cytn");
+    Tensor A = Tensor::Load("./test_data_base/linalg/Lanczos_Gnd/lan_block_A.cytn");
+    Tensor B = Tensor::Load("./test_data_base/linalg/Lanczos_Gnd/lan_block_B.cytn");
+    Tensor C = Tensor::Load("./test_data_base/linalg/Lanczos_Gnd/lan_block_C.cytn");
     Bond lan_I = Bond(BD_IN, {Qs(-1), Qs(0), Qs(1)}, {9, 9, 9});
     Bond lan_J = Bond(BD_OUT, {Qs(-1), Qs(0), Qs(1)}, {9, 9, 9});
     H = UniTensor({lan_I, lan_J});

--- a/tests/linalg_test/Svd_test.cpp
+++ b/tests/linalg_test/Svd_test.cpp
@@ -14,7 +14,7 @@ namespace SvdTest {
   bool ReComposeCheck(const UniTensor& Tin, const std::vector<UniTensor>& Tout);
   bool CheckLabels(const UniTensor& Tin, const std::vector<UniTensor>& Tout);
   bool SingularValsCorrect(const UniTensor& res, const UniTensor& ans);
-  std::string data_root = "../../tests/test_data_base/";
+  std::string data_root = "./test_data_base/";
   std::string src_data_root = data_root + "common/";
   std::string ans_data_root = data_root + "linalg/Svd/";
   // normal test

--- a/tests/linalg_test/linalg_test.h
+++ b/tests/linalg_test/linalg_test.h
@@ -27,7 +27,7 @@ class linalg_Test : public ::testing::Test {
   UniTensor ones3x3cd_ut = UniTensor(ones3x3cd, false, -1);
   UniTensor invertable3x3cd_ut = UniTensor(invertable3x3cd, false, -1);
 
-  std::string data_dir = "../../tests/test_data_base/linalg/";
+  std::string data_dir = "./test_data_base/linalg/";
   // ==================== svd_truncate ===================
   Bond svd_I = Bond(BD_OUT, {Qs(1), Qs(-1)}, {1, 1});
   Bond svd_J =


### PR DESCRIPTION
The main change of this PR is to change the CTest working directory to `tests/`, which resolves issue #452.

broken tests before and after this PR:
- BlockUniTensorTest.gpu_Trace
- DenseUniTensorTest.gpu_Trace
- ExpM.gpu_ExpM_test
- Lanczos_Gnd.gpu_Bk_Lanczos_Gnd_test
- Arnoldi.gpu_which_LM_test
- Arnoldi.gpu_which_LR_test
- Arnoldi.gpu_which_LI_test
- Arnoldi.gpu_which_SM_test
- Arnoldi.gpu_which_SR_test
- Arnoldi.gpu_which_SI_test
- Arnoldi.gpu_mat_type_real_test
- Arnoldi.gpu_k1_test
- Arnoldi.gpu_k_max
- Arnoldi.gpu_smallest_dim
- Svd.gpu_dense_one_elem
- Svd.gpu_dense_nondiag_test
- Svd.gpu_U1_zeros_test
- Gesvd.gpu_dense_one_elem
- Gesvd.gpu_dense_nondiag_test
- linalg_Test.gpu_BkUt_Svd_truncate3
- linalg_Test.gpu_BkUt_expM
- linalg_Test.gpu_DenseUt_Gesvd_truncate
- linalg_Test.gpu_DenseUt_Svd_truncate

the tests break by #451 (They are not fixed in this PR.):
- NetworkTest.gpu_Network_dense_no_order
- NetworkTest.gpu_Network_dense_order_line
- NetworkTest.gpu_Network_dense_specified_order
- NetworkTest.gpu_Network_dense_reuse
- ContractTest.gpu_Contract_denseUt_default_order
- ContractTest.gpu_Contract_denseUt_specified_order
- ContractTest.gpu_Contracts_denseUt_default_order
- ContractTest.gpu_Contracts_denseUt_specified_order
- NconTest.gpu_ncon_default_order