### PR TITLE
Uniform randomizing function respects given range

### DIFF
--- a/src/backend/Storage_base.cpp
+++ b/src/backend/Storage_base.cpp
@@ -547,9 +547,6 @@ namespace cytnx {
       "[ERROR] type mismatch. try to get < complex<double> > type from raw data of type %s",
       Type.getname(dtype).c_str());
 #ifdef UNI_GPU
-    cytnx_error_msg(this->device != Device.cpu, "%s",
-                    "[ERROR] the Storage is on GPU but try to get with CUDA complex type "
-                    "complex<double>. use type <cuDoubleComplex>  instead.");
     cudaDeviceSynchronize();
 #endif
     return static_cast<std::complex<double> *>(this->Mem);
@@ -562,9 +559,6 @@ namespace cytnx {
       "[ERROR] type mismatch. try to get < complex<float> > type from raw data of type %s",
       Type.getname(dtype).c_str());
 #ifdef UNI_GPU
-    cytnx_error_msg(this->device != Device.cpu, "%s",
-                    "[ERROR] the Storage is on GPU but try to get with CUDA complex type "
-                    "complex<float>. use type <cuFloatComplex>  instead.");
     cudaDeviceSynchronize();
 #endif
     return static_cast<std::complex<float> *>(this->Mem);

--- a/src/random/uniform_.cpp
+++ b/src/random/uniform_.cpp
@@ -1,17 +1,58 @@
 #include "random.hpp"
 
-#ifdef BACKEND_TORCH
-#else
+#ifndef BACKEND_TORCH
+  #include <random>
 
