### PR TITLE
Remove OpenMP usage

### DIFF
--- a/src/Accessor.cpp
+++ b/src/Accessor.cpp
@@ -223,7 +223,6 @@ namespace cytnx {
       pos.resize(this->idx_list.size());
       len = pos.size();
       // cout << "list in accessor len:" <<len << endl;
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 i = 0; i < this->idx_list.size(); i++) {
         // checking:
         if (this->idx_list[i] < 0) {

--- a/src/BlockUniTensor.cpp
+++ b/src/BlockUniTensor.cpp
@@ -14,9 +14,6 @@ using namespace std;
 #ifdef BACKEND_TORCH
 #else
 
-  #ifdef UNI_OMP
-    #include <omp.h>
-  #endif
 namespace cytnx {
   typedef Accessor ac;
   void BlockUniTensor::Init(const std::vector<Bond> &bonds, const std::vector<string> &in_labels,
@@ -912,7 +909,6 @@ namespace cytnx {
         std::vector<Bond> out_bonds;
         cytnx_int64 out_rowrank;
 
-        // these two cannot omp parallel, due to intrusive_ptr
         for (cytnx_uint64 i = 0; i < non_comm_idx1.size(); i++)
           out_bonds.push_back(this->_bonds[non_comm_idx1[i]].clone());
         for (cytnx_uint64 i = 0; i < non_comm_idx2.size(); i++)

--- a/src/Bond.cpp
+++ b/src/Bond.cpp
@@ -4,10 +4,6 @@
 #include "utils/utils.hpp"
 using namespace std;
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
   void Bond_impl::Init(const cytnx_uint64 &dim, const bondType &bd_type) {
     cytnx_error_msg(dim == 0, "%s", "[ERROR] Bond_impl cannot have 0 or negative dimension.");
@@ -139,7 +135,6 @@ namespace cytnx {
           new_qnums = std::vector<std::vector<cytnx_int64>>(Dnew_qnums,
                                                             std::vector<cytnx_int64>(this->Nsym()));
 
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 d = 0; d < new_qnums.size(); d++) {
             for (cytnx_uint32 i = 0; i < this->Nsym(); i++) {
               if (bd_in->type() != this->type()) {
@@ -167,7 +162,6 @@ namespace cytnx {
         new_qnums =
           std::vector<std::vector<cytnx_int64>>(this->_dim, std::vector<cytnx_int64>(this->Nsym()));
 
-#pragma omp parallel for schedule(dynamic)
         for (cytnx_uint64 d = 0; d < this->_dim; d++) {
           for (cytnx_uint32 i = 0; i < this->Nsym(); i++) {
             if (bd_in->type() != this->type()) {
@@ -248,7 +242,6 @@ namespace cytnx {
           new_qnums = std::vector<std::vector<cytnx_int64>>(Dnew_qnums,
                                                             std::vector<cytnx_int64>(this->Nsym()));
 
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 d = 0; d < new_qnums.size(); d++) {
             for (cytnx_uint32 i = 0; i < this->Nsym(); i++) {
               this->_syms[i].combine_rule_(new_qnums[d][i],
@@ -270,7 +263,6 @@ namespace cytnx {
         new_qnums =
           std::vector<std::vector<cytnx_int64>>(this->_dim, std::vector<cytnx_int64>(this->Nsym()));
 
-#pragma omp parallel for schedule(dynamic)
         for (cytnx_uint64 d = 0; d < this->_dim; d++) {
           for (cytnx_uint32 i = 0; i < this->Nsym(); i++) {
             this->_syms[i].combine_rule_(new_qnums[d][i],
@@ -384,43 +376,6 @@ namespace cytnx {
       } else {
         // old format
         if (return_indices) {
-#ifdef UNI_OMP
-          std::vector<cytnx_uint64> tmp_cnts;
-          std::vector<std::vector<cytnx_uint64>> tmp_indices;
-  #pragma omp parallel
-          {
-            if (omp_get_thread_num() == 0) {
-              tmp_cnts.resize(omp_get_num_threads(), 0);
-              tmp_indices.resize(omp_get_num_threads());
-            }
-          }
-
-  #pragma omp parallel for schedule(dynamic)
-          for (cytnx_uint64 i = 0; i < this->_qnums.size(); i++) {
-            if (this->_qnums[i] == qnum) {
-              tmp_cnts[omp_get_thread_num()]++;
-              tmp_indices[omp_get_thread_num()].push_back(i);
-            }
-          }
-
-          // sum over all counts from each thread.
-          cytnx_uint64 cnt = tmp_cnts[0];
-          for (cytnx_uint64 i = 1; i < tmp_cnts.size(); i++) {
-            cnt += tmp_cnts[i];
-            tmp_cnts[i] += tmp_cnts[i - 1];  // tmp_cnts[i-1];
-          }
-          indices.resize(cnt);
-
-          // concate the indices from each thread
-          memcpy(&indices[0], &tmp_indices[0][0], sizeof(cytnx_uint64) * tmp_indices[0].size());
-          for (cytnx_uint64 i = 1; i < tmp_cnts.size(); i++) {
-            memcpy(&indices[tmp_cnts[i - 1]], &tmp_indices[i][0],
-                   sizeof(cytnx_uint64) * tmp_indices[i].size());
-          }
-          std::sort(indices.begin(), indices.end());
-
-          return cnt;
-#else
           cytnx_uint64 cnt = 0;
           indices.clear();
           for (cytnx_uint64 i = 0; i < this->_qnums.size(); i++) {
@@ -431,28 +386,8 @@ namespace cytnx {
           }
           return cnt;
 
-#endif
         } else {
-#ifdef UNI_OMP
-          std::vector<cytnx_uint64> tmp_cnts;
-  #pragma omp parallel
-          {
-            if (omp_get_thread_num() == 0) tmp_cnts.resize(omp_get_num_threads(), 0);
-          }
-
-  #pragma omp parallel for schedule(dynamic)
-          for (cytnx_uint64 i = 0; i < this->_qnums.size(); i++) {
-            if (this->_qnums[i] == qnum) {
-              tmp_cnts[omp_get_thread_num()]++;
-            }
-          }
-
-          for (cytnx_uint64 i = 1; i < tmp_cnts.size(); i++) tmp_cnts[0] += tmp_cnts[i];
-          return tmp_cnts[0];
-#else
           return std::count(this->_qnums.begin(), this->_qnums.end(), qnum);
-
-#endif
         }  // if return indices
       }  // check format.
 
@@ -462,7 +397,6 @@ namespace cytnx {
   std::vector<std::vector<cytnx_int64>> Bond_impl::calc_reverse_qnums() {
     std::vector<std::vector<cytnx_int64>> out(this->_qnums.size(),
                                               std::vector<cytnx_int64>(this->_syms.size()));
-#pragma omp parallel for
     for (cytnx_uint64 i = 0; i < out.size(); i++) {
       for (int j = 0; j < out[i].size(); j++) {
         this->_syms[j].reverse_rule_(out[i][j], this->_qnums[i][j]);

--- a/src/DenseUniTensor.cpp
+++ b/src/DenseUniTensor.cpp
@@ -965,7 +965,6 @@ namespace cytnx {
       // process meta
       vec_concatenate_(tmp->_labels, this->labels(), rhs->labels());
 
-      // these two cannot omp parallel, due to intrusive_ptr
       for (cytnx_uint64 i = 0; i < this->_bonds.size(); i++)
         tmp->_bonds.push_back(this->_bonds[i].clone());
       for (cytnx_uint64 i = 0; i < rhs->_bonds.size(); i++)
@@ -1030,7 +1029,6 @@ namespace cytnx {
       vec_concatenate_(tmp->_labels, vec_clone(this->_labels, non_comm_idx1),
                        vec_clone(rhs->_labels, non_comm_idx2));
 
-      // these two cannot omp parallel, due to intrusive_ptr
       for (cytnx_uint64 i = 0; i < non_comm_idx1.size(); i++)
         tmp->_bonds.push_back(this->_bonds[non_comm_idx1[i]].clone());
       for (cytnx_uint64 i = 0; i < non_comm_idx2.size(); i++)

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -3,9 +3,6 @@
 #include <thread>
 
 #include "cytnx_error.hpp"
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 
 using namespace std;
 namespace cytnx {

--- a/src/LinOp.cpp
+++ b/src/LinOp.cpp
@@ -5,10 +5,6 @@
 #ifdef BACKEND_TORCH
 #else
 
-  #ifdef UNI_OMP
-    #include <omp.h>
-  #endif
-
 namespace cytnx {
 
   void LinOp::_print() {
@@ -31,26 +27,6 @@ namespace cytnx {
 
     Tensor out(Tin.shape(), Tin.dtype(), Tin.device());
 
-  #ifdef UNI_OMP
-
-    // #pragma omp parallel for
-    for (cytnx_uint64 x = 0; x < this->_elems.size(); x++) {
-      auto it = this->_elems.begin();
-      advance(it, x);
-
-      Tensor e_i = it->second.second;
-      auto &v_i = it->second.first;
-
-      // std::cout << "row:" << x << std::endl;
-      // std::cout << v_i <<e_i << std::endl;
-      for (cytnx_uint64 j = 0; j < v_i.size(); j++) {
-        out(it->first) += e_i(j) * Tin(v_i[j]);
-      }
-      // std::cout << out << std::endl;
-    }
-
-  #else
-
     // traversal all the rows:
     for (auto it = this->_elems.begin(); it != this->_elems.end(); it++) {
       Tensor e_i = it->second.second;
@@ -59,9 +35,6 @@ namespace cytnx {
         out(it->first) += e_i(j) * Tin(v_i[j]);
       }
     }
-
-  #endif
-
     return out;
   }
 

--- a/src/SparseUniTensor.cpp
+++ b/src/SparseUniTensor.cpp
@@ -9,10 +9,6 @@
 #include "utils/vec_concatenate.hpp"
 #include <map>
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 using namespace std;
 namespace cytnx {
   typedef Accessor ac;
@@ -168,7 +164,6 @@ namespace cytnx {
       for (cytnx_uint64 i = 0; i < cb_inbonds.size(); i++) {
         N_sym = cb_inbonds[i].Nsym();
 
-#pragma omp parallel for schedule(dynamic)
         for (cytnx_uint64 d = 0; d < N_sym * cb_inbonds[i].dim(); d++) {
           cb_inbonds[i].qnums()[cytnx_uint64(d / N_sym)][d % N_sym] *=
             cb_inbonds[i].type() * bondType::BD_KET;
@@ -185,7 +180,6 @@ namespace cytnx {
       for (cytnx_uint64 i = 0; i < cb_outbonds.size(); i++) {
         N_sym = cb_outbonds[i].Nsym();
 
-#pragma omp parallel for schedule(dynamic)
         for (cytnx_uint64 d = 0; d < N_sym * cb_outbonds[i].dim(); d++) {
           cb_outbonds[i].qnums()[cytnx_uint64(d / N_sym)][d % N_sym] *=
             cb_outbonds[i].type() * bondType::BD_BRA;
@@ -2181,7 +2175,6 @@ namespace cytnx {
                          vec_clone(rhs->_labels, non_comm_idx2));
       }
 
-      // these two cannot omp parallel, due to intrusive_ptr
       for (cytnx_uint64 i = 0; i < non_comm_idx1.size(); i++)
         out_bonds.push_back(this->_bonds[non_comm_idx1[i]]);
       for (cytnx_uint64 i = 0; i < non_comm_idx2.size(); i++)

--- a/src/Symmetry.cpp
+++ b/src/Symmetry.cpp
@@ -4,10 +4,6 @@
 
 using namespace std;
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
 
   bool cytnx::Symmetry::operator==(const cytnx::Symmetry &rhs) const {
@@ -82,7 +78,6 @@ namespace cytnx {
                                         const std::vector<cytnx_int64> &inL,
                                         const std::vector<cytnx_int64> &inR) {
     out.resize(inL.size() * inR.size());
-#pragma omp parallel for schedule(dynamic)
     for (cytnx_uint64 i = 0; i < out.size(); i++) {
       out[i] = inL[cytnx_uint64(i / inR.size())] + inR[i % inR.size()];
     }
@@ -111,40 +106,18 @@ namespace cytnx {
   }
 
   bool cytnx::ZnSymmetry::check_qnums(const std::vector<cytnx_int64> &qnums) {
-#ifdef UNI_OMP
-    std::vector<bool> buf(1, true);
-  #pragma omp parallel
-    {
-      if (omp_get_thread_num() == 0) buf.assign(omp_get_num_threads(), true);
-    }
-
-  #pragma omp parallel for schedule(dynamic)
-    for (cytnx_uint64 i = 0; i < qnums.size(); i++) {
-      if (buf[omp_get_thread_num()] == false)
-        continue;
-      else
-        buf[omp_get_thread_num()] = ((qnums[i] >= 0) && (qnums[i] < this->n));
-    }
-
-    for (cytnx_uint64 i = 0; i < buf.size(); i++) {
-      buf[0] = (buf[0] && buf[i]);
-    }
-    return buf[0];
-#else
     bool out = true;
     for (cytnx_uint64 i = 0; i < qnums.size(); i++) {
       out = ((qnums[i] >= 0) && (qnums[i] < this->n));
       if (out == false) break;
     }
     return out;
-#endif
   }
 
   void cytnx::ZnSymmetry::combine_rule_(std::vector<cytnx_int64> &out,
                                         const std::vector<cytnx_int64> &inL,
                                         const std::vector<cytnx_int64> &inR) {
     out.resize(inL.size() * inR.size());
-#pragma omp parallel for schedule(dynamic)
     for (cytnx_uint64 i = 0; i < out.size(); i++) {
       out[i] = (inL[cytnx_uint64(i / inR.size())] + inR[i % inR.size()]) % (this->n);
     }

--- a/src/backend/Storage.cpp
+++ b/src/backend/Storage.cpp
@@ -1,6 +1,3 @@
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 #include "backend/Storage.hpp"
 
 #include <iostream>

--- a/src/backend/Storage_base.cpp
+++ b/src/backend/Storage_base.cpp
@@ -1,6 +1,3 @@
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 #include "backend/Storage.hpp"
 #include "utils_internal_interface.hpp"
 #include "utils/vec_print.hpp"
@@ -971,7 +968,6 @@ namespace cytnx {
   void Storage_base::_cpy_bool(void *ptr, const std::vector<cytnx_bool> &vin) {
     bool *tmp = static_cast<bool *>(ptr);
 
-#pragma omp parallel for schedule(dynamic)
     for (cytnx_uint64 i = 0; i < vin.size(); i++) {
       tmp[i] = vin[i];
     }

--- a/src/backend/algo_internal_cpu/Concate_internal.cpp
+++ b/src/backend/algo_internal_cpu/Concate_internal.cpp
@@ -3,10 +3,6 @@
 #include <iostream>
 #include <algorithm>
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
 
   namespace algo_internal {

--- a/src/backend/algo_internal_cpu/Sort_internal.cpp
+++ b/src/backend/algo_internal_cpu/Sort_internal.cpp
@@ -3,10 +3,6 @@
 #include <iostream>
 #include <algorithm>
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
 
   namespace algo_internal {

--- a/src/backend/algo_internal_cpu/Split_internal.cpp
+++ b/src/backend/algo_internal_cpu/Split_internal.cpp
@@ -3,10 +3,6 @@
 #include <iostream>
 #include <algorithm>
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
 
   namespace algo_internal {

--- a/src/backend/linalg_internal_cpu/Abs_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Abs_internal.cpp
@@ -1,10 +1,6 @@
 #include "backend/linalg_internal_cpu/Abs_internal.hpp"
 #include "cytnx_error.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 // stackoverflow.com/questions/33738509/whats-the-difference-between-abs-and-fabs
 
 namespace cytnx {
@@ -14,7 +10,6 @@ namespace cytnx {
       cytnx_double *_out = (cytnx_double *)out->data();
       cytnx_complex128 *_ten = (cytnx_complex128 *)ten->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = std::abs(_ten[n]);
       }
@@ -25,7 +20,6 @@ namespace cytnx {
       cytnx_float *_out = (cytnx_float *)out->data();
       cytnx_complex64 *_ten = (cytnx_complex64 *)ten->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = std::abs(_ten[n]);
       }
@@ -36,7 +30,6 @@ namespace cytnx {
       cytnx_double *_out = (cytnx_double *)out->data();
       cytnx_double *_ten = (cytnx_double *)ten->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = std::abs(_ten[n]);
       }
@@ -47,7 +40,6 @@ namespace cytnx {
       cytnx_float *_out = (cytnx_float *)out->data();
       cytnx_float *_ten = (cytnx_float *)ten->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = std::abs(_ten[n]);
       }
@@ -59,7 +51,6 @@ namespace cytnx {
       cytnx_int64 *_out = (cytnx_int64 *)out->data();
       cytnx_int64 *_ten = (cytnx_int64 *)ten->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = std::abs(_ten[n]);
       }
@@ -71,7 +62,6 @@ namespace cytnx {
       cytnx_int32 *_out = (cytnx_int32 *)out->data();
       cytnx_int32 *_ten = (cytnx_int32 *)ten->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = std::abs(_ten[n]);
       }
@@ -83,7 +73,6 @@ namespace cytnx {
       cytnx_int16 *_out = (cytnx_int16 *)out->data();
       cytnx_int16 *_ten = (cytnx_int16 *)ten->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = std::abs(cytnx_double(_ten[n]));
       }

--- a/src/backend/linalg_internal_cpu/Add_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Add_internal.cpp
@@ -2,9 +2,6 @@
 #include "../utils_internal_interface.hpp"
 #include "utils/utils.hpp"
 #include <iostream>
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 
 namespace cytnx {
 
@@ -21,18 +18,15 @@ namespace cytnx {
       cytnx_complex128 *_Lin = (cytnx_complex128 *)Lin->data();
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -53,7 +47,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -73,18 +66,15 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -105,7 +95,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -125,18 +114,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -157,7 +143,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -177,18 +162,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -209,7 +191,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -229,18 +210,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -261,7 +239,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -281,18 +258,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -313,7 +287,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -333,18 +306,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -365,7 +335,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -385,18 +354,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -417,7 +383,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -437,18 +402,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -469,7 +431,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -489,18 +450,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -521,7 +479,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -541,18 +498,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + cytnx_complex128(_Rin[i], 0);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + cytnx_complex128(_Rin[0], 0);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + cytnx_complex128(_Rin[i], 0);
           }
@@ -573,7 +527,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -604,18 +557,15 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -636,7 +586,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -656,18 +605,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -688,7 +634,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -708,18 +653,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -740,7 +682,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -759,18 +700,15 @@ namespace cytnx {
       cytnx_complex64 *_Lin = (cytnx_complex64 *)Lin->data();
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -791,7 +729,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -811,18 +748,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -843,7 +777,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -863,18 +796,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -895,7 +825,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -915,18 +844,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -947,7 +873,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -967,18 +892,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -999,7 +921,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1019,18 +940,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -1051,7 +969,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1071,18 +988,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + cytnx_complex64(_Rin[i], 0);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + cytnx_complex64(_Rin[0], 0);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + cytnx_complex64(_Rin[i], 0);
           }
@@ -1103,7 +1017,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -1142,18 +1055,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -1174,7 +1084,6 @@ namespace cytnx {
 
           // std::cout << "len" << len << std::endl;
           //  handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1194,18 +1103,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -1226,7 +1132,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1246,18 +1151,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -1278,7 +1180,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1298,18 +1199,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -1330,7 +1228,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1350,18 +1247,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -1382,7 +1276,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1402,18 +1295,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -1434,7 +1324,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1454,18 +1343,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -1486,7 +1372,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1506,18 +1391,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -1538,7 +1420,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1558,18 +1439,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + double(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + double(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + double(_Rin[i]);
           }
@@ -1590,7 +1468,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1635,18 +1512,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -1667,7 +1541,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1687,18 +1560,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -1719,7 +1589,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1739,18 +1608,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -1771,7 +1637,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1791,18 +1656,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -1823,7 +1685,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1843,18 +1704,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -1875,7 +1733,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1895,18 +1752,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -1927,7 +1781,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1947,18 +1800,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -1979,7 +1829,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -1999,18 +1848,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + float(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + float(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + float(_Rin[i]);
           }
@@ -2031,7 +1877,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -2085,18 +1930,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -2117,7 +1959,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -2137,18 +1978,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -2169,7 +2007,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -2189,18 +2026,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -2221,7 +2055,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -2241,18 +2074,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -2273,7 +2103,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -2293,18 +2122,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -2325,7 +2151,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -2345,18 +2170,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -2377,7 +2199,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -2397,18 +2218,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + cytnx_int64(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + cytnx_int64(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + cytnx_int64(_Rin[i]);
           }
@@ -2429,7 +2247,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -2491,18 +2308,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -2523,7 +2337,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -2543,18 +2356,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -2575,7 +2385,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -2595,18 +2404,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -2627,7 +2433,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -2647,18 +2452,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -2679,7 +2481,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -2699,18 +2500,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -2731,7 +2529,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -2751,18 +2548,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + cytnx_uint64(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + cytnx_uint64(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + cytnx_uint64(_Rin[i]);
           }
@@ -2783,7 +2577,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -2853,18 +2646,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -2885,7 +2675,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -2905,18 +2694,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -2937,7 +2723,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -2957,18 +2742,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -2989,7 +2771,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -3009,18 +2790,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -3041,7 +2819,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -3061,18 +2838,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + cytnx_int32(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + cytnx_int32(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + cytnx_int32(_Rin[i]);
           }
@@ -3093,7 +2867,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -3171,18 +2944,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -3203,7 +2973,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -3223,18 +2992,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -3255,7 +3021,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -3275,18 +3040,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -3307,7 +3069,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -3327,18 +3088,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + cytnx_uint32(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + cytnx_uint32(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + cytnx_uint32(_Rin[i]);
           }
@@ -3359,7 +3117,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -3445,18 +3202,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -3477,7 +3231,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -3497,18 +3250,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -3529,7 +3279,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -3549,18 +3298,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + cytnx_int16(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + cytnx_int16(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + cytnx_int16(_Rin[i]);
           }
@@ -3581,7 +3327,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -3675,18 +3420,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -3707,7 +3449,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -3727,18 +3468,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + cytnx_uint16(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + cytnx_uint16(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + cytnx_uint16(_Rin[i]);
           }
@@ -3759,7 +3497,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +
@@ -3861,18 +3598,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] + _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] + _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] + _Rin[i];
           }
@@ -3893,7 +3627,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +

--- a/src/backend/linalg_internal_cpu/Conj_inplace_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Conj_inplace_internal.cpp
@@ -2,10 +2,6 @@
 #include "cytnx_error.hpp"
 #include "backend/lapack_wrapper.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
   namespace linalg_internal {
 
@@ -13,7 +9,6 @@ namespace cytnx {
                                   const cytnx_uint64 &Nelem) {
       cytnx_complex64 *tmp = (cytnx_complex64 *)ten->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         tmp[n].imag(-tmp[n].imag());
       }
@@ -23,7 +18,6 @@ namespace cytnx {
                                   const cytnx_uint64 &Nelem) {
       cytnx_complex128 *tmp = (cytnx_complex128 *)ten->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         tmp[n].imag(-tmp[n].imag());
       }

--- a/src/backend/linalg_internal_cpu/Cpr_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Cpr_internal.cpp
@@ -2,9 +2,6 @@
 #include "../utils_internal_interface.hpp"
 #include "utils/utils.hpp"
 #include <iostream>
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 
 namespace cytnx {
 
@@ -21,18 +18,15 @@ namespace cytnx {
       cytnx_complex128 *_Lin = (cytnx_complex128 *)Lin->data();
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -53,7 +47,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -73,18 +66,15 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex128(_Rin[i]));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex128(_Rin[0]));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex128(_Rin[i]));
           }
@@ -105,7 +95,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -126,18 +115,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex128(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex128(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex128(_Rin[i], 0));
           }
@@ -158,7 +144,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -179,18 +164,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex128(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex128(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex128(_Rin[i], 0));
           }
@@ -211,7 +193,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -232,18 +213,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex128(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex128(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex128(_Rin[i], 0));
           }
@@ -264,7 +242,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -285,18 +262,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex128(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex128(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex128(_Rin[i], 0));
           }
@@ -317,7 +291,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -338,18 +311,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex128(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex128(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex128(_Rin[i], 0));
           }
@@ -370,7 +340,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -391,18 +360,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex128(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex128(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex128(_Rin[i], 0));
           }
@@ -423,7 +389,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -444,18 +409,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex128(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex128(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex128(_Rin[i], 0));
           }
@@ -476,7 +438,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -497,18 +458,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex128(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex128(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex128(_Rin[i], 0));
           }
@@ -529,7 +487,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -550,18 +507,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex128(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex128(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex128(_Rin[i], 0));
           }
@@ -582,7 +536,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -613,18 +566,15 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -645,7 +595,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -665,18 +614,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex64(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex64(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex64(_Rin[i], 0));
           }
@@ -697,7 +643,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -718,18 +663,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex64(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex64(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex64(_Rin[i], 0));
           }
@@ -750,7 +692,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -770,18 +711,15 @@ namespace cytnx {
       cytnx_complex64 *_Lin = (cytnx_complex64 *)Lin->data();
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex64(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex64(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex64(_Rin[i], 0));
           }
@@ -802,7 +740,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -823,18 +760,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex64(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex64(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex64(_Rin[i], 0));
           }
@@ -855,7 +789,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -876,18 +809,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex64(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex64(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex64(_Rin[i], 0));
           }
@@ -908,7 +838,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -929,18 +858,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex64(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex64(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex64(_Rin[i], 0));
           }
@@ -961,7 +887,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -982,18 +907,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex64(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex64(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex64(_Rin[i], 0));
           }
@@ -1014,7 +936,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -1035,18 +956,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex64(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex64(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex64(_Rin[i], 0));
           }
@@ -1067,7 +985,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -1088,18 +1005,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_complex64(_Rin[i], 0));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_complex64(_Rin[0], 0));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_complex64(_Rin[i], 0));
           }
@@ -1120,7 +1034,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -1159,18 +1072,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
       // std::cout << "good" << std::endl;
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -1191,7 +1101,6 @@ namespace cytnx {
 
           // std::cout << "len" << len << std::endl;
           //  handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -1211,18 +1120,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -1243,7 +1149,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -1263,18 +1168,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -1295,7 +1197,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -1315,18 +1216,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -1347,7 +1245,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -1367,18 +1264,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -1399,7 +1293,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -1419,18 +1312,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -1451,7 +1341,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -1471,18 +1360,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -1503,7 +1389,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -1523,18 +1408,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -1555,7 +1437,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -1575,18 +1456,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == double(_Rin[i]));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == double(_Rin[0]));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == double(_Rin[i]));
           }
@@ -1607,7 +1485,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -1652,18 +1529,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -1684,7 +1558,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -1704,18 +1577,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -1736,7 +1606,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -1756,18 +1625,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -1788,7 +1654,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -1808,18 +1673,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -1840,7 +1702,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -1860,18 +1721,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -1892,7 +1750,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -1912,18 +1769,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -1944,7 +1798,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -1964,18 +1817,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -1996,7 +1846,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -2016,18 +1865,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == float(_Rin[i]));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == float(_Rin[0]));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == float(_Rin[i]));
           }
@@ -2048,7 +1894,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -2102,18 +1947,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -2134,7 +1976,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -2154,18 +1995,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -2186,7 +2024,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -2206,18 +2043,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -2238,7 +2072,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -2258,18 +2091,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -2290,7 +2120,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -2310,18 +2139,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -2342,7 +2168,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -2362,18 +2187,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -2394,7 +2216,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -2414,18 +2235,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_int64(_Rin[i]));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_int64(_Rin[0]));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_int64(_Rin[i]));
           }
@@ -2446,7 +2264,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -2508,18 +2325,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -2540,7 +2354,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -2560,18 +2373,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -2592,7 +2402,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -2612,18 +2421,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -2644,7 +2450,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -2664,18 +2469,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -2696,7 +2498,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -2716,18 +2517,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -2748,7 +2546,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -2768,18 +2565,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_uint64(_Rin[i]));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_uint64(_Rin[0]));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_uint64(_Rin[i]));
           }
@@ -2800,7 +2594,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -2871,18 +2664,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -2903,7 +2693,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -2923,18 +2712,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -2955,7 +2741,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -2975,18 +2760,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -3007,7 +2789,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -3027,18 +2808,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -3059,7 +2837,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -3079,18 +2856,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_int32(_Rin[i]));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_int32(_Rin[0]));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_int32(_Rin[i]));
           }
@@ -3111,7 +2885,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -3189,18 +2962,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -3221,7 +2991,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -3241,18 +3010,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -3273,7 +3039,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -3293,18 +3058,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -3325,7 +3087,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -3345,18 +3106,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_uint32(_Rin[i]));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_uint32(_Rin[0]));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_uint32(_Rin[i]));
           }
@@ -3377,7 +3135,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -3464,18 +3221,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -3496,7 +3250,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -3516,18 +3269,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -3548,7 +3298,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -3568,18 +3317,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_int16(_Rin[i]));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_int16(_Rin[0]));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_int16(_Rin[i]));
           }
@@ -3600,7 +3346,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -3694,18 +3439,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -3726,7 +3468,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==
@@ -3746,18 +3487,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == cytnx_uint16(_Rin[i]));
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == cytnx_uint16(_Rin[0]));
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == cytnx_uint16(_Rin[i]));
           }
@@ -3778,7 +3516,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -3881,18 +3618,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[0] == _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = (_Lin[i] == _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = (_Lin[i] == _Rin[i]);
           }
@@ -3913,7 +3647,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = (_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] ==

--- a/src/backend/linalg_internal_cpu/Det_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Det_internal.cpp
@@ -7,10 +7,6 @@
 #include "backend/utils_internal_interface.hpp"
 #include "utils/utils.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
 
   namespace linalg_internal {

--- a/src/backend/linalg_internal_cpu/Diag_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Diag_internal.cpp
@@ -2,20 +2,14 @@
 #include "cytnx_error.hpp"
 #include "backend/lapack_wrapper.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
   namespace linalg_internal {
 
     template <class T>
     void Diag_internal_driver(T *out, T *in, const cytnx_uint64 &L, const cytnx_bool &isrank2) {
       if (isrank2) {
-#pragma omp parallel for
         for (cytnx_uint64 i = 0; i < L; i++) out[i] = in[i * L + i];
       } else {
-#pragma omp parallel for
         for (cytnx_uint64 i = 0; i < L; i++) out[i * L + i] = in[i];
       }
     }

--- a/src/backend/linalg_internal_cpu/Div_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Div_internal.cpp
@@ -1,9 +1,6 @@
 #include "Div_internal.hpp"
 #include "../utils_internal_interface.hpp"
 #include "utils/utils.hpp"
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 #include "backend/lapack_wrapper.hpp"
 
 namespace cytnx {
@@ -21,13 +18,11 @@ namespace cytnx {
       cytnx_complex128 *_Lin = (cytnx_complex128 *)Lin->data();
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -41,7 +36,6 @@ namespace cytnx {
 
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -63,7 +57,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -83,13 +76,11 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -102,7 +93,6 @@ namespace cytnx {
         zscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -123,7 +113,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -145,20 +134,10 @@ namespace cytnx {
       // std::cout << Lin->size() << " " << Rin->size() << " " << len << std::endl;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-        /*
-        //#ifdef UNI_OMP
-        //    #pragma omp parallel for schedule(dynamic)
-        //#endif
-            for(unsigned long long i=0;i<len;i++){
-                //std::cout << i << std::endl;
-                _out[i] = _Lin[i] / _Rin[0];
-            }
-        */
         blas_int N = len;
         blas_int ONE = 1;
         cytnx_complex128 a = 1. / _Rin[0];
@@ -166,7 +145,6 @@ namespace cytnx {
         zscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -187,7 +165,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -207,13 +184,11 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -226,7 +201,6 @@ namespace cytnx {
         zscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -247,7 +221,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -267,13 +240,11 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -286,7 +257,6 @@ namespace cytnx {
         zscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -307,7 +277,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -327,13 +296,11 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -346,7 +313,6 @@ namespace cytnx {
         zscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -367,7 +333,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -387,13 +352,11 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -406,7 +369,6 @@ namespace cytnx {
         zscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -427,7 +389,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -447,13 +408,11 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -466,7 +425,6 @@ namespace cytnx {
         zscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -487,7 +445,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -507,13 +464,11 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -526,7 +481,6 @@ namespace cytnx {
         zscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -547,7 +501,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -567,13 +520,11 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -586,7 +537,6 @@ namespace cytnx {
         zscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -607,7 +557,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -627,13 +576,11 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / cytnx_complex128(_Rin[i], 0);
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -646,7 +593,6 @@ namespace cytnx {
         zscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / cytnx_complex128(_Rin[i], 0);
           }
@@ -667,7 +613,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -689,18 +634,15 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -721,7 +663,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -741,7 +682,6 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
@@ -753,7 +693,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -774,7 +713,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -794,13 +732,11 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -813,7 +749,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -834,7 +769,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -854,13 +788,11 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -873,7 +805,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -894,7 +825,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -914,13 +844,11 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -933,7 +861,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -954,7 +881,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -974,13 +900,11 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -993,7 +917,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -1014,7 +937,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -1034,13 +956,11 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -1053,7 +973,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -1074,7 +993,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -1094,13 +1012,11 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -1113,7 +1029,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -1134,7 +1049,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -1154,13 +1068,11 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -1173,7 +1085,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -1194,7 +1105,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -1214,13 +1124,11 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -1233,7 +1141,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -1254,7 +1161,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -1274,13 +1180,11 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / cytnx_complex64(_Rin[i], 0);
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -1293,7 +1197,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / cytnx_complex64(_Rin[i], 0);
           }
@@ -1314,7 +1217,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -1336,18 +1238,15 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -1368,7 +1267,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -1388,18 +1286,15 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -1420,7 +1315,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -1440,13 +1334,11 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -1459,7 +1351,6 @@ namespace cytnx {
         dscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -1480,7 +1371,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -1500,13 +1390,11 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -1519,7 +1407,6 @@ namespace cytnx {
         dscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -1540,7 +1427,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -1560,13 +1446,11 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -1579,7 +1463,6 @@ namespace cytnx {
         dscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -1600,7 +1483,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -1620,13 +1502,11 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -1639,7 +1519,6 @@ namespace cytnx {
         dscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -1660,7 +1539,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -1680,13 +1558,11 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -1699,7 +1575,6 @@ namespace cytnx {
         dscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -1720,7 +1595,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -1740,13 +1614,11 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -1759,7 +1631,6 @@ namespace cytnx {
         dscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -1780,7 +1651,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -1800,13 +1670,11 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -1819,7 +1687,6 @@ namespace cytnx {
         dscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -1840,7 +1707,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -1860,13 +1726,11 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -1879,7 +1743,6 @@ namespace cytnx {
         dscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -1900,7 +1763,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -1920,13 +1782,11 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / double(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -1939,7 +1799,6 @@ namespace cytnx {
         dscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / double(_Rin[i]);
           }
@@ -1960,7 +1819,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -1981,18 +1839,15 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2013,7 +1868,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2033,18 +1887,15 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2065,7 +1916,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2085,18 +1935,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2117,7 +1964,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2137,13 +1983,11 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -2156,7 +2000,6 @@ namespace cytnx {
         sscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2177,7 +2020,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2197,13 +2039,11 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -2216,7 +2056,6 @@ namespace cytnx {
         sscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2237,7 +2076,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2257,13 +2095,11 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -2276,7 +2112,6 @@ namespace cytnx {
         sscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2297,7 +2132,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2317,13 +2151,11 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -2336,7 +2168,6 @@ namespace cytnx {
         sscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2357,7 +2188,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2377,13 +2207,11 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -2396,7 +2224,6 @@ namespace cytnx {
         sscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2417,7 +2244,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2437,13 +2263,11 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -2456,7 +2280,6 @@ namespace cytnx {
         sscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2477,7 +2300,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2497,13 +2319,11 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -2516,7 +2336,6 @@ namespace cytnx {
         sscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2537,7 +2356,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2557,13 +2375,11 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / float(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] / _Rin[0];
@@ -2576,7 +2392,6 @@ namespace cytnx {
         sscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / float(_Rin[i]);
           }
@@ -2597,7 +2412,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2618,18 +2432,15 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2650,7 +2461,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2670,18 +2480,15 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2702,7 +2509,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2722,18 +2528,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2754,7 +2557,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2774,18 +2576,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2806,7 +2605,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2826,18 +2624,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2858,7 +2653,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2878,18 +2672,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2910,7 +2701,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2930,18 +2720,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -2962,7 +2749,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -2982,18 +2768,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3014,7 +2797,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3034,18 +2816,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3066,7 +2845,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3086,18 +2864,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3118,7 +2893,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3138,18 +2912,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / cytnx_int64(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / cytnx_int64(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / cytnx_int64(_Rin[i]);
           }
@@ -3170,7 +2941,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3191,18 +2961,15 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3223,7 +2990,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3243,18 +3009,15 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3275,7 +3038,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3295,18 +3057,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3327,7 +3086,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3347,18 +3105,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3379,7 +3134,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3399,18 +3153,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3431,7 +3182,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3451,18 +3201,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3483,7 +3230,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3503,18 +3249,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3535,7 +3278,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3555,18 +3297,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3587,7 +3326,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3607,18 +3345,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3639,7 +3374,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3659,18 +3393,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3691,7 +3422,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3711,18 +3441,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / cytnx_uint64(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / cytnx_uint64(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / cytnx_uint64(_Rin[i]);
           }
@@ -3743,7 +3470,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3764,18 +3490,15 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3796,7 +3519,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3816,18 +3538,15 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3848,7 +3567,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3868,18 +3586,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3900,7 +3615,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3920,18 +3634,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -3952,7 +3663,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -3972,18 +3682,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4004,7 +3711,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4024,18 +3730,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4056,7 +3759,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4076,18 +3778,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4108,7 +3807,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4128,18 +3826,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4160,7 +3855,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4180,18 +3874,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4212,7 +3903,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4232,18 +3922,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4264,7 +3951,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4284,18 +3970,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / cytnx_int32(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / cytnx_int32(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / cytnx_int32(_Rin[i]);
           }
@@ -4316,7 +3999,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4337,18 +4019,15 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4369,7 +4048,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4389,18 +4067,15 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4421,7 +4096,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4441,18 +4115,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4473,7 +4144,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4493,18 +4163,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4525,7 +4192,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4545,18 +4211,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4577,7 +4240,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4597,18 +4259,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4629,7 +4288,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4649,18 +4307,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4681,7 +4336,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4701,18 +4355,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4733,7 +4384,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4753,18 +4403,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4785,7 +4432,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4805,18 +4451,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4837,7 +4480,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4857,18 +4499,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / cytnx_uint32(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / cytnx_uint32(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / cytnx_uint32(_Rin[i]);
           }
@@ -4889,7 +4528,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4910,18 +4548,15 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4942,7 +4577,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -4962,18 +4596,15 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -4994,7 +4625,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5014,18 +4644,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5046,7 +4673,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5066,18 +4692,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5098,7 +4721,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5118,18 +4740,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5150,7 +4769,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5170,18 +4788,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5202,7 +4817,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5222,18 +4836,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5254,7 +4865,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5274,18 +4884,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5306,7 +4913,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5326,18 +4932,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5358,7 +4961,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5378,18 +4980,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5410,7 +5009,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5430,18 +5028,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / cytnx_int16(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / cytnx_int16(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / cytnx_int16(_Rin[i]);
           }
@@ -5462,7 +5057,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5483,18 +5077,15 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5515,7 +5106,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5535,18 +5125,15 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5567,7 +5154,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5587,18 +5173,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5619,7 +5202,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5639,18 +5221,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5671,7 +5250,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5691,18 +5269,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5723,7 +5298,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5743,18 +5317,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5775,7 +5346,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5795,18 +5365,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5827,7 +5394,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5847,18 +5413,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5879,7 +5442,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5899,18 +5461,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5931,7 +5490,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -5951,18 +5509,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -5983,7 +5538,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -6003,18 +5557,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / cytnx_uint16(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / cytnx_uint16(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / cytnx_uint16(_Rin[i]);
           }
@@ -6035,7 +5586,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /
@@ -6056,18 +5606,15 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_complex128(_Lin[0], 0) / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_complex128(_Lin[i], 0) / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_complex128(_Lin[0], 0) / _Rin[i];
           }
@@ -6088,7 +5635,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -6109,18 +5655,15 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_complex64(_Lin[0], 0) / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_complex64(_Lin[i], 0) / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_complex64(_Lin[i], 0) / _Rin[i];
           }
@@ -6141,7 +5684,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -6162,18 +5704,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = double(_Lin[0]) / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = double(_Lin[i]) / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = double(_Lin[i]) / _Rin[i];
           }
@@ -6194,7 +5733,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = double(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) /
@@ -6214,18 +5752,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = float(_Lin[0]) / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = float(_Lin[i]) / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = float(_Lin[i]) / _Rin[i];
           }
@@ -6246,7 +5781,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = float(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) /
@@ -6266,18 +5800,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int64(_Lin[0]) / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int64(_Lin[i]) / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_int64(_Lin[i]) / _Rin[i];
           }
@@ -6298,7 +5829,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_int64(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) /
@@ -6318,18 +5848,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint64(_Lin[0]) / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint64(_Lin[i]) / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_uint64(_Lin[i]) / _Rin[i];
           }
@@ -6350,7 +5877,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_uint64(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) /
@@ -6370,18 +5896,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int32(_Lin[0]) / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int32(_Lin[i]) / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_int32(_Lin[i]) / _Rin[i];
           }
@@ -6402,7 +5925,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_int32(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) /
@@ -6422,18 +5944,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint32(_Lin[0]) / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint32(_Lin[i]) / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_uint32(_Lin[i]) / _Rin[i];
           }
@@ -6454,7 +5973,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_uint32(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) /
@@ -6474,18 +5992,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int16(_Lin[0]) / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int16(_Lin[i]) / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_int16(_Lin[i]) / _Rin[i];
           }
@@ -6506,7 +6021,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_int16(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) /
@@ -6526,18 +6040,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint16(_Lin[0]) / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint16(_Lin[i]) / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_uint16(_Lin[i]) / _Rin[i];
           }
@@ -6558,7 +6069,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_uint16(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) /
@@ -6578,18 +6088,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] / _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] / _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] / _Rin[i];
           }
@@ -6610,7 +6117,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /

--- a/src/backend/linalg_internal_cpu/Exp_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Exp_internal.cpp
@@ -2,10 +2,6 @@
 #include "cytnx_error.hpp"
 #include "backend/lapack_wrapper.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
   namespace linalg_internal {
 
@@ -14,7 +10,6 @@ namespace cytnx {
       cytnx_double *_ten = (cytnx_double *)ten->data();
       cytnx_double *_out = (cytnx_double *)out->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = exp(_ten[n]);
       }
@@ -25,7 +20,6 @@ namespace cytnx {
       cytnx_float *_ten = (cytnx_float *)ten->data();
       cytnx_float *_out = (cytnx_float *)out->data();
 
-#pragma omp parallel for
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = expf(_ten[n]);
       }
@@ -36,7 +30,6 @@ namespace cytnx {
       cytnx_complex128 *_out = (cytnx_complex128 *)out->data();
       cytnx_complex128 *_ten = (cytnx_complex128 *)ten->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = exp(_ten[n]);
       }
@@ -47,7 +40,6 @@ namespace cytnx {
       cytnx_complex64 *_out = (cytnx_complex64 *)out->data();
       cytnx_complex64 *_ten = (cytnx_complex64 *)ten->data();
 
-#pragma omp parallel for
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = exp(_ten[n]);
       }

--- a/src/backend/linalg_internal_cpu/Gemm_Batch_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Gemm_Batch_internal.cpp
@@ -1,10 +1,6 @@
 #include "Gemm_Batch_internal.hpp"
 #include "cytnx_error.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
   namespace linalg_internal {
 

--- a/src/backend/linalg_internal_cpu/Gemm_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Gemm_internal.cpp
@@ -2,10 +2,6 @@
 #include "cytnx_error.hpp"
 #include "backend/lapack_wrapper.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
   namespace linalg_internal {
 

--- a/src/backend/linalg_internal_cpu/Inv_inplace_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Inv_inplace_internal.cpp
@@ -2,10 +2,6 @@
 #include "cytnx_error.hpp"
 #include "backend/lapack_wrapper.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
   namespace linalg_internal {
 
@@ -13,7 +9,6 @@ namespace cytnx {
                                 const double &clip) {
       cytnx_double *_ten = (cytnx_double *)ten->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _ten[n] = _ten[n] < clip ? 0 : double(1) / _ten[n];
       }
@@ -23,7 +18,6 @@ namespace cytnx {
                                 const double &clip) {
       cytnx_float *_ten = (cytnx_float *)ten->data();
 
-#pragma omp parallel for
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _ten[n] = _ten[n] < clip ? 0 : float(1) / _ten[n];
       }
@@ -33,7 +27,6 @@ namespace cytnx {
                                  const double &clip) {
       cytnx_complex128 *_ten = (cytnx_complex128 *)ten->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _ten[n] =
           std::norm(_ten[n]) < clip ? cytnx_complex128(0, 0) : cytnx_complex128(1., 0) / _ten[n];
@@ -44,7 +37,6 @@ namespace cytnx {
                                  const double &clip) {
       cytnx_complex64 *_ten = (cytnx_complex64 *)ten->data();
 
-#pragma omp parallel for
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _ten[n] =
           std::norm(_ten[n]) < clip ? cytnx_complex64(0, 0) : cytnx_complex64(1., 0) / _ten[n];

--- a/src/backend/linalg_internal_cpu/Matmul_dg_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Matmul_dg_internal.cpp
@@ -2,17 +2,12 @@
 #include "cytnx_error.hpp"
 #include "backend/lapack_wrapper.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
   namespace linalg_internal {
 
     template <class T1>
     void Matmul_dg_diagL_driver(T1 *out, const T1 *inl, const T1 *inr, const cytnx_int64 &Ml,
                                 const cytnx_int64 &Comm, const cytnx_int64 &Nr) {
-#pragma omp parallel for
       for (cytnx_uint64 n = 0; n < cytnx_uint64(Ml) * Nr; n++) {
         out[n] = inl[(n / Nr)] * inr[n];
       }
@@ -21,7 +16,6 @@ namespace cytnx {
     template <class T1>
     void Matmul_dg_diagR_driver(T1 *out, const T1 *inl, const T1 *inr, const cytnx_int64 &Ml,
                                 const cytnx_int64 &Comm, const cytnx_int64 &Nr) {
-#pragma omp parallel for
       for (cytnx_uint64 n = 0; n < cytnx_uint64(Ml) * Nr; n++) {
         out[n] = inl[n] * inr[n % Nr];
       }

--- a/src/backend/linalg_internal_cpu/Matmul_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Matmul_internal.cpp
@@ -2,17 +2,12 @@
 #include "cytnx_error.hpp"
 #include "backend/lapack_wrapper.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
   namespace linalg_internal {
 
     template <class T1>
     void Matmul_driver(T1 *out, const T1 *inl, const T1 *inr, const cytnx_int64 &Ml,
                        const cytnx_int64 &Comm, const cytnx_int64 &Nr) {
-#pragma omp parallel for
       for (cytnx_uint64 n = 0; n < cytnx_uint64(Ml) * Nr; n++) {
         cytnx_int64 i = n % Nr;
         cytnx_int64 j = n / Nr;

--- a/src/backend/linalg_internal_cpu/Matvec_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Matvec_internal.cpp
@@ -2,17 +2,12 @@
 #include "cytnx_error.hpp"
 #include "backend/lapack_wrapper.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
   namespace linalg_internal {
 
     template <class T1>
     void Matvec_driver(T1 *out, const T1 *inl, const T1 *inr, const cytnx_int64 &Ml,
                        const cytnx_int64 &Nr) {
-#pragma omp parallel for
       for (cytnx_uint64 n = 0; n < cytnx_uint64(Ml); n++) {
         out[n] = 0;
         for (cytnx_int64 c = 0; c < Nr; c++) {

--- a/src/backend/linalg_internal_cpu/MaxMin_internal.cpp
+++ b/src/backend/linalg_internal_cpu/MaxMin_internal.cpp
@@ -4,9 +4,6 @@
 #include <cfloat>
 #include <limits>
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 using namespace std;
 
 namespace cytnx {
@@ -19,56 +16,15 @@ namespace cytnx {
       cytnx_uint64 *_out = (cytnx_uint64 *)out->data();
 
       if (type == 'x') {
-#ifdef UNI_OMP
-        vector<cytnx_uint64> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_uint64>(Nproc, numeric_limits<cytnx_uint64>::min());
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n] > buf[omp_get_thread_num()]) buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i] > buf[0]) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-
-#else
         _out[0] = numeric_limits<cytnx_uint64>::min();
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n] > _out[0]) _out[0] = _ten[n];
         }
-#endif
       } else if (type == 'n') {
-#ifdef UNI_OMP
-        vector<cytnx_uint64> buf;
-        unsigned int Nproc = 1;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_uint64>(Nproc, numeric_limits<cytnx_uint64>::max());
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n] < buf[omp_get_thread_num()]) buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i] < buf[0]) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-#else
         _out[0] = numeric_limits<cytnx_uint64>::max();
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n] < _out[0]) _out[0] = _ten[n];
         }
-#endif
       }
     }
 
@@ -79,56 +35,15 @@ namespace cytnx {
       cytnx_int64 *_out = (cytnx_int64 *)out->data();
 
       if (type == 'x') {
-#ifdef UNI_OMP
-        vector<cytnx_int64> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_int64>(Nproc, numeric_limits<cytnx_int64>::min());
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n] > buf[omp_get_thread_num()]) buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i] > buf[0]) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-
-#else
         _out[0] = numeric_limits<cytnx_int64>::min();
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n] > _out[0]) _out[0] = _ten[n];
         }
-#endif
       } else if (type == 'n') {
-#ifdef UNI_OMP
-        vector<cytnx_int64> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_int64>(Nproc, numeric_limits<cytnx_int64>::max());
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n] < buf[omp_get_thread_num()]) buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i] < buf[0]) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-#else
         _out[0] = numeric_limits<cytnx_int64>::max();
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n] < _out[0]) _out[0] = _ten[n];
         }
-#endif
       }
     }
 
@@ -139,56 +54,15 @@ namespace cytnx {
       cytnx_uint32 *_out = (cytnx_uint32 *)out->data();
 
       if (type == 'x') {
-#ifdef UNI_OMP
-        vector<cytnx_uint32> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_uint32>(Nproc, numeric_limits<cytnx_uint32>::min());
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n] > buf[omp_get_thread_num()]) buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i] > buf[0]) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-
-#else
         _out[0] = numeric_limits<cytnx_uint32>::min();
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n] > _out[0]) _out[0] = _ten[n];
         }
-#endif
       } else if (type == 'n') {
-#ifdef UNI_OMP
-        vector<cytnx_uint32> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_uint32>(Nproc, numeric_limits<cytnx_uint32>::max());
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n] < buf[omp_get_thread_num()]) buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i] < buf[0]) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-#else
         _out[0] = numeric_limits<cytnx_uint32>::max();
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n] < _out[0]) _out[0] = _ten[n];
         }
-#endif
       }
     }
 
@@ -199,56 +73,15 @@ namespace cytnx {
       cytnx_int32 *_out = (cytnx_int32 *)out->data();
 
       if (type == 'x') {
-#ifdef UNI_OMP
-        vector<cytnx_int32> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_int32>(Nproc, numeric_limits<cytnx_int32>::min());
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n] > buf[omp_get_thread_num()]) buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i] > buf[0]) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-
-#else
         _out[0] = numeric_limits<cytnx_int32>::min();
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n] > _out[0]) _out[0] = _ten[n];
         }
-#endif
       } else if (type == 'n') {
-#ifdef UNI_OMP
-        vector<cytnx_int32> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_int32>(Nproc, numeric_limits<cytnx_int32>::max());
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n] < buf[omp_get_thread_num()]) buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i] < buf[0]) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-#else
         _out[0] = numeric_limits<cytnx_int32>::max();
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n] < _out[0]) _out[0] = _ten[n];
         }
-#endif
       }
     }
 
@@ -259,56 +92,15 @@ namespace cytnx {
       cytnx_uint16 *_out = (cytnx_uint16 *)out->data();
 
       if (type == 'x') {
-#ifdef UNI_OMP
-        vector<cytnx_uint16> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_uint16>(Nproc, numeric_limits<cytnx_uint16>::min());
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n] > buf[omp_get_thread_num()]) buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i] > buf[0]) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-
-#else
         _out[0] = numeric_limits<cytnx_uint16>::min();
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n] > _out[0]) _out[0] = _ten[n];
         }
