### PR TITLE
Re-fix setOrder

### DIFF
--- a/src/RegularNetwork.cpp
+++ b/src/RegularNetwork.cpp
@@ -261,7 +261,6 @@ namespace cytnx {
             tns.erase(tns.begin() + id2);
           else
             tns.erase(tns.begin() + id2 - 1);
-          // tns.push_back(root->name);
           tns.push_back("(" + root->left->name + "," + root->right->name + ")");
           root->name = "(" + root->left->name + "," + root->right->name + ")";
           path.push_back(std::pair<cytnx_int64, cytnx_int64>(id1, id2));

--- a/src/RegularNetwork.cpp
+++ b/src/RegularNetwork.cpp
@@ -261,7 +261,9 @@ namespace cytnx {
             tns.erase(tns.begin() + id2);
           else
             tns.erase(tns.begin() + id2 - 1);
-          tns.push_back(root->name);
+          // tns.push_back(root->name);
+          tns.push_back("(" + root->left->name + "," + root->right->name + ")");
+          root->name = "(" + root->left->name + "," + root->right->name + ")";
           path.push_back(std::pair<cytnx_int64, cytnx_int64>(id1, id2));
         }
         root = nullptr;

--- a/src/RegularNetwork.cpp
+++ b/src/RegularNetwork.cpp
@@ -226,16 +226,8 @@ namespace cytnx {
     return res;
   }
 
-  /*
-   * This function is not used in the codebase and not implemented properly.
-   * Currently disabled.
-   */
   vector<pair<cytnx_int64, cytnx_int64>> CtTree_to_eisumpath(ContractionTree CtTree,
                                                              vector<string> tns) {
-    cytnx_error_msg(true,
-                    "[Error][RegularNetwork] CtTree_to_eisumpath is not properly implemented, "
-                    "disabled for now.%s",
-                    "\n");
     vector<pair<cytnx_int64, cytnx_int64>> path;
     stack<Node *> stk;
     Node *root = &(CtTree.nodes_container.back());
@@ -645,7 +637,7 @@ namespace cytnx {
     } else {
       CtTree.build_default_contraction_tree();
     }
-    // this->einsum_path = CtTree_to_eisumpath(CtTree, names);
+    this->einsum_path = CtTree_to_eisumpath(CtTree, names);
   }
 
   void RegularNetwork::Fromfile(const string &fname) {
@@ -932,7 +924,7 @@ namespace cytnx {
       if (contract_order != "") {
         _parse_ORDER_line_(ORDER_tokens, contract_order, 999999);
         CtTree.build_contraction_tree_by_tokens(this->name2pos, ORDER_tokens);
-        // this->einsum_path = CtTree_to_eisumpath(CtTree, names);
+        this->einsum_path = CtTree_to_eisumpath(CtTree, names);
       } else {
         CtTree.build_default_contraction_tree();
       }
@@ -1290,7 +1282,7 @@ namespace cytnx {
     } else {
       CtTree.build_default_contraction_tree();
     }
-    // this->einsum_path = CtTree_to_eisumpath(CtTree, names);
+    this->einsum_path = CtTree_to_eisumpath(CtTree, names);
   }  // end construct
 
 }  // namespace cytnx


### PR DESCRIPTION
Previous fix on this problem cause GPU test to fail.

This time the RegularNetwork::CtTree_to_eisumpath function is fixed.

This is related to #440 