-  #include "../backend/random_internal_interface.hpp"
+  #include "backend/random_internal_interface.hpp"
+  #include "backend/Storage.hpp"
+  #include "Tensor.hpp"
+  #include "Type.hpp"
+  #include "UniTensor.hpp"
 
 namespace cytnx {
   namespace random {
     std::random_device __static_random_device;
 
+    /**
+     * Equivalent to low + Tin * (high - low)
+     *
+     * Adding or multiplying a tensor with the double value will change the dtype of the tensor. To
+     * keep the dtype of the tensor, we have to cast the double values before doing addition and
+     * multiplication.
+     *
+     * @param Tin A tensor of which elements are in the range of (0.0, 1.0]. For the tensor holding
+     * a complex type, both of the real part and the image part of each element are in (0.0, 1.0]
+     * @param low the lower bound of the new range
+     * @param hight the higher bound of the new range
+     */
+    void TransformToRange(Tensor &Tin, double low, double high) {
+      if (high - low != 1.0) {
+        if (Tin.dtype() == Type.ComplexDouble || Tin.dtype() == Type.Double) {
+          Tin *= (high - low);
+        } else if (Tin.dtype() == Type.ComplexFloat || Tin.dtype() == Type.Float) {
+          Tin *= cytnx_float(high - low);
+        } else {
+          assert(false);
+        }
+      }
+      if (low != 0) {
+        if (Tin.dtype() == Type.ComplexDouble) {
+          Tin += cytnx_complex128{low, low};
+        } else if (Tin.dtype() == Type.ComplexFloat) {
+          Tin += cytnx_complex64{low, low};
+        } else if (Tin.dtype() == Type.Double) {
+          Tin += low;
+        } else if (Tin.dtype() == Type.Float) {
+          Tin += cytnx_float(low);
+        } else {
+          assert(false);
+        }
+      }
+    }
+
     void uniform_(Storage &Sin, const double &low, const double &high, const unsigned int &seed) {
       cytnx_error_msg(
-        (Sin.dtype() < 1) || (Sin.dtype() > 4),
+        (!Type.is_float(Sin.dtype())),
         "[ERROR][Random.uniform_] Uniform distribution only accept real/imag floating type.%s",
         "\n");
       cytnx_error_msg(high <= low,
@@ -20,18 +61,21 @@ namespace cytnx {
         random_internal::rii.Uniform[Sin.dtype()](Sin._impl, low, high, seed);
       } else {
   #ifdef UNI_GPU
-        cytnx_error_msg(true, "[Developing.]%s", "\n");
         random_internal::rii.cuUniform[Sin.dtype()](Sin._impl, low, high, seed);
-          // Sin = low + Sin*(high-low); // we need Storage arithmetic!
-
+        // TODO: The element-wise linear algebra functions should take iterators as the arguments
+        // like `std` instead of the instances related to the Storage class. After landing that we
+        // can refactor this workaround.
+        Tensor wrapper = Tensor::from_storage(Sin);
+        TransformToRange(wrapper, low, high);
+        Sin._impl = wrapper.storage()._impl;
   #else
-        cytnx_error_msg(true, "[ERROR][uniform_] Tensor is on GPU without CUDA support.%s", "\n");
+        cytnx_error_msg(true, "[ERROR][uniform_] Storage is on GPU without CUDA support.%s", "\n");
   #endif
       }
     }
     void uniform_(Tensor &Tin, const double &low, const double &high, const unsigned int &seed) {
       cytnx_error_msg(
-        (Tin.dtype() < 1) || (Tin.dtype() > 4),
+        (!Type.is_float(Tin.dtype())),
         "[ERROR][Random.uniform_] Uniform distribution only accept real/imag floating type.%s",
         "\n");
       cytnx_error_msg(high <= low,
@@ -40,9 +84,11 @@ namespace cytnx {
         random_internal::rii.Uniform[Tin.dtype()](Tin._impl->storage()._impl, low, high, seed);
       } else {
   #ifdef UNI_GPU
-        // cytnx_error_msg(true, "[Developing]%s", "\n");
         random_internal::rii.cuUniform[Tin.dtype()](Tin._impl->storage()._impl, low, high, seed);
-          // Tin = low + Tin*(high-low);
+        // TODO: Use cublas's cublas<t>axpy() in the underlying function instead. Because
+        // modifiying the underlying function will make conflicts with the #528 pull request,
+        // leave this temporary solution here now.
+        TransformToRange(Tin, low, high);
   #else
         cytnx_error_msg(true, "[ERROR][uniform_] Tensor is on GPU without CUDA support.%s", "\n");
   #endif
@@ -61,4 +107,4 @@ namespace cytnx {
 
   }  // namespace random
 }  // namespace cytnx
-#endif
+#endif  // BACKEND_TORCH

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(
   algo_test/Hstack_test.cpp
   algo_test/Vsplit_test.cpp
   algo_test/Vstack_test.cpp
+  random_test/uniform_test.cpp
 )
 
 if(USE_CUDA)

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   algo_test/Hstack_test.cpp
   algo_test/Vsplit_test.cpp
   algo_test/Vstack_test.cpp
+  random_test/uniform_test.cpp
 )
 
 target_link_libraries(

--- a/tests/gpu/random_test/uniform_test.cpp
+++ b/tests/gpu/random_test/uniform_test.cpp
@@ -1,0 +1,117 @@
+#include <algorithm>
+#include <complex>
+#include <type_traits>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "backend/Storage.hpp"
+#include "Device.hpp"
+#include "random.hpp"
+#include "Tensor.hpp"
+#include "Type.hpp"
+
+namespace cytnx {
+
+  template <typename Container, typename T>
+  struct PushFront;
+
+  template <template <typename...> typename Container, typename T, typename... Ts>
+  struct PushFront<Container<Ts...>, T> {
+    using type = Container<Ts..., T>;
+  };
+
+  template <typename Types, template <typename> typename Predicate>
+  struct TypeFilter;
+
+  template <template <typename...> typename Container, template <typename> typename Predicate,
+            typename T>
+  struct TypeFilter<Container<T>, Predicate> {
+    using type = std::conditional_t<Predicate<T>::value, Container<T>, Container<>>;
+  };
+
+  template <template <typename...> typename Container, template <typename> typename Predicate,
+            typename T, typename... Ts>
+  struct TypeFilter<Container<T, Ts...>, Predicate> {
+    using Next = typename TypeFilter<Container<Ts...>, Predicate>::type;
+    using type = std::conditional_t<Predicate<T>::value, typename PushFront<Next, T>::type, Next>;
+  };
+
+  template <typename T>
+  struct is_floating_point_layout {
+    constexpr static bool value = Type_struct_t<T>::is_float;
+  };
+
+  template <typename From, template <typename...> typename To>
+  struct ContainerConverterHelper;
+
+  template <template <typename...> typename From, template <typename...> typename To,
+            typename... Ts>
+  struct ContainerConverterHelper<From<Ts...>, To> {
+    using type = To<Ts...>;
+  };
+
+  template <typename From, template <typename...> typename To>
+  using ContainerConverter = typename ContainerConverterHelper<From, To>::type;
+
+  template <typename Dtype>
+  struct MemoryLayoutHelper {
+    using type = Dtype;
+  };
+
+  template <typename ValueType>
+  struct MemoryLayoutHelper<std::complex<ValueType>> {
+    using type = ValueType;
+  };
+
+  template <typename Dtype>
+  using MemoryLayout = typename MemoryLayoutHelper<Dtype>::type;
+
+  using SupportedTypes =
+    ContainerConverter<TypeFilter<Type_list, is_floating_point_layout>::type, ::testing::Types>;
+
+  template <typename Dtype>
+  class RandomUniformGpu : public ::testing::Test {};
+
+  TYPED_TEST_SUITE(RandomUniformGpu, SupportedTypes);
+
+  using ::testing::Contains;
+  using ::testing::Ge;
+  using ::testing::Gt;
+  using ::testing::Le;
+  using ::testing::Lt;
+  using ::testing::Not;
+
+  TYPED_TEST(RandomUniformGpu, RespectGivenRange) {
+    // (2/3)^50 = 1.57e-9, so there is only a very small chance of failing this test even if giving
+    // an arbitrary seed.
+    const int kCount = 50;
+    const int kCountInValueType = is_complex_v<TypeParam> ? kCount * 2 : kCount;
+    // TODO: Stop copying after we apply c++20 or provide begin() and end() for Storage and Tensor
+    std::vector<MemoryLayout<TypeParam>> copied_numbers(kCountInValueType);
+    MemoryLayout<TypeParam>* start;
+    unsigned int dtype = Type_struct_t<TypeParam>::cy_typeid;
+
+    Storage storage(kCount, dtype, Device.cuda);
+    random::Make_uniform(storage, /*low=*/-2.0, /*high=*/5.0, /*seed=*/3);
+    // call typed data<T>() to trigger cudaDeviceSynchronize()
+    start = reinterpret_cast<MemoryLayout<TypeParam>*>(storage.data<TypeParam>());
+    std::copy(start, start + kCountInValueType, copied_numbers.begin());
+    EXPECT_THAT(copied_numbers, Contains(Le(-1.0)));
+    EXPECT_THAT(copied_numbers, Not(Contains(Lt(-2.0))));
+    EXPECT_THAT(copied_numbers, Contains(Ge(4.0)));
+    EXPECT_THAT(copied_numbers, Not(Contains(Gt(5.0))));
+
+    Tensor tensor({kCount}, dtype, Device.cuda);
+    random::Make_uniform(tensor, /*low=*/-2.0, /*high=*/5.0, /*seed=*/4);
+    // call typed data<T>() to trigger cudaDeviceSynchronize()
+    start = reinterpret_cast<MemoryLayout<TypeParam>*>(tensor.storage().data<TypeParam>());
+    std::copy(start, start + kCountInValueType, copied_numbers.begin());
+    EXPECT_THAT(copied_numbers, Contains(Le(-1.0)));
+    EXPECT_THAT(copied_numbers, Not(Contains(Lt(-2.0))));
+    EXPECT_THAT(copied_numbers, Contains(Ge(4.0)));
+    EXPECT_THAT(copied_numbers, Not(Contains(Gt(5.0))));
+  }
+
+}  // namespace cytnx

--- a/tests/random_test/uniform_test.cpp
+++ b/tests/random_test/uniform_test.cpp
@@ -1,0 +1,115 @@
+#include <algorithm>
+#include <complex>
+#include <type_traits>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "backend/Storage.hpp"
+#include "Device.hpp"
+#include "random.hpp"
+#include "Tensor.hpp"
+#include "Type.hpp"
+
+namespace cytnx {
+
+  template <typename Container, typename T>
+  struct PushFront;
+
+  template <template <typename...> typename Container, typename T, typename... Ts>
+  struct PushFront<Container<Ts...>, T> {
+    using type = Container<Ts..., T>;
+  };
+
+  template <typename Types, template <typename> typename Predicate>
+  struct TypeFilter;
+
+  template <template <typename...> typename Container, template <typename> typename Predicate,
+            typename T>
+  struct TypeFilter<Container<T>, Predicate> {
+    using type = std::conditional_t<Predicate<T>::value, Container<T>, Container<>>;
+  };
+
+  template <template <typename...> typename Container, template <typename> typename Predicate,
+            typename T, typename... Ts>
+  struct TypeFilter<Container<T, Ts...>, Predicate> {
+    using Next = typename TypeFilter<Container<Ts...>, Predicate>::type;
+    using type = std::conditional_t<Predicate<T>::value, typename PushFront<Next, T>::type, Next>;
+  };
+
+  template <typename T>
+  struct is_floating_point_layout {
+    constexpr static bool value = Type_struct_t<T>::is_float;
+  };
+
+  template <typename From, template <typename...> typename To>
+  struct ContainerConverterHelper;
+
+  template <template <typename...> typename From, template <typename...> typename To,
+            typename... Ts>
+  struct ContainerConverterHelper<From<Ts...>, To> {
+    using type = To<Ts...>;
+  };
+
+  template <typename From, template <typename...> typename To>
+  using ContainerConverter = typename ContainerConverterHelper<From, To>::type;
+
+  template <typename Dtype>
+  struct MemoryLayoutHelper {
+    using type = Dtype;
+  };
+
+  template <typename ValueType>
+  struct MemoryLayoutHelper<std::complex<ValueType>> {
+    using type = ValueType;
+  };
+
+  template <typename Dtype>
+  using MemoryLayout = typename MemoryLayoutHelper<Dtype>::type;
+
+  using SupportedTypes =
+    ContainerConverter<TypeFilter<Type_list, is_floating_point_layout>::type, ::testing::Types>;
+
+  template <typename Dtype>
+  class RandomUniform : public ::testing::Test {};
+
+  TYPED_TEST_SUITE(RandomUniform, SupportedTypes);
+
+  using ::testing::Contains;
+  using ::testing::Ge;
+  using ::testing::Gt;
+  using ::testing::Le;
+  using ::testing::Lt;
+  using ::testing::Not;
+
+  TYPED_TEST(RandomUniform, RespectGivenRange) {
+    // (2/3)^50 = 1.57e-9, so there is only a very small chance of failing this test even if giving
+    // an arbitrary seed.
+    const int kCount = 50;
+    const int kCountInValueType = is_complex_v<TypeParam> ? kCount * 2 : kCount;
+    // TODO: Stop copying after we apply c++20 or provide begin() and end() for Storage and Tensor
+    std::vector<MemoryLayout<TypeParam>> copied_numbers(kCountInValueType);
+    MemoryLayout<TypeParam>* start;
+    unsigned int dtype = Type_struct_t<TypeParam>::cy_typeid;
+
+    Storage storage(kCount, dtype, Device.cpu);
+    random::Make_uniform(storage, /*low=*/-2.0, /*high=*/5.0, /*seed=*/3);
+    start = reinterpret_cast<MemoryLayout<TypeParam>*>(storage.data<TypeParam>());
+    std::copy(start, start + kCountInValueType, copied_numbers.begin());
+    EXPECT_THAT(copied_numbers, Contains(Le(-1.0)));
+    EXPECT_THAT(copied_numbers, Not(Contains(Lt(-2.0))));
+    EXPECT_THAT(copied_numbers, Contains(Ge(4.0)));
+    EXPECT_THAT(copied_numbers, Not(Contains(Gt(5.0))));
+
+    Tensor tensor({kCount}, dtype, Device.cpu);
+    random::Make_uniform(tensor, /*low=*/-2.0, /*high=*/5.0, /*seed=*/4);
+    start = reinterpret_cast<MemoryLayout<TypeParam>*>(tensor.storage().data<TypeParam>());
+    std::copy(start, start + kCountInValueType, copied_numbers.begin());
+    EXPECT_THAT(copied_numbers, Contains(Le(-1.0)));
+    EXPECT_THAT(copied_numbers, Not(Contains(Lt(-2.0))));
+    EXPECT_THAT(copied_numbers, Contains(Ge(4.0)));
+    EXPECT_THAT(copied_numbers, Not(Contains(Gt(5.0))));
+  }
+
+}  // namespace cytnx


### PR DESCRIPTION
This change fixes the problem that the uniform random number generator ignores the given lower bound and higher bound when the view types (Storage, Tensor, and UniTensor) are assigned on the GPU.