-#endif
       } else if (type == 'n') {
-#ifdef UNI_OMP
-        vector<cytnx_uint16> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_uint16>(Nproc, numeric_limits<cytnx_uint16>::max());
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n] < buf[omp_get_thread_num()]) buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i] < buf[0]) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-#else
         _out[0] = numeric_limits<cytnx_uint16>::max();
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n] < _out[0]) _out[0] = _ten[n];
         }
-#endif
       }
     }
 
@@ -319,56 +111,15 @@ namespace cytnx {
       cytnx_int16 *_out = (cytnx_int16 *)out->data();
 
       if (type == 'x') {
-#ifdef UNI_OMP
-        vector<cytnx_int16> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_int16>(Nproc, numeric_limits<cytnx_int16>::min());
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n] > buf[omp_get_thread_num()]) buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i] > buf[0]) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-
-#else
         _out[0] = numeric_limits<cytnx_int16>::min();
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n] > _out[0]) _out[0] = _ten[n];
         }
-#endif
       } else if (type == 'n') {
-#ifdef UNI_OMP
-        vector<cytnx_int16> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_int16>(Nproc, numeric_limits<cytnx_int16>::max());
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n] < buf[omp_get_thread_num()]) buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i] < buf[0]) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-#else
         _out[0] = numeric_limits<cytnx_int16>::max();
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n] < _out[0]) _out[0] = _ten[n];
         }
