### PR TITLE
Add macos platform in BuildAndTest workflow.

### DIFF
--- a/.github/workflows/ci-cmake_pytests.yml
+++ b/.github/workflows/ci-cmake_pytests.yml
@@ -5,7 +5,11 @@ on:
 
 jobs:
   BuildAndTest:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
     defaults:
       run:

--- a/.github/workflows/ci-cmake_pytests.yml
+++ b/.github/workflows/ci-cmake_pytests.yml
@@ -5,11 +5,7 @@ on:
 
 jobs:
   BuildAndTest:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -3,7 +3,8 @@ name: Tests and Codecov
 on:
   pull_request:
     branches:
-      - haoti/test_mac_build
+      - master
+      - dev-master
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -49,7 +49,12 @@ jobs:
 
     - name: CPU info
       shell: bash -l {0}
-      run: lscpu
+      run: |
+        if [ "${{ runner.os }}" == "Linux" ]; then
+          lscpu
+        elif [ "${{ runner.os }}" == "macOS" ]; then
+          sysctl -a | grep machdep.cpu
+        fi
 
     - name: Configure CMake
       shell: bash -l {0}

--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -3,13 +3,16 @@ name: Tests and Codecov
 on:
   pull_request:
     branches:
-      - master
-      - dev-master
+      - haoti/test_mac_build
   workflow_dispatch:
 
 jobs:
   BuildAndTest:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
     defaults:
       run:

--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Configure CMake
       shell: bash -l {0}
-      run: cmake -S ${{github.workspace}} -B ${{github.workspace}}/build -DCMAKE_INSTALL_PREFIX=/home/runner/work/Cytnx_lib -DUSE_MKL=on -DUSE_HPTT=on -DHPTT_ENABLE_FINE_TUNE=on -DHPTT_ENABLE_AVX=off -DBUILD_PYTHON=on -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DRUN_TESTS=on
+      run: cmake -S ${{github.workspace}} -B ${{github.workspace}}/build -DCMAKE_INSTALL_PREFIX=/home/runner/work/Cytnx_lib -DUSE_MKL=on -DUSE_HPTT=on -DHPTT_ENABLE_FINE_TUNE=off -DHPTT_ENABLE_AVX=off -DBUILD_PYTHON=on -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DRUN_TESTS=on
 
     - name: Build
       shell: bash -l {0}

--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -37,7 +37,12 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}
       run: |
-        mamba install _openmp_mutex=*=*_llvm cmake make boost git compilers numpy mkl mkl-include mkl-service pybind11 libblas=*=*mkl beartype
+        if [ "${{ runner.os }}" == "Linux" ]; then
+          mamba install _openmp_mutex=*=*_llvm
+        elif [ "${{ runner.os }}" == "macOS" ]; then
+          mamba install llvm-openmp
+        fi
+        mamba install cmake make boost git compilers numpy mkl mkl-include mkl-service pybind11 libblas=*=*mkl beartype
         python -m pip install gcovr
         mamba install gtest
         mamba install pytest pytest-cov

--- a/.github/workflows/conda_build_macos.yml
+++ b/.github/workflows/conda_build_macos.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - master
-      - dev-master
 
   workflow_dispatch:
 


### PR DESCRIPTION
Add `Macos` platform in `BuildAndTest` workflow. To confirm that each change also work for `Clang` compiler.