### PR TITLE
Fix Mamba error when running GitHub actions

### DIFF
--- a/.github/workflows/conda_build_linux.yml
+++ b/.github/workflows/conda_build_linux.yml
@@ -18,44 +18,26 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
-        # Specify python version your environment will have. Remember to quote this, or
-        # YAML will think you want python 3.1 not 3.10
-        python-version: "3.11"
-        # This uses *miniforge*, rather than *minicond*. The primary difference is that
-        # the defaults channel is not enabled at all
+        # Remember to quote this, or YAML will think you want python 3.1 not 3.10
+        python-version: "3.10"
+        # Using miniforge to the enable conda-forge channel only.
         miniforge-version: latest
-        # These properties enable the use of mamba, which is much faster and far less error
-        # prone than conda while being completely compatible with the conda CLI
-        use-mamba: true
-        mamba-version: "*"
-
     - name: Config Conda
-      working-directory: ${{github.workspace}}
       shell: bash -l {0}
       run: |
         echo "Config Conda---------------------------------"
-        mamba install anaconda-client boa -c conda-forge
-
-    - name: start building
-      working-directory: ${{github.workspace}}
-      shell: bash -l {0}
-      run: |
-        echo "Building begin---------------------------------"
+        conda info
         conda config --set anaconda_upload no
-
-        # these are infos used to check environ
-        mamba info -a
-        mamba list
-        mamba -h
-
-        echo "Get Output file names:_________________"
-        # OUTPUT_FN=$(conda build conda_build/conda_gen/ --output)
-
+        conda install conda-build
+    - name: start building
+      shell: bash -l {0}
+      # TODO: Consider to replace conda-build with rattler-build to speed up
+      #   the build process.
+      run: |
         echo "Start building---------------------------------"
-        conda mambabuild conda_build/conda_gen/
-
+        conda build conda_build/conda_gen/
 
       env:
         TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN }}

--- a/.github/workflows/conda_build_macos.yml
+++ b/.github/workflows/conda_build_macos.yml
@@ -19,45 +19,26 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
-        # Specify python version your environment will have. Remember to quote this, or
-        # YAML will think you want python 3.1 not 3.10
+        # Remember to quote this, or YAML will think you want python 3.1 not 3.10
         python-version: "3.10"
-        # This uses *miniforge*, rather than *minicond*. The primary difference is that
-        # the defaults channel is not enabled at all
+        # Using miniforge to the enable conda-forge channel only.
         miniforge-version: latest
-        # These properties enable the use of mamba, which is much faster and far less error
-        # prone than conda while being completely compatible with the conda CLI
-        use-mamba: true
-        mamba-version: "*"
-
     - name: Config Conda
-      working-directory: ${{github.workspace}}
       shell: bash -l {0}
       run: |
         echo "Config Conda---------------------------------"
-        mamba install anaconda-client boa -c conda-forge
-
-
-    - name: start building
-      working-directory: ${{github.workspace}}
-      shell: bash -l {0}
-      run: |
-        echo "Building begin---------------------------------"
+        conda info
         conda config --set anaconda_upload no
-
-        # these are infos used to check environ
-        mamba info -a
-        mamba list
-        mamba -h
-
-        echo "Get Output file names:_________________"
-        # OUTPUT_FN=$(conda build conda_build/conda_gen_mac/ --output)
-
+        conda install conda-build
+    - name: start building
+      shell: bash -l {0}
+      # TODO: Consider to replace conda-build with rattler-build to speed up
+      #   the build process.
+      run: |
         echo "Start building---------------------------------"
-        conda mambabuild conda_build/conda_gen_mac/
-
+        conda build conda_build/conda_gen_mac/
 
       env:
         TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN }}


### PR DESCRIPTION
Drop boa and mamba because they almost don't speed the build process up comparing with using the built-in conda-build now. Conda uses libmamba as the default solver since 23.10, which made conda comparable to mamba. Additaionally, boa was archived in 2024 Dec. The replacement of boa is rattler-build. rattler-build may reduce some overheads of conda-build. It's worth to try in the future.

Downgrade the Python version to 3.10 to support older Python version in the future. Alought the oldest Python version under security maintaince is 3.9 now, the support will be terminated in 2025 Oct. To avoid changing the Python version too freqently, downgrade the version to 3.10 instead of 3.9.