### PR TITLE
Require minimum CMake version 3.24 for CUDA builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ message(STATUS "")
 # #####################################################################
 # ## CMAKE and CXX VERSION
 # #####################################################################
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.24) # require for the "native" value of CUDA_ARCHITECTURES
 
 include(cmake/target_sources_local.cmake)
 include(ExternalProject)


### PR DESCRIPTION
CMake versions between 3.18 and 3.23 incorrectly interpret the `CUDA_ARCHITECTURES` keyword "native", generating an invalid compiler flag for nvcc:

    --arch=compute_native

This invalid flag leads to compilation errors. By raising the minimum required version to 3.24, we ensure such configuration issues are detected early during CMake configuration rather than later during the build phase.

This change addresses #577.