### PR TITLE
Fix Svd_truncate for dtypes other than (complex) float/double

### DIFF
--- a/include/Generator.hpp
+++ b/include/Generator.hpp
@@ -58,7 +58,7 @@ namespace cytnx {
                   const int &device = Device.cpu);
 
   /**
-  @brief create an square rank-2 Tensor with all diagonal to be one.
+  @brief create a square rank-2 Tensor with all diagonal to be one.
   @param Dim the dimension of diagonal.
   @param dtype the dtype of the Tensor. It can be any type defined in \link cytnx::Type cytnx::Type
   \endlink

--- a/src/backend/linalg_internal_cpu/memcpyTruncation.cpp
+++ b/src/backend/linalg_internal_cpu/memcpyTruncation.cpp
@@ -14,31 +14,31 @@ namespace cytnx {
                              const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
                              const bool &is_vT, const unsigned int &return_err,
                              const unsigned int &mindim) {
-      // determine the truc_dim
+      // determine the trunc_dim
       cytnx_uint64 Kdim = keepdim;
       cytnx_uint64 nums = S.storage().size();
       if (nums < keepdim) {
         Kdim = nums;
       }
-      cytnx_uint64 truc_dim = Kdim;
+      cytnx_uint64 trunc_dim = Kdim;
       for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
-        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err and truc_dim - 1 >= mindim) {
-          truc_dim--;
+        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err and trunc_dim - 1 >= mindim) {
+          trunc_dim--;
         } else {
           break;
         }
       }
-      if (truc_dim == 0) {
-        truc_dim = 1;
+      if (trunc_dim == 0) {
+        trunc_dim = 1;
       }
-      if (truc_dim != nums) {
+      if (trunc_dim != nums) {
         // perform the manual truncation
 
-        Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
+        Tensor newS = Tensor({trunc_dim}, S.dtype(), S.device());
         memcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
-               (cytnx_double *)S._impl->storage()._impl->Mem, truc_dim * sizeof(cytnx_double));
+               (cytnx_double *)S._impl->storage()._impl->Mem, trunc_dim * sizeof(cytnx_double));
         if (is_U) {
-          Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+          Tensor newU = Tensor({U.shape()[0], trunc_dim}, U.dtype(), U.device());
 
           int src = 0;
           int dest = 0;
@@ -46,30 +46,30 @@ namespace cytnx {
           for (int i = 0; i < U.shape()[0]; i++) {
             memcpy((cytnx_complex128 *)newU._impl->storage()._impl->Mem + src,
                    (cytnx_complex128 *)U._impl->storage()._impl->Mem + dest,
-                   truc_dim * sizeof(cytnx_complex128));
-            src += truc_dim;
+                   trunc_dim * sizeof(cytnx_complex128));
+            src += trunc_dim;
             dest += U.shape()[1];
           }
           U = newU;
         }
         if (is_vT) {
-          Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+          Tensor newvT = Tensor({trunc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
           // simply copy a new one dropping the tail.
           memcpy((cytnx_complex128 *)newvT._impl->storage()._impl->Mem,
                  (cytnx_complex128 *)vT._impl->storage()._impl->Mem,
-                 vT.shape()[1] * truc_dim * sizeof(cytnx_complex128));
+                 vT.shape()[1] * trunc_dim * sizeof(cytnx_complex128));
           vT = newvT;
         }
         if (return_err == 1) {
           Tensor newterr = Tensor({1}, S.dtype(), S.device());
           ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
-            ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
+            ((cytnx_double *)S._impl->storage()._impl->Mem)[trunc_dim];
           terr = newterr;
         } else if (return_err) {
-          cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
+          cytnx_uint64 discared_dim = S.shape()[0] - trunc_dim;
           Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
           memcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
-                 (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
+                 (cytnx_double *)S._impl->storage()._impl->Mem + trunc_dim,
                  discared_dim * sizeof(cytnx_double));
           terr = newterr;
         }
@@ -81,31 +81,31 @@ namespace cytnx {
                              const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
                              const bool &is_vT, const unsigned int &return_err,
                              const unsigned int &mindim) {
-      // determine the truc_dim
+      // determine the trunc_dim
       cytnx_uint64 Kdim = keepdim;
       cytnx_uint64 nums = S.storage().size();
       if (nums < keepdim) {
         Kdim = nums;
       }
-      cytnx_uint64 truc_dim = Kdim;
+      cytnx_uint64 trunc_dim = Kdim;
       for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
-        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err and truc_dim - 1 >= mindim) {
-          truc_dim--;
+        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err and trunc_dim - 1 >= mindim) {
+          trunc_dim--;
         } else {
           break;
         }
       }
-      if (truc_dim == 0) {
-        truc_dim = 1;
+      if (trunc_dim == 0) {
+        trunc_dim = 1;
       }
-      if (truc_dim != nums) {
+      if (trunc_dim != nums) {
         // perform the manual truncation
 
-        Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
+        Tensor newS = Tensor({trunc_dim}, S.dtype(), S.device());
         memcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
-               (cytnx_double *)S._impl->storage()._impl->Mem, truc_dim * sizeof(cytnx_double));
+               (cytnx_double *)S._impl->storage()._impl->Mem, trunc_dim * sizeof(cytnx_double));
         if (is_U) {
-          Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+          Tensor newU = Tensor({U.shape()[0], trunc_dim}, U.dtype(), U.device());
 
           int src = 0;
           int dest = 0;
@@ -113,30 +113,30 @@ namespace cytnx {
           for (int i = 0; i < U.shape()[0]; i++) {
             memcpy((cytnx_complex64 *)newU._impl->storage()._impl->Mem + src,
                    (cytnx_complex64 *)U._impl->storage()._impl->Mem + dest,
-                   truc_dim * sizeof(cytnx_complex64));
-            src += truc_dim;
+                   trunc_dim * sizeof(cytnx_complex64));
+            src += trunc_dim;
             dest += U.shape()[1];
           }
           U = newU;
         }
         if (is_vT) {
-          Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+          Tensor newvT = Tensor({trunc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
           // simply copy a new one dropping the tail.
           memcpy((cytnx_complex64 *)newvT._impl->storage()._impl->Mem,
                  (cytnx_complex64 *)vT._impl->storage()._impl->Mem,
-                 vT.shape()[1] * truc_dim * sizeof(cytnx_complex64));
+                 vT.shape()[1] * trunc_dim * sizeof(cytnx_complex64));
           vT = newvT;
         }
         if (return_err == 1) {
           Tensor newterr = Tensor({1}, S.dtype(), S.device());
           ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
-            ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
+            ((cytnx_double *)S._impl->storage()._impl->Mem)[trunc_dim];
           terr = newterr;
         } else if (return_err) {
-          cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
+          cytnx_uint64 discared_dim = S.shape()[0] - trunc_dim;
           Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
           memcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
-                 (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
+                 (cytnx_double *)S._impl->storage()._impl->Mem + trunc_dim,
                  discared_dim * sizeof(cytnx_double));
           terr = newterr;
         }
@@ -148,31 +148,31 @@ namespace cytnx {
                             const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
                             const bool &is_vT, const unsigned int &return_err,
                             const unsigned int &mindim) {
-      // determine the truc_dim
+      // determine the trunc_dim
       cytnx_uint64 Kdim = keepdim;
       cytnx_uint64 nums = S.storage().size();
       if (nums < keepdim) {
         Kdim = nums;
       }
-      cytnx_uint64 truc_dim = Kdim;
+      cytnx_uint64 trunc_dim = Kdim;
       for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
-        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err and truc_dim - 1 >= mindim) {
-          truc_dim--;
+        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err and trunc_dim - 1 >= mindim) {
+          trunc_dim--;
         } else {
           break;
         }
       }
-      if (truc_dim == 0) {
-        truc_dim = 1;
+      if (trunc_dim == 0) {
+        trunc_dim = 1;
       }
-      if (truc_dim != nums) {
+      if (trunc_dim != nums) {
         // perform the manual truncation
 
-        Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
+        Tensor newS = Tensor({trunc_dim}, S.dtype(), S.device());
         memcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
-               (cytnx_double *)S._impl->storage()._impl->Mem, truc_dim * sizeof(cytnx_double));
+               (cytnx_double *)S._impl->storage()._impl->Mem, trunc_dim * sizeof(cytnx_double));
         if (is_U) {
-          Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+          Tensor newU = Tensor({U.shape()[0], trunc_dim}, U.dtype(), U.device());
 
           int src = 0;
           int dest = 0;
@@ -180,30 +180,30 @@ namespace cytnx {
           for (int i = 0; i < U.shape()[0]; i++) {
             memcpy((cytnx_double *)newU._impl->storage()._impl->Mem + src,
                    (cytnx_double *)U._impl->storage()._impl->Mem + dest,
-                   truc_dim * sizeof(cytnx_double));
-            src += truc_dim;
+                   trunc_dim * sizeof(cytnx_double));
+            src += trunc_dim;
             dest += U.shape()[1];
           }
           U = newU;
         }
         if (is_vT) {
-          Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+          Tensor newvT = Tensor({trunc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
           // simply copy a new one dropping the tail.
           memcpy((cytnx_double *)newvT._impl->storage()._impl->Mem,
                  (cytnx_double *)vT._impl->storage()._impl->Mem,
-                 vT.shape()[1] * truc_dim * sizeof(cytnx_double));
+                 vT.shape()[1] * trunc_dim * sizeof(cytnx_double));
           vT = newvT;
         }
         if (return_err == 1) {
           Tensor newterr = Tensor({1}, S.dtype(), S.device());
           ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
-            ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
+            ((cytnx_double *)S._impl->storage()._impl->Mem)[trunc_dim];
           terr = newterr;
         } else if (return_err) {
-          cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
+          cytnx_uint64 discared_dim = S.shape()[0] - trunc_dim;
           Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
           memcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
-                 (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
+                 (cytnx_double *)S._impl->storage()._impl->Mem + trunc_dim,
                  discared_dim * sizeof(cytnx_double));
           terr = newterr;
         }
@@ -215,31 +215,31 @@ namespace cytnx {
                             const cytnx_uint64 &keepdim, const double &err, const bool &is_U,
                             const bool &is_vT, const unsigned int &return_err,
                             const unsigned int &mindim) {
-      // determine the truc_dim
+      // determine the trunc_dim
       cytnx_uint64 Kdim = keepdim;
       cytnx_uint64 nums = S.storage().size();
       if (nums < keepdim) {
         Kdim = nums;
       }
-      cytnx_uint64 truc_dim = Kdim;
+      cytnx_uint64 trunc_dim = Kdim;
       for (cytnx_int64 i = Kdim - 1; i >= 0; i--) {
-        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err and truc_dim - 1 >= mindim) {
-          truc_dim--;
+        if (((cytnx_double *)S._impl->storage()._impl->Mem)[i] < err and trunc_dim - 1 >= mindim) {
+          trunc_dim--;
         } else {
           break;
         }
       }
-      if (truc_dim == 0) {
-        truc_dim = 1;
+      if (trunc_dim == 0) {
+        trunc_dim = 1;
       }
-      if (truc_dim != nums) {
+      if (trunc_dim != nums) {
         // perform the manual truncation
 
-        Tensor newS = Tensor({truc_dim}, S.dtype(), S.device());
+        Tensor newS = Tensor({trunc_dim}, S.dtype(), S.device());
         memcpy((cytnx_double *)newS._impl->storage()._impl->Mem,
-               (cytnx_double *)S._impl->storage()._impl->Mem, truc_dim * sizeof(cytnx_double));
+               (cytnx_double *)S._impl->storage()._impl->Mem, trunc_dim * sizeof(cytnx_double));
         if (is_U) {
-          Tensor newU = Tensor({U.shape()[0], truc_dim}, U.dtype(), U.device());
+          Tensor newU = Tensor({U.shape()[0], trunc_dim}, U.dtype(), U.device());
 
           int src = 0;
           int dest = 0;
@@ -247,30 +247,30 @@ namespace cytnx {
           for (int i = 0; i < U.shape()[0]; i++) {
             memcpy((cytnx_float *)newU._impl->storage()._impl->Mem + src,
                    (cytnx_float *)U._impl->storage()._impl->Mem + dest,
-                   truc_dim * sizeof(cytnx_float));
-            src += truc_dim;
+                   trunc_dim * sizeof(cytnx_float));
+            src += trunc_dim;
             dest += U.shape()[1];
           }
           U = newU;
         }
         if (is_vT) {
-          Tensor newvT = Tensor({truc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
+          Tensor newvT = Tensor({trunc_dim, vT.shape()[1]}, vT.dtype(), vT.device());
           // simply copy a new one dropping the tail.
           memcpy((cytnx_float *)newvT._impl->storage()._impl->Mem,
                  (cytnx_float *)vT._impl->storage()._impl->Mem,
-                 vT.shape()[1] * truc_dim * sizeof(cytnx_float));
+                 vT.shape()[1] * trunc_dim * sizeof(cytnx_float));
           vT = newvT;
         }
         if (return_err == 1) {
           Tensor newterr = Tensor({1}, S.dtype(), S.device());
           ((cytnx_double *)newterr._impl->storage()._impl->Mem)[0] =
-            ((cytnx_double *)S._impl->storage()._impl->Mem)[truc_dim];
+            ((cytnx_double *)S._impl->storage()._impl->Mem)[trunc_dim];
           terr = newterr;
         } else if (return_err) {
-          cytnx_uint64 discared_dim = S.shape()[0] - truc_dim;
+          cytnx_uint64 discared_dim = S.shape()[0] - trunc_dim;
           Tensor newterr = Tensor({discared_dim}, S.dtype(), S.device());
           memcpy((cytnx_double *)newterr._impl->storage()._impl->Mem,
-                 (cytnx_double *)S._impl->storage()._impl->Mem + truc_dim,
+                 (cytnx_double *)S._impl->storage()._impl->Mem + trunc_dim,
                  discared_dim * sizeof(cytnx_double));
           terr = newterr;
         }

--- a/src/linalg/Diag.cpp
+++ b/src/linalg/Diag.cpp
@@ -11,7 +11,7 @@ namespace cytnx {
   namespace linalg {
     Tensor Diag(const Tensor &Tin) {
       cytnx_error_msg(Tin.shape().size() > 2,
-                      "[ERROR] the input tensor shoud be rank-1 or rank-2 Tensor.%s", "\n");
+                      "[ERROR] the input tensor should be rank-1 or rank-2 Tensor.%s", "\n");
 
       Tensor out;
 

--- a/src/linalg/Svd_truncate.cpp
+++ b/src/linalg/Svd_truncate.cpp
@@ -22,7 +22,8 @@ namespace cytnx {
 
         Tensor terr({1}, Tin.dtype(), Tin.device());
 
-        cytnx::linalg_internal::lii.memcpyTruncation_ii[tmps[0].dtype()](
+        // dtype should be that of U (or Vt) here, since S is real and Tin could be Int, Bool etc.
+        cytnx::linalg_internal::lii.memcpyTruncation_ii[tmps[1].dtype()](
           tmps[1], tmps[2], tmps[0], terr, keepdim, err, is_UvT, is_UvT, return_err, mindim);
 
         std::vector<Tensor> outT;
@@ -39,7 +40,7 @@ namespace cytnx {
         std::vector<Tensor> tmps = Svd(Tin, is_UvT);
         Tensor terr({1}, Tin.dtype(), Tin.device());
 
-        cytnx::linalg_internal::lii.cudaMemcpyTruncation_ii[tmps[0].dtype()](
+        cytnx::linalg_internal::lii.cudaMemcpyTruncation_ii[tmps[1].dtype()](
           tmps[1], tmps[2], tmps[0], terr, keepdim, err, is_UvT, is_UvT, return_err, mindim);
 
         std::vector<Tensor> outT;

--- a/src/linalg/Svd_truncate.cpp
+++ b/src/linalg/Svd_truncate.cpp
@@ -22,7 +22,7 @@ namespace cytnx {
 
         Tensor terr({1}, Tin.dtype(), Tin.device());
 
-        cytnx::linalg_internal::lii.memcpyTruncation_ii[Tin.dtype()](
+        cytnx::linalg_internal::lii.memcpyTruncation_ii[tmps[0].dtype()](
           tmps[1], tmps[2], tmps[0], terr, keepdim, err, is_UvT, is_UvT, return_err, mindim);
 
         std::vector<Tensor> outT;
@@ -39,7 +39,7 @@ namespace cytnx {
         std::vector<Tensor> tmps = Svd(Tin, is_UvT);
         Tensor terr({1}, Tin.dtype(), Tin.device());
 
-        cytnx::linalg_internal::lii.cudaMemcpyTruncation_ii[Tin.dtype()](
+        cytnx::linalg_internal::lii.cudaMemcpyTruncation_ii[tmps[0].dtype()](
           tmps[1], tmps[2], tmps[0], terr, keepdim, err, is_UvT, is_UvT, return_err, mindim);
 
         std::vector<Tensor> outT;


### PR DESCRIPTION
The previous implementation of Svd_truncate did not work for `Int`, `Bool`, etc input dtypes. Instead, it resulted in a segfault or kernel crash.

I changed the behavior to be similar to SVD: for these dtypes the output tensors are now of type `Double` by default.

All relevant changes in `src/linalg/Svd_truncate.cpp`, the rest are typos only.

This fixes [#479]