### PR TITLE
Fix and refactor tests for Det()

### DIFF
--- a/tests/gpu/linalg_test/Det_test.cpp
+++ b/tests/gpu/linalg_test/Det_test.cpp
@@ -1,18 +1,38 @@
-#include <gtest/gtest.h>
+#include <exception>
+#include <iomanip>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #include "../test_tools.h"
+#include "Device.hpp"
+#include "Type.hpp"
 
-using namespace cytnx;
-using namespace testing;
-using namespace TestTools;
+namespace cytnx {
 
-namespace DetTest {
+  using TestTools::dtype_list;
+  using TestTools::InitTensorUniform;
 
-  static cytnx_uint64 rand_seed1, rand_seed2;
+  Tensor CalculateDeterminant(const Tensor& T);
 
-  void ExcuteDetTest(const Tensor& T);
+  cytnx_complex128 ExpectedDeterminant(const Tensor& T) {
+    return CalculateDeterminant(Type_class::is_float(T.dtype()) ? T : T.astype(Type.Double))
+      .astype(Type.ComplexDouble)
+      .at<cytnx_complex128>({0});
+  }
 
-  void ErrorTestExcute(const Tensor& T);
+  cytnx_complex128 TestingDeterminant(const Tensor& T) {
+    return linalg::Det(T).astype(Type.ComplexDouble).at<cytnx_complex128>({0});
+  }
+
+  cytnx_double Tolerance(cytnx_double testing_value) { return std::abs(testing_value) / 1.0e6; }
+
+  MATCHER_P(ComplexDoubleEq, n, ::testing::PrintToString(n) + " (of type std::complex<double>)") {
+    return ExplainMatchResult(::testing::DoubleNear(n.real(), Tolerance(arg.real())), arg.real(),
+                              result_listener) &&
+           ExplainMatchResult(::testing::DoubleNear(n.imag(), Tolerance(arg.imag())), arg.imag(),
+                              result_listener);
+  }
 
   /*=====test info=====
   describe:Test all possible data type and check the results.
@@ -20,58 +40,54 @@ namespace DetTest {
     T:Tensor with shape {6, 6} or {2, 2}, {1, 1}, {3, 3}, {4, 4} and test for all
   possilbe data type.
   ====================*/
-  TEST(Det, allDType) {
-    for (auto device : device_list) {
-      for (auto dtype : dtype_list) {
-        // The GPU version of Det is just too slow.
-        // So we lower the size of the tensor from 6,6 to 3,3.
-        Tensor T = Tensor({3, 3}, dtype, device);
-        InitTensorUniform(T, rand_seed1 = 3);
-        ExcuteDetTest(T);
+  TEST(DetGpu, HandleAllDtype) {
+    for (auto dtype : dtype_list) {
+      Tensor T = Tensor({6, 6}, dtype, Device.cuda);
+      InitTensorUniform(T, /*rand_seed=*/3);
+      EXPECT_THAT(TestingDeterminant(T), ComplexDoubleEq(ExpectedDeterminant(T))) << T;
 
-        T = Tensor({2, 2}, dtype, device);
-        InitTensorUniform(T, rand_seed1 = 3);
-        ExcuteDetTest(T);
+      T = Tensor({2, 2}, dtype, Device.cuda);
+      InitTensorUniform(T, /*rand_seed=*/3);
+      EXPECT_THAT(TestingDeterminant(T), ComplexDoubleEq(ExpectedDeterminant(T))) << T;
 
-        T = Tensor({1, 1}, dtype, device);
-        InitTensorUniform(T, rand_seed1 = 3);
-        ExcuteDetTest(T);
+      T = Tensor({1, 1}, dtype, Device.cuda);
+      InitTensorUniform(T, /*rand_seed=*/3);
+      EXPECT_THAT(TestingDeterminant(T), ComplexDoubleEq(ExpectedDeterminant(T))) << T;
 
-        T = Tensor({3, 3}, dtype, device);
-        InitTensorUniform(T, rand_seed1 = 3);
-        ExcuteDetTest(T);
+      T = Tensor({3, 3}, dtype, Device.cuda);
+      InitTensorUniform(T, /*rand_seed=*/3);
+      EXPECT_THAT(TestingDeterminant(T), ComplexDoubleEq(ExpectedDeterminant(T))) << T;
 
-        T = Tensor({4, 4}, dtype, device);
-        InitTensorUniform(T, rand_seed1 = 3);
-        ExcuteDetTest(T);
-      }
+      T = Tensor({4, 4}, dtype, Device.cuda);
+      InitTensorUniform(T, /*rand_seed=*/3);
+      EXPECT_THAT(TestingDeterminant(T), ComplexDoubleEq(ExpectedDeterminant(T))) << T;
     }
   }
 
   /*=====test info=====
   describe:Test the tensor only 1 have one element. Test for all possible data type.
   input:
-    T:Tensor with shape {1} on cpu, testing for all possible data type.
+    T:Tensor with shape {1} on the GPU, testing for all possible data type.
   ====================*/
-  TEST(Det, one_elem_tens) {
+  TEST(DetGpu, HandleSingleElementTensor) {
     for (auto dtype : dtype_list) {
-      Tensor T = Tensor({1, 1}, dtype);
-      InitTensorUniform(T, rand_seed1 = 3);
-      ExcuteDetTest(T);
+      Tensor T = Tensor({1, 1}, dtype, Device.cuda);
+      InitTensorUniform(T, /*rand_seed=*/6);
+      EXPECT_THAT(TestingDeterminant(T), ComplexDoubleEq(ExpectedDeterminant(T))) << T;
     }
   }
 
   /*=====test info=====
   describe:Test for not contiguous tensor.
   input:
-    T:Double data type not contiguous tensor with shape {9,9} on cpu.
+    T:Double data type not contiguous tensor with shape {9,9} on the GPU.
   ====================*/
-  TEST(Det, not_contiguous) {
-    Tensor T = Tensor({9, 9}, Type.Double);
-    InitTensorUniform(T, rand_seed1 = 1);
+  TEST(DetGpu, HandleNotContiguous) {
+    Tensor T = Tensor({9, 9}, Type.Double, Device.cuda);
+    InitTensorUniform(T, /*rand_seed=*/1);
     // permute then they will not contiguous
     T.permute_({1, 0});  // shape:[9,9]
-    ExcuteDetTest(T);
+    EXPECT_THAT(TestingDeterminant(T), ComplexDoubleEq(ExpectedDeterminant(T))) << T;
   }
 
   // error test
@@ -80,31 +96,34 @@ namespace DetTest {
   input:
     T:void tensor
   ====================*/
-  TEST(Det, err_void_tens) {
+  TEST(DetGpu, ThrowsOnNonInitializedTensor) {
     Tensor T = Tensor();
-    ErrorTestExcute(T);
+    EXPECT_THROW(linalg::Det(T), std::logic_error);
   }
 
   /*=====test info=====
   describe:Test contains shared axis of the tensors are not same.
   input:
-    T:double type tensor with shape {2, 3} on cpu.
+    T:double type tensor with shape {2, 3} on the GPU.
   ====================*/
-  TEST(Det, err_axis_dim_wrong) {
-    Tensor T = Tensor({2, 3});
-    InitTensorUniform(T, rand_seed1 = 0);
-    ErrorTestExcute(T);
+  TEST(DetGpu, ThrowsOnNonSquareTensor) {
+    Tensor T = Tensor({2, 3}, Type.Double, Device.cuda);
+    InitTensorUniform(T, /*rand_seed=*/0);
+    EXPECT_THROW(linalg::Det(T), std::logic_error);
   }
 
-  Tensor ConstructExpectTens(const Tensor& T) {
-    Tensor dst_T = zeros(1, T.dtype(), T.device());
-    int n = T.shape()[0];
+  Tensor CalculateDeterminant(const Tensor& T) {
+    // Regardless of whether the input tensor is on the GPU or CPU, the result tensor of Det is
+    // always on the CPU, so we always initialize `determinant` on the CPU to avoid the error of
+    // adding two tensors on different devices.
+    Tensor determinant = zeros(1, T.dtype(), Device.cpu);
+    size_t n = T.shape()[0];
     if (n == 1) {
-      dst_T.at({0}) = T.at({0, 0});
-      return dst_T;
+      determinant.at({0}) = T.at({0, 0});
+      return determinant;
     } else if (n == 2) {
-      dst_T.at({0}) = T.at({0, 0}) * T.at({1, 1}) - T.at({0, 1}) * T.at({1, 0});
-      return dst_T;
+      determinant.at({0}) = T.at({0, 0}) * T.at({1, 1}) - T.at({0, 1}) * T.at({1, 0});
+      return determinant;
     }
     for (cytnx_uint64 a = 0; a < n; a++) {
       Tensor T2 = zeros({T.shape()[0] - 1, T.shape()[1] - 1}, T.dtype(), T.device());
@@ -115,34 +134,9 @@ namespace DetTest {
           T2.at({i, j}) = T.at({ii, jj});
         }
       }
-      dst_T({0}) += (a % 2 == 0 ? 1 : -1) * T.at({0, a}) * ConstructExpectTens(T2);
+      determinant({0}) += (a % 2 == 0 ? 1 : -1) * T.at({0, a}) * linalg::Det(T2);
     }
-    return dst_T;
+    return determinant;
   }
 
-  void ExcuteDetTest(const Tensor& T) {
-    Tensor det_T = linalg::Det(T);
-    Tensor expect_T;
-    expect_T =
-      ConstructExpectTens(T.dtype() > 4 ? T.astype(Type.Double).to(-1) : T.to(-1)).to(T.device());
-    const double tolerance =
-      std::pow(10.0, std::max((int)std::abs(std::log10(det_T(0).item<cytnx_double>())) - 6, 0));
-    // Because the determinant will be casted to at least double, so we just cast the result to
-    // ComplexDouble for comparison.
-    EXPECT_TRUE(AreNearlyEqTensor(det_T.astype(Type.ComplexDouble),
-                                  expect_T.astype(Type.ComplexDouble), tolerance));
-  }
-
-  void ErrorTestExcute(const Tensor& T) {
-    try {
-      auto dirsum_T = linalg::Det(T);
-      std::cerr << "[Test Error] This test should throw error but not !" << std::endl;
-      FAIL();
-    } catch (const std::exception& ex) {
-      auto err_msg = ex.what();
-      std::cerr << err_msg << std::endl;
-      SUCCEED();
-    }
-  }
-
-}  // namespace DetTest
+}  // namespace cytnx

--- a/tests/gpu/linalg_test/Det_test.cpp
+++ b/tests/gpu/linalg_test/Det_test.cpp
@@ -6,6 +6,7 @@
 
 #include "../test_tools.h"
 #include "Device.hpp"
+#include "linalg.hpp"
 #include "Type.hpp"
 
 namespace cytnx {

--- a/tests/gpu/linalg_test/Det_test.cpp
+++ b/tests/gpu/linalg_test/Det_test.cpp
@@ -13,7 +13,32 @@ namespace cytnx {
   using TestTools::dtype_list;
   using TestTools::InitTensorUniform;
 
-  Tensor CalculateDeterminant(const Tensor& T);
+  Tensor CalculateDeterminant(const Tensor& T) {
+    // Regardless of whether the input tensor is on the GPU or CPU, the result tensor of Det is
+    // always on the CPU, so we always initialize `determinant` on the CPU to avoid the error of
+    // adding two tensors on different devices.
+    Tensor determinant = zeros(1, T.dtype(), Device.cpu);
+    size_t n = T.shape()[0];
+    if (n == 1) {
+      determinant.at({0}) = T.at({0, 0});
+      return determinant;
+    } else if (n == 2) {
+      determinant.at({0}) = T.at({0, 0}) * T.at({1, 1}) - T.at({0, 1}) * T.at({1, 0});
+      return determinant;
+    }
+    for (cytnx_uint64 a = 0; a < n; a++) {
+      Tensor T2 = zeros({T.shape()[0] - 1, T.shape()[1] - 1}, T.dtype(), T.device());
+      for (cytnx_uint64 i = 0; i < n - 1; i++) {
+        for (cytnx_uint64 j = 0; j < n - 1; j++) {
+          cytnx_uint64 ii = i + (i >= 0);
+          cytnx_uint64 jj = j + (j >= a);
+          T2.at({i, j}) = T.at({ii, jj});
+        }
+      }
+      determinant({0}) += (a % 2 == 0 ? 1 : -1) * T.at({0, a}) * linalg::Det(T2);
+    }
+    return determinant;
+  }
 
   cytnx_complex128 ExpectedDeterminant(const Tensor& T) {
     return CalculateDeterminant(Type_class::is_float(T.dtype()) ? T : T.astype(Type.Double))
@@ -110,33 +135,6 @@ namespace cytnx {
     Tensor T = Tensor({2, 3}, Type.Double, Device.cuda);
     InitTensorUniform(T, /*rand_seed=*/0);
     EXPECT_THROW(linalg::Det(T), std::logic_error);
-  }
-
-  Tensor CalculateDeterminant(const Tensor& T) {
-    // Regardless of whether the input tensor is on the GPU or CPU, the result tensor of Det is
-    // always on the CPU, so we always initialize `determinant` on the CPU to avoid the error of
-    // adding two tensors on different devices.
-    Tensor determinant = zeros(1, T.dtype(), Device.cpu);
-    size_t n = T.shape()[0];
-    if (n == 1) {
-      determinant.at({0}) = T.at({0, 0});
-      return determinant;
-    } else if (n == 2) {
-      determinant.at({0}) = T.at({0, 0}) * T.at({1, 1}) - T.at({0, 1}) * T.at({1, 0});
-      return determinant;
-    }
-    for (cytnx_uint64 a = 0; a < n; a++) {
-      Tensor T2 = zeros({T.shape()[0] - 1, T.shape()[1] - 1}, T.dtype(), T.device());
-      for (cytnx_uint64 i = 0; i < n - 1; i++) {
-        for (cytnx_uint64 j = 0; j < n - 1; j++) {
-          cytnx_uint64 ii = i + (i >= 0);
-          cytnx_uint64 jj = j + (j >= a);
-          T2.at({i, j}) = T.at({ii, jj});
-        }
-      }
-      determinant({0}) += (a % 2 == 0 ? 1 : -1) * T.at({0, a}) * linalg::Det(T2);
-    }
-    return determinant;
   }
 
 }  // namespace cytnx

--- a/tests/linalg_test/Det_test.cpp
+++ b/tests/linalg_test/Det_test.cpp
@@ -6,6 +6,7 @@
 
 #include "../test_tools.h"
 #include "Device.hpp"
+#include "linalg.hpp"
 #include "Type.hpp"
 
 namespace cytnx {

--- a/tests/linalg_test/Det_test.cpp
+++ b/tests/linalg_test/Det_test.cpp
@@ -1,18 +1,38 @@
-#include <gtest/gtest.h>
+#include <exception>
+#include <iomanip>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #include "../test_tools.h"
+#include "Device.hpp"
+#include "Type.hpp"
 
-using namespace cytnx;
-using namespace testing;
-using namespace TestTools;
+namespace cytnx {
 
-namespace DetTest {
+  using TestTools::dtype_list;
+  using TestTools::InitTensorUniform;
 
-  static cytnx_uint64 rand_seed1, rand_seed2;
+  Tensor CalculateDeterminant(const Tensor& T);
 
-  void ExcuteDetTest(const Tensor& T);
+  cytnx_complex128 ExpectedDeterminant(const Tensor& T) {
+    return CalculateDeterminant(Type_class::is_float(T.dtype()) ? T : T.astype(Type.Double))
+      .astype(Type.ComplexDouble)
+      .at<cytnx_complex128>({0});
+  }
 
-  void ErrorTestExcute(const Tensor& T);
+  cytnx_complex128 TestingDeterminant(const Tensor& T) {
+    return linalg::Det(T).astype(Type.ComplexDouble).at<cytnx_complex128>({0});
+  }
+
+  cytnx_double Tolerance(cytnx_double testing_value) { return std::abs(testing_value) / 1.0e6; }
+
+  MATCHER_P(ComplexDoubleEq, n, ::testing::PrintToString(n) + " (of type std::complex<double>)") {
+    return ExplainMatchResult(::testing::DoubleNear(n.real(), Tolerance(arg.real())), arg.real(),
+                              result_listener) &&
+           ExplainMatchResult(::testing::DoubleNear(n.imag(), Tolerance(arg.imag())), arg.imag(),
+                              result_listener);
+  }
 
   /*=====test info=====
   describe:Test all possible data type and check the results.
@@ -20,56 +40,54 @@ namespace DetTest {
     T:Tensor with shape {6, 6} or {2, 2}, {1, 1}, {3, 3}, {4, 4} and test for all
   possilbe data type.
   ====================*/
-  TEST(Det, allDType) {
-    for (auto device : device_list) {  // now only test for cpu device.
-      for (auto dtype : dtype_list) {
-        Tensor T = Tensor({6, 6}, dtype, device);
-        InitTensorUniform(T, rand_seed1 = 3);
-        ExcuteDetTest(T);
+  TEST(Det, HandleAllDtype) {
+    for (auto dtype : dtype_list) {
+      Tensor T = Tensor({6, 6}, dtype, Device.cpu);
+      InitTensorUniform(T, /*rand_seed=*/3);
+      EXPECT_THAT(TestingDeterminant(T), ComplexDoubleEq(ExpectedDeterminant(T))) << T;
 
-        T = Tensor({2, 2}, dtype, device);
-        InitTensorUniform(T, rand_seed1 = 3);
-        ExcuteDetTest(T);
+      T = Tensor({2, 2}, dtype, Device.cpu);
+      InitTensorUniform(T, /*rand_seed=*/3);
+      EXPECT_THAT(TestingDeterminant(T), ComplexDoubleEq(ExpectedDeterminant(T))) << T;
 
-        T = Tensor({1, 1}, dtype, device);
-        InitTensorUniform(T, rand_seed1 = 3);
-        ExcuteDetTest(T);
+      T = Tensor({1, 1}, dtype, Device.cpu);
+      InitTensorUniform(T, /*rand_seed=*/3);
+      EXPECT_THAT(TestingDeterminant(T), ComplexDoubleEq(ExpectedDeterminant(T))) << T;
 
-        T = Tensor({3, 3}, dtype, device);
-        InitTensorUniform(T, rand_seed1 = 3);
-        ExcuteDetTest(T);
+      T = Tensor({3, 3}, dtype, Device.cpu);
+      InitTensorUniform(T, /*rand_seed=*/3);
+      EXPECT_THAT(TestingDeterminant(T), ComplexDoubleEq(ExpectedDeterminant(T))) << T;
 
-        T = Tensor({4, 4}, dtype, device);
-        InitTensorUniform(T, rand_seed1 = 3);
-        ExcuteDetTest(T);
-      }
+      T = Tensor({4, 4}, dtype, Device.cpu);
+      InitTensorUniform(T, /*rand_seed=*/3);
+      EXPECT_THAT(TestingDeterminant(T), ComplexDoubleEq(ExpectedDeterminant(T))) << T;
     }
   }
 
   /*=====test info=====
   describe:Test the tensor only 1 have one element. Test for all possible data type.
   input:
-    T:Tensor with shape {1} on cpu, testing for all possible data type.
+    T:Tensor with shape {1} on the CPU, testing for all possible data type.
   ====================*/
-  TEST(Det, one_elem_tens) {
+  TEST(Det, HandleSingleElementTensor) {
     for (auto dtype : dtype_list) {
-      Tensor T = Tensor({1, 1}, dtype);
-      InitTensorUniform(T, rand_seed1 = 3);
-      ExcuteDetTest(T);
+      Tensor T = Tensor({1, 1}, dtype, Device.cpu);
+      InitTensorUniform(T, /*rand_seed=*/6);
+      EXPECT_THAT(TestingDeterminant(T), ComplexDoubleEq(ExpectedDeterminant(T))) << T;
     }
   }
 
   /*=====test info=====
   describe:Test for not contiguous tensor.
   input:
-    T:Double data type not contiguous tensor with shape {9,9} on cpu.
+    T:Double data type not contiguous tensor with shape {9,9} on the CPU.
   ====================*/
-  TEST(Det, not_contiguous) {
-    Tensor T = Tensor({9, 9}, Type.Double);
-    InitTensorUniform(T, rand_seed1 = 1);
+  TEST(Det, HandleNotContiguous) {
+    Tensor T = Tensor({9, 9}, Type.Double, Device.cpu);
+    InitTensorUniform(T, /*rand_seed=*/1);
     // permute then they will not contiguous
     T.permute_({1, 0});  // shape:[9,9]
-    ExcuteDetTest(T);
+    EXPECT_THAT(TestingDeterminant(T), ComplexDoubleEq(ExpectedDeterminant(T))) << T;
   }
 
   // error test
@@ -78,31 +96,34 @@ namespace DetTest {
   input:
     T:void tensor
   ====================*/
-  TEST(Det, err_void_tens) {
+  TEST(Det, ThrowsOnNonInitializedTensor) {
     Tensor T = Tensor();
-    ErrorTestExcute(T);
+    EXPECT_THROW(linalg::Det(T), std::logic_error);
   }
 
   /*=====test info=====
   describe:Test contains shared axis of the tensors are not same.
   input:
-    T:double type tensor with shape {2, 3} on cpu.
+    T:double type tensor with shape {2, 3} on the CPU.
   ====================*/
-  TEST(Det, err_axis_dim_wrong) {
-    Tensor T = Tensor({2, 3});
-    InitTensorUniform(T, rand_seed1 = 0);
-    ErrorTestExcute(T);
+  TEST(Det, ThrowsOnNonSquareTensor) {
+    Tensor T = Tensor({2, 3}, Type.Double, Device.cpu);
+    InitTensorUniform(T, /*rand_seed=*/0);
+    EXPECT_THROW(linalg::Det(T), std::logic_error);
   }
 
-  Tensor ConstructExpectTens(const Tensor& T) {
-    Tensor dst_T = zeros(1, T.dtype(), T.device());
-    int n = T.shape()[0];
+  Tensor CalculateDeterminant(const Tensor& T) {
+    // Regardless of whether the input tensor is on the CPU or CPU, the result tensor of Det is
+    // always on the CPU, so we always initialize `determinant` on the CPU to avoid the error of
+    // adding two tensors on different devices.
+    Tensor determinant = zeros(1, T.dtype(), Device.cpu);
+    size_t n = T.shape()[0];
     if (n == 1) {
-      dst_T.at({0}) = T.at({0, 0});
-      return dst_T;
+      determinant.at({0}) = T.at({0, 0});
+      return determinant;
     } else if (n == 2) {
-      dst_T.at({0}) = T.at({0, 0}) * T.at({1, 1}) - T.at({0, 1}) * T.at({1, 0});
-      return dst_T;
+      determinant.at({0}) = T.at({0, 0}) * T.at({1, 1}) - T.at({0, 1}) * T.at({1, 0});
+      return determinant;
     }
     for (cytnx_uint64 a = 0; a < n; a++) {
       Tensor T2 = zeros({T.shape()[0] - 1, T.shape()[1] - 1}, T.dtype(), T.device());
@@ -113,33 +134,9 @@ namespace DetTest {
           T2.at({i, j}) = T.at({ii, jj});
         }
       }
-      dst_T({0}) += (a % 2 == 0 ? 1 : -1) * T.at({0, a}) * ConstructExpectTens(T2);
+      determinant({0}) += (a % 2 == 0 ? 1 : -1) * T.at({0, a}) * linalg::Det(T2);
     }
-    return dst_T;
+    return determinant;
   }
 
-  void ExcuteDetTest(const Tensor& T) {
-    Tensor det_T = linalg::Det(T);
-    Tensor expect_T;
-    expect_T = ConstructExpectTens(T.dtype() > 4 ? T.astype(Type.Double) : T);
-    const double tolerance =
-      std::pow(10.0, std::max((int)std::abs(std::log10(det_T(0).item<cytnx_double>())) - 6, 0));
-    // Because the determinant will be casted to at least double, so we just cast the result to
-    // ComplexDouble for comparison.
-    EXPECT_TRUE(AreNearlyEqTensor(det_T.astype(Type.ComplexDouble),
-                                  expect_T.astype(Type.ComplexDouble), tolerance));
-  }
-
-  void ErrorTestExcute(const Tensor& T) {
-    try {
-      auto dirsum_T = linalg::Det(T);
-      std::cerr << "[Test Error] This test should throw error but not !" << std::endl;
-      FAIL();
-    } catch (const std::exception& ex) {
-      auto err_msg = ex.what();
-      std::cerr << err_msg << std::endl;
-      SUCCEED();
-    }
-  }
-
-}  // namespace DetTest
+}  // namespace cytnx


### PR DESCRIPTION
Changes:

1. Set the tolerence to 1e-6 * expected_value
2. Used EXPECT_THAT and matchers to provide better error messages
3. Renamed the tests to follow the rules of gtest: do not use "_" on the name of the test

The failed tests will pass after merging #533.