-#endif
       }
     }
 
@@ -379,56 +130,15 @@ namespace cytnx {
       cytnx_double *_out = (cytnx_double *)out->data();
 
       if (type == 'x') {
-#ifdef UNI_OMP
-        vector<cytnx_double> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_double>(Nproc, DBL_MIN);
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n] > buf[omp_get_thread_num()]) buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i] > buf[0]) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-
-#else
         _out[0] = DBL_MIN;
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n] > _out[0]) _out[0] = _ten[n];
         }
-#endif
       } else if (type == 'n') {
-#ifdef UNI_OMP
-        vector<cytnx_double> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_double>(Nproc, DBL_MAX);
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n] < buf[omp_get_thread_num()]) buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i] < buf[0]) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-#else
         _out[0] = DBL_MAX;
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n] < _out[0]) _out[0] = _ten[n];
         }
-#endif
       }
     }
 
@@ -439,56 +149,15 @@ namespace cytnx {
       cytnx_float *_out = (cytnx_float *)out->data();
 
       if (type == 'x') {
-#ifdef UNI_OMP
-        vector<cytnx_float> buf;
-        unsigned int Nproc = 1;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_float>(Nproc, FLT_MIN);
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n] > buf[omp_get_thread_num()]) buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i] > buf[0]) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-
-#else
         _out[0] = FLT_MIN;
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n] > _out[0]) _out[0] = _ten[n];
         }
-#endif
       } else if (type == 'n') {
-#ifdef UNI_OMP
-        vector<cytnx_float> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_float>(Nproc, FLT_MAX);
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n] < buf[omp_get_thread_num()]) buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i] < buf[0]) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-#else
         _out[0] = FLT_MAX;
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n] < _out[0]) _out[0] = _ten[n];
         }
-#endif
       }
     }
     void MaxMin_internal_cd(boost::intrusive_ptr<Storage_base> &out,
@@ -498,58 +167,15 @@ namespace cytnx {
       cytnx_complex128 *_out = (cytnx_complex128 *)out->data();
 
       if (type == 'x') {
-#ifdef UNI_OMP
-        vector<cytnx_complex128> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_complex128>(Nproc, cytnx_complex128(DBL_MIN, DBL_MIN));
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n].real() >= buf[omp_get_thread_num()].real())
-            buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i].real() >= buf[0].real()) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-
-#else
         _out[0] = cytnx_complex128(DBL_MIN, DBL_MIN);
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n].real() >= _out[0].real()) _out[0] = _ten[n];
         }
-#endif
       } else if (type == 'n') {
-#ifdef UNI_OMP
-        vector<cytnx_complex128> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_complex128>(Nproc, cytnx_complex128(DBL_MAX, DBL_MAX));
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n].real() <= buf[omp_get_thread_num()].real())
-            buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i].real() <= buf[0].real()) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-#else
         _out[0] = cytnx_complex128(DBL_MAX, DBL_MAX);
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n].real() <= _out[0].real()) _out[0] = _ten[n];
         }
-#endif
       }
     }
 
@@ -560,58 +186,15 @@ namespace cytnx {
       cytnx_complex64 *_out = (cytnx_complex64 *)out->data();
 
       if (type == 'x') {
-#ifdef UNI_OMP
-        vector<cytnx_complex64> buf;
-        unsigned int Nproc = 1;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_complex64>(Nproc, cytnx_complex64(FLT_MIN, FLT_MIN));
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n].real() >= buf[omp_get_thread_num()].real())
-            buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i].real() >= buf[0].real()) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-
-#else
         _out[0] = cytnx_complex64(FLT_MIN, FLT_MIN);
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n].real() >= _out[0].real()) _out[0] = _ten[n];
         }
-#endif
       } else if (type == 'n') {
-#ifdef UNI_OMP
-        vector<cytnx_complex64> buf;
-        unsigned int Nproc;
-  #pragma omp parallel
-        {
-          if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-        }
-        buf = vector<cytnx_complex64>(Nproc, cytnx_complex64(FLT_MAX, FLT_MAX));
-
-  #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 n = 0; n < Nelem; n++) {
-          if (_ten[n].real() <= buf[omp_get_thread_num()].real())
-            buf[omp_get_thread_num()] = _ten[n];
-        }
-
-        for (int i = 1; i < Nproc; i++) {
-          if (buf[i].real() <= buf[0].real()) buf[0] = buf[i];
-        }
-        _out[0] = buf[0];
-#else
         _out[0] = cytnx_complex64(FLT_MAX, FLT_MAX);
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           if (_ten[n].real() <= _out[0].real()) _out[0] = _ten[n];
         }
-#endif
       }
     }
 

--- a/src/backend/linalg_internal_cpu/Mod_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Mod_internal.cpp
@@ -1,9 +1,6 @@
 #include "Mod_internal.hpp"
 #include "../utils_internal_interface.hpp"
 #include "utils/utils.hpp"
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 
 namespace cytnx {
 
@@ -215,18 +212,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmod(_Lin[i], _Rin[i]);
           }
@@ -247,7 +241,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmod(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -267,18 +260,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmod(_Lin[i], _Rin[i]);
           }
@@ -299,7 +289,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmod(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -319,18 +308,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmod(_Lin[i], _Rin[i]);
           }
@@ -351,7 +337,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmod(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -371,18 +356,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmod(_Lin[i], _Rin[i]);
           }
@@ -403,7 +385,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmod(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -423,18 +404,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmod(_Lin[i], _Rin[i]);
           }
@@ -455,7 +433,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmod(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -475,18 +452,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmod(_Lin[i], _Rin[i]);
           }
@@ -507,7 +481,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmod(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -527,18 +500,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmod(_Lin[i], _Rin[i]);
           }
@@ -559,7 +529,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmod(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -579,18 +548,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmod(_Lin[i], _Rin[i]);
           }
@@ -611,7 +577,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmod(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -631,18 +596,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmod(_Lin[i], _Rin[i]);
           }
@@ -663,7 +625,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmod(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -700,18 +661,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmodf(_Lin[i], _Rin[i]);
           }
@@ -732,7 +690,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmodf(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -752,18 +709,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmodf(_Lin[i], _Rin[i]);
           }
@@ -784,7 +738,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmodf(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -804,18 +757,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmodf(_Lin[i], _Rin[i]);
           }
@@ -836,7 +786,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmodf(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -856,18 +805,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmodf(_Lin[i], _Rin[i]);
           }
@@ -888,7 +834,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmodf(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -908,18 +853,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmodf(_Lin[i], _Rin[i]);
           }
@@ -940,7 +882,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmodf(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -960,18 +901,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmodf(_Lin[i], _Rin[i]);
           }
@@ -992,7 +930,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmodf(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -1012,18 +949,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmodf(_Lin[i], _Rin[i]);
           }
@@ -1044,7 +978,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmodf(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -1064,18 +997,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmodf(_Lin[i], _Rin[i]);
           }
@@ -1096,7 +1026,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmodf(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -1116,18 +1045,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmodf(_Lin[i], _Rin[i]);
           }
@@ -1148,7 +1074,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmodf(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -1186,18 +1111,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmod(_Lin[i], _Rin[i]);
           }
@@ -1218,7 +1140,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmod(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -1238,18 +1159,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmodf(_Lin[i], _Rin[i]);
           }
@@ -1270,7 +1188,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmodf(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -1290,18 +1207,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -1322,7 +1236,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -1342,18 +1255,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -1374,7 +1284,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -1394,18 +1303,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -1426,7 +1332,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -1446,18 +1351,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -1478,7 +1380,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -1498,18 +1399,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -1530,7 +1428,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -1550,18 +1447,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -1582,7 +1476,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -1602,18 +1495,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % cytnx_int64(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % cytnx_int64(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % cytnx_int64(_Rin[i]);
           }
@@ -1634,7 +1524,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -1672,18 +1561,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmod(_Lin[i], _Rin[i]);
           }
@@ -1704,7 +1590,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmod(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -1724,18 +1609,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmodf(_Lin[i], _Rin[i]);
           }
@@ -1756,7 +1638,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmodf(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -1776,18 +1657,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -1808,7 +1686,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -1828,18 +1705,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -1860,7 +1734,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -1880,18 +1753,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -1912,7 +1782,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -1932,18 +1801,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -1964,7 +1830,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -1984,18 +1849,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -2016,7 +1878,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -2036,18 +1897,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -2068,7 +1926,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -2088,18 +1945,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % cytnx_uint64(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % cytnx_uint64(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % cytnx_uint64(_Rin[i]);
           }
@@ -2120,7 +1974,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -2158,18 +2011,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmod(_Lin[i], _Rin[i]);
           }
@@ -2190,7 +2040,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmod(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -2210,18 +2059,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmodf(_Lin[i], _Rin[i]);
           }
@@ -2242,7 +2088,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmodf(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -2262,18 +2107,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -2294,7 +2136,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -2314,18 +2155,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -2346,7 +2184,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -2366,18 +2203,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -2398,7 +2232,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -2418,18 +2251,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -2450,7 +2280,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -2470,18 +2299,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -2502,7 +2328,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -2522,18 +2347,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -2554,7 +2376,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -2574,18 +2395,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % cytnx_int32(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % cytnx_int32(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % cytnx_int32(_Rin[i]);
           }
@@ -2606,7 +2424,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -2644,18 +2461,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmod(_Lin[i], _Rin[i]);
           }
@@ -2676,7 +2490,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmod(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -2696,18 +2509,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmodf(_Lin[i], _Rin[i]);
           }
@@ -2728,7 +2538,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmodf(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -2748,18 +2557,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -2780,7 +2586,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -2800,18 +2605,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -2832,7 +2634,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -2852,18 +2653,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -2884,7 +2682,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -2904,18 +2701,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -2936,7 +2730,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -2956,18 +2749,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -2988,7 +2778,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -3008,18 +2797,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -3040,7 +2826,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -3060,18 +2845,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % cytnx_uint32(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % cytnx_uint32(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % cytnx_uint32(_Rin[i]);
           }
@@ -3092,7 +2874,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -3130,18 +2911,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmod(_Lin[i], _Rin[i]);
           }
@@ -3162,7 +2940,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmod(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -3182,18 +2959,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmodf(_Lin[i], _Rin[i]);
           }
@@ -3214,7 +2988,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmodf(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -3234,18 +3007,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -3266,7 +3036,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -3286,18 +3055,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -3318,7 +3084,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -3338,18 +3103,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -3370,7 +3132,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -3390,18 +3151,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -3422,7 +3180,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -3442,18 +3199,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -3474,7 +3228,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -3494,18 +3247,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -3526,7 +3276,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -3546,18 +3295,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % cytnx_int16(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % cytnx_int16(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % cytnx_int16(_Rin[i]);
           }
@@ -3578,7 +3324,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -3615,18 +3360,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmod(_Lin[i], _Rin[i]);
           }
@@ -3647,7 +3389,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmod(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -3667,18 +3408,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmodf(_Lin[i], _Rin[i]);
           }
@@ -3699,7 +3437,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmodf(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -3719,18 +3456,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -3751,7 +3485,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -3771,18 +3504,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -3803,7 +3533,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -3823,18 +3552,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -3855,7 +3581,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -3875,18 +3600,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -3907,7 +3629,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -3927,18 +3648,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -3959,7 +3677,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -3979,18 +3696,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -4011,7 +3725,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -4031,18 +3744,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % cytnx_uint16(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % cytnx_uint16(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % cytnx_uint16(_Rin[i]);
           }
@@ -4063,7 +3773,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %
@@ -4100,18 +3809,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmod(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmod(_Lin[i], _Rin[i]);
           }
@@ -4132,7 +3838,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmod(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -4152,18 +3857,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[0], _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = fmodf(_Lin[i], _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = fmodf(_Lin[i], _Rin[i]);
           }
@@ -4184,7 +3886,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = fmodf(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)],
@@ -4204,18 +3905,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int64(_Lin[0]) % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int64(_Lin[i]) % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_int64(_Lin[i]) % _Rin[i];
           }
@@ -4236,7 +3934,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_int64(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) %
@@ -4256,18 +3953,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint64(_Lin[0]) % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint64(_Lin[i]) % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_uint64(_Lin[i]) % _Rin[i];
           }
@@ -4288,7 +3982,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_uint64(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) %
@@ -4308,18 +4001,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int32(_Lin[0]) % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int32(_Lin[i]) % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_int32(_Lin[i]) % _Rin[i];
           }
@@ -4340,7 +4030,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_int32(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) %
@@ -4360,18 +4049,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint32(_Lin[0]) % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint32(_Lin[i]) % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_uint32(_Lin[i]) % _Rin[i];
           }
@@ -4392,7 +4078,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_uint32(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) %
@@ -4412,18 +4097,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int16(_Lin[0]) % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int16(_Lin[i]) % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_int16(_Lin[i]) % _Rin[i];
           }
@@ -4444,7 +4126,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_int16(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) %
@@ -4464,18 +4145,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint16(_Lin[0]) % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint16(_Lin[i]) % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_uint16(_Lin[i]) % _Rin[i];
           }
@@ -4496,7 +4174,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_uint16(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) %
@@ -4516,18 +4193,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] % _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] % _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] % _Rin[i];
           }
@@ -4548,7 +4222,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] %

