### PR TITLE
Fix HPTT build when using OpenBLAS

### DIFF
--- a/CytnxBKNDCMakeLists.cmake
+++ b/CytnxBKNDCMakeLists.cmake
@@ -212,4 +212,7 @@ if(USE_HPTT)
 
     # relocate hptt
     install(DIRECTORY ${CMAKE_BINARY_DIR}/hptt DESTINATION ${CMAKE_INSTALL_PREFIX})
+
+    # XXX: `cytnx` itself doesn't need this linking flag. Why?
+    target_link_options(cytnx INTERFACE -fopenmp)
 endif()


### PR DESCRIPTION
## 1. Propagate `-fopenmp` linking flag when using HPTT
    
When enabling HPTT and using OpenBLAS as the BLAS vendor, we didn't propagate `-fopenmp` flag. As a result, the executables linked with Cytnx static library will fail to find the definition of OpenMP, which is used by HPTT.

The GitHub flow only builds Cytnx with enabling HPTT and using MKL, so this issue wasn't caught by the CI before.

## 2. Install HPTT's headers to the correct location
    
The method which HPTT installs its header files may conflict with other packages. HPTT installs its header files to "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}" (include folder) directly without packing the files into a folder. In addition, the header filenames of HPTT are trivial, e.g. "utils.h". As a result, there will be conflicts if the user has some other packages' header files named with the same filename of HPTT's header files. To make the installation safer, this change installs HPTT's include files under a "hptt" folder.

However, **the drawback is that the user who installs HPTT from Cytnx has to add the "hptt" folder as an include path if they wants to use HPTT's API.**
    
