### PR TITLE
Refactor: Templatise `Movemem()` function

### DIFF
--- a/src/backend/BoolStorage.cpp
+++ b/src/backend/BoolStorage.cpp
@@ -89,10 +89,10 @@ namespace cytnx {
                                  const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      utils_internal::Movemem_cpu_b(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryCpu<cytnx_bool>(tmp, old_shape, mapper, invmapper, 1);
     } else {
 #ifdef UNI_GPU
-      utils_internal::cuMovemem_gpu_b(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryGpu<cytnx_bool>(tmp, old_shape, mapper, invmapper, 1);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
 #endif
@@ -104,10 +104,10 @@ namespace cytnx {
     const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      return utils_internal::Movemem_cpu_b(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryCpu<cytnx_bool>(tmp, old_shape, mapper, invmapper, 0);
     } else {
 #ifdef UNI_GPU
-      return utils_internal::cuMovemem_gpu_b(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryGpu<cytnx_bool>(tmp, old_shape, mapper, invmapper, 0);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
       return nullptr;

--- a/src/backend/ComplexDoubleStorage.cpp
+++ b/src/backend/ComplexDoubleStorage.cpp
@@ -90,11 +90,11 @@ namespace cytnx {
                                           const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      utils_internal::Movemem_cpu_cd(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryCpu<cytnx_complex128>(tmp, old_shape, mapper, invmapper, 1);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      utils_internal::cuMovemem_gpu_cd(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryGpu<cytnx_complex128>(tmp, old_shape, mapper, invmapper, 1);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
 #endif
@@ -106,11 +106,11 @@ namespace cytnx {
     const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      return utils_internal::Movemem_cpu_cd(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryCpu<cytnx_complex128>(tmp, old_shape, mapper, invmapper, 0);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      return utils_internal::cuMovemem_gpu_cd(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryGpu<cytnx_complex128>(tmp, old_shape, mapper, invmapper, 0);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
 #endif

--- a/src/backend/ComplexFloatStorage.cpp
+++ b/src/backend/ComplexFloatStorage.cpp
@@ -91,11 +91,11 @@ namespace cytnx {
                                          const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      utils_internal::Movemem_cpu_cf(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryCpu<cytnx_complex64>(tmp, old_shape, mapper, invmapper, 1);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      utils_internal::cuMovemem_gpu_cf(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryGpu<cytnx_complex64>(tmp, old_shape, mapper, invmapper, 1);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
 #endif
@@ -107,11 +107,11 @@ namespace cytnx {
     const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      return utils_internal::Movemem_cpu_cf(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryCpu<cytnx_complex64>(tmp, old_shape, mapper, invmapper, 0);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      return utils_internal::cuMovemem_gpu_cf(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryGpu<cytnx_complex64>(tmp, old_shape, mapper, invmapper, 0);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
       return nullptr;

--- a/src/backend/DoubleStorage.cpp
+++ b/src/backend/DoubleStorage.cpp
@@ -93,11 +93,11 @@ namespace cytnx {
                                    const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      utils_internal::Movemem_cpu_d(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryCpu<cytnx_double>(tmp, old_shape, mapper, invmapper, 1);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      utils_internal::cuMovemem_gpu_d(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryGpu<cytnx_double>(tmp, old_shape, mapper, invmapper, 1);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
 #endif
@@ -111,11 +111,11 @@ namespace cytnx {
     // cout << this->device << " " << Device.cpu << endl;
     if (this->device == Device.cpu) {
       // cout << "[OK]" << endl;
-      return utils_internal::Movemem_cpu_d(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryCpu<cytnx_double>(tmp, old_shape, mapper, invmapper, 0);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      return utils_internal::cuMovemem_gpu_d(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryGpu<cytnx_double>(tmp, old_shape, mapper, invmapper, 0);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
       return nullptr;

--- a/src/backend/FloatStorage.cpp
+++ b/src/backend/FloatStorage.cpp
@@ -90,10 +90,10 @@ namespace cytnx {
                                   const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      utils_internal::Movemem_cpu_f(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryCpu<cytnx_float>(tmp, old_shape, mapper, invmapper, 1);
     } else {
 #ifdef UNI_GPU
-      utils_internal::cuMovemem_gpu_f(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryGpu<cytnx_float>(tmp, old_shape, mapper, invmapper, 1);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
 #endif
@@ -105,10 +105,10 @@ namespace cytnx {
     const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      return utils_internal::Movemem_cpu_f(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryCpu<cytnx_float>(tmp, old_shape, mapper, invmapper, 0);
     } else {
 #ifdef UNI_GPU
-      return utils_internal::cuMovemem_gpu_f(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryGpu<cytnx_float>(tmp, old_shape, mapper, invmapper, 0);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
       return nullptr;

--- a/src/backend/Int16Storage.cpp
+++ b/src/backend/Int16Storage.cpp
@@ -85,11 +85,11 @@ namespace cytnx {
                                   const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      utils_internal::Movemem_cpu_i16(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryCpu<cytnx_int16>(tmp, old_shape, mapper, invmapper, 1);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      utils_internal::cuMovemem_gpu_i16(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryGpu<cytnx_int16>(tmp, old_shape, mapper, invmapper, 1);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
 #endif
@@ -101,11 +101,11 @@ namespace cytnx {
     const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      return utils_internal::Movemem_cpu_i16(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryCpu<cytnx_int16>(tmp, old_shape, mapper, invmapper, 0);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      return utils_internal::cuMovemem_gpu_i16(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryGpu<cytnx_int16>(tmp, old_shape, mapper, invmapper, 0);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
       return nullptr;

--- a/src/backend/Int32Storage.cpp
+++ b/src/backend/Int32Storage.cpp
@@ -88,11 +88,11 @@ namespace cytnx {
                                   const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      utils_internal::Movemem_cpu_i32(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryCpu<cytnx_int32>(tmp, old_shape, mapper, invmapper, 1);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      utils_internal::cuMovemem_gpu_i32(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryGpu<cytnx_int32>(tmp, old_shape, mapper, invmapper, 1);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
 #endif
@@ -104,11 +104,11 @@ namespace cytnx {
     const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      return utils_internal::Movemem_cpu_i32(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryCpu<cytnx_int32>(tmp, old_shape, mapper, invmapper, 0);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      return utils_internal::cuMovemem_gpu_i32(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryGpu<cytnx_int32>(tmp, old_shape, mapper, invmapper, 0);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
       return nullptr;

--- a/src/backend/Int64Storage.cpp
+++ b/src/backend/Int64Storage.cpp
@@ -87,11 +87,11 @@ namespace cytnx {
                                   const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      utils_internal::Movemem_cpu_i64(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryCpu<cytnx_int64>(tmp, old_shape, mapper, invmapper, 1);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      utils_internal::cuMovemem_gpu_i64(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryGpu<cytnx_int64>(tmp, old_shape, mapper, invmapper, 1);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
 #endif
@@ -103,11 +103,11 @@ namespace cytnx {
     const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      return utils_internal::Movemem_cpu_i64(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryCpu<cytnx_int64>(tmp, old_shape, mapper, invmapper, 0);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      return utils_internal::cuMovemem_gpu_i64(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryGpu<cytnx_int64>(tmp, old_shape, mapper, invmapper, 0);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
       return nullptr;

--- a/src/backend/Uint16Storage.cpp
+++ b/src/backend/Uint16Storage.cpp
@@ -85,11 +85,11 @@ namespace cytnx {
                                    const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      utils_internal::Movemem_cpu_u16(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryCpu<cytnx_uint16>(tmp, old_shape, mapper, invmapper, 1);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      utils_internal::cuMovemem_gpu_u16(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryGpu<cytnx_uint16>(tmp, old_shape, mapper, invmapper, 1);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
 #endif
@@ -101,11 +101,11 @@ namespace cytnx {
     const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      return utils_internal::Movemem_cpu_u16(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryCpu<cytnx_uint16>(tmp, old_shape, mapper, invmapper, 0);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      return utils_internal::cuMovemem_gpu_u16(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryGpu<cytnx_uint16>(tmp, old_shape, mapper, invmapper, 0);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
       return nullptr;

--- a/src/backend/Uint32Storage.cpp
+++ b/src/backend/Uint32Storage.cpp
@@ -91,11 +91,11 @@ namespace cytnx {
                                    const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      utils_internal::Movemem_cpu_u32(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryCpu<cytnx_uint32>(tmp, old_shape, mapper, invmapper, 1);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      utils_internal::cuMovemem_gpu_u32(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryGpu<cytnx_uint32>(tmp, old_shape, mapper, invmapper, 1);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
 #endif
@@ -107,11 +107,11 @@ namespace cytnx {
     const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      return utils_internal::Movemem_cpu_u32(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryCpu<cytnx_uint32>(tmp, old_shape, mapper, invmapper, 0);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      return utils_internal::cuMovemem_gpu_u32(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryGpu<cytnx_uint32>(tmp, old_shape, mapper, invmapper, 0);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
       return nullptr;

--- a/src/backend/Uint64Storage.cpp
+++ b/src/backend/Uint64Storage.cpp
@@ -87,11 +87,11 @@ namespace cytnx {
                                    const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      utils_internal::Movemem_cpu_u64(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryCpu<cytnx_uint64>(tmp, old_shape, mapper, invmapper, 1);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      utils_internal::cuMovemem_gpu_u64(tmp, old_shape, mapper, invmapper, 1);
+      utils_internal::MoveMemoryGpu<cytnx_uint64>(tmp, old_shape, mapper, invmapper, 1);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
 #endif
@@ -103,11 +103,11 @@ namespace cytnx {
     const std::vector<cytnx_uint64> &invmapper) {
     boost::intrusive_ptr<Storage_base> tmp(this);
     if (this->device == Device.cpu) {
-      return utils_internal::Movemem_cpu_u64(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryCpu<cytnx_uint64>(tmp, old_shape, mapper, invmapper, 0);
     } else {
 #ifdef UNI_GPU
       checkCudaErrors(cudaSetDevice(this->device));
-      return utils_internal::cuMovemem_gpu_u64(tmp, old_shape, mapper, invmapper, 0);
+      return utils_internal::MoveMemoryGpu<cytnx_uint64>(tmp, old_shape, mapper, invmapper, 0);
 #else
       cytnx_error_msg(1, "%s", "[ERROR][Internal] try to call GPU section without CUDA support");
       return nullptr;

--- a/src/backend/utils_internal_cpu/Movemem_cpu.cpp
+++ b/src/backend/utils_internal_cpu/Movemem_cpu.cpp
@@ -1,5 +1,12 @@
 #include "Movemem_cpu.hpp"
+
+#include <type_traits>
+#include <vector>
+
+#include "boost/smart_ptr/intrusive_ptr.hpp"
+
 #include "backend/Storage.hpp"
+
 #ifdef UNI_OMP
   #include <omp.h>
 #endif
@@ -13,20 +20,119 @@ namespace cytnx {
 
   namespace utils_internal {
 
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_cd(boost::intrusive_ptr<Storage_base> &in,
-                                                      const std::vector<cytnx_uint64> &old_shape,
-                                                      const std::vector<cytnx_uint64> &mapper,
-                                                      const std::vector<cytnx_uint64> &invmapper,
-                                                      const bool is_inplace) {
+    template <typename T, typename std::enable_if_t<std::is_integral_v<T>, bool>>
+    boost::intrusive_ptr<Storage_base> MoveMemoryCpu(boost::intrusive_ptr<Storage_base> &in,
+                                                     const std::vector<cytnx_uint64> &old_shape,
+                                                     const std::vector<cytnx_uint64> &mapper,
+                                                     const std::vector<cytnx_uint64> &invmapper,
+                                                     const bool is_inplace) {
 #ifdef UNI_DEBUG
       cytnx_error_msg(
-        in->dtype != Type.ComplexDouble,
-        "[DEBUG][internal error] in.dtype_str is [%s] but call Movemem_cpu with type ComplexDouble",
-        in->dtype_str().c_str());
+        in->dtype != Type.cy_typeid(T()),
+        "[DEBUG][internal error] in.dtype_str is [%s] but call MoveMemoryCpu with type %s",
+        in->dtype_str().c_str(), Type.getname(Type.cy_typeid(T())));
 #endif
 
-      cytnx_complex128 *des = (cytnx_complex128 *)malloc(in->cap * sizeof(cytnx_complex128));
-      cytnx_complex128 *src = static_cast<cytnx_complex128 *>(in->Mem);
+      std::vector<cytnx_uint64> newshape(old_shape.size());
+      for (cytnx_uint64 i = 0; i < old_shape.size(); i++) newshape[i] = old_shape[mapper[i]];
+
+      std::vector<cytnx_uint64> shifter_old(old_shape.size());
+      std::vector<cytnx_uint64> shifter_new(old_shape.size());
+
+      cytnx_uint64 accu_old = 1, accu_new = 1;
+      for (cytnx_int64 i = old_shape.size() - 1; i >= 0; i--) {
+        shifter_old[i] = accu_old;
+        shifter_new[i] = accu_new;
+        accu_old *= old_shape[i];
+        accu_new *= newshape[i];
+      }
+
+      T *des = (T *)malloc(in->cap * sizeof(T));
+      T *src = static_cast<T *>(in->Mem);
+
+#ifdef UNI_OMP
+      std::vector<std::vector<cytnx_uint64>> old_inds;
+  #pragma omp parallel
+      {
+        if (omp_get_thread_num() == 0)
+          old_inds = std::vector<std::vector<cytnx_uint64>>(
+            omp_get_num_threads(), std::vector<cytnx_uint64>(old_shape.size()));
+      }
+
+  #pragma omp parallel for schedule(dynamic)
+      for (cytnx_uint64 n = 0; n < accu_old; n++) {
+        // calc new id:
+        cytnx_uint64 j;
+        cytnx_uint64 old_loc = n;
+        for (j = 0; j < old_shape.size(); j++) {
+          old_inds[omp_get_thread_num()][j] = old_loc / shifter_old[j];
+          old_loc = old_loc % shifter_old[j];
+        }
+        old_loc = 0;  // position:
+        for (j = 0; j < old_shape.size(); j++) {
+          old_loc += shifter_new[j] * old_inds[omp_get_thread_num()][mapper[j]];
+        }
+        des[old_loc] = src[n];
+      }
+
+#else
+      std::vector<cytnx_uint64> old_inds(old_shape.size());
+      cytnx_uint64 j, old_loc;
+      for (cytnx_uint64 n = 0; n < accu_old; n++) {
+        // calc new id:
+        old_loc = n;
+        for (j = 0; j < old_shape.size(); j++) {
+          old_inds[j] = old_loc / shifter_old[j];
+          old_loc = old_loc % shifter_old[j];
+        }
+        old_loc = 0;  // position:
+        for (j = 0; j < old_shape.size(); j++) {
+          old_loc += shifter_new[j] * old_inds[mapper[j]];
+        }
+        des[old_loc] = src[n];
+      }
+#endif
+      boost::intrusive_ptr<Storage_base> out;
+      if constexpr (std::is_same_v<T, cytnx_uint64>) {
+        out = new Uint64Storage();
+      } else if (std::is_same_v<T, cytnx_int64>) {
+        out = new Int64Storage();
+      } else if (std::is_same_v<T, cytnx_uint32>) {
+        out = new Uint32Storage();
+      } else if (std::is_same_v<T, cytnx_int32>) {
+        out = new Int32Storage();
+      } else if (std::is_same_v<T, cytnx_uint16>) {
+        out = new Uint16Storage();
+      } else if (std::is_same_v<T, cytnx_int16>) {
+        out = new Int16Storage();
+      } else if (std::is_same_v<T, cytnx_bool>) {
+        out = new BoolStorage();
+      }
+      if (is_inplace) {
+        memcpy(in->Mem, des, sizeof(T) * accu_old);
+        free(des);
+        return out;
+      } else {
+        out->_Init_byptr(des, accu_old, in->device, true, in->cap);
+        return out;
+      }
+    }
+
+    template <typename T, typename std::enable_if_t<!std::is_integral_v<T>, bool>>
+    boost::intrusive_ptr<Storage_base> MoveMemoryCpu(boost::intrusive_ptr<Storage_base> &in,
+                                                     const std::vector<cytnx_uint64> &old_shape,
+                                                     const std::vector<cytnx_uint64> &mapper,
+                                                     const std::vector<cytnx_uint64> &invmapper,
+                                                     const bool is_inplace) {
+#ifdef UNI_DEBUG
+      cytnx_error_msg(
+        in->dtype != Type.cy_typeid(T()),
+        "[DEBUG][internal error] in.dtype_str is [%s] but call MoveMemoryCpu with type %s",
+        in->dtype_str().c_str(), Type.getname(Type.cy_typeid(T())));
+#endif
+
+      T *des = (T *)malloc(in->cap * sizeof(T));
+      T *src = static_cast<T *>(in->Mem);
       cytnx_uint64 accu_old = 1, accu_new = 1;
 
 #ifdef UNI_HPTT
@@ -144,10 +250,18 @@ namespace cytnx {
       }
   #endif
 #endif  // hptt
-
-      boost::intrusive_ptr<Storage_base> out(new ComplexDoubleStorage());
+      boost::intrusive_ptr<Storage_base> out;
+      if constexpr (std::is_same_v<T, cytnx_complex128>) {
+        out = new ComplexDoubleStorage();
+      } else if (std::is_same_v<T, cytnx_complex64>) {
+        out = new ComplexFloatStorage();
+      } else if (std::is_same_v<T, cytnx_double>) {
+        out = new DoubleStorage();
+      } else if (std::is_same_v<T, cytnx_float>) {
+        out = new FloatStorage();
+      }
       if (is_inplace) {
-        memcpy(in->Mem, des, sizeof(cytnx_complex128) * accu_old);
+        memcpy(in->Mem, des, sizeof(T) * accu_old);
         free(des);
         return out;
       } else {
@@ -156,1010 +270,39 @@ namespace cytnx {
       }
     }
 
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_cf(boost::intrusive_ptr<Storage_base> &in,
-                                                      const std::vector<cytnx_uint64> &old_shape,
-                                                      const std::vector<cytnx_uint64> &mapper,
-                                                      const std::vector<cytnx_uint64> &invmapper,
-                                                      const bool is_inplace) {
-#ifdef UNI_DEBUG
-      cytnx_error_msg(
-        in->dtype != Type.ComplexFloat,
-        "[DEBUG][internal error] in.dtype_str is [%s] but call Movemem_cpu with type ComplexFloat",
-        in->dtype_str().c_str());
-#endif
-
-      cytnx_complex64 *des = (cytnx_complex64 *)malloc(in->cap * sizeof(cytnx_complex64));
-      cytnx_complex64 *src = static_cast<cytnx_complex64 *>(in->Mem);
-      cytnx_uint64 accu_old = 1, accu_new = 1;
-
-#ifdef UNI_HPTT
-  #ifdef UNI_DEBUG
-      cytnx_error_msg(true, "[DEBUG][Internal prompt] USE HPTT%s", "\n");
-  #endif
-      if (in->size() > 64) {
-        std::vector<int> perm(mapper.begin(), mapper.end());
-        std::vector<int> size(old_shape.begin(), old_shape.end());
-        auto plan = hptt::create_plan(&perm[0], perm.size(), 1, src, &size[0], NULL, 0, des, NULL,
-                                      hptt::ESTIMATE, cytnx::Device.Ncpus, nullptr, true);
-        plan->execute();
-        accu_old = in->size();
-      } else {
-        std::vector<cytnx_int64> newshape(old_shape.size());
-        for (cytnx_int64 i = 0; i < old_shape.size(); i++) {
-          newshape[i] = old_shape[mapper[i]];
-        }
-        std::vector<cytnx_int64> shifter_new(old_shape.size());
-
-        for (cytnx_int64 i = old_shape.size() - 1; i >= 0; i--) {
-          shifter_new[i] = accu_new;
-          accu_old *= old_shape[i];
-          accu_new *= newshape[i];
-        }
-        std::vector<cytnx_int64> old_inds(old_shape.size());
-        cytnx_int64 j, new_loc = 0;
-        for (cytnx_int64 n = 0; n < accu_old; n++) {
-          bool recalc = 0;
-          for (int i = (int)old_shape.size() - 1; i >= 0; i--) {
-            if (old_inds[i] >= old_shape[i]) {
-              recalc = 1;
-              old_inds[i - 1]++;
-              old_inds[i] = 0;
-            } else
-              break;
-          }
-          if (recalc) {
-            new_loc = 0;
-            for (j = 0; j < old_shape.size(); j++) {
-              new_loc += shifter_new[j] * old_inds[mapper[j]];
-            }
-          } else {
-            if (n != 0) new_loc += shifter_new[invmapper[old_shape.size() - 1]];
-          }
-          des[new_loc] = src[n];
-
-          old_inds[old_shape.size() - 1]++;
-        }
-      }
-#else
-
-      std::vector<cytnx_int64> newshape(old_shape.size());
-      for (cytnx_int64 i = 0; i < old_shape.size(); i++) {
-        newshape[i] = old_shape[mapper[i]];
-      }
-      std::vector<cytnx_int64> shifter_new(old_shape.size());
-
-      for (cytnx_int64 i = old_shape.size() - 1; i >= 0; i--) {
-        shifter_new[i] = accu_new;
-        accu_old *= old_shape[i];
-        accu_new *= newshape[i];
-      }
-
-  #ifdef UNI_OMP
-      std::vector<std::vector<cytnx_uint64>> old_inds;
-    #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0)
-          old_inds = std::vector<std::vector<cytnx_uint64>>(
-            omp_get_num_threads(), std::vector<cytnx_uint64>(old_shape.size()));
-      }
-
-    #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        cytnx_uint64 j;
-        cytnx_uint64 old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[omp_get_thread_num()][j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[omp_get_thread_num()][mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-
-  #else
-      std::vector<cytnx_int64> old_inds(old_shape.size());
-      cytnx_int64 j, new_loc = 0;
-      for (cytnx_int64 n = 0; n < accu_old; n++) {
-        bool recalc = 0;
-        for (int i = (int)old_shape.size() - 1; i >= 0; i--) {
-          if (old_inds[i] >= old_shape[i]) {
-            recalc = 1;
-            old_inds[i - 1]++;
-            old_inds[i] = 0;
-          } else
-            break;
-        }
-        if (recalc) {
-          new_loc = 0;
-          for (j = 0; j < old_shape.size(); j++) {
-            new_loc += shifter_new[j] * old_inds[mapper[j]];
-          }
-        } else {
-          if (n != 0) new_loc += shifter_new[invmapper[old_shape.size() - 1]];
-        }
-        des[new_loc] = src[n];
-
-        old_inds[old_shape.size() - 1]++;
-      }
-  #endif
-#endif  // hptt
-
-      boost::intrusive_ptr<Storage_base> out(new ComplexFloatStorage());
-      if (is_inplace) {
-        memcpy(in->Mem, des, sizeof(cytnx_complex64) * accu_old);
-        free(des);
-        return out;
-      } else {
-        out->_Init_byptr(des, accu_old, in->device, true, in->cap);
-        return out;
-      }
-    }
-
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_d(boost::intrusive_ptr<Storage_base> &in,
-                                                     const std::vector<cytnx_uint64> &old_shape,
-                                                     const std::vector<cytnx_uint64> &mapper,
-                                                     const std::vector<cytnx_uint64> &invmapper,
-                                                     const bool is_inplace) {
-#ifdef UNI_DEBUG
-      cytnx_error_msg(
-        in->dtype != Type.Double,
-        "[DEBUG][internal error] in.dtype_str is [%s] but call Movemem_cpu with type Double",
-        in->dtype_str().c_str());
-#endif
-
-      // cytnx_double *des = (cytnx_double *)calloc(in->cap, sizeof(cytnx_double));
-      cytnx_double *des = (cytnx_double *)malloc(in->cap * sizeof(cytnx_double));
-      cytnx_double *src = static_cast<cytnx_double *>(in->Mem);
-      cytnx_uint64 accu_old = 1, accu_new = 1;
-
-#ifdef UNI_HPTT
-  #ifdef UNI_DEBUG
-      cytnx_error_msg(true, "[DEBUG][Internal prompt] USE HPTT%s", "\n");
-  #endif
-      if (in->size() > 64) {
-        std::vector<int> perm(mapper.begin(), mapper.end());
-        std::vector<int> size(old_shape.begin(), old_shape.end());
-        auto plan = hptt::create_plan(&perm[0], perm.size(), 1, src, &size[0], NULL, 0, des, NULL,
-                                      hptt::ESTIMATE, cytnx::Device.Ncpus, nullptr, true);
-        plan->execute();
-        accu_old = in->size();
-      } else {
-        std::vector<cytnx_int64> newshape(old_shape.size());
-        for (cytnx_int64 i = 0; i < old_shape.size(); i++) {
-          newshape[i] = old_shape[mapper[i]];
-        }
-        std::vector<cytnx_int64> shifter_new(old_shape.size());
-
-        for (cytnx_int64 i = old_shape.size() - 1; i >= 0; i--) {
-          shifter_new[i] = accu_new;
-          accu_old *= old_shape[i];
-          accu_new *= newshape[i];
-        }
-        std::vector<cytnx_int64> old_inds(old_shape.size());
-        cytnx_int64 j, new_loc = 0;
-        for (cytnx_int64 n = 0; n < accu_old; n++) {
-          bool recalc = 0;
-          for (int i = (int)old_shape.size() - 1; i >= 0; i--) {
-            if (old_inds[i] >= old_shape[i]) {
-              recalc = 1;
-              old_inds[i - 1]++;
-              old_inds[i] = 0;
-            } else
-              break;
-          }
-          if (recalc) {
-            new_loc = 0;
-            for (j = 0; j < old_shape.size(); j++) {
-              new_loc += shifter_new[j] * old_inds[mapper[j]];
-            }
-          } else {
-            if (n != 0) new_loc += shifter_new[invmapper[old_shape.size() - 1]];
-          }
-          des[new_loc] = src[n];
-
-          old_inds[old_shape.size() - 1]++;
-        }
-      }
-#else
-
-      std::vector<cytnx_int64> newshape(old_shape.size());
-      for (cytnx_int64 i = 0; i < old_shape.size(); i++) {
-        newshape[i] = old_shape[mapper[i]];
-      }
-      std::vector<cytnx_int64> shifter_new(old_shape.size());
-
-      for (cytnx_int64 i = old_shape.size() - 1; i >= 0; i--) {
-        shifter_new[i] = accu_new;
-        accu_old *= old_shape[i];
-        accu_new *= newshape[i];
-      }
-
-  #ifdef UNI_OMP
-      std::vector<std::vector<cytnx_uint64>> old_inds;
-    #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0)
-          old_inds = std::vector<std::vector<cytnx_uint64>>(
-            omp_get_num_threads(), std::vector<cytnx_uint64>(old_shape.size()));
-      }
-
-    #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        cytnx_uint64 j;
-        cytnx_uint64 old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[omp_get_thread_num()][j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[omp_get_thread_num()][mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-
-  #else
-      std::vector<cytnx_int64> old_inds(old_shape.size());
-      cytnx_int64 j, new_loc = 0;
-      for (cytnx_int64 n = 0; n < accu_old; n++) {
-        bool recalc = 0;
-        for (int i = (int)old_shape.size() - 1; i >= 0; i--) {
-          if (old_inds[i] >= old_shape[i]) {
-            recalc = 1;
-            old_inds[i - 1]++;
-            old_inds[i] = 0;
-          } else
-            break;
-        }
-        if (recalc) {
-          new_loc = 0;
-          for (j = 0; j < old_shape.size(); j++) {
-            new_loc += shifter_new[j] * old_inds[mapper[j]];
-          }
-        } else {
-          if (n != 0) new_loc += shifter_new[invmapper[old_shape.size() - 1]];
-        }
-        des[new_loc] = src[n];
-
-        old_inds[old_shape.size() - 1]++;
-      }
-  #endif
-
-#endif  // HPTT
-
-      boost::intrusive_ptr<Storage_base> out(new DoubleStorage());
-      if (is_inplace) {
-        memcpy(in->Mem, des, sizeof(cytnx_double) * accu_old);
-        free(des);
-        return out;
-      } else {
-        out->_Init_byptr(des, accu_old, in->device, true, in->cap);
-        return out;
-      }
-    }
-
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_f(boost::intrusive_ptr<Storage_base> &in,
-                                                     const std::vector<cytnx_uint64> &old_shape,
-                                                     const std::vector<cytnx_uint64> &mapper,
-                                                     const std::vector<cytnx_uint64> &invmapper,
-                                                     const bool is_inplace) {
-#ifdef UNI_DEBUG
-      cytnx_error_msg(
-        in->dtype != Type.Float,
-        "[DEBUG][internal error] in.dtype_str is [%s] but call Movemem_cpu with type Float",
-        in->dtype_str().c_str());
-#endif
-
-      cytnx_float *des = (cytnx_float *)malloc(in->cap * sizeof(cytnx_float));
-      cytnx_float *src = static_cast<cytnx_float *>(in->Mem);
-      cytnx_uint64 accu_old = 1, accu_new = 1;
-#ifdef UNI_HPTT
-  #ifdef UNI_DEBUG
-      cytnx_error_msg(true, "[DEBUG][Internal prompt] USE HPTT%s", "\n");
-  #endif
-      if (in->size() > 64) {
-        std::vector<int> perm(mapper.begin(), mapper.end());
-        std::vector<int> size(old_shape.begin(), old_shape.end());
-        auto plan = hptt::create_plan(&perm[0], perm.size(), 1, src, &size[0], NULL, 0, des, NULL,
-                                      hptt::ESTIMATE, cytnx::Device.Ncpus, nullptr, true);
-        plan->execute();
-        accu_old = in->size();
-      } else {
-        std::vector<cytnx_int64> newshape(old_shape.size());
-        for (cytnx_int64 i = 0; i < old_shape.size(); i++) {
-          newshape[i] = old_shape[mapper[i]];
-        }
-        std::vector<cytnx_int64> shifter_new(old_shape.size());
-
-        for (cytnx_int64 i = old_shape.size() - 1; i >= 0; i--) {
-          shifter_new[i] = accu_new;
-          accu_old *= old_shape[i];
-          accu_new *= newshape[i];
-        }
-        std::vector<cytnx_int64> old_inds(old_shape.size());
-        cytnx_int64 j, new_loc = 0;
-        for (cytnx_int64 n = 0; n < accu_old; n++) {
-          bool recalc = 0;
-          for (int i = (int)old_shape.size() - 1; i >= 0; i--) {
-            if (old_inds[i] >= old_shape[i]) {
-              recalc = 1;
-              old_inds[i - 1]++;
-              old_inds[i] = 0;
-            } else
-              break;
-          }
-          if (recalc) {
-            new_loc = 0;
-            for (j = 0; j < old_shape.size(); j++) {
-              new_loc += shifter_new[j] * old_inds[mapper[j]];
-            }
-          } else {
-            if (n != 0) new_loc += shifter_new[invmapper[old_shape.size() - 1]];
-          }
-          des[new_loc] = src[n];
-
-          old_inds[old_shape.size() - 1]++;
-        }
-      }
-#else
-
-      std::vector<cytnx_int64> newshape(old_shape.size());
-      for (cytnx_int64 i = 0; i < old_shape.size(); i++) {
-        newshape[i] = old_shape[mapper[i]];
-      }
-      std::vector<cytnx_int64> shifter_new(old_shape.size());
-
-      for (cytnx_int64 i = old_shape.size() - 1; i >= 0; i--) {
-        shifter_new[i] = accu_new;
-        accu_old *= old_shape[i];
-        accu_new *= newshape[i];
-      }
-
-  #ifdef UNI_OMP
-      std::vector<std::vector<cytnx_uint64>> old_inds;
-    #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0)
-          old_inds = std::vector<std::vector<cytnx_uint64>>(
-            omp_get_num_threads(), std::vector<cytnx_uint64>(old_shape.size()));
-      }
-
-    #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        cytnx_uint64 j;
-        cytnx_uint64 old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[omp_get_thread_num()][j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[omp_get_thread_num()][mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-
-  #else
-      std::vector<cytnx_int64> old_inds(old_shape.size());
-      cytnx_int64 j, new_loc = 0;
-      for (cytnx_int64 n = 0; n < accu_old; n++) {
-        bool recalc = 0;
-        for (int i = (int)old_shape.size() - 1; i >= 0; i--) {
-          if (old_inds[i] >= old_shape[i]) {
-            recalc = 1;
-            old_inds[i - 1]++;
-            old_inds[i] = 0;
-          } else
-            break;
-        }
-        if (recalc) {
-          new_loc = 0;
-          for (j = 0; j < old_shape.size(); j++) {
-            new_loc += shifter_new[j] * old_inds[mapper[j]];
-          }
-        } else {
-          if (n != 0) new_loc += shifter_new[invmapper[old_shape.size() - 1]];
-        }
-        des[new_loc] = src[n];
-
-        old_inds[old_shape.size() - 1]++;
-      }
-  #endif
-#endif  // hptt
-
-      boost::intrusive_ptr<Storage_base> out(new FloatStorage());
-      if (is_inplace) {
-        memcpy(in->Mem, des, sizeof(cytnx_float) * accu_old);
-        free(des);
-        return out;
-      } else {
-        out->_Init_byptr(des, accu_old, in->device, true, in->cap);
-        return out;
-      }
-    }
-
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_i64(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace) {
-#ifdef UNI_DEBUG
-      cytnx_error_msg(
-        in->dtype != Type.Int64,
-        "[DEBUG][internal error] in.dtype_str is [%s] but call Movemem_cpu with type Int64",
-        in->dtype_str().c_str());
-#endif
-
-      std::vector<cytnx_uint64> newshape(old_shape.size());
-      for (cytnx_uint64 i = 0; i < old_shape.size(); i++) newshape[i] = old_shape[mapper[i]];
-
-      std::vector<cytnx_uint64> shifter_old(old_shape.size());
-      std::vector<cytnx_uint64> shifter_new(old_shape.size());
-
-      cytnx_uint64 accu_old = 1, accu_new = 1;
-      for (cytnx_int64 i = old_shape.size() - 1; i >= 0; i--) {
-        shifter_old[i] = accu_old;
-        shifter_new[i] = accu_new;
-        accu_old *= old_shape[i];
-        accu_new *= newshape[i];
-      }
-
-      cytnx_int64 *des = (cytnx_int64 *)malloc(in->cap * sizeof(cytnx_int64));
-      cytnx_int64 *src = static_cast<cytnx_int64 *>(in->Mem);
-
-#ifdef UNI_OMP
-      std::vector<std::vector<cytnx_uint64>> old_inds;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0)
-          old_inds = std::vector<std::vector<cytnx_uint64>>(
-            omp_get_num_threads(), std::vector<cytnx_uint64>(old_shape.size()));
-      }
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        cytnx_uint64 j;
-        cytnx_uint64 old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[omp_get_thread_num()][j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[omp_get_thread_num()][mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-
-#else
-      std::vector<cytnx_uint64> old_inds(old_shape.size());
-      cytnx_uint64 j, old_loc;
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-#endif
-
-      boost::intrusive_ptr<Storage_base> out(new Int64Storage());
-      if (is_inplace) {
-        memcpy(in->Mem, des, sizeof(cytnx_int64) * accu_old);
-        free(des);
-        return out;
-      } else {
-        out->_Init_byptr(des, accu_old, in->device, true, in->cap);
-        return out;
-      }
-    }
-
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_u64(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace) {
-#ifdef UNI_DEBUG
-      cytnx_error_msg(
-        in->dtype != Type.Uint64,
-        "[DEBUG][internal error] in.dtype_str is [%s] but call Movemem_cpu with type Uint64",
-        in->dtype_str().c_str());
-#endif
-
-      std::vector<cytnx_uint64> newshape(old_shape.size());
-      for (cytnx_uint64 i = 0; i < old_shape.size(); i++) newshape[i] = old_shape[mapper[i]];
-
-      std::vector<cytnx_uint64> shifter_old(old_shape.size());
-      std::vector<cytnx_uint64> shifter_new(old_shape.size());
-
-      cytnx_uint64 accu_old = 1, accu_new = 1;
-      for (cytnx_int64 i = old_shape.size() - 1; i >= 0; i--) {
-        shifter_old[i] = accu_old;
-        shifter_new[i] = accu_new;
-        accu_old *= old_shape[i];
-        accu_new *= newshape[i];
-      }
-
-      cytnx_uint64 *des = (cytnx_uint64 *)malloc(in->cap * sizeof(cytnx_uint64));
-      cytnx_uint64 *src = static_cast<cytnx_uint64 *>(in->Mem);
-
-#ifdef UNI_OMP
-      std::vector<std::vector<cytnx_uint64>> old_inds;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0)
-          old_inds = std::vector<std::vector<cytnx_uint64>>(
-            omp_get_num_threads(), std::vector<cytnx_uint64>(old_shape.size()));
-      }
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        cytnx_uint64 j;
-        cytnx_uint64 old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[omp_get_thread_num()][j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[omp_get_thread_num()][mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-
-#else
-      std::vector<cytnx_uint64> old_inds(old_shape.size());
-      cytnx_uint64 j, old_loc;
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-#endif
-
-      boost::intrusive_ptr<Storage_base> out(new Uint64Storage());
-      if (is_inplace) {
-        memcpy(in->Mem, des, sizeof(cytnx_uint64) * accu_old);
-        free(des);
-        return out;
-      } else {
-        out->_Init_byptr(des, accu_old, in->device, true, in->cap);
-        return out;
-      }
-    }
-
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_i32(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace) {
-#ifdef UNI_DEBUG
-      cytnx_error_msg(
-        in->dtype != Type.Int32,
-        "[DEBUG][internal error] in.dtype_str is [%s] but call Movemem_cpu with type Int32",
-        in->dtype_str().c_str());
-#endif
-
-      std::vector<cytnx_uint64> newshape(old_shape.size());
-      for (cytnx_uint64 i = 0; i < old_shape.size(); i++) newshape[i] = old_shape[mapper[i]];
-
-      std::vector<cytnx_uint64> shifter_old(old_shape.size());
-      std::vector<cytnx_uint64> shifter_new(old_shape.size());
-
-      cytnx_uint64 accu_old = 1, accu_new = 1;
-      for (cytnx_int64 i = old_shape.size() - 1; i >= 0; i--) {
-        shifter_old[i] = accu_old;
-        shifter_new[i] = accu_new;
-        accu_old *= old_shape[i];
-        accu_new *= newshape[i];
-      }
-
-      cytnx_int32 *des = (cytnx_int32 *)malloc(in->cap * sizeof(cytnx_int32));
-      cytnx_int32 *src = static_cast<cytnx_int32 *>(in->Mem);
-
-#ifdef UNI_OMP
-      std::vector<std::vector<cytnx_uint64>> old_inds;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0)
-          old_inds = std::vector<std::vector<cytnx_uint64>>(
-            omp_get_num_threads(), std::vector<cytnx_uint64>(old_shape.size()));
-      }
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        cytnx_uint64 j;
-        cytnx_uint64 old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[omp_get_thread_num()][j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[omp_get_thread_num()][mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-
-#else
-      std::vector<cytnx_uint64> old_inds(old_shape.size());
-      cytnx_uint64 j, old_loc;
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-#endif
-
-      boost::intrusive_ptr<Storage_base> out(new Int32Storage());
-      if (is_inplace) {
-        memcpy(in->Mem, des, sizeof(cytnx_int32) * accu_old);
-        free(des);
-        return out;
-      } else {
-        out->_Init_byptr(des, accu_old, in->device, true, in->cap);
-        return out;
-      }
-    }
-
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_u32(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace) {
-#ifdef UNI_DEBUG
-      cytnx_error_msg(
-        in->dtype != Type.Uint32,
-        "[DEBUG][internal error] in.dtype_str is [%s] but call Movemem_cpu with type Uint32",
-        in->dtype_str().c_str());
-#endif
-
-      std::vector<cytnx_uint64> newshape(old_shape.size());
-      for (cytnx_uint64 i = 0; i < old_shape.size(); i++) newshape[i] = old_shape[mapper[i]];
-
-      std::vector<cytnx_uint64> shifter_old(old_shape.size());
-      std::vector<cytnx_uint64> shifter_new(old_shape.size());
-
-      cytnx_uint64 accu_old = 1, accu_new = 1;
-      for (cytnx_int64 i = old_shape.size() - 1; i >= 0; i--) {
-        shifter_old[i] = accu_old;
-        shifter_new[i] = accu_new;
-        accu_old *= old_shape[i];
-        accu_new *= newshape[i];
-      }
-
-      cytnx_uint32 *des = (cytnx_uint32 *)malloc(in->cap * sizeof(cytnx_uint32));
-      cytnx_uint32 *src = static_cast<cytnx_uint32 *>(in->Mem);
-
-#ifdef UNI_OMP
-      std::vector<std::vector<cytnx_uint64>> old_inds;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0)
-          old_inds = std::vector<std::vector<cytnx_uint64>>(
-            omp_get_num_threads(), std::vector<cytnx_uint64>(old_shape.size()));
-      }
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        cytnx_uint64 j;
-        cytnx_uint64 old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[omp_get_thread_num()][j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[omp_get_thread_num()][mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-
-#else
-      std::vector<cytnx_uint64> old_inds(old_shape.size());
-      cytnx_uint64 j, old_loc;
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-#endif
-
-      boost::intrusive_ptr<Storage_base> out(new Uint32Storage());
-      if (is_inplace) {
-        memcpy(in->Mem, des, sizeof(cytnx_uint32) * accu_old);
-        free(des);
-        return out;
-      } else {
-        out->_Init_byptr(des, accu_old, in->device, true, in->cap);
-        return out;
-      }
-    }
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_u16(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace) {
-#ifdef UNI_DEBUG
-      cytnx_error_msg(
-        in->dtype != Type.Uint16,
-        "[DEBUG][internal error] in.dtype_str is [%s] but call Movemem_cpu with type Uint16",
-        in->dtype_str().c_str());
-#endif
-
-      std::vector<cytnx_uint64> newshape(old_shape.size());
-      for (cytnx_uint64 i = 0; i < old_shape.size(); i++) newshape[i] = old_shape[mapper[i]];
-
-      std::vector<cytnx_uint64> shifter_old(old_shape.size());
-      std::vector<cytnx_uint64> shifter_new(old_shape.size());
-
-      cytnx_uint64 accu_old = 1, accu_new = 1;
-      for (cytnx_int64 i = old_shape.size() - 1; i >= 0; i--) {
-        shifter_old[i] = accu_old;
-        shifter_new[i] = accu_new;
-        accu_old *= old_shape[i];
-        accu_new *= newshape[i];
-      }
-
-      cytnx_uint16 *des = (cytnx_uint16 *)malloc(in->cap * sizeof(cytnx_uint16));
-      cytnx_uint16 *src = static_cast<cytnx_uint16 *>(in->Mem);
-
-#ifdef UNI_OMP
-      std::vector<std::vector<cytnx_uint64>> old_inds;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0)
-          old_inds = std::vector<std::vector<cytnx_uint64>>(
-            omp_get_num_threads(), std::vector<cytnx_uint64>(old_shape.size()));
-      }
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        cytnx_uint64 j;
-        cytnx_uint64 old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[omp_get_thread_num()][j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[omp_get_thread_num()][mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-
-#else
-      std::vector<cytnx_uint64> old_inds(old_shape.size());
-      cytnx_uint64 j, old_loc;
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-#endif
-
-      boost::intrusive_ptr<Storage_base> out(new Uint16Storage());
-      if (is_inplace) {
-        memcpy(in->Mem, des, sizeof(cytnx_uint16) * accu_old);
-        free(des);
-        return out;
-      } else {
-        out->_Init_byptr(des, accu_old, in->device, true, in->cap);
-        return out;
-      }
-    }
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_i16(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace) {
-#ifdef UNI_DEBUG
-      cytnx_error_msg(
-        in->dtype != Type.Int16,
-        "[DEBUG][internal error] in.dtype_str is [%s] but call Movemem_cpu with type Int16",
-        in->dtype_str().c_str());
-#endif
-
-      std::vector<cytnx_uint64> newshape(old_shape.size());
-      for (cytnx_uint64 i = 0; i < old_shape.size(); i++) newshape[i] = old_shape[mapper[i]];
-
-      std::vector<cytnx_uint64> shifter_old(old_shape.size());
-      std::vector<cytnx_uint64> shifter_new(old_shape.size());
-
-      cytnx_uint64 accu_old = 1, accu_new = 1;
-      for (cytnx_int64 i = old_shape.size() - 1; i >= 0; i--) {
-        shifter_old[i] = accu_old;
-        shifter_new[i] = accu_new;
-        accu_old *= old_shape[i];
-        accu_new *= newshape[i];
-      }
-
-      cytnx_int16 *des = (cytnx_int16 *)malloc(in->cap * sizeof(cytnx_int16));
-      cytnx_int16 *src = static_cast<cytnx_int16 *>(in->Mem);
-
-#ifdef UNI_OMP
-      std::vector<std::vector<cytnx_uint64>> old_inds;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0)
-          old_inds = std::vector<std::vector<cytnx_uint64>>(
-            omp_get_num_threads(), std::vector<cytnx_uint64>(old_shape.size()));
-      }
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        cytnx_uint64 j;
-        cytnx_uint64 old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[omp_get_thread_num()][j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[omp_get_thread_num()][mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-
-#else
-      std::vector<cytnx_uint64> old_inds(old_shape.size());
-      cytnx_uint64 j, old_loc;
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-#endif
-
-      boost::intrusive_ptr<Storage_base> out(new Int16Storage());
-      if (is_inplace) {
-        memcpy(in->Mem, des, sizeof(cytnx_int16) * accu_old);
-        free(des);
-        return out;
-      } else {
-        out->_Init_byptr(des, accu_old, in->device, true, in->cap);
-        return out;
-      }
-    }
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_b(boost::intrusive_ptr<Storage_base> &in,
-                                                     const std::vector<cytnx_uint64> &old_shape,
-                                                     const std::vector<cytnx_uint64> &mapper,
-                                                     const std::vector<cytnx_uint64> &invmapper,
-                                                     const bool is_inplace) {
-#ifdef UNI_DEBUG
-      cytnx_error_msg(
-        in->dtype != Type.Bool,
-        "[DEBUG][internal error] in.dtype_str is [%s] but call Movemem_cpu with type Bool",
-        in->dtype_str().c_str());
-#endif
-
-      std::vector<cytnx_uint64> newshape(old_shape.size());
-      for (cytnx_uint64 i = 0; i < old_shape.size(); i++) newshape[i] = old_shape[mapper[i]];
-
-      std::vector<cytnx_uint64> shifter_old(old_shape.size());
-      std::vector<cytnx_uint64> shifter_new(old_shape.size());
-
-      cytnx_uint64 accu_old = 1, accu_new = 1;
-      for (cytnx_int64 i = old_shape.size() - 1; i >= 0; i--) {
-        shifter_old[i] = accu_old;
-        shifter_new[i] = accu_new;
-        accu_old *= old_shape[i];
-        accu_new *= newshape[i];
-      }
-
-      cytnx_bool *des = (cytnx_bool *)malloc(in->cap * sizeof(cytnx_bool));
-      cytnx_bool *src = static_cast<cytnx_bool *>(in->Mem);
-
-#ifdef UNI_OMP
-      std::vector<std::vector<cytnx_uint64>> old_inds;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0)
-          old_inds = std::vector<std::vector<cytnx_uint64>>(
-            omp_get_num_threads(), std::vector<cytnx_uint64>(old_shape.size()));
-      }
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        cytnx_uint64 j;
-        cytnx_uint64 old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[omp_get_thread_num()][j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[omp_get_thread_num()][mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-
-#else
-      std::vector<cytnx_uint64> old_inds(old_shape.size());
-      cytnx_uint64 j, old_loc;
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-#endif
-
-      boost::intrusive_ptr<Storage_base> out(new BoolStorage());
-      if (is_inplace) {
-        memcpy(in->Mem, des, sizeof(cytnx_bool) * accu_old);
-        free(des);
-        return out;
-      } else {
-        out->_Init_byptr(des, accu_old, in->device, true, in->cap);
-        return out;
-      }
-    }
+    template boost::intrusive_ptr<Storage_base> MoveMemoryCpu<cytnx_complex128>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, const bool is_inplace);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryCpu<cytnx_complex64>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, const bool is_inplace);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryCpu<cytnx_double>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, const bool is_inplace);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryCpu<cytnx_float>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, const bool is_inplace);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryCpu<cytnx_uint64>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, const bool is_inplace);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryCpu<cytnx_int64>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, const bool is_inplace);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryCpu<cytnx_uint32>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, const bool is_inplace);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryCpu<cytnx_int32>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, const bool is_inplace);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryCpu<cytnx_uint16>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, const bool is_inplace);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryCpu<cytnx_int16>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, const bool is_inplace);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryCpu<cytnx_bool>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, const bool is_inplace);
 
   }  // namespace utils_internal
 }  // namespace cytnx

--- a/src/backend/utils_internal_cpu/Movemem_cpu.hpp
+++ b/src/backend/utils_internal_cpu/Movemem_cpu.hpp
@@ -1,80 +1,30 @@
-#ifndef _H_Movemem_cpu_
-#define _H_Movemem_cpu_
+#ifndef SRC_BACKEND_UTILS_INTERNAL_CPU_MOVEMEM_CPU_H_
+#define SRC_BACKEND_UTILS_INTERNAL_CPU_MOVEMEM_CPU_H_
 
-#include <cstdio>
-#include <cstdlib>
-#include <stdint.h>
-#include <climits>
-#include "Type.hpp"
+#include <type_traits>
+#include <vector>
+
+#include "boost/smart_ptr/intrusive_ptr.hpp"
+
 #include "backend/Storage.hpp"
-#include "cytnx_error.hpp"
+#include "Type.hpp"
 
 namespace cytnx {
   namespace utils_internal {
 
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_cd(boost::intrusive_ptr<Storage_base> &in,
-                                                      const std::vector<cytnx_uint64> &old_shape,
-                                                      const std::vector<cytnx_uint64> &mapper,
-                                                      const std::vector<cytnx_uint64> &invmapper,
-                                                      const bool is_inplace);
-
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_cf(boost::intrusive_ptr<Storage_base> &in,
-                                                      const std::vector<cytnx_uint64> &old_shape,
-                                                      const std::vector<cytnx_uint64> &mapper,
-                                                      const std::vector<cytnx_uint64> &invmapper,
-                                                      const bool is_inplace);
-
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_d(boost::intrusive_ptr<Storage_base> &in,
+    template <typename T, typename std::enable_if_t<!std::is_integral_v<T>, bool> = true>
+    boost::intrusive_ptr<Storage_base> MoveMemoryCpu(boost::intrusive_ptr<Storage_base> &in,
                                                      const std::vector<cytnx_uint64> &old_shape,
                                                      const std::vector<cytnx_uint64> &mapper,
                                                      const std::vector<cytnx_uint64> &invmapper,
                                                      const bool is_inplace);
 
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_f(boost::intrusive_ptr<Storage_base> &in,
-                                                     const std::vector<cytnx_uint64> &old_shape,
-                                                     const std::vector<cytnx_uint64> &mapper,
-                                                     const std::vector<cytnx_uint64> &invmapper,
-                                                     const bool is_inplace);
-
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_i64(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace);
-
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_u64(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace);
-
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_i32(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace);
-
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_u32(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace);
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_i16(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace);
-
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_u16(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace);
-    boost::intrusive_ptr<Storage_base> Movemem_cpu_b(boost::intrusive_ptr<Storage_base> &in,
+    template <typename T, typename std::enable_if_t<std::is_integral_v<T>, bool> = true>
+    boost::intrusive_ptr<Storage_base> MoveMemoryCpu(boost::intrusive_ptr<Storage_base> &in,
                                                      const std::vector<cytnx_uint64> &old_shape,
                                                      const std::vector<cytnx_uint64> &mapper,
                                                      const std::vector<cytnx_uint64> &invmapper,
                                                      const bool is_inplace);
   }  // namespace utils_internal
 }  // namespace cytnx
-#endif
+#endif  // SRC_BACKEND_UTILS_INTERNAL_CPU_MOVEMEM_CPU_H_

--- a/src/backend/utils_internal_gpu/cuMovemem_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuMovemem_gpu.cu
@@ -1,8 +1,15 @@
 #include "cuMovemem_gpu.hpp"
-#include "cuAlloc_gpu.hpp"
-#include "backend/Storage.hpp"
+
 #include <algorithm>
-#include "utils/vec_print.hpp"
+#include <vector>
+#include <type_traits>
+
+#include "boost/smart_ptr/intrusive_ptr.hpp"
+#include "cuda_runtime_api.h"
+
+#include "backend/Storage.hpp"
+#include "cuAlloc_gpu.hpp"
+#include "Type.hpp"
 
 #ifdef UNI_GPU
   #ifdef UNI_CUTT
@@ -21,6 +28,28 @@ namespace cytnx {
   namespace utils_internal {
 
 #ifdef UNI_GPU
+
+    /**
+     * A helper class that retrieves corresponding complex type defined in CUDA for the complex
+     * dtype.
+     */
+    template <class DType>
+    struct ToCudaTypeMap {
+      typedef DType type;
+    };
+
+    template <>
+    struct ToCudaTypeMap<cytnx_complex128> {
+      typedef cuDoubleComplex type;
+    };
+    template <>
+    struct ToCudaTypeMap<cytnx_complex64> {
+      typedef cuFloatComplex type;
+    };
+
+    template <class DType>
+    using ToCudaType = typename ToCudaTypeMap<DType>::type;
+
     template <class BidirectionalIterator>
     void reverse_perm(BidirectionalIterator first, BidirectionalIterator last, int N) {
       while ((first != last) && (first != --last)) {
@@ -70,11 +99,12 @@ namespace cytnx {
 
     // T is the cytnx type, cuT is the cuda type. For all types they should be the same except for
     // cuDoubleComplex and cuFloatComplex.
-    template <class T, class cuT>
+    template <class T>
     boost::intrusive_ptr<Storage_base> cuMovemem_gpu_general(
       boost::intrusive_ptr<Storage_base> &in, const std::vector<cytnx_uint64> &old_shape,
       const std::vector<cytnx_uint64> &mapper, const std::vector<cytnx_uint64> &invmapper,
       const bool is_inplace) {
+      using cuT = ToCudaType<T>;
       T proxy;
       unsigned int dtype_T = Type_class::cy_typeid(proxy);
   #ifdef UNI_DEBUG
@@ -151,11 +181,12 @@ namespace cytnx {
     }
 
   #ifdef UNI_CUTT
-    template <class T, class cuT>
+    template <class T>
     boost::intrusive_ptr<Storage_base> cuMovemem_cutt_gpu(
       boost::intrusive_ptr<Storage_base> &in, const std::vector<cytnx_uint64> &old_shape,
       const std::vector<cytnx_uint64> &mapper, const std::vector<cytnx_uint64> &invmapper,
       const bool is_inplace) {
+      using cuT = ToCudaType<T>;
       T proxy;
       unsigned int dtype_T = Type_class::cy_typeid(proxy);
     #ifdef UNI_DEBUG
@@ -195,14 +226,14 @@ namespace cytnx {
   #endif
 
   #ifdef UNI_CUTENSOR
-    template <class T, class cuT>  // T: cpu type, cuT: gpu type, cutnT: cntensor type
+    template <class DType>
     boost::intrusive_ptr<Storage_base> cuMovemem_cutensor_gpu(
       boost::intrusive_ptr<Storage_base> &in, const std::vector<cytnx_uint64> &old_shape,
       const std::vector<cytnx_uint64> &mapper, const std::vector<cytnx_uint64> &invmapper,
-      const bool is_inplace, cutensorDataType_t type_in, cutensorDataType_t type_out,
-      const cutensorComputeDescriptor_t descCompute, const cuT &ONE) {
-      T proxy;
-      unsigned int dtype_T = Type_class::cy_typeid(proxy);
+      const bool is_inplace) {
+      using CudaType = ToCudaType<DType>;
+
+      unsigned int dtype_T = Type_class::cy_typeid(DType());
     #ifdef UNI_DEBUG
       cytnx_error_msg(
         in->dtype != dtype_T,
@@ -212,8 +243,7 @@ namespace cytnx {
                       "[DEBUG][internal error] in.device is on cpu but all cuda function.");
     #endif
 
-      cuT *dtmp;
-      dtmp = (cuT *)cuMalloc_gpu(sizeof(cuT) * in->cap);
+      CudaType *dtmp = reinterpret_cast<CudaType *>(cuMalloc_gpu(sizeof(CudaType) * in->cap));
       cytnx_uint64 Nelem = in->len;
 
       std::vector<int> perm(mapper.begin(), mapper.end());
@@ -230,6 +260,27 @@ namespace cytnx {
       std::reverse(new_size.begin(), new_size.end());  // matching API
       std::reverse(ori.begin(), ori.end());  // matching API
 
+      cutensorDataType_t cutensor_data_type;
+      cutensorComputeDescriptor_t compute_descriptor;
+      CudaType one;
+      if constexpr (std::is_same_v<cytnx_complex128, DType>) {
+        cutensor_data_type = CUTENSOR_C_64F;
+        compute_descriptor = CUTENSOR_COMPUTE_DESC_64F;
+        one = make_cuDoubleComplex(1, 0);
+      } else if constexpr (std::is_same_v<cytnx_complex64, DType>) {
+        cutensor_data_type = CUTENSOR_C_32F;
+        compute_descriptor = CUTENSOR_COMPUTE_DESC_32F;
+        one = make_cuFloatComplex(1, 0);
+      } else if constexpr (std::is_same_v<cytnx_double, DType>) {
+        cutensor_data_type = CUTENSOR_R_64F;
+        compute_descriptor = CUTENSOR_COMPUTE_DESC_64F;
+        one = 1;
+      } else if constexpr (std::is_same_v<cytnx_float, DType>) {
+        cutensor_data_type = CUTENSOR_R_32F;
+        compute_descriptor = CUTENSOR_COMPUTE_DESC_32F;
+        one = 1;
+      }
+
       cutensorHandle_t handle;
       checkCudaErrors(cutensorCreate(&handle));
 
@@ -238,16 +289,17 @@ namespace cytnx {
       cytnx_uint64 defaultAlignment = 256;
       cutensorTensorDescriptor_t descA;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descA, size.size(), size.data(),
-                                                     NULL /* stride */, type_in, defaultAlignment));
+                                                     NULL /* stride */, cutensor_data_type,
+                                                     defaultAlignment));
 
       cutensorTensorDescriptor_t descC;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descC, new_size.size(),
-                                                     new_size.data(), NULL /* stride */, type_out,
-                                                     defaultAlignment));
-      // TODO: verify the type of ONE matches descCompute
+                                                     new_size.data(), NULL /* stride */,
+                                                     cutensor_data_type, defaultAlignment));
       cutensorOperationDescriptor_t desc;
-      checkCudaErrors(cutensorCreatePermutation(
-        handle, &desc, descA, ori.data(), CUTENSOR_OP_IDENTITY, descC, perm.data(), descCompute));
+      checkCudaErrors(cutensorCreatePermutation(handle, &desc, descA, ori.data(),
+                                                CUTENSOR_OP_IDENTITY, descC, perm.data(),
+                                                compute_descriptor));
 
       const cutensorAlgo_t algo = CUTENSOR_ALGO_DEFAULT;
 
@@ -259,7 +311,8 @@ namespace cytnx {
       checkCudaErrors(
         cutensorCreatePlan(handle, &plan, desc, planPref, 0 /* workspaceSizeLimit */));
 
-      checkCudaErrors(cutensorPermute(handle, plan, &ONE, (cuT *)in->Mem, dtmp, 0 /* stream */));
+      checkCudaErrors(cutensorPermute(handle, plan, &one, reinterpret_cast<CudaType *>(in->Mem),
+                                      dtmp, 0 /* stream */));
 
       checkCudaErrors(cutensorDestroyTensorDescriptor(descA));
       checkCudaErrors(cutensorDestroyTensorDescriptor(descC));
@@ -270,7 +323,7 @@ namespace cytnx {
       boost::intrusive_ptr<Storage_base> out = __SII.USIInit[dtype_T]();
       if (is_inplace) {
         /// cpy back:
-        checkCudaErrors(cudaMemcpy(in->Mem, dtmp, sizeof(T) * Nelem, cudaMemcpyDeviceToDevice));
+        checkCudaErrors(cudaMemcpy(in->Mem, dtmp, sizeof(DType) * Nelem, cudaMemcpyDeviceToDevice));
         cudaFree(dtmp);
         return out;
 
@@ -281,137 +334,58 @@ namespace cytnx {
     }
   #endif
 
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_cd(boost::intrusive_ptr<Storage_base> &in,
-                                                        const std::vector<cytnx_uint64> &old_shape,
-                                                        const std::vector<cytnx_uint64> &mapper,
-                                                        const std::vector<cytnx_uint64> &invmapper,
-                                                        const bool is_inplace) {
-  #ifdef UNI_CUTENSOR
-      return cuMovemem_cutensor_gpu<cytnx_complex128, cuDoubleComplex>(
-        in, old_shape, mapper, invmapper, is_inplace, CUTENSOR_C_64F, CUTENSOR_C_64F,
-        CUTENSOR_COMPUTE_DESC_64F, make_cuDoubleComplex(1, 0));
-  #elif defined(UNI_CUTT)
-      return cuMovemem_cutt_gpu<cytnx_complex128, cuDoubleComplex>(in, old_shape, mapper, invmapper,
-                                                                   is_inplace);
-  #else
-      return cuMovemem_gpu_general<cytnx_complex128, cuDoubleComplex>(in, old_shape, mapper,
-                                                                      invmapper, is_inplace);
-  #endif
-    }
-
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_cf(boost::intrusive_ptr<Storage_base> &in,
-                                                        const std::vector<cytnx_uint64> &old_shape,
-                                                        const std::vector<cytnx_uint64> &mapper,
-                                                        const std::vector<cytnx_uint64> &invmapper,
-                                                        const bool is_inplace) {
+    template <typename DType>
+    boost::intrusive_ptr<Storage_base> MoveMemoryGpu(boost::intrusive_ptr<Storage_base> &in,
+                                                     const std::vector<cytnx_uint64> &old_shape,
+                                                     const std::vector<cytnx_uint64> &mapper,
+                                                     const std::vector<cytnx_uint64> &invmapper,
+                                                     bool is_inplace) {
+      if constexpr (is_complex_v<DType> || std::is_floating_point_v<DType>) {
   #if defined(UNI_CUTENSOR)
-      return cuMovemem_cutensor_gpu<cytnx_complex64, cuFloatComplex>(
-        in, old_shape, mapper, invmapper, is_inplace, CUTENSOR_C_32F, CUTENSOR_C_32F,
-        CUTENSOR_COMPUTE_DESC_32F, make_cuFloatComplex(1, 0));
+        return cuMovemem_cutensor_gpu<DType>(in, old_shape, mapper, invmapper, is_inplace);
   #elif defined(UNI_CUTT)
-      return cuMovemem_cutt_gpu<cytnx_complex64, cuFloatComplex>(in, old_shape, mapper, invmapper,
-                                                                 is_inplace);
+        return cuMovemem_cutt_gpu<DType>(in, old_shape, mapper, invmapper, is_inplace);
   #else
-      return cuMovemem_gpu_general<cytnx_complex64, cuFloatComplex>(in, old_shape, mapper,
-                                                                    invmapper, is_inplace);
+        return cuMovemem_gpu_general<DType>(in, old_shape, mapper, invmapper, is_inplace);
   #endif
+      } else {
+        return cuMovemem_gpu_general<DType>(in, old_shape, mapper, invmapper, is_inplace);
+      }
     }
 
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_d(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace) {
-  #if defined(UNI_CUTENSOR)
-      return cuMovemem_cutensor_gpu<double, double>(in, old_shape, mapper, invmapper, is_inplace,
-                                                    CUTENSOR_R_64F, CUTENSOR_R_64F,
-                                                    CUTENSOR_COMPUTE_DESC_64F, double(1));
-  #elif defined(UNI_CUTT)
-      return cuMovemem_cutt_gpu<cytnx_double, cytnx_double>(in, old_shape, mapper, invmapper,
-                                                            is_inplace);
-  #else
-      return cuMovemem_gpu_general<cytnx_double, cytnx_double>(in, old_shape, mapper, invmapper,
-                                                               is_inplace);
-  #endif
-    }
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_f(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace) {
-  #if defined(UNI_CUTENSOR)
-      return cuMovemem_cutensor_gpu<float, float>(in, old_shape, mapper, invmapper, is_inplace,
-                                                  CUTENSOR_R_32F, CUTENSOR_R_32F,
-                                                  CUTENSOR_COMPUTE_DESC_32F, float(1));
-  #elif defined(UNI_CUTT)
-      return cuMovemem_cutt_gpu<cytnx_float, cytnx_float>(in, old_shape, mapper, invmapper,
-                                                          is_inplace);
-  #else
-      return cuMovemem_gpu_general<cytnx_float, cytnx_float>(in, old_shape, mapper, invmapper,
-                                                             is_inplace);
-  #endif
-    }
-
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_i64(boost::intrusive_ptr<Storage_base> &in,
-                                                         const std::vector<cytnx_uint64> &old_shape,
-                                                         const std::vector<cytnx_uint64> &mapper,
-                                                         const std::vector<cytnx_uint64> &invmapper,
-                                                         const bool is_inplace) {
-      return cuMovemem_gpu_general<cytnx_int64, cytnx_int64>(in, old_shape, mapper, invmapper,
-                                                             is_inplace);
-    }
-
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_u64(boost::intrusive_ptr<Storage_base> &in,
-                                                         const std::vector<cytnx_uint64> &old_shape,
-                                                         const std::vector<cytnx_uint64> &mapper,
-                                                         const std::vector<cytnx_uint64> &invmapper,
-                                                         const bool is_inplace) {
-      return cuMovemem_gpu_general<cytnx_uint64, cytnx_uint64>(in, old_shape, mapper, invmapper,
-                                                               is_inplace);
-    }
-
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_i32(boost::intrusive_ptr<Storage_base> &in,
-                                                         const std::vector<cytnx_uint64> &old_shape,
-                                                         const std::vector<cytnx_uint64> &mapper,
-                                                         const std::vector<cytnx_uint64> &invmapper,
-                                                         const bool is_inplace) {
-      return cuMovemem_gpu_general<cytnx_int32, cytnx_int32>(in, old_shape, mapper, invmapper,
-                                                             is_inplace);
-    }
-
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_u32(boost::intrusive_ptr<Storage_base> &in,
-                                                         const std::vector<cytnx_uint64> &old_shape,
-                                                         const std::vector<cytnx_uint64> &mapper,
-                                                         const std::vector<cytnx_uint64> &invmapper,
-                                                         const bool is_inplace) {
-      return cuMovemem_gpu_general<cytnx_uint32, cytnx_uint32>(in, old_shape, mapper, invmapper,
-                                                               is_inplace);
-    }
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_u16(boost::intrusive_ptr<Storage_base> &in,
-                                                         const std::vector<cytnx_uint64> &old_shape,
-                                                         const std::vector<cytnx_uint64> &mapper,
-                                                         const std::vector<cytnx_uint64> &invmapper,
-                                                         const bool is_inplace) {
-      return cuMovemem_gpu_general<cytnx_uint16, cytnx_uint16>(in, old_shape, mapper, invmapper,
-                                                               is_inplace);
-    }
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_i16(boost::intrusive_ptr<Storage_base> &in,
-                                                         const std::vector<cytnx_uint64> &old_shape,
-                                                         const std::vector<cytnx_uint64> &mapper,
-                                                         const std::vector<cytnx_uint64> &invmapper,
-                                                         const bool is_inplace) {
-      return cuMovemem_gpu_general<cytnx_int16, cytnx_int16>(in, old_shape, mapper, invmapper,
-                                                             is_inplace);
-    }
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_b(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace) {
-      return cuMovemem_gpu_general<cytnx_bool, cytnx_bool>(in, old_shape, mapper, invmapper,
-                                                           is_inplace);
-    }
-
+    template boost::intrusive_ptr<Storage_base> MoveMemoryGpu<cytnx_complex128>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, bool);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryGpu<cytnx_complex64>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, bool);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryGpu<cytnx_double>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, bool);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryGpu<cytnx_float>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, bool);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryGpu<cytnx_uint64>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, bool);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryGpu<cytnx_int64>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, bool);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryGpu<cytnx_uint32>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, bool);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryGpu<cytnx_int32>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, bool);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryGpu<cytnx_uint16>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, bool);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryGpu<cytnx_int16>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, bool);
+    template boost::intrusive_ptr<Storage_base> MoveMemoryGpu<cytnx_bool>(
+      boost::intrusive_ptr<Storage_base> &, const std::vector<cytnx_uint64> &,
+      const std::vector<cytnx_uint64> &, const std::vector<cytnx_uint64> &, bool);
 #endif  // UNI_GPU
   }  // namespace utils_internal
 }  // namespace cytnx

--- a/src/backend/utils_internal_gpu/cuMovemem_gpu.hpp
+++ b/src/backend/utils_internal_gpu/cuMovemem_gpu.hpp
@@ -1,83 +1,26 @@
-#ifndef _H_cuMovemem_gpu_
-#define _H_cuMovemem_gpu_
+#ifndef SRC_BACKEND_UTILS_INTERNAL_GPU_CUMOVEMEM_GPU_H_
+#define SRC_BACKEND_UTILS_INTERNAL_GPU_CUMOVEMEM_GPU_H_
 
-#include <cstdio>
-#include <cstdlib>
-#include <stdint.h>
-#include <climits>
-#include "Type.hpp"
+#include <type_traits>
+#include <vector>
+
+#include "boost/smart_ptr/intrusive_ptr.hpp"
+
 #include "backend/Storage.hpp"
-#include "cytnx_error.hpp"
+#include "Type.hpp"
 
 namespace cytnx {
   namespace utils_internal {
 #ifdef UNI_GPU
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_cd(boost::intrusive_ptr<Storage_base> &in,
-                                                        const std::vector<cytnx_uint64> &old_shape,
-                                                        const std::vector<cytnx_uint64> &mapper,
-                                                        const std::vector<cytnx_uint64> &invmapper,
-                                                        const bool is_inplace);
+    template <typename DType>
+    boost::intrusive_ptr<Storage_base> MoveMemoryGpu(boost::intrusive_ptr<Storage_base> &in,
+                                                     const std::vector<cytnx_uint64> &old_shape,
+                                                     const std::vector<cytnx_uint64> &mapper,
+                                                     const std::vector<cytnx_uint64> &invmapper,
+                                                     bool is_inplace);
 
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_cf(boost::intrusive_ptr<Storage_base> &in,
-                                                        const std::vector<cytnx_uint64> &old_shape,
-                                                        const std::vector<cytnx_uint64> &mapper,
-                                                        const std::vector<cytnx_uint64> &invmapper,
-                                                        const bool is_inplace);
-
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_d(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace);
-
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_f(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace);
-
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_i64(boost::intrusive_ptr<Storage_base> &in,
-                                                         const std::vector<cytnx_uint64> &old_shape,
-                                                         const std::vector<cytnx_uint64> &mapper,
-                                                         const std::vector<cytnx_uint64> &invmapper,
-                                                         const bool is_inplace);
-
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_u64(boost::intrusive_ptr<Storage_base> &in,
-                                                         const std::vector<cytnx_uint64> &old_shape,
-                                                         const std::vector<cytnx_uint64> &mapper,
-                                                         const std::vector<cytnx_uint64> &invmapper,
-                                                         const bool is_inplace);
-
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_i32(boost::intrusive_ptr<Storage_base> &in,
-                                                         const std::vector<cytnx_uint64> &old_shape,
-                                                         const std::vector<cytnx_uint64> &mapper,
-                                                         const std::vector<cytnx_uint64> &invmapper,
-                                                         const bool is_inplace);
-
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_u32(boost::intrusive_ptr<Storage_base> &in,
-                                                         const std::vector<cytnx_uint64> &old_shape,
-                                                         const std::vector<cytnx_uint64> &mapper,
-                                                         const std::vector<cytnx_uint64> &invmapper,
-                                                         const bool is_inplace);
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_u16(boost::intrusive_ptr<Storage_base> &in,
-                                                         const std::vector<cytnx_uint64> &old_shape,
-                                                         const std::vector<cytnx_uint64> &mapper,
-                                                         const std::vector<cytnx_uint64> &invmapper,
-                                                         const bool is_inplace);
-
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_i16(boost::intrusive_ptr<Storage_base> &in,
-                                                         const std::vector<cytnx_uint64> &old_shape,
-                                                         const std::vector<cytnx_uint64> &mapper,
-                                                         const std::vector<cytnx_uint64> &invmapper,
-                                                         const bool is_inplace);
-
-    boost::intrusive_ptr<Storage_base> cuMovemem_gpu_b(boost::intrusive_ptr<Storage_base> &in,
-                                                       const std::vector<cytnx_uint64> &old_shape,
-                                                       const std::vector<cytnx_uint64> &mapper,
-                                                       const std::vector<cytnx_uint64> &invmapper,
-                                                       const bool is_inplace);
 #endif
 
   }  // namespace utils_internal
 }  // namespace cytnx
-#endif
+#endif  // SRC_BACKEND_UTILS_INTERNAL_GPU_CUMOVEMEM_GPU_H_


### PR DESCRIPTION
This PR is a task listed in #500.

The `Movemem_cpu()` function has two versions of implementation. One is for integral types, the other is for the other types. Two versions may be combined into one. However, this PR only templatises them and doesn't dip into the implementations.

This PR doesn't break any test for both CPU and GPU.