### PR TITLE
Skip test cases testing unimplemented functions

### DIFF
--- a/tests/gpu/BlockUniTensor_test.cpp
+++ b/tests/gpu/BlockUniTensor_test.cpp
@@ -1,6 +1,7 @@
 #include "BlockUniTensor_test.h"
 
 TEST_F(BlockUniTensorTest, gpu_Trace) {
+  GTEST_SKIP() << "Calculating the trace of a matrix is not implemented on the GPU.";
   // std::cout<<BUT4<<std::endl;
   auto tmp = BUT4.Trace(0, 3);
   // std::cout<<BUtrT4<<std::endl;

--- a/tests/gpu/DenseUniTensor_test.cpp
+++ b/tests/gpu/DenseUniTensor_test.cpp
@@ -3,6 +3,7 @@ using namespace std;
 using namespace cytnx;
 using namespace std::complex_literals;
 TEST_F(DenseUniTensorTest, gpu_Trace) {
+  GTEST_SKIP() << "Calculating the trace of a matrix is not implemented on the GPU.";
   auto tmp = dense4trtensor.Trace(0, 3);
   for (size_t j = 1; j <= 4; j++)
     for (size_t k = 1; k <= 5; k++)

--- a/tests/gpu/linalg_test/Arnoldi_test.cpp
+++ b/tests/gpu/linalg_test/Arnoldi_test.cpp
@@ -50,42 +50,49 @@ namespace ArnoldiTest {
   // corrected test
   // 1-1, test for 'which' = 'LM'
   TEST(Arnoldi, gpu_which_LM_test) {
+    GTEST_SKIP() << "Arnoldi is not implemented in CUDA.";
     std::string which = "LM";
     ExcuteTest(which);
   }
 
   // 1-2, test for 'which' = 'LR'
   TEST(Arnoldi, gpu_which_LR_test) {
+    GTEST_SKIP() << "Arnoldi is not implemented in CUDA.";
     std::string which = "LR";
     ExcuteTest(which);
   }
 
   // 1-3, test for 'which' = 'LI'
   TEST(Arnoldi, gpu_which_LI_test) {
+    GTEST_SKIP() << "Arnoldi is not implemented in CUDA.";
     std::string which = "LI";
     ExcuteTest(which);
   }
 
   // 1-4, test for 'which' = 'SM'
   TEST(Arnoldi, gpu_which_SM_test) {
+    GTEST_SKIP() << "Arnoldi is not implemented in CUDA.";
     std::string which = "SM";
     ExcuteTest(which);
   }
 
   // 1-5, test for 'which' = 'SR'
   TEST(Arnoldi, gpu_which_SR_test) {
+    GTEST_SKIP() << "Arnoldi is not implemented in CUDA.";
     std::string which = "SR";
     ExcuteTest(which);
   }
 
   // 1-6, test for 'which' = 'SI'
   TEST(Arnoldi, gpu_which_SI_test) {
+    GTEST_SKIP() << "Arnoldi is not implemented in CUDA.";
     std::string which = "SI";
     ExcuteTest(which);
   }
 
   // 1-7, test matrix is real type
   TEST(Arnoldi, gpu_mat_type_real_test) {
+    GTEST_SKIP() << "Arnoldi is not implemented in CUDA.";
     std::string which = "LM";
     auto mat_type = Type.Double;
     ExcuteTest(which, mat_type);
@@ -93,6 +100,7 @@ namespace ArnoldiTest {
 
   // 1-8, test eigenalue number k = 1
   TEST(Arnoldi, gpu_k1_test) {
+    GTEST_SKIP() << "Arnoldi is not implemented in CUDA.";
     std::string which = "LM";
     auto mat_type = Type.ComplexDouble;
     cytnx_uint64 k = 1;
@@ -101,6 +109,7 @@ namespace ArnoldiTest {
 
   // 1-9, test eigenalue number k match maximum, that means k = dim.
   TEST(Arnoldi, gpu_k_max) {
+    GTEST_SKIP() << "Arnoldi is not implemented in CUDA.";
     std::string which = "LM";
     auto mat_type = Type.ComplexDouble;
     cytnx_uint64 k, dim;
@@ -110,6 +119,7 @@ namespace ArnoldiTest {
 
   // 1-10, test the smallest matrix dimenstion.
   TEST(Arnoldi, gpu_smallest_dim) {
+    GTEST_SKIP() << "Arnoldi is not implemented in CUDA.";
     std::string which = "LM";
     auto mat_type = Type.ComplexDouble;
     cytnx_uint64 k, dim;

--- a/tests/gpu/linalg_test/ExpM_test.cpp
+++ b/tests/gpu/linalg_test/ExpM_test.cpp
@@ -1,6 +1,7 @@
 #include "ExpM_test.h"
 
 TEST(ExpM, gpu_ExpM_test) {
+  GTEST_SKIP() << "ExpM is not implemented on the GPU.";
   // CompareWithScipy
   std::complex<double> t_i_e[4][4] = {{{-2.0, 0}, {0, 0}, {0, 0}, {-1, 0}},
                                       {{0, 0}, {0, 0}, {-1, 0}, {0, 0}},


### PR DESCRIPTION
Some functions is not implemented in CUDA.

The test cases below are skipped:
- Arnoldi.gpu_k_max
- Arnoldi.gpu_k1_test
- Arnoldi.gpu_mat_type_real_test
- Arnoldi.gpu_smallest_dim
- Arnoldi.gpu_which_LM_test
- Arnoldi.gpu_which_LR_test
- Arnoldi.gpu_which_LI_test
- Arnoldi.gpu_which_SM_test
- Arnoldi.gpu_which_SR_test
- Arnoldi.gpu_which_SI_test
- BlockUniTensorTest.gpu_Trace
- DenseUniTensorTest.gpu_Trace
- ExpM.gpu_ExpM_test