### PR TITLE
Modify reshape_ and permute_ to return itself.

### DIFF
--- a/include/Tensor.hpp
+++ b/include/Tensor.hpp
@@ -620,13 +620,13 @@ namespace cytnx {
     */
     const bool &is_contiguous() const { return this->_impl->is_contiguous(); }
 
-    Tensor permute_(const std::vector<cytnx_uint64> &rnks) {
+    Tensor &permute_(const std::vector<cytnx_uint64> &rnks) {
       this->_impl->permute_(rnks);
       return *this;
     }
     /// @cond
     template <class... Ts>
-    Tensor permute_(const cytnx_uint64 &e1, const Ts &...elems) {
+    Tensor &permute_(const cytnx_uint64 &e1, const Ts &...elems) {
       std::vector<cytnx_uint64> argv = dynamic_arg_uint64_resolver(e1, elems...);
       this->_impl->permute_(argv);
       return *this;
@@ -725,21 +725,27 @@ namespace cytnx {
     #### output>
     \verbinclude example/Tensor/reshape_.py.out
     */
-    void reshape_(const std::vector<cytnx_int64> &new_shape) { this->_impl->reshape_(new_shape); }
+    Tensor &reshape_(const std::vector<cytnx_int64> &new_shape) {
+      this->_impl->reshape_(new_shape);
+      return *this;
+    }
     /// @cond
-    void reshape_(const std::vector<cytnx_uint64> &new_shape) {
+    Tensor &reshape_(const std::vector<cytnx_uint64> &new_shape) {
       std::vector<cytnx_int64> shape(new_shape.begin(), new_shape.end());
       this->_impl->reshape_(shape);
+      return *this;
     }
-    void reshape_(const std::initializer_list<cytnx_int64> &new_shape) {
+    Tensor &reshape_(const std::initializer_list<cytnx_int64> &new_shape) {
       std::vector<cytnx_int64> shape = new_shape;
       this->_impl->reshape_(shape);
+      return *this;
     }
     template <class... Ts>
-    void reshape_(const cytnx_int64 &e1, const Ts... elems) {
+    Tensor &reshape_(const cytnx_int64 &e1, const Ts... elems) {
       std::vector<cytnx_int64> shape = dynamic_arg_int64_resolver(e1, elems...);
       // std::cout << shape << std::endl;
       this->_impl->reshape_(shape);
+      return *this;
     }
     /// @endcond
 

--- a/include/UniTensor.hpp
+++ b/include/UniTensor.hpp
@@ -2718,8 +2718,9 @@ namespace cytnx {
     @param[in] rowrank the row rank after the permutation
           @warning \p by_label will be deprecated!
     */
-    void permute_(const std::vector<cytnx_int64> &mapper, const cytnx_int64 &rowrank = -1) {
+    UniTensor &permute_(const std::vector<cytnx_int64> &mapper, const cytnx_int64 &rowrank = -1) {
       this->_impl->permute_(mapper, rowrank);
+      return *this;
     }
 
     /**
@@ -2728,8 +2729,9 @@ namespace cytnx {
     @param[in] rowrank the row rank after the permutation
         @see permute(const std::vector<std::string> &mapper, const cytnx_int64 &rowrank = -1)
     */
-    void permute_(const std::vector<std::string> &mapper, const cytnx_int64 &rowrank = -1) {
+    UniTensor &permute_(const std::vector<std::string> &mapper, const cytnx_int64 &rowrank = -1) {
       this->_impl->permute_(mapper, rowrank);
+      return *this;
     }
 
     // void permute_( const std::initializer_list<char*> &mapper, const cytnx_int64 &rowrank= -1){
@@ -3337,8 +3339,10 @@ namespace cytnx {
         cannot be UTenType::Block.
           @see reshape(const std::vector<cytnx_int64> &new_shape, const cytnx_uint64 &rowrank)
         */
-    void reshape_(const std::vector<cytnx_int64> &new_shape, const cytnx_uint64 &rowrank = 0) {
+    UniTensor &reshape_(const std::vector<cytnx_int64> &new_shape,
+                        const cytnx_uint64 &rowrank = 0) {
       this->_impl->reshape_(new_shape, rowrank);
+      return *this;
     }
 
     /**

--- a/pybind/tensor_py.cpp
+++ b/pybind/tensor_py.cpp
@@ -184,7 +184,7 @@ void tensor_binding(py::module &m) {
          [](cytnx::Tensor &self, py::args args) {
            std::vector<cytnx::cytnx_uint64> c_args = args.cast<std::vector<cytnx::cytnx_uint64>>();
            // std::cout << c_args.size() << std::endl;
-           self.permute_(c_args);
+           return &self.permute_(c_args);
          })
     .def("permute",
          [](cytnx::Tensor &self, py::args args) -> cytnx::Tensor {
@@ -200,7 +200,7 @@ void tensor_binding(py::module &m) {
     .def("reshape_",
          [](cytnx::Tensor &self, py::args args) {
            std::vector<cytnx::cytnx_int64> c_args = args.cast<std::vector<cytnx::cytnx_int64>>();
-           self.reshape_(c_args);
+           return &self.reshape_(c_args);
          })
     .def("reshape",
          [](cytnx::Tensor &self, py::args args) -> cytnx::Tensor {

--- a/pybind/unitensor_py.cpp
+++ b/pybind/unitensor_py.cpp
@@ -227,7 +227,7 @@ void unitensor_binding(py::module &m) {
              if (kwargs.contains("rowrank")) rowrank = kwargs["rowrank"].cast<cytnx::cytnx_int64>();
            }
 
-           self.reshape_(c_args, rowrank);
+           return &self.reshape_(c_args, rowrank);
          })
     .def("elem_exists", &UniTensor::elem_exists)
     .def("item",
@@ -592,12 +592,12 @@ void unitensor_binding(py::module &m) {
     // [Deprecated by_label!]
     .def("permute_", [](UniTensor &self, const std::vector<cytnx_int64> &mapper, const cytnx_int64 &rowrank){
 
-                        self.permute_(mapper,rowrank);
+                        return &self.permute_(mapper,rowrank);
 
                 },py::arg("mapper"), py::arg("rowrank")=(cytnx_int64)(-1))
 
     .def("permute_", [](UniTensor &self, const std::vector<std::string> &mapper, const cytnx_int64 &rowrank){
-                        self.permute_(mapper,rowrank);
+                        return &self.permute_(mapper,rowrank);
                 },py::arg("mapper"), py::arg("rowrank")=(cytnx_int64)(-1))
 
     .def("permute", [](UniTensor &self, const std::vector<cytnx_int64> &mapper, const cytnx_int64 &rowrank){


### PR DESCRIPTION
I modified reshape_, permute_ functions in both UniTensor and Tensor object. So now they will return itself, just like relabel_(), instead of None as a void function.
I have test the following code and work well:
```python
A = cytnx.UniTensor.zeros([2,3])
B = A.permute([1,0]) # A and B share tensor elements, different metadata
B[0,1] = 1.
C = A.clone().permute([1,0]) # C is independent of A
C[0,1] = 2.
print(A) # Original shape, element A[1,0] == 1.
print(B) # Permuted shape, element B[0,1] == 1.
print(C) # Permuted shape, element C[0,1] == 2.
D = A.permute_([1,0])
# D is a reference to A
print(A) # Permuted shape, element A[0,1] == 1.
print(D is A) # Output: True

```
```python
A = cytnx.zeros([2,3])
A[0,1] = 1 
print(A)
D = A.permute_(1,0)
print(D)
print(D is A) # Output: True
```
`print(D is A)` gives True
This PR solve the issue #380 