--- a/src/backend/linalg_internal_cpu/Mul_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Mul_internal.cpp
@@ -1,9 +1,6 @@
 #include "Mul_internal.hpp"
 #include "../utils_internal_interface.hpp"
 #include "utils/utils.hpp"
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 #include "backend/lapack_wrapper.hpp"
 
 namespace cytnx {
@@ -23,30 +20,15 @@ namespace cytnx {
       blas_int N = len;
       blas_int ONE = 1;
       if (Lin->size() == 1) {
-        // #ifdef UNI_OMP
-        //     #pragma omp parallel for schedule(dynamic)
-        // #endif
-        //  for(unsigned long long i=0;i<len;i++){
-        //     _out[i] = _Lin[0] * _Rin[i];
-        // }
-        //  std::cout << "entroy internal" << std::endl;
-        //  std::cout << *_Lin << std::endl;
         memcpy(_out, _Rin, sizeof(cytnx_complex128) * len);
         zscal(&N, _Lin, _out, &ONE);
 
       } else if (Rin->size() == 1) {
-        // #ifdef UNI_OMP
-        // #pragma omp parallel for schedule(dynamic)
-        // #endif
-        //  for(unsigned long long i=0;i<len;i++){
-        //     _out[i] = _Lin[i] * _Rin[0];
-        // }
         memcpy(_out, _Lin, sizeof(cytnx_complex128) * len);
         zscal(&N, _Rin, _out, &ONE);
 
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -67,7 +49,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -89,23 +70,15 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-        // #ifdef UNI_OMP
-        // #pragma omp parallel for schedule(dynamic)
-        // #endif
-        //  for(unsigned long long i=0;i<len;i++){
-        //     _out[i] = _Lin[i] * _Rin[0];
-        // }
         cytnx_complex128 a = _Rin[0];
         memcpy(_out, _Lin, sizeof(cytnx_complex128) * len);
         zscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -126,7 +99,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -148,24 +120,16 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-        // #ifdef UNI_OMP
-        // #pragma omp parallel for schedule(dynamic)
-        // #endif
-        //  for(unsigned long long i=0;i<len;i++){
-        //     _out[i] = _Lin[i] * _Rin[0];
-        // }
         cytnx_complex128 a = _Rin[0];
         memcpy(_out, _Lin, sizeof(cytnx_complex128) * len);
         zscal(&N, &a, _out, &ONE);
 
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -186,7 +150,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -208,24 +171,16 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-        // #ifdef UNI_OMP
-        // #pragma omp parallel for schedule(dynamic)
-        // #endif
-        //  for(unsigned long long i=0;i<len;i++){
-        //     _out[i] = _Lin[i] * _Rin[0];
-        // }
         cytnx_complex128 a = _Rin[0];
         memcpy(_out, _Lin, sizeof(cytnx_complex128) * len);
         zscal(&N, &a, _out, &ONE);
 
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -246,7 +201,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -268,24 +222,16 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-        // #ifdef UNI_OMP
-        // #pragma omp parallel for schedule(dynamic)
-        // #endif
-        //  for(unsigned long long i=0;i<len;i++){
-        //     _out[i] = _Lin[i] * _Rin[0];
-        // }
         cytnx_complex128 a = _Rin[0];
         memcpy(_out, _Lin, sizeof(cytnx_complex128) * len);
         zscal(&N, &a, _out, &ONE);
 
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -306,7 +252,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -328,23 +273,15 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-        // #ifdef UNI_OMP
-        // #pragma omp parallel for schedule(dynamic)
-        // #endif
-        //  for(unsigned long long i=0;i<len;i++){
-        //     _out[i] = _Lin[i] * _Rin[0];
-        // }
         cytnx_complex128 a = _Rin[0];
         memcpy(_out, _Lin, sizeof(cytnx_complex128) * len);
         zscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -365,7 +302,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -387,13 +323,11 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                  #pragma omp parallel for schedule(dynamic)
 
         for(unsigned long long i=0;i<len;i++){
             _out[i] = _Lin[i] * _Rin[0];
@@ -404,7 +338,6 @@ namespace cytnx {
         zscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -425,7 +358,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -447,13 +379,11 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                  #pragma omp parallel for schedule(dynamic)
 
         for(unsigned long long i=0;i<len;i++){
             _out[i] = _Lin[i] * _Rin[0];
@@ -464,7 +394,6 @@ namespace cytnx {
         zscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -485,7 +414,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -507,24 +435,16 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * cytnx_complex128(_Rin[i], 0);
         }
       } else if (Rin->size() == 1) {
-        // #ifdef UNI_OMP
-        // #pragma omp parallel for schedule(dynamic)
-        // #endif
-        //  for(unsigned long long i=0;i<len;i++){
-        //     _out[i] = _Lin[i] * cytnx_complex128(_Rin[0],0);
-        // }
         cytnx_complex128 a = _Rin[0];
         memcpy(_out, _Lin, sizeof(cytnx_complex128) * len);
         zscal(&N, &a, _out, &ONE);
 
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * cytnx_complex128(_Rin[i], 0);
           }
@@ -545,7 +465,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -568,13 +487,11 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * cytnx_complex128(_Rin[i], 0);
         }
       } else if (Rin->size() == 1) {
         /*
-                  #pragma omp parallel for schedule(dynamic)
 
         for(unsigned long long i=0;i<len;i++){
             _out[i] = _Lin[i] * cytnx_complex128(_Rin[0],0);
@@ -586,7 +503,6 @@ namespace cytnx {
 
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * cytnx_complex128(_Rin[i], 0);
           }
@@ -607,7 +523,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -631,7 +546,6 @@ namespace cytnx {
         memset(
           _out, 0,
           sizeof(cytnx_complex128) * len);  // since Rin cannot be the same as out, set to zero.
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           if (_Rin[i]) _out[i] = _Lin[0];
         }
@@ -642,7 +556,6 @@ namespace cytnx {
         else
           memset(_out, 0, sizeof(cytnx_complex128) * len);
         /*
-                  #pragma omp parallel for schedule(dynamic)
 
         for(unsigned long long i=0;i<len;i++){
             if(_Rin[0])
@@ -652,7 +565,6 @@ namespace cytnx {
       } else {
         if (shape.size() == 0) {
           memcpy(_out, _Lin, sizeof(cytnx_complex128) * len);
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             if (!_Rin[i]) _out[i] = 0;
           }
@@ -673,7 +585,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             if (_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)])
@@ -707,7 +618,6 @@ namespace cytnx {
 
       if (Lin->size() == 1) {
         /*
-                  #pragma omp parallel for schedule(dynamic)
 
         for(unsigned long long i=0;i<len;i++){
             _out[i] = _Lin[0] * _Rin[i];
@@ -716,14 +626,12 @@ namespace cytnx {
         memcpy(_out, _Rin, sizeof(cytnx_complex64) * len);
         cscal(&N, _Lin, _out, &ONE);
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
           /*
-                      #pragma omp parallel for schedule(dynamic)
 
           for(unsigned long long i=0;i<len;i++){
               _out[i] = _Lin[i] * _Rin[i];
@@ -748,7 +656,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -770,13 +677,11 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                  #pragma omp parallel for schedule(dynamic)
 
         for(unsigned long long i=0;i<len;i++){
             _out[i] = _Lin[i] * _Rin[0];
@@ -787,7 +692,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -808,7 +712,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -830,13 +733,11 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                  #pragma omp parallel for schedule(dynamic)
 
         for(unsigned long long i=0;i<len;i++){
             _out[i] = _Lin[i] * _Rin[0];
@@ -847,7 +748,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -868,7 +768,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -890,13 +789,11 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                  #pragma omp parallel for schedule(dynamic)
 
         for(unsigned long long i=0;i<len;i++){
             _out[i] = _Lin[i] * _Rin[0];
@@ -907,7 +804,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -928,7 +824,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -949,13 +844,11 @@ namespace cytnx {
       blas_int N = len;
       blas_int ONE = 1;
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -967,7 +860,6 @@ namespace cytnx {
 
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -988,7 +880,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -1009,13 +900,11 @@ namespace cytnx {
       blas_int N = len;
       blas_int ONE = 1;
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -1026,7 +915,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -1047,7 +935,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -1068,13 +955,11 @@ namespace cytnx {
       blas_int N = len;
       blas_int ONE = 1;
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -1085,7 +970,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -1106,7 +990,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -1127,13 +1010,11 @@ namespace cytnx {
       blas_int N = len;
       blas_int ONE = 1;
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -1144,7 +1025,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -1165,7 +1045,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -1186,13 +1065,11 @@ namespace cytnx {
       blas_int N = len;
       blas_int ONE = 1;
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -1203,7 +1080,6 @@ namespace cytnx {
         cscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -1224,7 +1100,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -1246,7 +1121,6 @@ namespace cytnx {
       if (Lin->size() == 1) {
         memset(_out, 0,
                sizeof(cytnx_complex64) * len);  // since Rin cannot be the same as out, set to zero.
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           if (_Rin[i]) _out[i] = _Lin[0];
         }
@@ -1257,7 +1131,6 @@ namespace cytnx {
         else
           memset(_out, 0, sizeof(cytnx_complex64) * len);
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * cytnx_complex64(_Rin[0],0);
@@ -1266,7 +1139,6 @@ namespace cytnx {
       } else {
         if (shape.size() == 0) {
           memcpy(_out, _Lin, sizeof(cytnx_complex64) * len);
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             if (!_Rin[i]) _out[i] = 0;
           }
@@ -1287,7 +1159,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             if (_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)])
@@ -1329,28 +1200,15 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-        // #ifdef UNI_OMP
-        // #pragma omp parallel for schedule(dynamic)
-        // #endif
-        //  for(unsigned long long i=0;i<len;i++){
-        //     _out[i] = _Lin[0] * _Rin[i];
-        // }
         memcpy(_out, _Rin, sizeof(double) * len);
         dscal(&N, _Lin, _out, &ONE);
 
       } else if (Rin->size() == 1) {
-        // #ifdef UNI_OMP
-        // #pragma omp parallel for schedule(dynamic)
-        // #endif
-        //  for(unsigned long long i=0;i<len;i++){
-        //     _out[i] = _Lin[i] * _Rin[0];
-        // }
         memcpy(_out, _Lin, sizeof(double) * len);
         dscal(&N, _Rin, _out, &ONE);
 
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -1371,7 +1229,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -1393,13 +1250,11 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                  #pragma omp parallel for schedule(dynamic)
 
         for(unsigned long long i=0;i<len;i++){
             _out[i] = _Lin[i] * _Rin[0];
@@ -1410,7 +1265,6 @@ namespace cytnx {
         dscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -1431,7 +1285,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -1453,13 +1306,11 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -1470,7 +1321,6 @@ namespace cytnx {
         dscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -1491,7 +1341,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -1512,13 +1361,11 @@ namespace cytnx {
       blas_int N = len;
       blas_int ONE = 1;
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -1529,7 +1376,6 @@ namespace cytnx {
         dscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -1550,7 +1396,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -1572,13 +1417,11 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -1589,7 +1432,6 @@ namespace cytnx {
         dscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -1610,7 +1452,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -1631,13 +1472,11 @@ namespace cytnx {
       blas_int N = len;
       blas_int ONE = 1;
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -1648,7 +1487,6 @@ namespace cytnx {
         dscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -1669,7 +1507,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -1691,13 +1528,11 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -1708,7 +1543,6 @@ namespace cytnx {
         dscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -1729,7 +1563,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -1750,13 +1583,11 @@ namespace cytnx {
       blas_int N = len;
       blas_int ONE = 1;
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -1767,7 +1598,6 @@ namespace cytnx {
         dscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -1788,7 +1618,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -1810,7 +1639,6 @@ namespace cytnx {
       if (Lin->size() == 1) {
         memset(_out, 0,
                sizeof(cytnx_double) * len);  // since Rin cannot be the same as out, set to zero.
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           if (_Rin[i]) _out[i] = _Lin[0];
         }
@@ -1821,7 +1649,6 @@ namespace cytnx {
         else
           memset(_out, 0, sizeof(cytnx_double) * len);
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * double(_Rin[0]);
@@ -1830,7 +1657,6 @@ namespace cytnx {
       } else {
         if (shape.size() == 0) {
           memcpy(_out, _Lin, sizeof(cytnx_double) * len);
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             if (!_Rin[i]) _out[i] = 0;
           }
@@ -1851,7 +1677,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             if (_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)])
@@ -1901,27 +1726,14 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-        // #ifdef UNI_OMP
-        // #pragma omp parallel for schedule(dynamic)
-        // #endif
-        //  for(unsigned long long i=0;i<len;i++){
-        //     _out[i] = _Lin[0] * _Rin[i];
-        // }
         memcpy(_out, _Rin, sizeof(float) * len);
         sscal(&N, _Lin, _out, &ONE);
 
       } else if (Rin->size() == 1) {
-        // #ifdef UNI_OMP
-        // #pragma omp parallel for schedule(dynamic)
-        // #endif
-        //  for(unsigned long long i=0;i<len;i++){
-        //     _out[i] = _Lin[i] * _Rin[0];
-        // }
         memcpy(_out, _Lin, sizeof(float) * len);
         sscal(&N, _Rin, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -1942,7 +1754,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -1964,13 +1775,11 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -1981,7 +1790,6 @@ namespace cytnx {
         sscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -2002,7 +1810,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -2023,13 +1830,11 @@ namespace cytnx {
       blas_int N = len;
       blas_int ONE = 1;
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -2040,7 +1845,6 @@ namespace cytnx {
         sscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -2061,7 +1865,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -2082,13 +1885,11 @@ namespace cytnx {
       blas_int N = len;
       blas_int ONE = 1;
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -2099,7 +1900,6 @@ namespace cytnx {
         sscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -2120,7 +1920,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -2142,13 +1941,11 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -2159,7 +1956,6 @@ namespace cytnx {
         sscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -2180,7 +1976,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -2202,13 +1997,11 @@ namespace cytnx {
       blas_int ONE = 1;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -2219,7 +2012,6 @@ namespace cytnx {
         sscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -2240,7 +2032,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -2261,13 +2052,11 @@ namespace cytnx {
       blas_int N = len;
       blas_int ONE = 1;
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -2278,7 +2067,6 @@ namespace cytnx {
         sscal(&N, &a, _out, &ONE);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -2299,7 +2087,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -2321,7 +2108,6 @@ namespace cytnx {
       if (Lin->size() == 1) {
         memset(_out, 0,
                sizeof(cytnx_float) * len);  // since Rin cannot be the same as out, set to zero.
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           if (_Rin[i]) _out[i] = _Lin[0];
         }
@@ -2332,7 +2118,6 @@ namespace cytnx {
         else
           memset(_out, 0, sizeof(cytnx_float) * len);
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * float(_Rin[0]);
@@ -2341,7 +2126,6 @@ namespace cytnx {
       } else {
         if (shape.size() == 0) {
           memcpy(_out, _Lin, sizeof(cytnx_float) * len);
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             if (!_Rin[i]) _out[i] = 0;
           }
@@ -2362,7 +2146,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             if (_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)])
@@ -2418,18 +2201,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -2450,7 +2230,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -2470,18 +2249,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -2502,7 +2278,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -2522,18 +2297,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -2554,7 +2326,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -2574,18 +2345,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -2606,7 +2374,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -2626,18 +2393,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -2658,7 +2422,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -2678,18 +2441,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -2710,7 +2470,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -2732,7 +2491,6 @@ namespace cytnx {
       if (Lin->size() == 1) {
         memset(_out, 0,
                sizeof(cytnx_int64) * len);  // since Rin cannot be the same as out, set to zero.
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           if (_Rin[i]) _out[i] = _Lin[0];
         }
@@ -2743,7 +2501,6 @@ namespace cytnx {
         else
           memset(_out, 0, sizeof(cytnx_int64) * len);
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * cytnx_int64(_Rin[0]);
@@ -2752,7 +2509,6 @@ namespace cytnx {
       } else {
         if (shape.size() == 0) {
           memcpy(_out, _Lin, sizeof(cytnx_int64) * len);
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             if (!_Rin[i]) _out[i] = 0;
           }
@@ -2773,7 +2529,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             if (_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)])
@@ -2836,18 +2591,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -2868,7 +2620,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -2888,18 +2639,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -2920,7 +2668,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -2940,18 +2687,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -2972,7 +2716,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -2992,18 +2735,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -3024,7 +2764,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -3044,18 +2783,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -3076,7 +2812,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -3098,7 +2833,6 @@ namespace cytnx {
       if (Lin->size() == 1) {
         memset(_out, 0,
                sizeof(cytnx_uint64) * len);  // since Rin cannot be the same as out, set to zero.
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           if (_Rin[i]) _out[i] = _Lin[0];
         }
@@ -3109,7 +2843,6 @@ namespace cytnx {
         else
           memset(_out, 0, sizeof(cytnx_uint64) * len);
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * cytnx_uint64(_Rin[0]);
@@ -3118,7 +2851,6 @@ namespace cytnx {
       } else {
         if (shape.size() == 0) {
           memcpy(_out, _Lin, sizeof(cytnx_uint64) * len);
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             if (!_Rin[i]) _out[i] = 0;
           }
@@ -3139,7 +2871,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             if (_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)])
@@ -3210,18 +2941,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -3242,7 +2970,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -3262,18 +2989,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -3294,7 +3018,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -3314,18 +3037,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -3346,7 +3066,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -3366,18 +3085,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -3398,7 +3114,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -3420,7 +3135,6 @@ namespace cytnx {
       if (Lin->size() == 1) {
         memset(_out, 0,
                sizeof(cytnx_int32) * len);  // since Rin cannot be the same as out, set to zero.
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           if (_Rin[i]) _out[i] = _Lin[0];
         }
@@ -3431,7 +3145,6 @@ namespace cytnx {
         else
           memset(_out, 0, sizeof(cytnx_int32) * len);
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * cytnx_int32(_Rin[0]);
@@ -3440,7 +3153,6 @@ namespace cytnx {
       } else {
         if (shape.size() == 0) {
           memcpy(_out, _Lin, sizeof(cytnx_int32) * len);
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             if (!_Rin[i]) _out[i] = 0;
           }
@@ -3461,7 +3173,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             if (_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)])
@@ -3541,18 +3252,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -3573,7 +3281,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -3593,18 +3300,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -3625,7 +3329,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -3645,18 +3348,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -3677,7 +3377,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -3699,7 +3398,6 @@ namespace cytnx {
       if (Lin->size() == 1) {
         memset(_out, 0,
                sizeof(cytnx_uint32) * len);  // since Rin cannot be the same as out, set to zero.
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           if (_Rin[i]) _out[i] = _Lin[0];
         }
@@ -3710,7 +3408,6 @@ namespace cytnx {
         else
           memset(_out, 0, sizeof(cytnx_uint32) * len);
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * cytnx_uint32(_Rin[0]);
@@ -3719,7 +3416,6 @@ namespace cytnx {
       } else {
         if (shape.size() == 0) {
           memcpy(_out, _Lin, sizeof(cytnx_uint32) * len);
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             if (!_Rin[i]) _out[i] = 0;
           }
@@ -3740,7 +3436,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             if (_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)])
@@ -3827,18 +3522,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -3859,7 +3551,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -3879,18 +3570,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -3911,7 +3599,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -3933,7 +3620,6 @@ namespace cytnx {
       if (Lin->size() == 1) {
         memset(_out, 0,
                sizeof(cytnx_int16) * len);  // since Rin cannot be the same as out, set to zero.
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           if (_Rin[i]) _out[i] = _Lin[0];
         }
@@ -3944,7 +3630,6 @@ namespace cytnx {
         else
           memset(_out, 0, sizeof(cytnx_int16) * len);
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * cytnx_int16(_Rin[0]);
@@ -3953,7 +3638,6 @@ namespace cytnx {
       } else {
         if (shape.size() == 0) {
           memcpy(_out, _Lin, sizeof(cytnx_int16) * len);
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             if (!_Rin[i]) _out[i] = 0;
           }
@@ -3974,7 +3658,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             if (_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)])
@@ -4069,18 +3752,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] * _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] * _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] * _Rin[i];
           }
@@ -4101,7 +3781,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *
@@ -4123,7 +3802,6 @@ namespace cytnx {
       if (Lin->size() == 1) {
         memset(_out, 0,
                sizeof(cytnx_uint16) * len);  // since Rin cannot be the same as out, set to zero.
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           if (_Rin[i]) _out[i] = _Lin[0];
         }
@@ -4134,7 +3812,6 @@ namespace cytnx {
         else
           memset(_out, 0, sizeof(cytnx_uint16) * len);
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * cytnx_int16(_Rin[0]);
@@ -4143,7 +3820,6 @@ namespace cytnx {
       } else {
         if (shape.size() == 0) {
           memcpy(_out, _Lin, sizeof(cytnx_uint16) * len);
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             if (!_Rin[i]) _out[i] = 0;
           }
@@ -4164,7 +3840,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             if (_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)])
@@ -4272,7 +3947,6 @@ namespace cytnx {
         else
           memset(_out, 0, sizeof(bool) * len);
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[0] * _Rin[i];
@@ -4280,7 +3954,6 @@ namespace cytnx {
         */
       } else if (Rin->size() == 1) {
         /*
-                      #pragma omp parallel for schedule(dynamic)
 
             for(unsigned long long i=0;i<len;i++){
                 _out[i] = _Lin[i] * _Rin[0];
@@ -4292,7 +3965,6 @@ namespace cytnx {
           memset(_out, 0, sizeof(bool) * len);
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] & _Rin[i];
           }
@@ -4313,7 +3985,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] &

--- a/src/backend/linalg_internal_cpu/Norm_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Norm_internal.cpp
@@ -2,9 +2,6 @@
 #include "../utils_internal_interface.hpp"
 #include "utils/utils.hpp"
 #include "backend/lapack_wrapper.hpp"
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 
 namespace cytnx {
 

--- a/src/backend/linalg_internal_cpu/Outer_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Outer_internal.cpp
@@ -4,10 +4,6 @@
 #include "utils/complex_arithmetic.hpp"
 #include "backend/lapack_wrapper.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 // change to *ger
 
 namespace cytnx {
@@ -23,7 +19,6 @@ namespace cytnx {
       T1 *_Lin = (T1 *)Lin->data();
       T2 *_Rin = (T2 *)Rin->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long r = 0; r < j1 * j2; r++) {
         _out[r] = _Lin[cytnx_uint64(r / j2)] * _Rin[(r % j2)];
       }

--- a/src/backend/linalg_internal_cpu/Pow_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Pow_internal.cpp
@@ -1,10 +1,6 @@
 #include "backend/linalg_internal_cpu/Pow_internal.hpp"
 #include "cytnx_error.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
   namespace linalg_internal {
 
@@ -14,7 +10,6 @@ namespace cytnx {
       cytnx_double *_out = (cytnx_double *)out->data();
       cytnx_double *_ten = (cytnx_double *)ten->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = pow(_ten[n], p);
       }
@@ -26,7 +21,6 @@ namespace cytnx {
       cytnx_float *_out = (cytnx_float *)out->data();
       cytnx_float *_ten = (cytnx_float *)ten->data();
 
-#pragma omp parallel for
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = powf(_ten[n], p);
       }
@@ -38,7 +32,6 @@ namespace cytnx {
       cytnx_complex128 *_out = (cytnx_complex128 *)out->data();
       cytnx_complex128 *_ten = (cytnx_complex128 *)ten->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = pow(_ten[n], p);
       }
@@ -50,7 +43,6 @@ namespace cytnx {
       cytnx_complex64 *_out = (cytnx_complex64 *)out->data();
       cytnx_complex64 *_ten = (cytnx_complex64 *)ten->data();
 
-#pragma omp parallel for
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = pow(_ten[n], p);
       }

--- a/src/backend/linalg_internal_cpu/QR_internal.cpp
+++ b/src/backend/linalg_internal_cpu/QR_internal.cpp
@@ -20,7 +20,6 @@ namespace cytnx {
       cytnx_uint64 min = M < N ? M : N;
       min = min < diag_N ? min : diag_N;
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 i = 0; i < min; i++) out[i] = elem[i * N + i];
     }
 

--- a/src/backend/linalg_internal_cpu/QR_pivot_internal.cpp
+++ b/src/backend/linalg_internal_cpu/QR_pivot_internal.cpp
@@ -20,7 +20,6 @@ namespace cytnx {
       cytnx_uint64 min = M < N ? M : N;
       min = min < diag_N ? min : diag_N;
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 i = 0; i < min; i++) out[i] = elem[i * N + i];
     }
 

--- a/src/backend/linalg_internal_cpu/Stat_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Stat_internal.cpp
@@ -1,10 +1,6 @@
 #include "backend/linalg_internal_cpu/Stat_internal.hpp"
 #include "cytnx_error.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
   namespace linalg_internal {
 
@@ -13,7 +9,6 @@ namespace cytnx {
       cytnx_double *_out = (cytnx_double *)out->Mem;
       cytnx_double *_ten = (cytnx_double *)ten->Mem;
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = pow(_ten[n], p);
       }
@@ -24,7 +19,6 @@ namespace cytnx {
       cytnx_float *_out = (cytnx_float *)out->Mem;
       cytnx_float *_ten = (cytnx_float *)ten->Mem;
 
-#pragma omp parallel for
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = powf(_ten[n], p);
       }
@@ -35,7 +29,6 @@ namespace cytnx {
       cytnx_complex128 *_out = (cytnx_complex128 *)out->Mem;
       cytnx_complex128 *_ten = (cytnx_complex128 *)ten->Mem;
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = pow(_ten[n], p);
       }
@@ -46,7 +39,6 @@ namespace cytnx {
       cytnx_complex64 *_out = (cytnx_complex64 *)out->Mem;
       cytnx_complex64 *_ten = (cytnx_complex64 *)ten->Mem;
 
-#pragma omp parallel for
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[n] = pow(_ten[n], p);
       }

--- a/src/backend/linalg_internal_cpu/Sub_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Sub_internal.cpp
@@ -1,9 +1,6 @@
 #include "Sub_internal.hpp"
 #include "../utils_internal_interface.hpp"
 #include "utils/utils.hpp"
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 
 namespace cytnx {
 
@@ -20,18 +17,15 @@ namespace cytnx {
       cytnx_complex128 *_Lin = (cytnx_complex128 *)Lin->data();
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -52,7 +46,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -72,18 +65,15 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -104,7 +94,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -124,20 +113,17 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0];
           _out[i].real(_out[i].real() - _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i];
           _out[i].real(_out[i].real() - _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i];
             _out[i].real(_out[i].real() - _Rin[i]);
@@ -159,7 +145,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)];
@@ -180,20 +165,17 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0];
           _out[i].real(_out[i].real() - _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i];
           _out[i].real(_out[i].real() - _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i];
             _out[i].real(_out[i].real() - _Rin[i]);
@@ -215,7 +197,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)];
@@ -236,20 +217,17 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0];
           _out[i].real(_out[i].real() - _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i];
           _out[i].real(_out[i].real() - _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i];
             _out[i].real(_out[i].real() - _Rin[i]);
@@ -271,7 +249,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)];
@@ -292,20 +269,17 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0];
           _out[i].real(_out[i].real() - _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i];
           _out[i].real(_out[i].real() - _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i];
             _out[i].real(_out[i].real() - _Rin[i]);
@@ -327,7 +301,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)];
@@ -348,20 +321,17 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0];
           _out[i].real(_out[i].real() - _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i];
           _out[i].real(_out[i].real() - _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i];
             _out[i].real(_out[i].real() - _Rin[i]);
@@ -383,7 +353,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)];
@@ -404,20 +373,17 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0];
           _out[i].real(_out[i].real() - _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i];
           _out[i].real(_out[i].real() - _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i];
             _out[i].real(_out[i].real() - _Rin[i]);
@@ -439,7 +405,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)];
@@ -460,20 +425,17 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0];
           _out[i].real(_out[i].real() - _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i];
           _out[i].real(_out[i].real() - _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i];
             _out[i].real(_out[i].real() - _Rin[i]);
@@ -495,7 +457,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)];
@@ -516,20 +477,17 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0];
           _out[i].real(_out[i].real() - _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i];
           _out[i].real(_out[i].real() - _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i];
             _out[i].real(_out[i].real() - _Rin[i]);
@@ -551,7 +509,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)];
@@ -572,18 +529,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - cytnx_complex128(_Rin[i], 0);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - cytnx_complex128(_Rin[0], 0);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - cytnx_complex128(_Rin[i], 0);
           }
@@ -604,7 +558,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -627,18 +580,15 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -659,7 +609,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -679,18 +628,15 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -711,7 +657,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -731,20 +676,17 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0];
           _out[i].real(_out[i].real() - _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i];
           _out[i].real(_out[i].real() - _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i];
             _out[i].real(_out[i].real() - _Rin[i]);
@@ -766,7 +708,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)];
@@ -787,20 +728,17 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0];
           _out[i].real(_out[i].real() - _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i];
           _out[i].real(_out[i].real() - _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i];
             _out[i].real(_out[i].real() - _Rin[i]);
@@ -822,7 +760,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)];
@@ -843,20 +780,17 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0];
           _out[i].real(_out[i].real() - _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i];
           _out[i].real(_out[i].real() - _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i];
             _out[i].real(_out[i].real() - _Rin[i]);
@@ -878,7 +812,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)];
@@ -899,20 +832,17 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0];
           _out[i].real(_out[i].real() - _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i];
           _out[i].real(_out[i].real() - _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i];
             _out[i].real(_out[i].real() - _Rin[i]);
@@ -934,7 +864,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)];
@@ -955,20 +884,17 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0];
           _out[i].real(_out[i].real() - _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i];
           _out[i].real(_out[i].real() - _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i];
             _out[i].real(_out[i].real() - _Rin[i]);
@@ -990,7 +916,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)];
@@ -1011,20 +936,17 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0];
           _out[i].real(_out[i].real() - _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i];
           _out[i].real(_out[i].real() - _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i];
             _out[i].real(_out[i].real() - _Rin[i]);
@@ -1046,7 +968,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)];
@@ -1067,20 +988,17 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0];
           _out[i].real(_out[i].real() - _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i];
           _out[i].real(_out[i].real() - _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i];
             _out[i].real(_out[i].real() - _Rin[i]);
@@ -1102,7 +1020,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)];
@@ -1123,20 +1040,17 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0];
           _out[i].real(_out[i].real() - _Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i];
           _out[i].real(_out[i].real() - _Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i];
             _out[i].real(_out[i].real() - _Rin[i]);
@@ -1158,7 +1072,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)];
@@ -1179,18 +1092,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - cytnx_complex64(_Rin[i], 0);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - cytnx_complex64(_Rin[0], 0);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - cytnx_complex64(_Rin[i], 0);
           }
@@ -1211,7 +1121,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -1234,20 +1143,17 @@ namespace cytnx {
       // std::cout << _Rin[0] << std::endl;
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[i];
           _out[i].real(_Lin[0] + _out[i].real());
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[0];
           _out[i].real(_Lin[i] + _out[i].real());
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = -_Rin[i];
             _out[i].real(_Lin[i] + _out[i].real());
@@ -1269,7 +1175,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = -_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)];
@@ -1290,20 +1195,17 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[i];
           _out[i].real(_Lin[0] + _out[i].real());
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[0];
           _out[i].real(_Lin[i] + _out[i].real());
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = -_Rin[i];
             _out[i].real(_Lin[i] + _out[i].real());
@@ -1325,7 +1227,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = -_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)];
@@ -1346,18 +1247,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -1378,7 +1276,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -1398,18 +1295,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -1430,7 +1324,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -1450,18 +1343,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -1482,7 +1372,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -1502,18 +1391,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -1534,7 +1420,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -1554,18 +1439,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -1586,7 +1468,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -1606,18 +1487,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -1638,7 +1516,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -1658,18 +1535,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -1690,7 +1564,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -1710,18 +1583,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -1742,7 +1612,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -1762,18 +1631,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - double(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - double(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - double(_Rin[i]);
           }
@@ -1794,7 +1660,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -1815,20 +1680,17 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[i];
           _out[i].real(_Lin[0] + _out[i].real());
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[0];
           _out[i].real(_Lin[i] + _out[i].real());
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = -_Rin[i];
             _out[i].real(_Lin[i] + _out[i].real());
@@ -1850,7 +1712,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = -_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)];
@@ -1871,20 +1732,17 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[i];
           _out[i].real(_Lin[0] + _out[i].real());
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[0];
           _out[i].real(_Lin[i] + _out[i].real());
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = -_Rin[i];
             _out[i].real(_Lin[i] + _out[i].real());
@@ -1906,7 +1764,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = -_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)];
@@ -1927,18 +1784,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -1959,7 +1813,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -1979,18 +1832,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -2011,7 +1861,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2031,18 +1880,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -2063,7 +1909,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2083,18 +1928,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -2115,7 +1957,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2135,18 +1976,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -2167,7 +2005,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2187,18 +2024,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -2219,7 +2053,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2239,18 +2072,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -2271,7 +2101,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2291,18 +2120,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -2323,7 +2149,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2343,18 +2168,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - float(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - float(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - float(_Rin[i]);
           }
@@ -2375,7 +2197,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2397,20 +2218,17 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[i];
           _out[i].real(_Lin[0] + _out[i].real());
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[0];
           _out[i].real(_Lin[i] + _out[i].real());
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = -_Rin[i];
             _out[i].real(_Lin[i] + _out[i].real());
@@ -2432,7 +2250,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = -_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)];
@@ -2453,20 +2270,17 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[i];
           _out[i].real(_Lin[0] + _out[i].real());
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[0];
           _out[i].real(_Lin[i] + _out[i].real());
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = -_Rin[i];
             _out[i].real(_Lin[i] + _out[i].real());
@@ -2488,7 +2302,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = -_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)];
@@ -2509,18 +2322,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -2541,7 +2351,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2561,18 +2370,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -2593,7 +2399,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2613,18 +2418,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -2645,7 +2447,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2665,18 +2466,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -2697,7 +2495,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2717,18 +2514,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -2749,7 +2543,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2769,18 +2562,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -2801,7 +2591,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2821,18 +2610,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -2853,7 +2639,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2873,18 +2658,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -2905,7 +2687,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2925,18 +2706,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - cytnx_int64(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - cytnx_int64(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - cytnx_int64(_Rin[i]);
           }
@@ -2957,7 +2735,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -2979,20 +2756,17 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[i];
           _out[i].real(_Lin[0] + _out[i].real());
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[0];
           _out[i].real(_Lin[i] + _out[i].real());
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = -_Rin[i];
             _out[i].real(_Lin[i] + _out[i].real());
@@ -3014,7 +2788,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = -_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)];
@@ -3035,20 +2808,17 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[i];
           _out[i].real(_Lin[0] + _out[i].real());
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[0];
           _out[i].real(_Lin[i] + _out[i].real());
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = -_Rin[i];
             _out[i].real(_Lin[i] + _out[i].real());
@@ -3070,7 +2840,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = -_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)];
@@ -3091,18 +2860,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -3123,7 +2889,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -3143,18 +2908,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -3175,7 +2937,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -3195,18 +2956,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -3227,7 +2985,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -3247,18 +3004,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -3279,7 +3033,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -3299,18 +3052,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -3331,7 +3081,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -3351,18 +3100,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -3383,7 +3129,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -3403,18 +3148,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -3435,7 +3177,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -3455,18 +3196,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -3487,7 +3225,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -3507,18 +3244,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - cytnx_uint64(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - cytnx_uint64(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - cytnx_uint64(_Rin[i]);
           }
@@ -3539,7 +3273,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -3560,20 +3293,17 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[i];
           _out[i].real(_Lin[0] + _out[i].real());
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[0];
           _out[i].real(_Lin[i] + _out[i].real());
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = -_Rin[i];
             _out[i].real(_Lin[i] + _out[i].real());
@@ -3595,7 +3325,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = -_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)];
@@ -3616,20 +3345,17 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[i];
           _out[i].real(_Lin[0] + _out[i].real());
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[0];
           _out[i].real(_Lin[i] + _out[i].real());
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = -_Rin[i];
             _out[i].real(_Lin[i] + _out[i].real());
@@ -3651,7 +3377,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = -_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)];
@@ -3672,18 +3397,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -3704,7 +3426,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -3724,18 +3445,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -3756,7 +3474,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -3776,18 +3493,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -3808,7 +3522,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -3828,18 +3541,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -3860,7 +3570,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -3880,18 +3589,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -3912,7 +3618,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -3932,18 +3637,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -3964,7 +3666,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -3984,18 +3685,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -4016,7 +3714,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -4036,18 +3733,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -4068,7 +3762,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -4088,18 +3781,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - cytnx_int32(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - cytnx_int32(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - cytnx_int32(_Rin[i]);
           }
@@ -4120,7 +3810,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -4142,20 +3831,17 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[i];
           _out[i].real(_Lin[0] + _out[i].real());
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[0];
           _out[i].real(_Lin[i] + _out[i].real());
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = -_Rin[i];
             _out[i].real(_Lin[i] + _out[i].real());
@@ -4177,7 +3863,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = -_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)];
@@ -4198,20 +3883,17 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[i];
           _out[i].real(_Lin[0] + _out[i].real());
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[0];
           _out[i].real(_Lin[i] + _out[i].real());
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = -_Rin[i];
             _out[i].real(_Lin[i] + _out[i].real());
@@ -4233,7 +3915,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = -_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)];
@@ -4254,18 +3935,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -4286,7 +3964,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -4306,18 +3983,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -4338,7 +4012,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -4358,18 +4031,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -4390,7 +4060,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -4410,18 +4079,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -4442,7 +4108,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -4462,18 +4127,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -4494,7 +4156,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -4514,18 +4175,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -4546,7 +4204,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -4566,18 +4223,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -4598,7 +4252,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -4618,18 +4271,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -4650,7 +4300,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -4670,18 +4319,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - cytnx_uint32(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - cytnx_uint32(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - cytnx_uint32(_Rin[i]);
           }
@@ -4702,7 +4348,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -4723,20 +4368,17 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[i];
           _out[i].real(_Lin[0] + _out[i].real());
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[0];
           _out[i].real(_Lin[i] + _out[i].real());
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = -_Rin[i];
             _out[i].real(_Lin[i] + _out[i].real());
@@ -4758,7 +4400,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = -_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)];
@@ -4779,20 +4420,17 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[i];
           _out[i].real(_Lin[0] + _out[i].real());
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[0];
           _out[i].real(_Lin[i] + _out[i].real());
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = -_Rin[i];
             _out[i].real(_Lin[i] + _out[i].real());
@@ -4814,7 +4452,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = -_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)];
@@ -4835,18 +4472,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -4867,7 +4501,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -4887,18 +4520,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -4919,7 +4549,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -4939,18 +4568,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -4971,7 +4597,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -4991,18 +4616,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -5023,7 +4645,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -5043,18 +4664,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -5075,7 +4693,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -5095,18 +4712,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -5127,7 +4741,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -5147,18 +4760,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -5179,7 +4789,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -5199,18 +4808,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -5231,7 +4837,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -5251,18 +4856,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - cytnx_int16(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - cytnx_int16(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - cytnx_int16(_Rin[i]);
           }
@@ -5283,7 +4885,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -5304,20 +4905,17 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[i];
           _out[i].real(_Lin[0] + _out[i].real());
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[0];
           _out[i].real(_Lin[i] + _out[i].real());
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = -_Rin[i];
             _out[i].real(_Lin[i] + _out[i].real());
@@ -5339,7 +4937,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = -_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)];
@@ -5360,20 +4957,17 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[i];
           _out[i].real(_Lin[0] + _out[i].real());
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = -_Rin[0];
           _out[i].real(_Lin[i] + _out[i].real());
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = -_Rin[i];
             _out[i].real(_Lin[i] + _out[i].real());
@@ -5395,7 +4989,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = -_Rin[cartesian2c(vec_map(tmpv, invmapper_R), old_accu_shapeR)];
@@ -5416,18 +5009,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -5448,7 +5038,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -5468,18 +5057,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -5500,7 +5086,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -5520,18 +5105,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -5552,7 +5134,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -5572,18 +5153,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -5604,7 +5182,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -5624,18 +5201,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -5656,7 +5230,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -5676,18 +5249,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -5708,7 +5278,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -5728,18 +5297,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -5760,7 +5326,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -5780,18 +5345,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -5812,7 +5374,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -5832,18 +5393,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - cytnx_uint16(_Rin[i]);
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - cytnx_uint16(_Rin[0]);
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - cytnx_uint16(_Rin[i]);
           }
@@ -5864,7 +5422,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -
@@ -5885,18 +5442,15 @@ namespace cytnx {
       cytnx_complex128 *_Rin = (cytnx_complex128 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_complex128(_Lin[0], 0) - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_complex128(_Lin[i], 0) - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_complex128(_Lin[i], 0) - _Rin[i];
           }
@@ -5917,7 +5471,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -5938,18 +5491,15 @@ namespace cytnx {
       cytnx_complex64 *_Rin = (cytnx_complex64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_complex64(_Lin[0], 0) - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_complex64(_Lin[i], 0) - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_complex64(_Lin[i], 0) - _Rin[i];
           }
@@ -5970,7 +5520,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] =
@@ -5991,18 +5540,15 @@ namespace cytnx {
       cytnx_double *_Rin = (cytnx_double *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = double(_Lin[0]) - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = double(_Lin[i]) - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = double(_Lin[i]) - _Rin[i];
           }
@@ -6023,7 +5569,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = double(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) -
@@ -6043,18 +5588,15 @@ namespace cytnx {
       cytnx_float *_Rin = (cytnx_float *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = float(_Lin[0]) - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = float(_Lin[i]) - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = float(_Lin[i]) - _Rin[i];
           }
@@ -6075,7 +5617,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = float(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) -
@@ -6095,18 +5636,15 @@ namespace cytnx {
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int64(_Lin[0]) - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int64(_Lin[i]) - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_int64(_Lin[i]) - _Rin[i];
           }
@@ -6127,7 +5665,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_int64(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) -
@@ -6147,18 +5684,15 @@ namespace cytnx {
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint64(_Lin[0]) - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint64(_Lin[i]) - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_uint64(_Lin[i]) - _Rin[i];
           }
@@ -6179,7 +5713,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_uint64(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) -
@@ -6199,18 +5732,15 @@ namespace cytnx {
       cytnx_int32 *_Rin = (cytnx_int32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int32(_Lin[0]) - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int32(_Lin[i]) - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_int32(_Lin[i]) - _Rin[i];
           }
@@ -6231,7 +5761,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_int32(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) -
@@ -6251,18 +5780,15 @@ namespace cytnx {
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint32(_Lin[0]) - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint32(_Lin[i]) - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_uint32(_Lin[i]) - _Rin[i];
           }
@@ -6283,7 +5809,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_uint32(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) -
@@ -6303,18 +5828,15 @@ namespace cytnx {
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int16(_Lin[0]) - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_int16(_Lin[i]) - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_int16(_Lin[i]) - _Rin[i];
           }
@@ -6335,7 +5857,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_int16(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) -
@@ -6355,18 +5876,15 @@ namespace cytnx {
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint16(_Lin[0]) - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = cytnx_uint16(_Lin[i]) - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = cytnx_uint16(_Lin[i]) - _Rin[i];
           }
@@ -6387,7 +5905,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = cytnx_uint16(_Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)]) -
@@ -6407,18 +5924,15 @@ namespace cytnx {
       cytnx_bool *_Rin = (cytnx_bool *)Rin->data();
 
       if (Lin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[0] - _Rin[i];
         }
       } else if (Rin->size() == 1) {
-#pragma omp parallel for schedule(dynamic)
         for (unsigned long long i = 0; i < len; i++) {
           _out[i] = _Lin[i] - _Rin[0];
         }
       } else {
         if (shape.size() == 0) {
-#pragma omp parallel for schedule(dynamic)
           for (unsigned long long i = 0; i < len; i++) {
             _out[i] = _Lin[i] - _Rin[i];
           }
@@ -6439,7 +5953,6 @@ namespace cytnx {
           }
 
           // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
           for (cytnx_uint64 i = 0; i < len; i++) {
             std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
             _out[i] = _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -

--- a/src/backend/linalg_internal_cpu/Sum_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Sum_internal.cpp
@@ -6,12 +6,6 @@
 #include "cytnx_error.hpp"
 #include "Type.hpp"
 
-#ifdef UNI_OMP
-  #include <vector>
-
-  #include <omp.h>
-#endif
-
 using namespace std;
 
 namespace cytnx {
@@ -23,31 +17,10 @@ namespace cytnx {
       cytnx_uint64 *_ten = (cytnx_uint64 *)ten->data();
       cytnx_uint64 *_out = (cytnx_uint64 *)out->data();
 
-#ifdef UNI_OMP
-      vector<cytnx_uint64> buf;
-      unsigned int Nproc;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-      }
-      buf = vector<cytnx_uint64>(Nproc, 0);
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < Nelem; n++) {
-        buf[omp_get_thread_num()] += _ten[n];
-      }
-
-      for (int i = 1; i < Nproc; i++) {
-        buf[0] += buf[i];
-      }
-      _out[0] = buf[0];
-
-#else
       _out[0] = 0;
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[0] += _ten[n];
       }
-#endif
     }
 
     void Sum_internal_i64(boost::intrusive_ptr<Storage_base> &out,
@@ -56,31 +29,10 @@ namespace cytnx {
       cytnx_int64 *_ten = (cytnx_int64 *)ten->data();
       cytnx_int64 *_out = (cytnx_int64 *)out->data();
 
-#ifdef UNI_OMP
-      vector<cytnx_int64> buf;
-      unsigned int Nproc = 1;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-      }
-      buf = vector<cytnx_int64>(Nproc, 0);
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < Nelem; n++) {
-        buf[omp_get_thread_num()] += _ten[n];
-      }
-
-      for (int i = 1; i < Nproc; i++) {
-        buf[0] += buf[i];
-      }
-      _out[0] = buf[0];
-
-#else
       _out[0] = 0;
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[0] += _ten[n];
       }
-#endif
     }
 
     void Sum_internal_u32(boost::intrusive_ptr<Storage_base> &out,
@@ -89,31 +41,10 @@ namespace cytnx {
       cytnx_uint32 *_ten = (cytnx_uint32 *)ten->data();
       cytnx_uint32 *_out = (cytnx_uint32 *)out->data();
 
-#ifdef UNI_OMP
-      vector<cytnx_uint32> buf;
-      unsigned int Nproc;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-      }
-      buf = vector<cytnx_uint32>(Nproc, 0);
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < Nelem; n++) {
-        buf[omp_get_thread_num()] += _ten[n];
-      }
-
-      for (int i = 1; i < Nproc; i++) {
-        buf[0] += buf[i];
-      }
-      _out[0] = buf[0];
-
-#else
       _out[0] = 0;
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[0] += _ten[n];
       }
-#endif
     }
 
     void Sum_internal_i32(boost::intrusive_ptr<Storage_base> &out,
@@ -122,31 +53,10 @@ namespace cytnx {
       cytnx_int32 *_ten = (cytnx_int32 *)ten->data();
       cytnx_int32 *_out = (cytnx_int32 *)out->data();
 
-#ifdef UNI_OMP
-      vector<cytnx_int32> buf;
-      unsigned int Nproc;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-      }
-      buf = vector<cytnx_int32>(Nproc, 0);
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < Nelem; n++) {
-        buf[omp_get_thread_num()] += _ten[n];
-      }
-
-      for (int i = 1; i < Nproc; i++) {
-        buf[0] += buf[i];
-      }
-      _out[0] = buf[0];
-
-#else
       _out[0] = 0;
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[0] += _ten[n];
       }
-#endif
     }
 
     void Sum_internal_u16(boost::intrusive_ptr<Storage_base> &out,
@@ -155,31 +65,10 @@ namespace cytnx {
       cytnx_uint16 *_ten = (cytnx_uint16 *)ten->data();
       cytnx_uint16 *_out = (cytnx_uint16 *)out->data();
 
-#ifdef UNI_OMP
-      vector<cytnx_uint16> buf;
-      unsigned int Nproc;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-      }
-      buf = vector<cytnx_uint16>(Nproc, 0);
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < Nelem; n++) {
-        buf[omp_get_thread_num()] += _ten[n];
-      }
-
-      for (int i = 1; i < Nproc; i++) {
-        buf[0] += buf[i];
-      }
-      _out[0] = buf[0];
-
-#else
       _out[0] = 0;
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[0] += _ten[n];
       }
-#endif
     }
 
     void Sum_internal_i16(boost::intrusive_ptr<Storage_base> &out,
@@ -188,31 +77,10 @@ namespace cytnx {
       cytnx_int16 *_ten = (cytnx_int16 *)ten->data();
       cytnx_int16 *_out = (cytnx_int16 *)out->data();
 
-#ifdef UNI_OMP
-      vector<cytnx_int16> buf;
-      unsigned int Nproc;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-      }
-      buf = vector<cytnx_int16>(Nproc, 0);
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < Nelem; n++) {
-        buf[omp_get_thread_num()] += _ten[n];
-      }
-
-      for (int i = 1; i < Nproc; i++) {
-        buf[0] += buf[i];
-      }
-      _out[0] = buf[0];
-
-#else
       _out[0] = 0;
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[0] += _ten[n];
       }
-#endif
     }
 
     void Sum_internal_d(boost::intrusive_ptr<Storage_base> &out,
@@ -220,31 +88,10 @@ namespace cytnx {
       cytnx_double *_ten = (cytnx_double *)ten->data();
       cytnx_double *_out = (cytnx_double *)out->data();
 
-#ifdef UNI_OMP
-      vector<cytnx_double> buf;
-      unsigned int Nproc;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-      }
-      buf = vector<cytnx_double>(Nproc, 0);
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < Nelem; n++) {
-        buf[omp_get_thread_num()] += _ten[n];
-      }
-
-      for (int i = 1; i < Nproc; i++) {
-        buf[0] += buf[i];
-      }
-      _out[0] = buf[0];
-
-#else
       _out[0] = 0;
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[0] += _ten[n];
       }
-#endif
     }
 
     void Sum_internal_f(boost::intrusive_ptr<Storage_base> &out,
@@ -252,62 +99,20 @@ namespace cytnx {
       cytnx_float *_ten = (cytnx_float *)ten->data();
       cytnx_float *_out = (cytnx_float *)out->data();
 
-#ifdef UNI_OMP
-      vector<cytnx_float> buf;
-      unsigned int Nproc;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-      }
-      buf = vector<cytnx_float>(Nproc, 0);
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < Nelem; n++) {
-        buf[omp_get_thread_num()] += _ten[n];
-      }
-
-      for (int i = 1; i < Nproc; i++) {
-        buf[0] += buf[i];
-      }
-      _out[0] = buf[0];
-
-#else
       _out[0] = 0;
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[0] += _ten[n];
       }
-#endif
     }
     void Sum_internal_cd(boost::intrusive_ptr<Storage_base> &out,
                          const boost::intrusive_ptr<Storage_base> &ten, const cytnx_uint64 &Nelem) {
       cytnx_complex128 *_ten = (cytnx_complex128 *)ten->data();
       cytnx_complex128 *_out = (cytnx_complex128 *)out->data();
 
-#ifdef UNI_OMP
-      vector<cytnx_complex128> buf;
-      unsigned int Nproc;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-      }
-      buf = vector<cytnx_complex128>(Nproc, 0);
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < Nelem; n++) {
-        buf[omp_get_thread_num()] += _ten[n];
-      }
-
-      for (int i = 1; i < Nproc; i++) {
-        buf[0] += buf[i];
-      }
-      _out[0] = buf[0];
-
-#else
       _out[0] = 0;
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[0] += _ten[n];
       }
-#endif
     }
 
     void Sum_internal_cf(boost::intrusive_ptr<Storage_base> &out,
@@ -315,31 +120,10 @@ namespace cytnx {
       cytnx_complex64 *_ten = (cytnx_complex64 *)ten->data();
       cytnx_complex64 *_out = (cytnx_complex64 *)out->data();
 
-#ifdef UNI_OMP
-      vector<cytnx_complex64> buf;
-      unsigned int Nproc;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0) Nproc = omp_get_num_threads();
-      }
-      buf = vector<cytnx_complex64>(Nproc, 0);
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < Nelem; n++) {
-        buf[omp_get_thread_num()] += _ten[n];
-      }
-
-      for (int i = 1; i < Nproc; i++) {
-        buf[0] += buf[i];
-      }
-      _out[0] = buf[0];
-
-#else
       _out[0] = 0;
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         _out[0] += _ten[n];
       }
-#endif
     }
 
     void Sum_internal_b(boost::intrusive_ptr<Storage_base> &out,

--- a/src/backend/linalg_internal_cpu/Trace_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Trace_internal.cpp
@@ -8,10 +8,6 @@
 #include "UniTensor.hpp"
 #include <vector>
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
   namespace linalg_internal {
 
@@ -54,74 +50,7 @@ namespace cytnx {
       // }
     }
 
-// parallel version:
-#ifdef UNI_OMP
-    template <class T>
-    void _trace_2d_para(Tensor &out, const Tensor &Tn, const cytnx_uint64 &Ndiag, const int &Nomp) {
-      T a = 0;
-      std::vector<T> buffer(Nomp);
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 i = 0; i < Ndiag; i++) buffer[omp_get_thread_num()] += Tn.at<T>({i, i});
-
-      for (int i = 1; i < Nomp; i++) buffer[0] += buffer[i];
-      out.storage().at<T>({0}) = buffer[0];
-    }
-
-    /*
-    template <class T>
-    void _trace_nd_para(Tensor &out, const Tensor &Tn, const cytnx_uint64 &Ndiag, const int &Nomp,
-                        const cytnx_uint64 &Nelem, const std::vector<cytnx_uint64> &accu,
-                        const std::vector<cytnx_uint64> &remain_rank_id, const
-    std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1, const cytnx_uint64 &ax2) {
-      // decide parallel Nelem or Ndiag:
-      if (false and Nelem < Ndiag) {
-        // each thread need it's own indexer:
-        std::vector<std::vector<cytnx_uint64>> indexers(Nomp,
-    std::vector<cytnx_uint64>(Tn.shape().size(), 0));
-
-        #pragma omp parallel for schedule(dynamic)
-        for (cytnx_uint64 i = 0; i < Nelem; i++) {
-          cytnx_uint64 tmp = i;
-          // calculate indexer
-          for (int x = 0; x < shape.size(); x++) {
-            indexers[omp_get_thread_num()][remain_rank_id[x]] = cytnx_uint64(tmp / accu[x]);
-            tmp %= accu[x];
-          }
-
-          for (cytnx_uint64 d = 0; d < Ndiag; d++) {
-            indexers[omp_get_thread_num()][ax1] = indexers[omp_get_thread_num()][ax2] = d;
-            out.storage().at<T>(i) += Tn.at<T>(indexers[omp_get_thread_num()]);
-          }
-        }
-
-      } else {
-        #pragma omp parallel
-        {
-          std::vector<cytnx_uint64> indexers(Tn.shape().size(), 0);
-
-          #pragma omp for schedule(static)
-          for (cytnx_uint64 i = 0; i < Nelem; i++) {
-            cytnx_uint64 tmp;
-            tmp = i;
-            // calculate indexer
-            for (int x = 0; x < shape.size(); x++) {
-              indexers[remain_rank_id[x]] = cytnx_uint64(tmp / accu[x]);
-              tmp %= accu[x];
-            }
-            std::cout << omp_get_thread_num() << " " << i << Nelem << std::endl;
-            for (cytnx_uint64 d = 0; d < Ndiag; d++) {
-              indexers[ax1] = indexers[ax2] = d;
-              out.storage().at<T>(i) += Tn.at<T>(indexers);
-            }
-          }// end omp for
-
-        }// end omp para
-      }// end if switch
-    }
-    [Deprecated] */
-#endif
-
+    // TODO: remove Nomp parameter
     void Trace_internal_cd(const bool &is_2d, Tensor &out, const Tensor &Tn,
                            const cytnx_uint64 &Ndiag, const int &Nomp, const cytnx_uint64 &Nelem,
                            const std::vector<cytnx_uint64> &accu,
@@ -129,17 +58,9 @@ namespace cytnx {
                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
                            const cytnx_uint64 &ax2) {
       if (is_2d) {
-#ifdef UNI_OMP
-        _trace_2d_para<cytnx_complex128>(out, Tn, Ndiag, Nomp);
-#else
         _trace_2d<cytnx_complex128>(out, Tn, Ndiag);
-#endif
       } else {
-#ifdef UNI_OMP
         _trace_nd<cytnx_complex128>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
-#else
-        _trace_nd<cytnx_complex128>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
-#endif
       }
     }
 
@@ -150,17 +71,9 @@ namespace cytnx {
                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
                            const cytnx_uint64 &ax2) {
       if (is_2d) {
-#ifdef UNI_OMP
-        _trace_2d_para<cytnx_complex64>(out, Tn, Ndiag, Nomp);
-#else
         _trace_2d<cytnx_complex64>(out, Tn, Ndiag);
-#endif
       } else {
-#ifdef UNI_OMP
         _trace_nd<cytnx_complex64>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
-#else
-        _trace_nd<cytnx_complex64>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
-#endif
       }
     }
 
@@ -171,17 +84,9 @@ namespace cytnx {
                           const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
                           const cytnx_uint64 &ax2) {
       if (is_2d) {
-#ifdef UNI_OMP
-        _trace_2d_para<cytnx_double>(out, Tn, Ndiag, Nomp);
-#else
         _trace_2d<cytnx_double>(out, Tn, Ndiag);
-#endif
       } else {
-#ifdef UNI_OMP
         _trace_nd<cytnx_double>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
-#else
-        _trace_nd<cytnx_double>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
-#endif
       }
     }
 
@@ -192,17 +97,9 @@ namespace cytnx {
                           const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
                           const cytnx_uint64 &ax2) {
       if (is_2d) {
-#ifdef UNI_OMP
-        _trace_2d_para<cytnx_float>(out, Tn, Ndiag, Nomp);
-#else
         _trace_2d<cytnx_float>(out, Tn, Ndiag);
-#endif
       } else {
-#ifdef UNI_OMP
         _trace_nd<cytnx_float>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
-#else
-        _trace_nd<cytnx_float>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
-#endif
       }
     }
 
@@ -213,17 +110,9 @@ namespace cytnx {
                             const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
                             const cytnx_uint64 &ax2) {
       if (is_2d) {
-#ifdef UNI_OMP
-        _trace_2d_para<cytnx_uint64>(out, Tn, Ndiag, Nomp);
-#else
         _trace_2d<cytnx_uint64>(out, Tn, Ndiag);
-#endif
       } else {
-#ifdef UNI_OMP
         _trace_nd<cytnx_uint64>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
-#else
-        _trace_nd<cytnx_uint64>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
-#endif
       }
     }
 
@@ -234,17 +123,9 @@ namespace cytnx {
                             const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
                             const cytnx_uint64 &ax2) {
       if (is_2d) {
-#ifdef UNI_OMP
-        _trace_2d_para<cytnx_int64>(out, tn, ndiag, nomp);
-#else
         _trace_2d<cytnx_int64>(out, tn, ndiag);
-#endif
       } else {
-#ifdef UNI_OMP
         _trace_nd<cytnx_int64>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
-#else
-        _trace_nd<cytnx_int64>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
-#endif
       }
     }
 
@@ -255,17 +136,9 @@ namespace cytnx {
                             const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
                             const cytnx_uint64 &ax2) {
       if (is_2d) {
-#ifdef UNI_OMP
-        _trace_2d_para<cytnx_uint32>(out, tn, ndiag, nomp);
-#else
         _trace_2d<cytnx_uint32>(out, tn, ndiag);
-#endif
       } else {
-#ifdef UNI_OMP
         _trace_nd<cytnx_uint32>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
-#else
-        _trace_nd<cytnx_uint32>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
-#endif
       }
     }
 
@@ -276,17 +149,9 @@ namespace cytnx {
                             const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
                             const cytnx_uint64 &ax2) {
       if (is_2d) {
-#ifdef UNI_OMP
-        _trace_2d_para<cytnx_int32>(out, tn, ndiag, nomp);
-#else
         _trace_2d<cytnx_int32>(out, tn, ndiag);
-#endif
       } else {
-#ifdef UNI_OMP
         _trace_nd<cytnx_int32>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
-#else
-        _trace_nd<cytnx_int32>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
-#endif
       }
     }
 
@@ -297,17 +162,9 @@ namespace cytnx {
                             const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
                             const cytnx_uint64 &ax2) {
       if (is_2d) {
-#ifdef UNI_OMP
-        _trace_2d_para<cytnx_uint16>(out, tn, ndiag, nomp);
-#else
         _trace_2d<cytnx_uint16>(out, tn, ndiag);
-#endif
       } else {
-#ifdef UNI_OMP
         _trace_nd<cytnx_uint16>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
-#else
-        _trace_nd<cytnx_uint16>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
-#endif
       }
     }
 
@@ -318,17 +175,9 @@ namespace cytnx {
                             const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
                             const cytnx_uint64 &ax2) {
       if (is_2d) {
-#ifdef UNI_OMP
-        _trace_2d_para<cytnx_int16>(out, tn, ndiag, nomp);
-#else
         _trace_2d<cytnx_int16>(out, tn, ndiag);
-#endif
       } else {
-#ifdef UNI_OMP
         _trace_nd<cytnx_int16>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
-#else
-        _trace_nd<cytnx_int16>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
-#endif
       }
     }
 

--- a/src/backend/linalg_internal_cpu/Vectordot_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Vectordot_internal.cpp
@@ -3,9 +3,6 @@
 #include "utils/utils.hpp"
 #include "backend/lapack_wrapper.hpp"
 #include <vector>
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 
 namespace cytnx {
 
@@ -164,28 +161,10 @@ namespace cytnx {
       cytnx_int64 *_Lin = (cytnx_int64 *)Lin->data();
       cytnx_int64 *_Rin = (cytnx_int64 *)Rin->data();
 
-#ifdef UNI_OMP
-      std::vector<cytnx_int64> tmp;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0) tmp.assign(omp_get_num_threads(), 0);
-      }
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 i = 0; i < len; i++) {
-        tmp[omp_get_thread_num()] += _Lin[i] * _Rin[i];
-      }
-      _out[0] = 0;
-      for (cytnx_uint32 n = 0; n < tmp.size(); n++) {
-        _out[0] += tmp[n];
-      }
-
-#else
       _out[0] = 0;
       for (cytnx_uint64 i = 0; i < len; i++) {
         _out[0] += _Lin[i] * _Rin[i];
       }
-#endif
     }
     void Vectordot_internal_u64(boost::intrusive_ptr<Storage_base> &out,
                                 const boost::intrusive_ptr<Storage_base> &Lin,
@@ -195,28 +174,10 @@ namespace cytnx {
       cytnx_uint64 *_Lin = (cytnx_uint64 *)Lin->data();
       cytnx_uint64 *_Rin = (cytnx_uint64 *)Rin->data();
 
-#ifdef UNI_OMP
-      std::vector<cytnx_uint64> tmp;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0) tmp.assign(omp_get_num_threads(), 0);
-      }
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 i = 0; i < len; i++) {
-        tmp[omp_get_thread_num()] += _Lin[i] * _Rin[i];
-      }
-      _out[0] = 0;
-      for (cytnx_uint32 n = 0; n < tmp.size(); n++) {
-        _out[0] += tmp[n];
-      }
-
-#else
       _out[0] = 0;
       for (cytnx_uint64 i = 0; i < len; i++) {
         _out[0] += _Lin[i] * _Rin[i];
       }
-#endif
     }
     void Vectordot_internal_i32(boost::intrusive_ptr<Storage_base> &out,
                                 const boost::intrusive_ptr<Storage_base> &Lin,
@@ -226,28 +187,10 @@ namespace cytnx {
       blas_int *_Lin = (blas_int *)Lin->data();
       blas_int *_Rin = (blas_int *)Rin->data();
 
-#ifdef UNI_OMP
-      std::vector<blas_int> tmp;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0) tmp.assign(omp_get_num_threads(), 0);
-      }
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 i = 0; i < len; i++) {
-        tmp[omp_get_thread_num()] += _Lin[i] * _Rin[i];
-      }
-      _out[0] = 0;
-      for (cytnx_uint32 n = 0; n < tmp.size(); n++) {
-        _out[0] += tmp[n];
-      }
-
-#else
       _out[0] = 0;
       for (cytnx_uint64 i = 0; i < len; i++) {
         _out[0] += _Lin[i] * _Rin[i];
       }
