### PR TITLE
fixed segfault when a BlockUniTensor with no valid blocks was printed…

### DIFF
--- a/include/UniTensor.hpp
+++ b/include/UniTensor.hpp
@@ -1167,34 +1167,36 @@ namespace cytnx {
     };
 
     unsigned int dtype() const {
+        //[21 Aug 2024] This is a copy from BlockUniTensor;
   #ifdef UNI_DEBUG
       cytnx_error_msg(this->_blocks.size() == 0, "[ERROR][internal] empty blocks for blockform.%s",
                       "\n");
   #endif
-      return this->_blocks.size() < 1 ? N_Type + 1 : this->_blocks[0].dtype();
+      return this->_blocks.size() < 1 ? Type.Void : this->_blocks[0].dtype();
     };
     int device() const {
+        //[21 Aug 2024] This is a copy from BlockUniTensor;
   #ifdef UNI_DEBUG
       cytnx_error_msg(this->_blocks.size() == 0, "[ERROR][internal] empty blocks for blockform.%s",
                       "\n");
   #endif
-      return this->_blocks.size() < 1 ? 404 : this->_blocks[0].device();
+      return this->_blocks.size() < 1 ? -404 : this->_blocks[0].device();
     };
     std::string dtype_str() const {
+        //[21 Aug 2024] This is a copy from BlockUniTensor;
   #ifdef UNI_DEBUG
       cytnx_error_msg(this->_blocks.size() == 0, "[ERROR][internal] empty blocks for blockform.%s",
                       "\n");
   #endif
-      return this->_blocks.size() < 1 ? "No valid blocks, so no dtype!"
-                                      : this->_blocks[0].dtype_str();
+      return this->_blocks.size() < 1 ? "Void, no valid blocks" : this->_blocks[0].dtype_str();
     };
     std::string device_str() const {
+        //[21 Aug 2024] This is a copy from BlockUniTensor;
   #ifdef UNI_DEBUG
       cytnx_error_msg(this->_blocks.size() == 0, "[ERROR][internal] empty blocks for blockform.%s",
                       "\n");
   #endif
-      return this->_blocks.size() < 1 ? "No valid blocks, so no device!"
-                                      : this->_blocks[0].device_str();
+      return this->_blocks.size() < 1 ? "None, no valid blocks" : this->_blocks[0].device_str();
     };
 
     Tensor get_block(const cytnx_uint64 &idx = 0) const {

--- a/include/UniTensor.hpp
+++ b/include/UniTensor.hpp
@@ -1171,28 +1171,30 @@ namespace cytnx {
       cytnx_error_msg(this->_blocks.size() == 0, "[ERROR][internal] empty blocks for blockform.%s",
                       "\n");
   #endif
-      return this->_blocks[0].dtype();
+      return this->_blocks.size() < 1 ? N_Type + 1 : this->_blocks[0].dtype();
     };
     int device() const {
   #ifdef UNI_DEBUG
       cytnx_error_msg(this->_blocks.size() == 0, "[ERROR][internal] empty blocks for blockform.%s",
                       "\n");
   #endif
-      return this->_blocks[0].device();
+      return this->_blocks.size() < 1 ? 404 : this->_blocks[0].device();
     };
     std::string dtype_str() const {
   #ifdef UNI_DEBUG
       cytnx_error_msg(this->_blocks.size() == 0, "[ERROR][internal] empty blocks for blockform.%s",
                       "\n");
   #endif
-      return this->_blocks[0].dtype_str();
+      return this->_blocks.size() < 1 ? "No valid blocks, so no dtype!"
+                                      : this->_blocks[0].dtype_str();
     };
     std::string device_str() const {
   #ifdef UNI_DEBUG
       cytnx_error_msg(this->_blocks.size() == 0, "[ERROR][internal] empty blocks for blockform.%s",
                       "\n");
   #endif
-      return this->_blocks[0].device_str();
+      return this->_blocks.size() < 1 ? "No valid blocks, so no device!"
+                                      : this->_blocks[0].device_str();
     };
 
     Tensor get_block(const cytnx_uint64 &idx = 0) const {


### PR DESCRIPTION
Fixed a segfault in case no valid block exists. For example, the following code resulted in a kernel crash:
```
bond_d = cytnx.Bond(
     cytnx.BD_IN, [cytnx.Qs(5)>>1, cytnx.Qs(-5)>>1],
     [cytnx.Symmetry.U1()]
)
bond_e = cytnx.Bond(
     cytnx.BD_IN, [cytnx.Qs(1)>>1, cytnx.Qs(-1)>>1],
     [cytnx.Symmetry.U1()]
)
bond_f = cytnx.Bond(
     cytnx.BD_OUT,
     [cytnx.Qs(2)>>1, cytnx.Qs(0)>>2, cytnx.Qs(-2)>>1],
     [cytnx.Symmetry.U1()]
)

Tsymm = cytnx.UniTensor([bond_d, bond_e, bond_f], name="symm. tensor",
labels=["d", "e", "f"])

Tsymm.print_diagram() 
```