### PR TITLE
Stop testing on `dev-master` branch

### DIFF
--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - master
-      - dev-master
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -1,102 +1,86 @@
 name: Tests and Codecov
-
 on:
   pull_request:
     branches:
       - master
   workflow_dispatch:
-
 jobs:
   BuildAndTest:
     runs-on: ubuntu-latest
-
     defaults:
       run:
         shell: bash -l {0}
-
     steps:
-    - uses: actions/checkout@v3
-
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        # Specify python version your environment will have. Remember to quote this, or
-        # YAML will think you want python 3.1 not 3.10
-        python-version: "3.11"
-        # This uses *miniforge*, rather than *minicond*. The primary difference is that
-        # the defaults channel is not enabled at all
-        miniforge-version: latest
-        # These properties enable the use of mamba, which is much faster and far less error
-        # prone than conda while being completely compatible with the conda CLI
-        use-mamba: true
-        mamba-version: "*"
-
-    - name: Install dependencies
-      shell: bash -l {0}
-      run: |
-        mamba install _openmp_mutex=*=*_llvm cmake make boost git compilers numpy mkl mkl-include mkl-service pybind11 libblas=*=*mkl beartype
-        python -m pip install gcovr
-        mamba install gtest
-        mamba install pytest pytest-cov
-
-    - name: CPU info
-      shell: bash -l {0}
-      run: lscpu
-
-    - name: Configure CMake
-      shell: bash -l {0}
-      run: cmake -S ${{github.workspace}} -B ${{github.workspace}}/build -DCMAKE_INSTALL_PREFIX=/home/runner/work/Cytnx_lib -DUSE_MKL=on -DUSE_HPTT=on -DHPTT_ENABLE_FINE_TUNE=on -DHPTT_ENABLE_AVX=off -DBUILD_PYTHON=on -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DRUN_TESTS=on
-
-    - name: Build
-      shell: bash -l {0}
-      working-directory: ${{github.workspace}}/build
-      run: |
-        cmake --version
-        cmake --build . -j `nproc`
-
-    - name: Run CTest
-      shell: bash -l {0}
-      working-directory: ${{github.workspace}}/build
-      run: GTEST_COLOR=1 ctest --output-on-failure --output-junit junit.xml
-
-    - name: Run gcovr
-      shell: bash -l {0}
-      working-directory: ${{github.workspace}}/build
-      run: |
-        gcovr -r .. . --xml gcovr.xml -e ".*_deps.*$"
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-        #directory: ${{runner.workspace}}/build
-        files: ${{github.workspace}}/build/gcovr.xml # optional
-        #working-directory: ${{runner.workspace}}/build
-        #root_dir: ${{runner.workspace}}
-        fail_ci_if_error: true # optional (default = false)
-        verbose: true # optional (default = false)
-        #version: "v0.1.15"
-
-    - name: Install for python tests
-      shell: bash -l {0}
-      working-directory: ${{github.workspace}}/build
-      run: |
-        make install
-
-    - name: Set python path
-      shell: bash -l {0}
-      run: |
-        echo "PYTHONPATH=/home/runner/work/Cytnx_lib" >> $GITHUB_ENV
-
-    - name: Test with pytest
-      shell: bash -l {0}
-      run: |
-        pytest pytests/ --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
+      - uses: actions/checkout@v3
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          # Specify python version your environment will have. Remember to quote this, or
+          # YAML will think you want python 3.1 not 3.10
+          python-version: "3.11"
+          # This uses *miniforge*, rather than *minicond*. The primary difference is that
+          # the defaults channel is not enabled at all
+          miniforge-version: latest
+          # These properties enable the use of mamba, which is much faster and far less error
+          # prone than conda while being completely compatible with the conda CLI
+          use-mamba: true
+          mamba-version: "*"
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: |
+          mamba install _openmp_mutex=*=*_llvm cmake make boost git compilers numpy mkl mkl-include mkl-service pybind11 libblas=*=*mkl beartype
+          python -m pip install gcovr
+          mamba install gtest
+          mamba install pytest pytest-cov
+      - name: CPU info
+        shell: bash -l {0}
+        run: lscpu
+      - name: Configure CMake
+        shell: bash -l {0}
+        run: cmake -S ${{github.workspace}} -B ${{github.workspace}}/build -DCMAKE_INSTALL_PREFIX=/home/runner/work/Cytnx_lib -DUSE_MKL=on -DUSE_HPTT=on -DHPTT_ENABLE_FINE_TUNE=on -DHPTT_ENABLE_AVX=off -DBUILD_PYTHON=on -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DRUN_TESTS=on
+      - name: Build
+        shell: bash -l {0}
+        working-directory: ${{github.workspace}}/build
+        run: |
+          cmake --version
+          cmake --build . -j `nproc`
+      - name: Run CTest
+        shell: bash -l {0}
+        working-directory: ${{github.workspace}}/build
+        run: GTEST_COLOR=1 ctest --output-on-failure --output-junit junit.xml
+      - name: Run gcovr
+        shell: bash -l {0}
+        working-directory: ${{github.workspace}}/build
+        run: |
+          gcovr -r .. . --xml gcovr.xml -e ".*_deps.*$"
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          #directory: ${{runner.workspace}}/build
+          files: ${{github.workspace}}/build/gcovr.xml # optional
+          #working-directory: ${{runner.workspace}}/build
+          #root_dir: ${{runner.workspace}}
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
+          #version: "v0.1.15"
+      - name: Install for python tests
+        shell: bash -l {0}
+        working-directory: ${{github.workspace}}/build
+        run: |
+          make install
+      - name: Set python path
+        shell: bash -l {0}
+        run: |
+          echo "PYTHONPATH=/home/runner/work/Cytnx_lib" >> $GITHUB_ENV
+      - name: Test with pytest
+        shell: bash -l {0}
+        run: |
+          pytest pytests/ --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
     #- name: Upload gcovr files
     #  uses: actions/upload-artifact@v3
     #  with:
     #    name: CMakeError.log
     #    path: /home/runner/work/Cytnx/Cytnx/build/CMakeFiles/CMakeError.log
-
     #- name: Upload junit files
     #  uses: actions/upload-artifact@v3
     #  with:


### PR DESCRIPTION
We have decided to switch to the GitHub flow based on #565. The `dev-master` branch may be removed in the future.