-#endif
     }
     void Vectordot_internal_u32(boost::intrusive_ptr<Storage_base> &out,
                                 const boost::intrusive_ptr<Storage_base> &Lin,
@@ -257,28 +200,10 @@ namespace cytnx {
       cytnx_uint32 *_Lin = (cytnx_uint32 *)Lin->data();
       cytnx_uint32 *_Rin = (cytnx_uint32 *)Rin->data();
 
-#ifdef UNI_OMP
-      std::vector<cytnx_uint32> tmp;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0) tmp.assign(omp_get_num_threads(), 0);
-      }
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 i = 0; i < len; i++) {
-        tmp[omp_get_thread_num()] += _Lin[i] * _Rin[i];
-      }
-      _out[0] = 0;
-      for (cytnx_uint32 n = 0; n < tmp.size(); n++) {
-        _out[0] += tmp[n];
-      }
-
-#else
       _out[0] = 0;
       for (cytnx_uint64 i = 0; i < len; i++) {
         _out[0] += _Lin[i] * _Rin[i];
       }
-#endif
     }
     void Vectordot_internal_i16(boost::intrusive_ptr<Storage_base> &out,
                                 const boost::intrusive_ptr<Storage_base> &Lin,
@@ -288,28 +213,10 @@ namespace cytnx {
       cytnx_int16 *_Lin = (cytnx_int16 *)Lin->data();
       cytnx_int16 *_Rin = (cytnx_int16 *)Rin->data();
 
-#ifdef UNI_OMP
-      std::vector<cytnx_int16> tmp;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0) tmp.assign(omp_get_num_threads(), 0);
-      }
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 i = 0; i < len; i++) {
-        tmp[omp_get_thread_num()] += _Lin[i] * _Rin[i];
-      }
-      _out[0] = 0;
-      for (cytnx_uint32 n = 0; n < tmp.size(); n++) {
-        _out[0] += tmp[n];
-      }
-
-#else
       _out[0] = 0;
       for (cytnx_uint64 i = 0; i < len; i++) {
         _out[0] += _Lin[i] * _Rin[i];
       }
