### PR TITLE
Fix build issue when CUDA is enabled

### DIFF
--- a/src/Tensor.cpp
+++ b/src/Tensor.cpp
@@ -80,6 +80,34 @@ namespace cytnx {
                                     std::make_index_sequence<std::variant_size_v<pointer_types>>{});
   }
 
+  #ifdef UNI_GPU
+  template <std::size_t... Is>
+  Tensor::gpu_pointer_types gpu_void_ptr_to_variant_impl(void *p, unsigned int dtype,
+                                                         std::index_sequence<Is...>) {
+    // Lambda to select the correct type based on dtype
+    Tensor::gpu_pointer_types result;
+    (
+      [&]() {
+        if (dtype == Is) {
+          using TargetType = std::variant_alternative_t<
+            Is, typename Tensor::internal::exclude_first<Type_list_gpu>::type>;
+          result = static_cast<TargetType *>(p);
+        }
+      }(),
+      ...);  // Fold expression
+    return result;
+  }
+
+  Tensor::gpu_pointer_types Tensor::gpu_ptr() const {
+    cytnx_error_msg(this->dtype() == 0, "[ERROR] operation not allowed for empty (void) Tensor.%s",
+                    "\n");
+    // dtype()-1 here because we have removed void from the variant
+    return gpu_void_ptr_to_variant_impl(
+      this->_impl->_storage._impl->Mem, this->dtype() - 1,
+      std::make_index_sequence<std::variant_size_v<gpu_pointer_types>>{});
+  }
+  #endif  // UNI_GPU
+
   // ADD
   Tensor Tensor::Tproxy::operator+(
     const cytnx_complex128 &rc) const {  //{return this->_operatorADD(rc);};

--- a/src/linalg/Tensordot.cpp
+++ b/src/linalg/Tensordot.cpp
@@ -101,7 +101,7 @@ namespace cytnx {
       if (t == Type.Uint64 || t == Type.Int64 || t == Type.Uint32 || t == Type.Int32 ||
           t == Type.Uint16 || t == Type.Int16 || t == Type.Bool) {
         cytnx_warning_msg(true, "Unsupported data type in cuTensor: %s, use default implementation",
-                          Type.Typeinfos[Tl.dtype()].name.c_str());
+                          Type.Typeinfos[Tl.dtype()].name);
         return _Tensordot_generic(out, Tl, Tr, idxl, idxr, cacheL, cacheR);
       }
       // This works:


### PR DESCRIPTION
This PR does two things:

1. Implement missing `Tensor::gpu_ptr()` introduced in #514. There may be a smarter way to implement it, but this is just a quick fix.
2. Be consistent with the type of `Type_struct::name`: The type of `Type_struct::name` was changed to `const char*`. All instances of `Type_struct` should follow the new type definition. 