-#endif
     }
     void Vectordot_internal_u16(boost::intrusive_ptr<Storage_base> &out,
                                 const boost::intrusive_ptr<Storage_base> &Lin,
@@ -319,28 +226,10 @@ namespace cytnx {
       cytnx_uint16 *_Lin = (cytnx_uint16 *)Lin->data();
       cytnx_uint16 *_Rin = (cytnx_uint16 *)Rin->data();
 
-#ifdef UNI_OMP
-      std::vector<cytnx_uint16> tmp;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0) tmp.assign(omp_get_num_threads(), 0);
-      }
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 i = 0; i < len; i++) {
-        tmp[omp_get_thread_num()] += _Lin[i] * _Rin[i];
-      }
-      _out[0] = 0;
-      for (cytnx_uint32 n = 0; n < tmp.size(); n++) {
-        _out[0] += tmp[n];
-      }
-
-#else
       _out[0] = 0;
       for (cytnx_uint64 i = 0; i < len; i++) {
         _out[0] += _Lin[i] * _Rin[i];
       }
-#endif
     }
     void Vectordot_internal_b(boost::intrusive_ptr<Storage_base> &out,
                               const boost::intrusive_ptr<Storage_base> &Lin,

--- a/src/backend/linalg_internal_cpu/iAdd_internal.cpp
+++ b/src/backend/linalg_internal_cpu/iAdd_internal.cpp
@@ -2,9 +2,6 @@
 #include "../utils_internal_interface.hpp"
 #include "utils/utils.hpp"
 #include <iostream>
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 
 namespace cytnx {
 
@@ -31,7 +28,6 @@ namespace cytnx {
       }
 
       // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 i = 0; i < len; i++) {
         std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
         _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] +=
@@ -41,7 +37,6 @@ namespace cytnx {
 
     template <class T1, class T2>
     void _kernel_conti_iadd(T1 *_Lin, T2 *_Rin, const unsigned long long &len) {
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len; i++) {
         _Lin[i] += _Rin[i];
       }
@@ -49,7 +44,6 @@ namespace cytnx {
 
     template <class T1, class T2>
     void _kernel_const_iadd(T1 *_Lin, T2 *_Rin, const unsigned long long &len) {
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len; i++) {
         _Lin[i] += _Rin[0];
       }

--- a/src/backend/linalg_internal_cpu/iDiv_internal.cpp
+++ b/src/backend/linalg_internal_cpu/iDiv_internal.cpp
@@ -2,9 +2,6 @@
 #include "../utils_internal_interface.hpp"
 #include "utils/utils.hpp"
 #include <iostream>
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 
 namespace cytnx {
 
@@ -31,7 +28,6 @@ namespace cytnx {
       }
 
       // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 i = 0; i < len; i++) {
         std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
         _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] /=
@@ -41,7 +37,6 @@ namespace cytnx {
 
     template <class T1, class T2>
     void _kernel_conti_idiv(T1 *_Lin, T2 *_Rin, const unsigned long long &len) {
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len; i++) {
         _Lin[i] /= _Rin[i];
       }
@@ -49,7 +44,6 @@ namespace cytnx {
 
     template <class T1, class T2>
     void _kernel_const_idiv(T1 *_Lin, T2 *_Rin, const unsigned long long &len) {
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len; i++) {
         _Lin[i] /= _Rin[0];
       }

--- a/src/backend/linalg_internal_cpu/iMul_internal.cpp
+++ b/src/backend/linalg_internal_cpu/iMul_internal.cpp
@@ -2,9 +2,6 @@
 #include "../utils_internal_interface.hpp"
 #include "utils/utils.hpp"
 #include <iostream>
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 
 namespace cytnx {
 
@@ -31,7 +28,6 @@ namespace cytnx {
       }
 
       // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 i = 0; i < len; i++) {
         std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
         _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] *=
@@ -41,7 +37,6 @@ namespace cytnx {
 
     template <class T1, class T2>
     void _kernel_conti_imul(T1 *_Lin, T2 *_Rin, const unsigned long long &len) {
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len; i++) {
         _Lin[i] *= _Rin[i];
       }
@@ -49,7 +44,6 @@ namespace cytnx {
 
     template <class T1, class T2>
     void _kernel_const_imul(T1 *_Lin, T2 *_Rin, const unsigned long long &len) {
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len; i++) {
         _Lin[i] *= _Rin[0];
       }

--- a/src/backend/linalg_internal_cpu/iSub_internal.cpp
+++ b/src/backend/linalg_internal_cpu/iSub_internal.cpp
@@ -2,9 +2,6 @@
 #include "../utils_internal_interface.hpp"
 #include "utils/utils.hpp"
 #include <iostream>
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 
 namespace cytnx {
 
@@ -31,7 +28,6 @@ namespace cytnx {
       }
 
       // handle non-contiguous
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 i = 0; i < len; i++) {
         std::vector<cytnx_uint64> tmpv = c2cartesian(i, accu_shape);
         _Lin[cartesian2c(vec_map(tmpv, invmapper_L), old_accu_shapeL)] -=
@@ -41,7 +37,6 @@ namespace cytnx {
 
     template <class T1, class T2>
     void _kernel_conti_isub(T1 *_Lin, T2 *_Rin, const unsigned long long &len) {
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len; i++) {
         _Lin[i] -= _Rin[i];
       }
@@ -49,7 +44,6 @@ namespace cytnx {
 
     template <class T1, class T2>
     void _kernel_const_isub(T1 *_Lin, T2 *_Rin, const unsigned long long &len) {
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len; i++) {
         _Lin[i] -= _Rin[0];
       }

--- a/src/backend/utils_internal_cpu/Cast_cpu.cpp
+++ b/src/backend/utils_internal_cpu/Cast_cpu.cpp
@@ -1,8 +1,5 @@
 #include "Cast_cpu.hpp"
 #include "backend/Storage.hpp"
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 
 using namespace std;
 
@@ -30,7 +27,6 @@ namespace cytnx {
       cytnx_complex128* _in = static_cast<cytnx_complex128*>(in->data());
       cytnx_complex64* _out = static_cast<cytnx_complex64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -46,7 +42,6 @@ namespace cytnx {
       cytnx_complex64* _in = static_cast<cytnx_complex64*>(in->data());
       cytnx_complex128* _out = static_cast<cytnx_complex128*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -74,7 +69,6 @@ namespace cytnx {
 
       memset(_out, 0, sizeof(cytnx_complex128) * len_in);
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -91,7 +85,6 @@ namespace cytnx {
       cytnx_complex64* _out = static_cast<cytnx_complex64*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex64) * len_in);
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -116,7 +109,6 @@ namespace cytnx {
       cytnx_double* _in = static_cast<cytnx_double*>(in->data());
       cytnx_float* _out = static_cast<cytnx_float*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -131,7 +123,6 @@ namespace cytnx {
       cytnx_double* _in = static_cast<cytnx_double*>(in->data());
       cytnx_int64* _out = static_cast<cytnx_int64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -146,7 +137,6 @@ namespace cytnx {
       cytnx_double* _in = static_cast<cytnx_double*>(in->data());
       cytnx_uint64* _out = static_cast<cytnx_uint64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -161,7 +151,6 @@ namespace cytnx {
       cytnx_double* _in = static_cast<cytnx_double*>(in->data());
       cytnx_int32* _out = static_cast<cytnx_int32*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -176,7 +165,6 @@ namespace cytnx {
       cytnx_double* _in = static_cast<cytnx_double*>(in->data());
       cytnx_uint32* _out = static_cast<cytnx_uint32*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -191,7 +179,6 @@ namespace cytnx {
       cytnx_double* _in = static_cast<cytnx_double*>(in->data());
       cytnx_int16* _out = static_cast<cytnx_int16*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -206,7 +193,6 @@ namespace cytnx {
       cytnx_double* _in = static_cast<cytnx_double*>(in->data());
       cytnx_uint16* _out = static_cast<cytnx_uint16*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -221,7 +207,6 @@ namespace cytnx {
       cytnx_double* _in = static_cast<cytnx_double*>(in->data());
       cytnx_bool* _out = static_cast<cytnx_bool*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = bool(_in[i]);
       }
@@ -238,7 +223,6 @@ namespace cytnx {
       cytnx_complex128* _out = static_cast<cytnx_complex128*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex128) * len_in);
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -253,7 +237,6 @@ namespace cytnx {
       cytnx_float* _in = static_cast<cytnx_float*>(in->data());
       cytnx_complex64* _out = static_cast<cytnx_complex64*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex64) * len_in);
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -268,7 +251,6 @@ namespace cytnx {
       cytnx_float* _in = static_cast<cytnx_float*>(in->data());
       cytnx_double* _out = static_cast<cytnx_double*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -292,7 +274,6 @@ namespace cytnx {
       cytnx_float* _in = static_cast<cytnx_float*>(in->data());
       cytnx_int64* _out = static_cast<cytnx_int64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -307,7 +288,6 @@ namespace cytnx {
       cytnx_float* _in = static_cast<cytnx_float*>(in->data());
       cytnx_uint64* _out = static_cast<cytnx_uint64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -322,7 +302,6 @@ namespace cytnx {
       cytnx_float* _in = static_cast<cytnx_float*>(in->data());
       cytnx_int32* _out = static_cast<cytnx_int32*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -337,7 +316,6 @@ namespace cytnx {
       cytnx_float* _in = static_cast<cytnx_float*>(in->data());
       cytnx_uint32* _out = static_cast<cytnx_uint32*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -352,7 +330,6 @@ namespace cytnx {
       cytnx_float* _in = static_cast<cytnx_float*>(in->data());
       cytnx_int16* _out = static_cast<cytnx_int16*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -367,7 +344,6 @@ namespace cytnx {
       cytnx_float* _in = static_cast<cytnx_float*>(in->data());
       cytnx_uint16* _out = static_cast<cytnx_uint16*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -382,7 +358,6 @@ namespace cytnx {
       cytnx_float* _in = static_cast<cytnx_float*>(in->data());
       cytnx_bool* _out = static_cast<cytnx_bool*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = bool(_in[i]);
       }
@@ -399,7 +374,6 @@ namespace cytnx {
       cytnx_complex128* _out = static_cast<cytnx_complex128*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex128) * len_in);
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -415,7 +389,6 @@ namespace cytnx {
       cytnx_complex64* _out = static_cast<cytnx_complex64*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex64) * len_in);
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -430,7 +403,6 @@ namespace cytnx {
       cytnx_int64* _in = static_cast<cytnx_int64*>(in->data());
       cytnx_double* _out = static_cast<cytnx_double*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -445,7 +417,6 @@ namespace cytnx {
       cytnx_int64* _in = static_cast<cytnx_int64*>(in->data());
       cytnx_float* _out = static_cast<cytnx_float*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -469,7 +440,6 @@ namespace cytnx {
       cytnx_int64* _in = static_cast<cytnx_int64*>(in->data());
       cytnx_uint64* _out = static_cast<cytnx_uint64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -484,7 +454,6 @@ namespace cytnx {
       cytnx_int64* _in = static_cast<cytnx_int64*>(in->data());
       cytnx_int32* _out = static_cast<cytnx_int32*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -499,7 +468,6 @@ namespace cytnx {
       cytnx_int64* _in = static_cast<cytnx_int64*>(in->data());
       cytnx_uint32* _out = static_cast<cytnx_uint32*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -514,7 +482,6 @@ namespace cytnx {
       cytnx_int64* _in = static_cast<cytnx_int64*>(in->data());
       cytnx_int16* _out = static_cast<cytnx_int16*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -529,7 +496,6 @@ namespace cytnx {
       cytnx_int64* _in = static_cast<cytnx_int64*>(in->data());
       cytnx_uint16* _out = static_cast<cytnx_uint16*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -544,7 +510,6 @@ namespace cytnx {
       cytnx_int64* _in = static_cast<cytnx_int64*>(in->data());
       cytnx_bool* _out = static_cast<cytnx_bool*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = bool(_in[i]);
       }
@@ -561,7 +526,6 @@ namespace cytnx {
       cytnx_uint64* _in = static_cast<cytnx_uint64*>(in->data());
       cytnx_complex128* _out = static_cast<cytnx_complex128*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex128) * len_in);
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -576,7 +540,6 @@ namespace cytnx {
       cytnx_uint64* _in = static_cast<cytnx_uint64*>(in->data());
       cytnx_complex64* _out = static_cast<cytnx_complex64*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex64) * len_in);
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -591,7 +554,6 @@ namespace cytnx {
       cytnx_uint64* _in = static_cast<cytnx_uint64*>(in->data());
       cytnx_double* _out = static_cast<cytnx_double*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -606,7 +568,6 @@ namespace cytnx {
       cytnx_uint64* _in = static_cast<cytnx_uint64*>(in->data());
       cytnx_float* _out = static_cast<cytnx_float*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -621,7 +582,6 @@ namespace cytnx {
       cytnx_uint64* _in = static_cast<cytnx_uint64*>(in->data());
       cytnx_int64* _out = static_cast<cytnx_int64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -645,7 +605,6 @@ namespace cytnx {
       cytnx_uint64* _in = static_cast<cytnx_uint64*>(in->data());
       cytnx_int32* _out = static_cast<cytnx_int32*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -660,7 +619,6 @@ namespace cytnx {
       cytnx_uint64* _in = static_cast<cytnx_uint64*>(in->data());
       cytnx_uint32* _out = static_cast<cytnx_uint32*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -675,7 +633,6 @@ namespace cytnx {
       cytnx_uint64* _in = static_cast<cytnx_uint64*>(in->data());
       cytnx_int16* _out = static_cast<cytnx_int16*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -690,7 +647,6 @@ namespace cytnx {
       cytnx_uint64* _in = static_cast<cytnx_uint64*>(in->data());
       cytnx_uint16* _out = static_cast<cytnx_uint16*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -705,7 +661,6 @@ namespace cytnx {
       cytnx_uint64* _in = static_cast<cytnx_uint64*>(in->data());
       cytnx_bool* _out = static_cast<cytnx_bool*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = bool(_in[i]);
       }
@@ -722,7 +677,6 @@ namespace cytnx {
       cytnx_int32* _in = static_cast<cytnx_int32*>(in->data());
       cytnx_complex128* _out = static_cast<cytnx_complex128*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex128) * len_in);
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -738,7 +692,6 @@ namespace cytnx {
       cytnx_complex64* _out = static_cast<cytnx_complex64*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex64) * len_in);
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -753,7 +706,6 @@ namespace cytnx {
       cytnx_int32* _in = static_cast<cytnx_int32*>(in->data());
       cytnx_double* _out = static_cast<cytnx_double*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -768,7 +720,6 @@ namespace cytnx {
       cytnx_int32* _in = static_cast<cytnx_int32*>(in->data());
       cytnx_float* _out = static_cast<cytnx_float*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -783,7 +734,6 @@ namespace cytnx {
       cytnx_int32* _in = static_cast<cytnx_int32*>(in->data());
       cytnx_int64* _out = static_cast<cytnx_int64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -798,7 +748,6 @@ namespace cytnx {
       cytnx_int32* _in = static_cast<cytnx_int32*>(in->data());
       cytnx_uint64* _out = static_cast<cytnx_uint64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -822,7 +771,6 @@ namespace cytnx {
       cytnx_int32* _in = static_cast<cytnx_int32*>(in->data());
       cytnx_uint32* _out = static_cast<cytnx_uint32*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -837,7 +785,6 @@ namespace cytnx {
       cytnx_int32* _in = static_cast<cytnx_int32*>(in->data());
       cytnx_uint16* _out = static_cast<cytnx_uint16*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -852,7 +799,6 @@ namespace cytnx {
       cytnx_int32* _in = static_cast<cytnx_int32*>(in->data());
       cytnx_int16* _out = static_cast<cytnx_int16*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -867,7 +813,6 @@ namespace cytnx {
       cytnx_int32* _in = static_cast<cytnx_int32*>(in->data());
       cytnx_bool* _out = static_cast<cytnx_bool*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = bool(_in[i]);
       }
@@ -883,7 +828,6 @@ namespace cytnx {
       cytnx_uint32* _in = static_cast<cytnx_uint32*>(in->data());
       cytnx_complex128* _out = static_cast<cytnx_complex128*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex128) * len_in);
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -899,7 +843,6 @@ namespace cytnx {
       cytnx_complex64* _out = static_cast<cytnx_complex64*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex64) * len_in);
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -914,7 +857,6 @@ namespace cytnx {
       cytnx_uint32* _in = static_cast<cytnx_uint32*>(in->data());
       cytnx_double* _out = static_cast<cytnx_double*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -929,7 +871,6 @@ namespace cytnx {
       cytnx_uint32* _in = static_cast<cytnx_uint32*>(in->data());
       cytnx_float* _out = static_cast<cytnx_float*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -944,7 +885,6 @@ namespace cytnx {
       cytnx_uint32* _in = static_cast<cytnx_uint32*>(in->data());
       cytnx_int64* _out = static_cast<cytnx_int64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -959,7 +899,6 @@ namespace cytnx {
       cytnx_uint32* _in = static_cast<cytnx_uint32*>(in->data());
       cytnx_uint64* _out = static_cast<cytnx_uint64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -974,7 +913,6 @@ namespace cytnx {
       cytnx_uint32* _in = static_cast<cytnx_uint32*>(in->data());
       cytnx_int32* _out = static_cast<cytnx_int32*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -998,7 +936,6 @@ namespace cytnx {
       cytnx_uint32* _in = static_cast<cytnx_uint32*>(in->data());
       cytnx_uint16* _out = static_cast<cytnx_uint16*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1013,7 +950,6 @@ namespace cytnx {
       cytnx_uint32* _in = static_cast<cytnx_uint32*>(in->data());
       cytnx_int16* _out = static_cast<cytnx_int16*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1028,7 +964,6 @@ namespace cytnx {
       cytnx_uint32* _in = static_cast<cytnx_uint32*>(in->data());
       cytnx_bool* _out = static_cast<cytnx_bool*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = bool(_in[i]);
       }
@@ -1044,7 +979,6 @@ namespace cytnx {
       cytnx_uint16* _in = static_cast<cytnx_uint16*>(in->data());
       cytnx_complex128* _out = static_cast<cytnx_complex128*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex128) * len_in);
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -1059,7 +993,6 @@ namespace cytnx {
       cytnx_uint16* _in = static_cast<cytnx_uint16*>(in->data());
       cytnx_complex64* _out = static_cast<cytnx_complex64*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex64) * len_in);
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -1074,7 +1007,6 @@ namespace cytnx {
       cytnx_uint16* _in = static_cast<cytnx_uint16*>(in->data());
       cytnx_double* _out = static_cast<cytnx_double*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1089,7 +1021,6 @@ namespace cytnx {
       cytnx_uint16* _in = static_cast<cytnx_uint16*>(in->data());
       cytnx_float* _out = static_cast<cytnx_float*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1104,7 +1035,6 @@ namespace cytnx {
       cytnx_uint16* _in = static_cast<cytnx_uint16*>(in->data());
       cytnx_int64* _out = static_cast<cytnx_int64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1119,7 +1049,6 @@ namespace cytnx {
       cytnx_uint16* _in = static_cast<cytnx_uint16*>(in->data());
       cytnx_uint64* _out = static_cast<cytnx_uint64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1134,7 +1063,6 @@ namespace cytnx {
       cytnx_uint16* _in = static_cast<cytnx_uint16*>(in->data());
       cytnx_int32* _out = static_cast<cytnx_int32*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1149,7 +1077,6 @@ namespace cytnx {
       cytnx_uint16* _in = static_cast<cytnx_uint16*>(in->data());
       cytnx_uint32* _out = static_cast<cytnx_uint32*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1173,7 +1100,6 @@ namespace cytnx {
       cytnx_uint16* _in = static_cast<cytnx_uint16*>(in->data());
       cytnx_int16* _out = static_cast<cytnx_int16*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1188,7 +1114,6 @@ namespace cytnx {
       cytnx_uint16* _in = static_cast<cytnx_uint16*>(in->data());
       cytnx_bool* _out = static_cast<cytnx_bool*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = bool(_in[i]);
       }
@@ -1204,7 +1129,6 @@ namespace cytnx {
       cytnx_int16* _in = static_cast<cytnx_int16*>(in->data());
       cytnx_complex128* _out = static_cast<cytnx_complex128*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex128) * len_in);
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -1219,7 +1143,6 @@ namespace cytnx {
       cytnx_int16* _in = static_cast<cytnx_int16*>(in->data());
       cytnx_complex64* _out = static_cast<cytnx_complex64*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex64) * len_in);
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -1234,7 +1157,6 @@ namespace cytnx {
       cytnx_int16* _in = static_cast<cytnx_int16*>(in->data());
       cytnx_double* _out = static_cast<cytnx_double*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1249,7 +1171,6 @@ namespace cytnx {
       cytnx_int16* _in = static_cast<cytnx_int16*>(in->data());
       cytnx_float* _out = static_cast<cytnx_float*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1264,7 +1185,6 @@ namespace cytnx {
       cytnx_int16* _in = static_cast<cytnx_int16*>(in->data());
       cytnx_int64* _out = static_cast<cytnx_int64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1279,7 +1199,6 @@ namespace cytnx {
       cytnx_int16* _in = static_cast<cytnx_int16*>(in->data());
       cytnx_uint64* _out = static_cast<cytnx_uint64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1294,7 +1213,6 @@ namespace cytnx {
       cytnx_int16* _in = static_cast<cytnx_int16*>(in->data());
       cytnx_int32* _out = static_cast<cytnx_int32*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1309,7 +1227,6 @@ namespace cytnx {
       cytnx_int16* _in = static_cast<cytnx_int16*>(in->data());
       cytnx_uint32* _out = static_cast<cytnx_uint32*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1324,7 +1241,6 @@ namespace cytnx {
       cytnx_int16* _in = static_cast<cytnx_int16*>(in->data());
       cytnx_uint16* _out = static_cast<cytnx_uint16*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1348,7 +1264,6 @@ namespace cytnx {
       cytnx_int16* _in = static_cast<cytnx_int16*>(in->data());
       cytnx_bool* _out = static_cast<cytnx_bool*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = bool(_in[i]);
       }
@@ -1364,7 +1279,6 @@ namespace cytnx {
       cytnx_bool* _in = static_cast<cytnx_bool*>(in->data());
       cytnx_complex128* _out = static_cast<cytnx_complex128*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex128) * len_in);
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -1379,7 +1293,6 @@ namespace cytnx {
       cytnx_bool* _in = static_cast<cytnx_bool*>(in->data());
       cytnx_complex64* _out = static_cast<cytnx_complex64*>(out->data());
       memset(_out, 0, sizeof(cytnx_complex64) * len_in);
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i].real(_in[i]);
       }
@@ -1394,7 +1307,6 @@ namespace cytnx {
       cytnx_bool* _in = static_cast<cytnx_bool*>(in->data());
       cytnx_double* _out = static_cast<cytnx_double*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1409,7 +1321,6 @@ namespace cytnx {
       cytnx_bool* _in = static_cast<cytnx_bool*>(in->data());
       cytnx_float* _out = static_cast<cytnx_float*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1424,7 +1335,6 @@ namespace cytnx {
       cytnx_bool* _in = static_cast<cytnx_bool*>(in->data());
       cytnx_int64* _out = static_cast<cytnx_int64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1439,7 +1349,6 @@ namespace cytnx {
       cytnx_bool* _in = static_cast<cytnx_bool*>(in->data());
       cytnx_uint64* _out = static_cast<cytnx_uint64*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1454,7 +1363,6 @@ namespace cytnx {
       cytnx_bool* _in = static_cast<cytnx_bool*>(in->data());
       cytnx_int32* _out = static_cast<cytnx_int32*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1469,7 +1377,6 @@ namespace cytnx {
       cytnx_bool* _in = static_cast<cytnx_bool*>(in->data());
       cytnx_uint32* _out = static_cast<cytnx_uint32*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1484,7 +1391,6 @@ namespace cytnx {
       cytnx_bool* _in = static_cast<cytnx_bool*>(in->data());
       cytnx_uint16* _out = static_cast<cytnx_uint16*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }
@@ -1499,7 +1405,6 @@ namespace cytnx {
       cytnx_bool* _in = static_cast<cytnx_bool*>(in->data());
       cytnx_int16* _out = static_cast<cytnx_int16*>(out->data());
 
-#pragma omp parallel for schedule(dynamic)
       for (unsigned long long i = 0; i < len_in; i++) {
         _out[i] = _in[i];
       }

--- a/src/backend/utils_internal_cpu/Complexmem_cpu.cpp
+++ b/src/backend/utils_internal_cpu/Complexmem_cpu.cpp
@@ -2,10 +2,6 @@
 #include "backend/Storage.hpp"
 #include "backend/lapack_wrapper.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 #ifdef UNI_MKL
   #define __Cpt_dbl cytnx_complex128 *
   #define __Cpt_flt cytnx_complex64 *
@@ -24,12 +20,10 @@ namespace cytnx {
       cytnx_complex128 *src = static_cast<cytnx_complex128 *>(in);
 
       if (get_real) {
-#pragma omp parallel for schedule(dynamic)
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           des[n] = src[n].real();
         }
       } else {
-#pragma omp parallel for schedule(dynamic)
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           des[n] = src[n].imag();
         }
@@ -41,12 +35,10 @@ namespace cytnx {
       cytnx_complex64 *src = static_cast<cytnx_complex64 *>(in);
 
       if (get_real) {
-#pragma omp parallel for schedule(dynamic)
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           des[n] = src[n].real();
         }
       } else {
-#pragma omp parallel for schedule(dynamic)
         for (cytnx_uint64 n = 0; n < Nelem; n++) {
           des[n] = src[n].imag();
         }

--- a/src/backend/utils_internal_cpu/Fill_cpu.hpp
+++ b/src/backend/utils_internal_cpu/Fill_cpu.hpp
@@ -3,10 +3,6 @@
 
 #include "Type.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
   namespace utils_internal {
 
@@ -14,8 +10,7 @@ namespace cytnx {
      * @brief Assign the given value to the first `count` elements in the range beginning at
      * `first`.
      *
-     * This function act the same as `std::fill_n`. The execution will be parallelized when OMP is
-     * enabled.
+     * This function act the same as `std::fill_n`.
      *
      * @tparam DType the data type of the elements in the range
      *
@@ -26,7 +21,6 @@ namespace cytnx {
     template <typename DType>
     void FillCpu(void *first, const DType &value, cytnx_uint64 count) {
       DType *typed_first = reinterpret_cast<DType *>(first);
-#pragma omp parallel for schedule(static)
       for (cytnx_uint64 i = 0; i < count; i++) {
         typed_first[i] = value;
       }

--- a/src/backend/utils_internal_cpu/GetElems_contiguous_cpu.cpp
+++ b/src/backend/utils_internal_cpu/GetElems_contiguous_cpu.cpp
@@ -1,9 +1,5 @@
 #include "GetElems_contiguous_cpu.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
   namespace utils_internal {
 
@@ -15,7 +11,6 @@ namespace cytnx {
       cytnx_complex128 *elem_ptr_ = static_cast<cytnx_complex128 *>(in);
       cytnx_complex128 *new_elem_ptr_ = static_cast<cytnx_complex128 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -40,7 +35,6 @@ namespace cytnx {
       cytnx_complex64 *elem_ptr_ = static_cast<cytnx_complex64 *>(in);
       cytnx_complex64 *new_elem_ptr_ = static_cast<cytnx_complex64 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -65,7 +59,6 @@ namespace cytnx {
       cytnx_double *elem_ptr_ = static_cast<cytnx_double *>(in);
       cytnx_double *new_elem_ptr_ = static_cast<cytnx_double *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -91,7 +84,6 @@ namespace cytnx {
       cytnx_float *elem_ptr_ = static_cast<cytnx_float *>(in);
       cytnx_float *new_elem_ptr_ = static_cast<cytnx_float *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -116,7 +108,6 @@ namespace cytnx {
       cytnx_int64 *elem_ptr_ = static_cast<cytnx_int64 *>(in);
       cytnx_int64 *new_elem_ptr_ = static_cast<cytnx_int64 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -141,7 +132,6 @@ namespace cytnx {
       cytnx_uint64 *elem_ptr_ = static_cast<cytnx_uint64 *>(in);
       cytnx_uint64 *new_elem_ptr_ = static_cast<cytnx_uint64 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -166,7 +156,6 @@ namespace cytnx {
       cytnx_int32 *elem_ptr_ = static_cast<cytnx_int32 *>(in);
       cytnx_int32 *new_elem_ptr_ = static_cast<cytnx_int32 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -191,7 +180,6 @@ namespace cytnx {
       cytnx_uint32 *elem_ptr_ = static_cast<cytnx_uint32 *>(in);
       cytnx_uint32 *new_elem_ptr_ = static_cast<cytnx_uint32 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -216,7 +204,6 @@ namespace cytnx {
       cytnx_int16 *elem_ptr_ = static_cast<cytnx_int16 *>(in);
       cytnx_int16 *new_elem_ptr_ = static_cast<cytnx_int16 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -241,7 +228,6 @@ namespace cytnx {
       cytnx_uint16 *elem_ptr_ = static_cast<cytnx_uint16 *>(in);
       cytnx_uint16 *new_elem_ptr_ = static_cast<cytnx_uint16 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -266,7 +252,6 @@ namespace cytnx {
       cytnx_bool *elem_ptr_ = static_cast<cytnx_bool *>(in);
       cytnx_bool *new_elem_ptr_ = static_cast<cytnx_bool *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;

--- a/src/backend/utils_internal_cpu/GetElems_cpu.cpp
+++ b/src/backend/utils_internal_cpu/GetElems_cpu.cpp
@@ -1,9 +1,5 @@
 #include "GetElems_cpu.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 namespace cytnx {
   namespace utils_internal {
 
@@ -15,7 +11,6 @@ namespace cytnx {
       cytnx_complex128 *elem_ptr_ = static_cast<cytnx_complex128 *>(in);
       cytnx_complex128 *new_elem_ptr_ = static_cast<cytnx_complex128 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -38,7 +33,6 @@ namespace cytnx {
       cytnx_complex64 *elem_ptr_ = static_cast<cytnx_complex64 *>(in);
       cytnx_complex64 *new_elem_ptr_ = static_cast<cytnx_complex64 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -61,7 +55,6 @@ namespace cytnx {
       cytnx_double *elem_ptr_ = static_cast<cytnx_double *>(in);
       cytnx_double *new_elem_ptr_ = static_cast<cytnx_double *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -84,7 +77,6 @@ namespace cytnx {
       cytnx_float *elem_ptr_ = static_cast<cytnx_float *>(in);
       cytnx_float *new_elem_ptr_ = static_cast<cytnx_float *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -107,7 +99,6 @@ namespace cytnx {
       cytnx_int64 *elem_ptr_ = static_cast<cytnx_int64 *>(in);
       cytnx_int64 *new_elem_ptr_ = static_cast<cytnx_int64 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -130,7 +121,6 @@ namespace cytnx {
       cytnx_uint64 *elem_ptr_ = static_cast<cytnx_uint64 *>(in);
       cytnx_uint64 *new_elem_ptr_ = static_cast<cytnx_uint64 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -153,7 +143,6 @@ namespace cytnx {
       cytnx_int32 *elem_ptr_ = static_cast<cytnx_int32 *>(in);
       cytnx_int32 *new_elem_ptr_ = static_cast<cytnx_int32 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -176,7 +165,6 @@ namespace cytnx {
       cytnx_uint32 *elem_ptr_ = static_cast<cytnx_uint32 *>(in);
       cytnx_uint32 *new_elem_ptr_ = static_cast<cytnx_uint32 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -199,7 +187,6 @@ namespace cytnx {
       cytnx_int16 *elem_ptr_ = static_cast<cytnx_int16 *>(in);
       cytnx_int16 *new_elem_ptr_ = static_cast<cytnx_int16 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -222,7 +209,6 @@ namespace cytnx {
       cytnx_uint16 *elem_ptr_ = static_cast<cytnx_uint16 *>(in);
       cytnx_uint16 *new_elem_ptr_ = static_cast<cytnx_uint16 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -245,7 +231,6 @@ namespace cytnx {
       cytnx_bool *elem_ptr_ = static_cast<cytnx_bool *>(in);
       cytnx_bool *new_elem_ptr_ = static_cast<cytnx_bool *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;

--- a/src/backend/utils_internal_cpu/Movemem_cpu.cpp
+++ b/src/backend/utils_internal_cpu/Movemem_cpu.cpp
@@ -7,10 +7,6 @@
 
 #include "backend/Storage.hpp"
 
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
-
 #ifdef UNI_HPTT
   #include "hptt.h"
 #endif
@@ -50,32 +46,6 @@ namespace cytnx {
       T *des = (T *)malloc(in->capacity() * sizeof(T));
       T *src = static_cast<T *>(in->data());
 
-#ifdef UNI_OMP
-      std::vector<std::vector<cytnx_uint64>> old_inds;
-  #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0)
-          old_inds = std::vector<std::vector<cytnx_uint64>>(
-            omp_get_num_threads(), std::vector<cytnx_uint64>(old_shape.size()));
-      }
-
-  #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        cytnx_uint64 j;
-        cytnx_uint64 old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[omp_get_thread_num()][j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[omp_get_thread_num()][mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-
-#else
       std::vector<cytnx_uint64> old_inds(old_shape.size());
       cytnx_uint64 j, old_loc;
       for (cytnx_uint64 n = 0; n < accu_old; n++) {
@@ -91,7 +61,6 @@ namespace cytnx {
         }
         des[old_loc] = src[n];
       }
-#endif
       boost::intrusive_ptr<Storage_base> out;
       if constexpr (std::is_same_v<T, cytnx_uint64>) {
         out = new Uint64Storage();
@@ -197,32 +166,6 @@ namespace cytnx {
         accu_new *= newshape[i];
       }
 
-  #ifdef UNI_OMP
-      std::vector<std::vector<cytnx_uint64>> old_inds;
-    #pragma omp parallel
-      {
-        if (omp_get_thread_num() == 0)
-          old_inds = std::vector<std::vector<cytnx_uint64>>(
-            omp_get_num_threads(), std::vector<cytnx_uint64>(old_shape.size()));
-      }
-
-    #pragma omp parallel for schedule(dynamic)
-      for (cytnx_uint64 n = 0; n < accu_old; n++) {
-        // calc new id:
-        cytnx_uint64 j;
-        cytnx_uint64 old_loc = n;
-        for (j = 0; j < old_shape.size(); j++) {
-          old_inds[omp_get_thread_num()][j] = old_loc / shifter_old[j];
-          old_loc = old_loc % shifter_old[j];
-        }
-        old_loc = 0;  // position:
-        for (j = 0; j < old_shape.size(); j++) {
-          old_loc += shifter_new[j] * old_inds[omp_get_thread_num()][mapper[j]];
-        }
-        des[old_loc] = src[n];
-      }
-
-  #else
       std::vector<cytnx_int64> old_inds(old_shape.size());
       cytnx_int64 j, new_loc = 0;
       for (cytnx_int64 n = 0; n < accu_old; n++) {
@@ -247,7 +190,6 @@ namespace cytnx {
 
         old_inds[old_shape.size() - 1]++;
       }
-  #endif
 #endif  // hptt
       boost::intrusive_ptr<Storage_base> out;
       if constexpr (std::is_same_v<T, cytnx_complex128>) {

--- a/src/backend/utils_internal_cpu/MvElems_blks_cpu.cpp
+++ b/src/backend/utils_internal_cpu/MvElems_blks_cpu.cpp
@@ -39,7 +39,6 @@ namespace cytnx {
             oldshape.back() * acc_in_old[acc_in_old.size() - 1 - s];
           oldshape.pop_back();
         }
-#pragma omp parallel for schedule(dynamic)
         for (unsigned int elem = 0; elem < src_blocks[b].storage().size(); elem++) {
           unsigned int i = elem / src_blocks[b].shape()[1];
           unsigned int j = elem % src_blocks[b].shape()[1];

--- a/src/backend/utils_internal_cpu/Range_cpu.cpp
+++ b/src/backend/utils_internal_cpu/Range_cpu.cpp
@@ -1,7 +1,4 @@
 #include "Range_cpu.hpp"
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 
 using namespace std;
 namespace cytnx {
@@ -11,7 +8,6 @@ namespace cytnx {
       cytnx_error_msg(end < start, "[ERROR] cannot have end < start%s", "\n");
       vector<cytnx_uint64> out(end - start);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 i = 0; i < end - start; i++) {
         out[i] = start + i;
       }
@@ -21,7 +17,6 @@ namespace cytnx {
     vector<cytnx_uint64> range_cpu(const cytnx_uint64 &len) {
       vector<cytnx_uint64> out(len);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 i = 0; i < len; i++) {
         out[i] = i;
       }
@@ -31,7 +26,6 @@ namespace cytnx {
     template <>
     vector<cytnx_int64> range_cpu<cytnx_int64>(const cytnx_int64 &len) {
       vector<cytnx_int64> out(len);
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_int64 i = 0; i < len; i++) {
         out[i] = i;
       }
@@ -42,7 +36,6 @@ namespace cytnx {
     vector<cytnx_int64> range_cpu<cytnx_int64>(const cytnx_int64 &start, const cytnx_int64 &end) {
       cytnx_error_msg(end < start, "[ERROR] cannot have end < start%s", "\n");
       vector<cytnx_int64> out(end - start);
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_int64 i = 0; i < end - start; i++) {
         out[i] = start + i;
       }

--- a/src/backend/utils_internal_cpu/SetArange_cpu.cpp
+++ b/src/backend/utils_internal_cpu/SetArange_cpu.cpp
@@ -8,7 +8,6 @@ namespace cytnx {
                           const cytnx_uint64 &Nelem) {
       cytnx_complex128 *ptr = (cytnx_complex128 *)in->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         ptr[n].real(start + n * step);
         ptr[n].imag(0);
@@ -19,7 +18,6 @@ namespace cytnx {
                           const cytnx_uint64 &Nelem) {
       cytnx_complex64 *ptr = (cytnx_complex64 *)in->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         ptr[n].real(start + n * step);
         ptr[n].imag(0);
@@ -30,7 +28,6 @@ namespace cytnx {
                          const cytnx_uint64 &Nelem) {
       cytnx_double *ptr = (cytnx_double *)in->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         ptr[n] = start + n * step;
       }
@@ -40,7 +37,6 @@ namespace cytnx {
                          const cytnx_uint64 &Nelem) {
       cytnx_float *ptr = (cytnx_float *)in->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         ptr[n] = start + n * step;
       }
@@ -50,7 +46,6 @@ namespace cytnx {
                            const cytnx_uint64 &Nelem) {
       cytnx_int64 *ptr = (cytnx_int64 *)in->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         ptr[n] = start + n * step;
       }
@@ -60,7 +55,6 @@ namespace cytnx {
                            const cytnx_uint64 &Nelem) {
       cytnx_uint64 *ptr = (cytnx_uint64 *)in->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         ptr[n] = start + n * step;
       }
@@ -70,7 +64,6 @@ namespace cytnx {
                            const cytnx_uint64 &Nelem) {
       cytnx_int32 *ptr = (cytnx_int32 *)in->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         ptr[n] = start + n * step;
       }
@@ -80,7 +73,6 @@ namespace cytnx {
                            const cytnx_uint64 &Nelem) {
       cytnx_uint32 *ptr = (cytnx_uint32 *)in->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         ptr[n] = start + n * step;
       }
@@ -90,7 +82,6 @@ namespace cytnx {
                            const cytnx_uint64 &Nelem) {
       cytnx_int16 *ptr = (cytnx_int16 *)in->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         ptr[n] = start + n * step;
       }
@@ -100,7 +91,6 @@ namespace cytnx {
                            const cytnx_uint64 &Nelem) {
       cytnx_uint16 *ptr = (cytnx_uint16 *)in->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         ptr[n] = start + n * step;
       }
@@ -110,7 +100,6 @@ namespace cytnx {
                          const cytnx_uint64 &Nelem) {
       cytnx_bool *ptr = (cytnx_bool *)in->data();
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < Nelem; n++) {
         ptr[n] = start + n * step;
       }

--- a/src/backend/utils_internal_cpu/SetElems_contiguous_cpu.cpp
+++ b/src/backend/utils_internal_cpu/SetElems_contiguous_cpu.cpp
@@ -1,8 +1,5 @@
 #include "SetElems_contiguous_cpu.hpp"
 #include "../utils_internal_interface.hpp"
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 
 namespace cytnx {
   namespace utils_internal {
@@ -18,7 +15,6 @@ namespace cytnx {
       T1 *new_elem_ptr_ = static_cast<T1 *>(in);
       T1 *elem_ptr_ = static_cast<T1 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -45,7 +41,6 @@ namespace cytnx {
       T1 *new_elem_ptr_ = static_cast<T1 *>(in);
       T2 *elem_ptr_ = static_cast<T2 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -71,7 +66,6 @@ namespace cytnx {
       T1 new_elem_ = *(static_cast<T1 *>(in));
       T2 *elem_ptr_ = static_cast<T2 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;

--- a/src/backend/utils_internal_cpu/SetElems_cpu.cpp
+++ b/src/backend/utils_internal_cpu/SetElems_cpu.cpp
@@ -1,8 +1,5 @@
 #include "SetElems_cpu.hpp"
 #include "../utils_internal_interface.hpp"
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 
 namespace cytnx {
   namespace utils_internal {
@@ -16,7 +13,6 @@ namespace cytnx {
       T1 *new_elem_ptr_ = static_cast<T1 *>(in);
       T2 *elem_ptr_ = static_cast<T2 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;
@@ -41,7 +37,6 @@ namespace cytnx {
       T1 new_elem_ = *(static_cast<T1 *>(in));
       T2 *elem_ptr_ = static_cast<T2 *>(out);
 
-#pragma omp parallel for schedule(dynamic)
       for (cytnx_uint64 n = 0; n < TotalElem; n++) {
         // map from mem loc of new tensor to old tensor
         cytnx_uint64 Loc = 0;

--- a/src/backend/utils_internal_cpu/blocks_mvelems_cpu.cpp
+++ b/src/backend/utils_internal_cpu/blocks_mvelems_cpu.cpp
@@ -55,9 +55,6 @@ namespace cytnx {
       std::vector<cytnx_uint64> tfidx(acc_in_old.size() + acc_out_old.size());
 
       for (unsigned int b = 0; b < src_blocks.size(); b++) {
-        // #ifdef UNI_OMP
-        // #pragma omp parallel for schedule(dynamic)
-        // #endif
         for (unsigned int elem = 0; elem < src_blocks[b].storage().size(); elem++) {
           unsigned int i = elem / src_blocks[b].shape()[1];
           unsigned int j = elem % src_blocks[b].shape()[1];

--- a/src/linalg/Directsum.cpp
+++ b/src/linalg/Directsum.cpp
@@ -9,10 +9,6 @@ using namespace std;
 #ifdef BACKEND_TORCH
 #else
 
-  #ifdef UNI_OMP
-    #include <omp.h>
-  #endif
-
 namespace cytnx {
   namespace linalg {
     cytnx::Tensor Directsum(const cytnx::Tensor &T1, const cytnx::Tensor &T2,

--- a/src/linalg/Trace.cpp
+++ b/src/linalg/Trace.cpp
@@ -9,10 +9,6 @@
 #else
   #include "../backend/linalg_internal_interface.hpp"
 
-  #ifdef UNI_OMP
-    #include <omp.h>
-  #endif
-
 using namespace std;
 namespace cytnx {
   namespace linalg {

--- a/src/utils/vec_concatenate.cpp
+++ b/src/utils/vec_concatenate.cpp
@@ -14,15 +14,9 @@ namespace cytnx {
   std::vector<bool> vec_concatenate(const std::vector<bool> &inL, const std::vector<bool> &inR) {
     std::vector<bool> out(inL.size() + inR.size());
     // vector bool does not guarentee concurrent modification
-    // #ifdef UNI_OMP
-    //   #pragma omp parallel for schedule(dynamic)
-    // #endif
     for (cytnx_uint64 i = 0; i < inL.size(); i++) {
       out[i] = inL[i];
     }
-    // #ifdef UNI_OMP
-    //   #pragma omp parallel for schedule(dynamic)
-    // #endif
     for (cytnx_uint64 i = 0; i < inR.size(); i++) out[inL.size() + i] = inR[i];
 
     return out;
@@ -32,15 +26,9 @@ namespace cytnx {
                                            const std::vector<std::string> &inR) {
     std::vector<std::string> out(inL.size() + inR.size());
     // vector bool does not guarentee concurrent modification
-    // #ifdef UNI_OMP
-    //   #pragma omp parallel for schedule(dynamic)
-    // #endif
     for (cytnx_uint64 i = 0; i < inL.size(); i++) {
       out[i] = inL[i];
     }
-    // #ifdef UNI_OMP
-    //   #pragma omp parallel for schedule(dynamic)
-    // #endif
     for (cytnx_uint64 i = 0; i < inR.size(); i++) out[inL.size() + i] = inR[i];
 
     return out;
@@ -65,13 +53,7 @@ namespace cytnx {
                     "\n");
     out.resize(inL.size() + inR.size());
     // vector bool does not guarentee concurrent modification
-    // #ifdef UNI_OMP
-    //   #pragma omp parallel for schedule(dynamic)
-    // #endif
     for (cytnx_uint64 i = 0; i < inL.size(); i++) out[i] = inL[i];
-    // #ifdef UNI_OMP
-    //   #pragma omp parallel for schedule(dynamic)
-    // #endif
     for (cytnx_uint64 i = 0; i < inR.size(); i++) out[inL.size() + i] = inR[i];
   }
   template <>
@@ -83,13 +65,7 @@ namespace cytnx {
                     "\n");
     out.resize(inL.size() + inR.size());
     // vector bool does not guarentee concurrent modification
-    // #ifdef UNI_OMP
-    //   #pragma omp parallel for schedule(dynamic)
-    // #endif
     for (cytnx_uint64 i = 0; i < inL.size(); i++) out[i] = inL[i];
-    // #ifdef UNI_OMP
-    //   #pragma omp parallel for schedule(dynamic)
-    // #endif
     for (cytnx_uint64 i = 0; i < inR.size(); i++) out[inL.size() + i] = inR[i];
   }
 

--- a/src/utils/vec_range.cpp
+++ b/src/utils/vec_range.cpp
@@ -1,7 +1,4 @@
 #include "utils/vec_range.hpp"
-#ifdef UNI_OMP
-  #include <omp.h>
-#endif
 
 using namespace std;
 namespace cytnx {
@@ -10,7 +7,6 @@ namespace cytnx {
     cytnx_error_msg(end < start, "[ERROR] cannot have end < start%s", "\n");
     vector<cytnx_uint64> out(end - start);
 
-#pragma omp parallel for schedule(dynamic)
     for (cytnx_uint64 i = 0; i < end - start; i++) {
       out[i] = start + i;
     }
@@ -20,7 +16,6 @@ namespace cytnx {
   vector<cytnx_uint64> vec_range(const cytnx_uint64 &len) {
     vector<cytnx_uint64> out(len);
 
-#pragma omp parallel for schedule(dynamic)
     for (cytnx_uint64 i = 0; i < len; i++) {
       out[i] = i;
     }
@@ -30,7 +25,6 @@ namespace cytnx {
   template <>
   vector<cytnx_int64> vec_range<cytnx_int64>(const cytnx_int64 &len) {
     vector<cytnx_int64> out(len);
-#pragma omp parallel for schedule(dynamic)
     for (cytnx_int64 i = 0; i < len; i++) {
       out[i] = i;
     }
@@ -41,7 +35,6 @@ namespace cytnx {
   vector<cytnx_int64> vec_range<cytnx_int64>(const cytnx_int64 &start, const cytnx_int64 &end) {
     cytnx_error_msg(end < start, "[ERROR] cannot have end < start%s", "\n");
     vector<cytnx_int64> out(end - start);
-#pragma omp parallel for schedule(dynamic)
     for (cytnx_int64 i = 0; i < end - start; i++) {
       out[i] = start + i;
     }
@@ -51,7 +44,6 @@ namespace cytnx {
   template <>
   vector<std::string> vec_range<std::string>(const cytnx_int64 &len) {
     vector<std::string> out(len);
-#pragma omp parallel for schedule(dynamic)
     for (cytnx_int64 i = 0; i < len; i++) {
       out[i] = to_string(i);
     }
@@ -62,7 +54,6 @@ namespace cytnx {
   vector<std::string> vec_range<std::string>(const cytnx_int64 &start, const cytnx_int64 &end) {
     cytnx_error_msg(end < start, "[ERROR] cannot have end < start%s", "\n");
     vector<std::string> out(end - start);
-#pragma omp parallel for schedule(dynamic)
     for (cytnx_int64 i = 0; i < end - start; i++) {
       out[i] = to_string(start + i);
     }
@@ -71,15 +62,13 @@ namespace cytnx {
 
   void vec_range_(vector<cytnx_uint64> &v, const cytnx_uint64 &start, const cytnx_uint64 &end) {
     cytnx_error_msg(end < start, "[ERROR] cannot have end < start%s", "\n");
-// v.resize(end - start);
-#pragma omp parallel for schedule(dynamic)
+    // v.resize(end - start);
     for (cytnx_uint64 i = 0; i < end - start; i++) {
       v[i] = start + i;
     }
   }
 
   void vec_range_(vector<cytnx_uint64> &v, const cytnx_uint64 &len) {
-#pragma omp parallel for schedule(dynamic)
     for (cytnx_uint64 i = 0; i < len; i++) {
       v[i] = i;
     }
@@ -87,7 +76,6 @@ namespace cytnx {
 
   template <>
   void vec_range_<cytnx_int64>(vector<cytnx_int64> &v, const cytnx_int64 &len) {
-#pragma omp parallel for schedule(dynamic)
     for (cytnx_int64 i = 0; i < len; i++) {
       v[i] = i;
     }
@@ -97,8 +85,7 @@ namespace cytnx {
   void vec_range_<cytnx_int64>(vector<cytnx_int64> &v, const cytnx_int64 &start,
                                const cytnx_int64 &end) {
     cytnx_error_msg(end < start, "[ERROR] cannot have end < start%s", "\n");
-// v.resize(end - start);
-#pragma omp parallel for schedule(dynamic)
+    // v.resize(end - start);
     for (cytnx_int64 i = 0; i < end - start; i++) {
       v[i] = start + i;
     }


### PR DESCRIPTION
The slow usage of OpenMP was addressed in #517 and #563.

Performance benchmarks in #517 with tensors containing millions of elements showed no benefit compared to the single-threaded version. This change completely removes OpenMP from the codebase.

The commands related to OpenMP in the build system will be removed in a future commit.