### PR TITLE
Fixed Gesvd and Svd_truncate with fermions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ endfunction()
 
 include(CMakeDependentOption)
 
-set(CMAKE_INSTALL_PREFIX "/usr/local/cytnx" CACHE PATH "the destination path for installation")
+set(CMAKE_INSTALL_PREFIX "/home/manuel/cytnx/Cytnx_lib" CACHE PATH "the destination path for installation")
 option(BUILD_PYTHON "Build Python API. Require Python and pybind11 installed." ON)
 option(BACKEND_TORCH "Use PyTorch as a backend container for tensors." OFF)
 cmake_dependent_option(USE_MKL "Use MKL as a BLAS provider otherwise use OpenBLAS." OFF "NOT BACKEND_TORCH" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ endfunction()
 
 include(CMakeDependentOption)
 
-set(CMAKE_INSTALL_PREFIX "/home/manuel/cytnx/Cytnx_lib" CACHE PATH "the destination path for installation")
+set(CMAKE_INSTALL_PREFIX "/usr/local/cytnx" CACHE PATH "the destination path for installation")
 option(BUILD_PYTHON "Build Python API. Require Python and pybind11 installed." ON)
 option(BACKEND_TORCH "Use PyTorch as a backend container for tensors." OFF)
 cmake_dependent_option(USE_MKL "Use MKL as a BLAS provider otherwise use OpenBLAS." OFF "NOT BACKEND_TORCH" OFF)

--- a/include/UniTensor.hpp
+++ b/include/UniTensor.hpp
@@ -226,6 +226,7 @@ namespace cytnx {
                                 const cytnx_int64 &rowrank = -1, const std::string &name = "");
     virtual std::vector<cytnx_uint64> shape() const;
     virtual std::vector<bool> signflip() const;
+    virtual std::vector<bool> &signflip_();
     virtual bool is_blockform() const;
     virtual bool is_contiguous() const;
     virtual void to_(const int &device);
@@ -1872,9 +1873,8 @@ namespace cytnx {
       return this->_blocks.size();
     };
 
-    std::vector<bool> signflip() const;
-    // std::vector<bool> &signflip_reference() { return this->_signflip; };
-    // const std::vector<bool> &signflip_reference() const { return this->_signflip; };
+    std::vector<bool> signflip() const override { return this->_signflip; };
+    std::vector<bool> &signflip_() override { return this->_signflip; };
 
     void to_(const int &device) {
       //[21 Aug 2024] This is a copy from BlockUniTensor;
@@ -3115,6 +3115,16 @@ namespace cytnx {
      * @return std::vector<bool>
      */
     std::vector<bool> signflip() const { return this->_impl->signflip(); }
+
+    /**
+     * @brief Get reference to the sign information of a fermionic UniTensor.
+     * @details Length is the number of blocks in the UniTensor. If the return is true, the sign of
+     * the elements of the corresponding block needs to be flipped.
+     * @warning This is an inline version which returns a reference. Changes to the reference affect
+     * the tensor!
+     * @return std::vector<bool> &
+     */
+    std::vector<bool> &signflip_() { return this->_impl->signflip_(); }
 
     /**
      * @brief Check whether the UniTensor is in block form.

--- a/pybind/unitensor_py.cpp
+++ b/pybind/unitensor_py.cpp
@@ -559,6 +559,7 @@ void unitensor_binding(py::module &m) {
     .def("bond", [](UniTensor &self, const std::string &label){return self.bond(label);} ,py::arg("label"))
     .def("shape", &UniTensor::shape)
     .def("signflip", &UniTensor::signflip)
+    .def("signflip_", &UniTensor::signflip_)
     .def("to_", &UniTensor::to_)
     .def(
       "to_different_device",

--- a/pybind/unitensor_py.cpp
+++ b/pybind/unitensor_py.cpp
@@ -559,7 +559,7 @@ void unitensor_binding(py::module &m) {
     .def("bond", [](UniTensor &self, const std::string &label){return self.bond(label);} ,py::arg("label"))
     .def("shape", &UniTensor::shape)
     .def("signflip", &UniTensor::signflip)
-    .def("signflip_", &UniTensor::signflip_)
+//     .def("signflip_", &UniTensor::signflip_)
     .def("to_", &UniTensor::to_)
     .def(
       "to_different_device",

--- a/src/BlockFermionicUniTensor.cpp
+++ b/src/BlockFermionicUniTensor.cpp
@@ -593,8 +593,6 @@ namespace cytnx {
     }
   }
 
-  std::vector<bool> BlockFermionicUniTensor::signflip() const { return this->_signflip; }
-
   std::vector<Symmetry> BlockFermionicUniTensor::syms() const {
     //[21 Aug 2024] This is a copy from BlockUniTensor;
     return this->_bonds[0].syms();

--- a/src/UniTensor_base.cpp
+++ b/src/UniTensor_base.cpp
@@ -67,6 +67,16 @@ namespace cytnx {
                     "\n");
     return std::vector<bool>();
   }
+
+  std::vector<bool> &UniTensor_base::signflip_() {
+    cytnx_error_msg(true,
+                    "[ERROR] fatal internal, signflip is only defined for BlockFermionicUniTensor, "
+                    "not for bosonic UniTensors. Cannot use signflip_().%s",
+                    "\n");
+    std::vector<bool> t;
+    return t;
+  }
+
   void UniTensor_base::set_rowrank_(const cytnx_uint64 &new_rowrank) {
     cytnx_error_msg(
       true, "[ERROR] fatal internal, cannot call on an un-initialized UniTensor_base%s", "\n");

--- a/src/linalg/Gesvd.cpp
+++ b/src/linalg/Gesvd.cpp
@@ -407,6 +407,7 @@ namespace cytnx {
     void _Gesvd_BlockFermionic_UT(std::vector<cytnx::UniTensor> &outCyT,
                                   const cytnx::UniTensor &Tin, const bool &is_U,
                                   const bool &is_vT) {
+      //[8 Oct 2024] This is a copy from BlockUniTensor; signflips included
       // outCyT must be empty and Tin must be checked with proper rowrank!
 
       // 1) getting the combineBond L and combineBond R for qnum list without grouping:
@@ -414,6 +415,7 @@ namespace cytnx {
       //   BDLeft -[ ]- BDRight
       //
       std::vector<cytnx_uint64> strides;
+      std::vector<bool> signflip = Tin.signflip();
       strides.reserve(Tin.rank());
       auto BdLeft = Tin.bonds()[0].clone();
       for (int i = 1; i < Tin.rowrank(); i++) {
@@ -463,9 +465,9 @@ namespace cytnx {
       }
 
       // 4) for each qcharge in key, combining the blocks into a big chunk!
-      // ->a initialize an empty shell of UniTensor!
+      // ->a initialize an empty shell of UniTensors!
       vec2d<cytnx_int64> aux_qnums;  // for sharing bond
-      std::vector<cytnx_uint64> aux_degs;  // forsharing bond
+      std::vector<cytnx_uint64> aux_degs;  // for sharing bond
       std::vector<Tensor> S_blocks;
 
       vec2d<cytnx_uint64> U_itoi;  // for U
@@ -487,16 +489,23 @@ namespace cytnx {
         std::vector<cytnx_int64> row_szs(order.size(), 1);
         cytnx_uint64 Rblk_dim = 0;
         cytnx_int64 tmp = -1;
+        cytnx_int64 current_block;
         for (int i = 0; i < order.size(); i++) {
+          current_block = x.second[order[i]];
           if (itoi_indicators[i][0] != tmp) {
             tmp = itoi_indicators[i][0];
             Rblk_dim++;
           }
-          Tlist[i] = Tin.get_blocks_()[x.second[order[i]]];
+          Tlist[i] = Tin.get_blocks_()[current_block];
           for (int j = 0; j < Tin.rowrank(); j++) {
             row_szs[i] *= Tlist[i].shape()[j];
           }
-          Tlist[i] = Tlist[i].reshape({row_szs[i], -1});
+          if (signflip[current_block]) {
+            Tlist[i] = -Tlist[i];  // copies Tensor
+            // Tlist[i] = Tlist[i].Mul(-1); // copies Tensor
+            Tlist[i].reshape_({row_szs[i], -1});
+          } else
+            Tlist[i] = Tlist[i].reshape({row_szs[i], -1});  // copies Tensor
         }
         cytnx_error_msg(Tlist.size() % Rblk_dim, "[Internal ERROR] Tlist is not complete!%s", "\n");
         // BTen is the big block!!
@@ -596,7 +605,7 @@ namespace cytnx {
         U_ptr->_is_braket_form = U_ptr->_update_braket();
         U_ptr->_inner_to_outer_idx = U_itoi;
         U_ptr->_blocks = U_blocks;
-        U_ptr->_signflip = Tin.signflip();
+        U_ptr->_signflip = std::vector(U_blocks.size(), false);
         UniTensor U;
         U._impl = boost::intrusive_ptr<UniTensor_base>(U_ptr);
         outCyT.push_back(U);

--- a/src/linalg/Svd.cpp
+++ b/src/linalg/Svd.cpp
@@ -254,9 +254,9 @@ namespace cytnx {
       }
 
       // 4) for each qcharge in key, combining the blocks into a big chunk!
-      // ->a initialize an empty shell of UniTensor!
+      // ->a initialize an empty shell of UniTensors!
       vec2d<cytnx_int64> aux_qnums;  // for sharing bond
-      std::vector<cytnx_uint64> aux_degs;  // forsharing bond
+      std::vector<cytnx_uint64> aux_degs;  // for sharing bond
       std::vector<Tensor> S_blocks;
 
       vec2d<cytnx_uint64> U_itoi;  // for U
@@ -415,7 +415,7 @@ namespace cytnx {
 
     void _svd_BlockFermionic_UT(std::vector<cytnx::UniTensor> &outCyT, const cytnx::UniTensor &Tin,
                                 const bool &compute_uv) {
-      //[8 Oct 2024] This is a copy from BlockUniTensor; signflips in U
+      //[8 Oct 2024] This is a copy from BlockUniTensor; signflips included
       // outCyT must be empty and Tin must be checked with proper rowrank!
 
       // 1) getting the combineBond L and combineBond R for qnum list without grouping:
@@ -473,9 +473,9 @@ namespace cytnx {
       }
 
       // 4) for each qcharge in key, combining the blocks into a big chunk!
-      // ->a initialize an empty shell of UniTensor!
+      // ->a initialize an empty shell of UniTensors!
       vec2d<cytnx_int64> aux_qnums;  // for sharing bond
-      std::vector<cytnx_uint64> aux_degs;  // forsharing bond
+      std::vector<cytnx_uint64> aux_degs;  // for sharing bond
       std::vector<Tensor> S_blocks;
 
       vec2d<cytnx_uint64> U_itoi;  // for U

--- a/src/linalg/Svd_truncate.cpp
+++ b/src/linalg/Svd_truncate.cpp
@@ -328,174 +328,155 @@ namespace cytnx {
       }
     }  // _svd_truncate_Block_UT
 
-    // void _svd_truncate_BlockFermionic_UT(std::vector<UniTensor> &outCyT,
-    //                                      const cytnx::UniTensor &Tin, const cytnx_uint64
-    //                                      &keepdim, const double &err, const bool &is_UvT, const
-    //                                      int &return_err, const unsigned int &mindim) {
-    //   //[29 Oct 2024] This is a copy from _svd_truncate_Block_UT with the signflips truncated as
-    //   // well
-    //   cytnx_uint64 keep_dim = keepdim;
+    void _svd_truncate_BlockFermionic_UT(std::vector<UniTensor> &outCyT,
+                                         const cytnx::UniTensor &Tin, const cytnx_uint64 &keepdim,
+                                         const double &err, const bool &is_UvT,
+                                         const int &return_err, const unsigned int &mindim) {
+      //[29 Oct 2024] This is a copy from _svd_truncate_Block_UT with the signflips truncated as
+      // well
+      cytnx_uint64 keep_dim = keepdim;
 
-    //   outCyT = linalg::Gesvd(Tin, is_UvT, is_UvT);
+      outCyT = linalg::Gesvd(Tin, is_UvT, is_UvT);
 
-    //   // process truncate:
-    //   // 1) concate all s vals from all blk
-    //   Tensor Sall = outCyT[0].get_block_(0);
-    //   for (int i = 1; i < outCyT[0].Nblocks(); i++) {
-    //     Sall = algo::Concatenate(Sall, outCyT[0].get_block_(i));
-    //   }
-    //   Sall = algo::Sort(Sall);
+      // process truncation:
+      // 1) concate all S vals from all blk
+      Tensor Sall = outCyT[0].get_block_(0);
+      for (int i = 1; i < outCyT[0].Nblocks(); i++) {
+        Sall = algo::Concatenate(Sall, outCyT[0].get_block_(i));
+      }
+      Sall = algo::Sort(Sall);  // all singular values, starting from the smallest
 
-    //   // 2) get the minimum base on the args input.
-    //   Scalar Smin;
-    //   cytnx_uint64 smidx;
-    //   if (keep_dim < Sall.shape()[0]) {
-    //     smidx = Sall.shape()[0] - keep_dim;
-    //     Smin = Sall.storage()(smidx);
-    //     while ((Smin < err)) {
-    //       keep_dim -= 1;
-    //       if (keep_dim == 0) break;
-    //       smidx = Sall.shape()[0] - keep_dim;
-    //       Smin = Sall.storage()(smidx);
-    //     }
+      // 2) get the minimum S value based on the args input.
+      Scalar Smin;
+      cytnx_uint64 smidx;
+      cytnx_uint64 Sshape = Sall.shape()[0];
+      if (keep_dim < Sshape) {
+        smidx = Sshape - keep_dim;
+        Smin = Sall.storage()(smidx);
+      } else {
+        keep_dim = Sshape;
+        smidx = 0;
+        Smin = Sall.storage()(0);
+      }
+      while ((Smin < err) and (keep_dim > (mindim < 1 ? 1 : mindim))) {
+        // at least one singular value is always kept!
+        keep_dim--;
+        // if (keep_dim == 0) break;
+        smidx++;
+        Smin = Sall.storage()(smidx);
+      }
 
-    //   } else {
-    //     keep_dim = Sall.shape()[0];
-    //     Smin = Sall.storage()(0);
-    //     smidx = 0;
-    //     while ((Smin < err) and keep_dim - 1 > mindim) {
-    //       keep_dim -= 1;
-    //       if (keep_dim == 0) break;
-    //       smidx = Sall.shape()[0] - keep_dim;
-    //       Smin = Sall.storage()(smidx);
-    //     }
-    //   }
+      // traversal each block and truncate!
+      UniTensor &S = outCyT[0];
+      std::vector<cytnx_uint64> new_dims;  // keep_dims for each block!
+      std::vector<cytnx_int64> keep_dims;
+      keep_dims.reserve(S.Nblocks());
+      std::vector<cytnx_int64> new_qid;
+      new_qid.reserve(S.Nblocks());
 
-    //   // traversal each block and truncate!
-    //   UniTensor &S = outCyT[0];
-    //   std::vector<cytnx_uint64> new_dims;  // keep_dims for each block!
-    //   std::vector<cytnx_int64> keep_dims;
-    //   keep_dims.reserve(S.Nblocks());
-    //   std::vector<cytnx_int64> new_qid;
-    //   new_qid.reserve(S.Nblocks());
+      std::vector<std::vector<cytnx_uint64>> new_itoi;  // assume S block is in same order as qnum:
+      std::vector<cytnx_uint64> to_be_remove;
 
-    //   std::vector<std::vector<cytnx_uint64>> new_itoi;  // assume S block is in same order as
-    //   qnum: std::vector<cytnx_uint64> to_be_remove;
+      cytnx_uint64 tot_dim = 0;
+      cytnx_uint64 cnt = 0;
+      for (int b = 0; b < S.Nblocks(); b++) {
+        Storage stmp = S.get_block_(b).storage();
+        cytnx_int64 kdim = 0;
+        for (int i = stmp.size(); i > 0; i--) {
+          if (stmp(i - 1) >= Smin) {
+            kdim = i;
+            break;
+          }
+        }
+        keep_dims.push_back(kdim);
+        if (kdim == 0) {
+          to_be_remove.push_back(b);
+          new_qid.push_back(-1);
 
-    //   cytnx_uint64 tot_dim = 0;
-    //   cytnx_uint64 cnt = 0;
-    //   for (int b = 0; b < S.Nblocks(); b++) {
-    //     Storage stmp = S.get_block_(b).storage();
-    //     cytnx_int64 kdim = 0;
-    //     for (int i = stmp.size() - 1; i >= 0; i--) {
-    //       if (stmp(i) >= Smin) {
-    //         kdim = i + 1;
-    //         break;
-    //       }
-    //     }
-    //     keep_dims.push_back(kdim);
-    //     if (kdim == 0) {
-    //       to_be_remove.push_back(b);
-    //       new_qid.push_back(-1);
+        } else {
+          new_qid.push_back(new_dims.size());
+          new_itoi.push_back({new_dims.size(), new_dims.size()});
+          new_dims.push_back(kdim);
+          tot_dim += kdim;
+          if (kdim != S.get_blocks_()[b].shape()[0])
+            S.get_blocks_()[b] = S.get_blocks_()[b].get({ac::range(0, kdim)});
+        }
+      }
 
-    //     } else {
-    //       new_qid.push_back(new_dims.size());
-    //       new_itoi.push_back({new_dims.size(), new_dims.size()});
-    //       new_dims.push_back(kdim);
-    //       tot_dim += kdim;
-    //       if (kdim != S.get_blocks_()[b].shape()[0])
-    //         S.get_blocks_()[b] = S.get_blocks_()[b].get({ac::range(0, kdim)});
-    //     }
-    //   }
+      // remove:
+      // vec_erase_(S.get_itoi(),to_be_remove);
+      S.get_itoi() = new_itoi;
+      vec_erase_(S.get_blocks_(), to_be_remove);
+      vec_erase_(S.bonds()[0].qnums(), to_be_remove);
+      vec_erase_(S.signflip_(), to_be_remove);
+      S.bonds()[0]._impl->_degs = new_dims;
+      S.bonds()[0]._impl->_dim = tot_dim;
+      S.bonds()[1] = S.bonds()[0].redirect();
 
-    //   // remove:
-    //   // vec_erase_(S.get_itoi(),to_be_remove);
-    //   S.get_itoi() = new_itoi;
-    //   vec_erase_(S.get_blocks_(), to_be_remove);
-    //   vec_erase_(S.bonds()[0].qnums(), to_be_remove);
-    //   cout << "Signflips before truncation: " << S.signflip() << endl;
-    //   std::vector<bool> signs = S.signflip();
-    //   cout << "signs before truncation: " << signs << endl;
-    //   vec_erase_(signs, to_be_remove);
-    //   cout << "Signflips after  truncation: " << S.signflip() << endl;
-    //   cout << "signs after  truncation: " << signs << endl;
-    //   S.bonds()[0]._impl->_degs = new_dims;
-    //   S.bonds()[0]._impl->_dim = tot_dim;
-    //   S.bonds()[1] = S.bonds()[0].redirect();
-    //   // to access _signflip in the tensor, a typecast is needed
-    //   cytnx_error_msg(true, "[Svdtruncate][ERROR] Svdtruncate still under development%s", "\n");
-    //   // boost:intrusive_ptr<cytnx::BlockFermionicUniTensor> Sfermionic =
-    //   // boost:static_pointer_cast<cytnx::BlockFermionicUniTensor>(S._impl);
-    //   BlockFermionicUniTensor
-    //   // &Sfermionic = boost::dynamic_pointer_cast<cytnx::BlockFermionicUniTensor&>(S._impl);
-    //   // Sfermionic.print_diagram();
-    //   // Sfermionic._signflip = signs;
-    //   // S.print_diagram();
-    //   // cytnx_error_msg(true, "[Svdtruncate][ERROR] Svdtruncate still under development%s",
-    //   "\n");
+      int t = 1;
+      if (is_UvT) {
+        // depends on S.bonds()[1], keep_dims, new_qid
+        UniTensor &U = outCyT[t];
+        to_be_remove.clear();
+        U.bonds().back() = S.bonds()[1].clone();
+        std::vector<Accessor> acs(U.rank());
+        for (int i = 0; i < U.rowrank(); i++) acs[i] = ac::all();
 
-    //   int t = 1;
-    //   if (is_UvT) {
-    //     // depends on S.bonds()[1], keep_dims, new_qid
-    //     UniTensor &U = outCyT[t];
-    //     to_be_remove.clear();
-    //     U.bonds().back() = S.bonds()[1].clone();
-    //     std::vector<Accessor> acs(U.rank());
-    //     for (int i = 0; i < U.rowrank(); i++) acs[i] = ac::all();
+        for (int b = 0; b < U.Nblocks(); b++) {
+          if (keep_dims[U.get_qindices(b).back()] == 0)
+            to_be_remove.push_back(b);
+          else {
+            /// process blocks:
+            if (keep_dims[U.get_qindices(b).back()] != U.get_blocks_()[b].shape().back()) {
+              acs.back() = ac::range(0, keep_dims[U.get_qindices(b).back()]);
+              U.get_blocks_()[b] = U.get_blocks_()[b].get(acs);
+            }
 
-    //     for (int b = 0; b < U.Nblocks(); b++) {
-    //       if (keep_dims[U.get_qindices(b).back()] == 0)
-    //         to_be_remove.push_back(b);
-    //       else {
-    //         /// process blocks:
-    //         if (keep_dims[U.get_qindices(b).back()] != U.get_blocks_()[b].shape().back()) {
-    //           acs.back() = ac::range(0, keep_dims[U.get_qindices(b).back()]);
-    //           U.get_blocks_()[b] = U.get_blocks_()[b].get(acs);
-    //         }
+            // change to new qindices:
+            U.get_qindices(b).back() = new_qid[U.get_qindices(b).back()];
+          }
+        }
+        vec_erase_(U.get_itoi(), to_be_remove);
+        vec_erase_(U.get_blocks_(), to_be_remove);
+        vec_erase_(U.signflip_(), to_be_remove);
 
-    //         // change to new qindices:
-    //         U.get_qindices(b).back() = new_qid[U.get_qindices(b).back()];
-    //       }
-    //     }
-    //     vec_erase_(U.get_itoi(), to_be_remove);
-    //     vec_erase_(U.get_blocks_(), to_be_remove);
+        t++;
+      }
 
-    //     t++;
-    //   }
+      if (is_UvT) {
+        UniTensor &vT = outCyT[t];
+        to_be_remove.clear();
+        vT.bonds().front() = S.bonds()[0].clone();
+        std::vector<Accessor> acs(vT.rank());
+        for (int i = 1; i < vT.rank(); i++) acs[i] = ac::all();
 
-    //   if (is_UvT) {
-    //     UniTensor &vT = outCyT[t];
-    //     to_be_remove.clear();
-    //     vT.bonds().front() = S.bonds()[0].clone();
-    //     std::vector<Accessor> acs(vT.rank());
-    //     for (int i = 1; i < vT.rank(); i++) acs[i] = ac::all();
+        for (int b = 0; b < vT.Nblocks(); b++) {
+          if (keep_dims[vT.get_qindices(b)[0]] == 0)
+            to_be_remove.push_back(b);
+          else {
+            /// process blocks:
+            if (keep_dims[vT.get_qindices(b)[0]] != vT.get_blocks_()[b].shape()[0]) {
+              acs[0] = ac::range(0, keep_dims[vT.get_qindices(b)[0]]);
+              vT.get_blocks_()[b] = vT.get_blocks_()[b].get(acs);
+            }
+            // change to new qindices:
+            vT.get_qindices(b)[0] = new_qid[vT.get_qindices(b)[0]];
+          }
+        }
+        vec_erase_(vT.get_itoi(), to_be_remove);
+        vec_erase_(vT.get_blocks_(), to_be_remove);
+        vec_erase_(vT.signflip_(), to_be_remove);
+        t++;
+      }
 
-    //     for (int b = 0; b < vT.Nblocks(); b++) {
-    //       if (keep_dims[vT.get_qindices(b)[0]] == 0)
-    //         to_be_remove.push_back(b);
-    //       else {
-    //         /// process blocks:
-    //         if (keep_dims[vT.get_qindices(b)[0]] != vT.get_blocks_()[b].shape()[0]) {
-    //           acs[0] = ac::range(0, keep_dims[vT.get_qindices(b)[0]]);
-    //           vT.get_blocks_()[b] = vT.get_blocks_()[b].get(acs);
-    //         }
-    //         // change to new qindices:
-    //         vT.get_qindices(b)[0] = new_qid[vT.get_qindices(b)[0]];
-    //       }
-    //     }
-    //     vec_erase_(vT.get_itoi(), to_be_remove);
-    //     vec_erase_(vT.get_blocks_(), to_be_remove);
-    //     t++;
-    //   }
-
-    //   // handle return_err!
-    //   if (return_err == 1) {
-    //     outCyT.push_back(UniTensor(Tensor({1}, Smin.dtype())));
-    //     outCyT.back().get_block_().storage().at(0) = Smin;
-    //   } else if (return_err) {
-    //     outCyT.push_back(UniTensor(Sall.get({ac::tilend(smidx)})));
-    //   }
-    // }  // _svd_truncate_BlockFermionic_UT
+      // handle return_err!
+      if (return_err == 1) {
+        outCyT.push_back(UniTensor(Tensor({1}, Smin.dtype())));
+        outCyT.back().get_block_().storage().at(0) = Smin;
+      } else if (return_err) {
+        outCyT.push_back(UniTensor(Sall.get({ac::tilend(smidx)})));
+      }
+    }  // _svd_truncate_BlockFermionic_UT
 
     std::vector<cytnx::UniTensor> Svd_truncate(const cytnx::UniTensor &Tin,
                                                const cytnx_uint64 &keepdim, const double &err,
@@ -520,11 +501,7 @@ namespace cytnx {
         _svd_truncate_Block_UT(outCyT, Tin, keepdim, err, is_UvT, return_err, mindim);
 
       } else if (Tin.uten_type() == UTenType.BlockFermionic) {
-        // _svd_truncate_BlockFermionic_UT(outCyT, Tin, keepdim, err, is_UvT, return_err, mindim);
-        cytnx_error_msg(true,
-                        "[ERROR][_svd_truncate_BlockFermionic_UT] not implemented yet. The "
-                        "signflips need to be removed if blocks are deleted in the truncation.%s",
-                        "\n");
+        _svd_truncate_BlockFermionic_UT(outCyT, Tin, keepdim, err, is_UvT, return_err, mindim);
       } else {
         cytnx_error_msg(
           true, "[ERROR] Svd_truncate only supports Dense/Block/BlockFermionic UniTensors.%s",

--- a/src/linalg/Svd_truncate.cpp
+++ b/src/linalg/Svd_truncate.cpp
@@ -183,10 +183,12 @@ namespace cytnx {
       if (return_err) outCyT.back().Init(outT.back(), false, 0);
     };  // svdt Dense
 
-    void _svd_truncate_Block_UT(std::vector<UniTensor> &outCyT, const cytnx::UniTensor &Tin,
-                                const cytnx_uint64 &keepdim, const double &err, const bool &is_UvT,
-                                const int &return_err, const cytnx_uint64 &mindim) {
+    void _svd_truncate_Block_UTs(std::vector<UniTensor> &outCyT, const cytnx::UniTensor &Tin,
+                                 const cytnx_uint64 &keepdim, const double &err, const bool &is_UvT,
+                                 const int &return_err, const cytnx_uint64 &mindim) {
       // currently, Gesvd is used as a standard for the full SVD before truncation
+      // handles BlockFermionicUniTensor as well: elements of _signflip are removed if blocks are
+      // erased
       cytnx_uint64 keep_dim = keepdim;
 
       outCyT = linalg::Gesvd(Tin, is_UvT, is_UvT);
@@ -259,8 +261,13 @@ namespace cytnx {
       // remove:
       // vec_erase_(S.get_itoi(),to_be_remove);
       S.get_itoi() = new_itoi;
-      vec_erase_(S.get_blocks_(), to_be_remove);
-      vec_erase_(S.bonds()[0].qnums(), to_be_remove);
+      if (!to_be_remove.empty()) {
+        vec_erase_(S.get_blocks_(), to_be_remove);
+        vec_erase_(S.bonds()[0].qnums(), to_be_remove);
+        if (Tin.uten_type() == UTenType.BlockFermionic) {
+          vec_erase_(S.signflip_(), to_be_remove);
+        }
+      }
       S.bonds()[0]._impl->_degs = new_dims;
       S.bonds()[0]._impl->_dim = tot_dim;
       S.bonds()[1] = S.bonds()[0].redirect();
@@ -288,8 +295,13 @@ namespace cytnx {
             U.get_qindices(b).back() = new_qid[U.get_qindices(b).back()];
           }
         }
-        vec_erase_(U.get_itoi(), to_be_remove);
-        vec_erase_(U.get_blocks_(), to_be_remove);
+        if (!to_be_remove.empty()) {
+          vec_erase_(U.get_itoi(), to_be_remove);
+          vec_erase_(U.get_blocks_(), to_be_remove);
+          if (Tin.uten_type() == UTenType.BlockFermionic) {
+            vec_erase_(U.signflip_(), to_be_remove);
+          }
+        }
 
         t++;
       }
@@ -314,8 +326,14 @@ namespace cytnx {
             vT.get_qindices(b)[0] = new_qid[vT.get_qindices(b)[0]];
           }
         }
-        vec_erase_(vT.get_itoi(), to_be_remove);
-        vec_erase_(vT.get_blocks_(), to_be_remove);
+        if (!to_be_remove.empty()) {
+          vec_erase_(vT.get_itoi(), to_be_remove);
+          vec_erase_(vT.get_blocks_(), to_be_remove);
+          if (Tin.uten_type() == UTenType.BlockFermionic) {
+            vec_erase_(vT.signflip_(), to_be_remove);
+          }
+        }
+
         t++;
       }
 
@@ -326,157 +344,7 @@ namespace cytnx {
       } else if (return_err) {
         outCyT.push_back(UniTensor(Sall.get({ac::tilend(smidx)})));
       }
-    }  // _svd_truncate_Block_UT
-
-    void _svd_truncate_BlockFermionic_UT(std::vector<UniTensor> &outCyT,
-                                         const cytnx::UniTensor &Tin, const cytnx_uint64 &keepdim,
-                                         const double &err, const bool &is_UvT,
-                                         const int &return_err, const unsigned int &mindim) {
-      //[29 Oct 2024] This is a copy from _svd_truncate_Block_UT with the signflips truncated as
-      // well
-      cytnx_uint64 keep_dim = keepdim;
-
-      outCyT = linalg::Gesvd(Tin, is_UvT, is_UvT);
-
-      // process truncation:
-      // 1) concate all S vals from all blk
-      Tensor Sall = outCyT[0].get_block_(0);
-      for (int i = 1; i < outCyT[0].Nblocks(); i++) {
-        Sall = algo::Concatenate(Sall, outCyT[0].get_block_(i));
-      }
-      Sall = algo::Sort(Sall);  // all singular values, starting from the smallest
-
-      // 2) get the minimum S value based on the args input.
-      Scalar Smin;
-      cytnx_uint64 smidx;
-      cytnx_uint64 Sshape = Sall.shape()[0];
-      if (keep_dim < Sshape) {
-        smidx = Sshape - keep_dim;
-        Smin = Sall.storage()(smidx);
-      } else {
-        keep_dim = Sshape;
-        smidx = 0;
-        Smin = Sall.storage()(0);
-      }
-      while ((Smin < err) and (keep_dim > (mindim < 1 ? 1 : mindim))) {
-        // at least one singular value is always kept!
-        keep_dim--;
-        // if (keep_dim == 0) break;
-        smidx++;
-        Smin = Sall.storage()(smidx);
-      }
-
-      // traversal each block and truncate!
-      UniTensor &S = outCyT[0];
-      std::vector<cytnx_uint64> new_dims;  // keep_dims for each block!
-      std::vector<cytnx_int64> keep_dims;
-      keep_dims.reserve(S.Nblocks());
-      std::vector<cytnx_int64> new_qid;
-      new_qid.reserve(S.Nblocks());
-
-      std::vector<std::vector<cytnx_uint64>> new_itoi;  // assume S block is in same order as qnum:
-      std::vector<cytnx_uint64> to_be_remove;
-
-      cytnx_uint64 tot_dim = 0;
-      cytnx_uint64 cnt = 0;
-      for (int b = 0; b < S.Nblocks(); b++) {
-        Storage stmp = S.get_block_(b).storage();
-        cytnx_int64 kdim = 0;
-        for (int i = stmp.size(); i > 0; i--) {
-          if (stmp(i - 1) >= Smin) {
-            kdim = i;
-            break;
-          }
-        }
-        keep_dims.push_back(kdim);
-        if (kdim == 0) {
-          to_be_remove.push_back(b);
-          new_qid.push_back(-1);
-
-        } else {
-          new_qid.push_back(new_dims.size());
-          new_itoi.push_back({new_dims.size(), new_dims.size()});
-          new_dims.push_back(kdim);
-          tot_dim += kdim;
-          if (kdim != S.get_blocks_()[b].shape()[0])
-            S.get_blocks_()[b] = S.get_blocks_()[b].get({ac::range(0, kdim)});
-        }
-      }
-
-      // remove:
-      // vec_erase_(S.get_itoi(),to_be_remove);
-      S.get_itoi() = new_itoi;
-      vec_erase_(S.get_blocks_(), to_be_remove);
-      vec_erase_(S.bonds()[0].qnums(), to_be_remove);
-      vec_erase_(S.signflip_(), to_be_remove);
-      S.bonds()[0]._impl->_degs = new_dims;
-      S.bonds()[0]._impl->_dim = tot_dim;
-      S.bonds()[1] = S.bonds()[0].redirect();
-
-      int t = 1;
-      if (is_UvT) {
-        // depends on S.bonds()[1], keep_dims, new_qid
-        UniTensor &U = outCyT[t];
-        to_be_remove.clear();
-        U.bonds().back() = S.bonds()[1].clone();
-        std::vector<Accessor> acs(U.rank());
-        for (int i = 0; i < U.rowrank(); i++) acs[i] = ac::all();
-
-        for (int b = 0; b < U.Nblocks(); b++) {
-          if (keep_dims[U.get_qindices(b).back()] == 0)
-            to_be_remove.push_back(b);
-          else {
-            /// process blocks:
-            if (keep_dims[U.get_qindices(b).back()] != U.get_blocks_()[b].shape().back()) {
-              acs.back() = ac::range(0, keep_dims[U.get_qindices(b).back()]);
-              U.get_blocks_()[b] = U.get_blocks_()[b].get(acs);
-            }
-
-            // change to new qindices:
-            U.get_qindices(b).back() = new_qid[U.get_qindices(b).back()];
-          }
-        }
-        vec_erase_(U.get_itoi(), to_be_remove);
-        vec_erase_(U.get_blocks_(), to_be_remove);
-        vec_erase_(U.signflip_(), to_be_remove);
-
-        t++;
-      }
-
-      if (is_UvT) {
-        UniTensor &vT = outCyT[t];
-        to_be_remove.clear();
-        vT.bonds().front() = S.bonds()[0].clone();
-        std::vector<Accessor> acs(vT.rank());
-        for (int i = 1; i < vT.rank(); i++) acs[i] = ac::all();
-
-        for (int b = 0; b < vT.Nblocks(); b++) {
-          if (keep_dims[vT.get_qindices(b)[0]] == 0)
-            to_be_remove.push_back(b);
-          else {
-            /// process blocks:
-            if (keep_dims[vT.get_qindices(b)[0]] != vT.get_blocks_()[b].shape()[0]) {
-              acs[0] = ac::range(0, keep_dims[vT.get_qindices(b)[0]]);
-              vT.get_blocks_()[b] = vT.get_blocks_()[b].get(acs);
-            }
-            // change to new qindices:
-            vT.get_qindices(b)[0] = new_qid[vT.get_qindices(b)[0]];
-          }
-        }
-        vec_erase_(vT.get_itoi(), to_be_remove);
-        vec_erase_(vT.get_blocks_(), to_be_remove);
-        vec_erase_(vT.signflip_(), to_be_remove);
-        t++;
-      }
-
-      // handle return_err!
-      if (return_err == 1) {
-        outCyT.push_back(UniTensor(Tensor({1}, Smin.dtype())));
-        outCyT.back().get_block_().storage().at(0) = Smin;
-      } else if (return_err) {
-        outCyT.push_back(UniTensor(Sall.get({ac::tilend(smidx)})));
-      }
-    }  // _svd_truncate_BlockFermionic_UT
+    }  // _svd_truncate_Block_UTs
 
     std::vector<cytnx::UniTensor> Svd_truncate(const cytnx::UniTensor &Tin,
                                                const cytnx_uint64 &keepdim, const double &err,
@@ -497,11 +365,9 @@ namespace cytnx {
       if (Tin.uten_type() == UTenType.Dense) {
         _svd_truncate_Dense_UT(outCyT, Tin, keepdim, err, is_UvT, return_err, mindim);
 
-      } else if (Tin.uten_type() == UTenType.Block) {
-        _svd_truncate_Block_UT(outCyT, Tin, keepdim, err, is_UvT, return_err, mindim);
-
-      } else if (Tin.uten_type() == UTenType.BlockFermionic) {
-        _svd_truncate_BlockFermionic_UT(outCyT, Tin, keepdim, err, is_UvT, return_err, mindim);
+      } else if ((Tin.uten_type() == UTenType.Block) ||
+                 (Tin.uten_type() == UTenType.BlockFermionic)) {
+        _svd_truncate_Block_UTs(outCyT, Tin, keepdim, err, is_UvT, return_err, mindim);
       } else {
         cytnx_error_msg(
           true, "[ERROR] Svd_truncate only supports Dense/Block/BlockFermionic UniTensors.%s",
@@ -511,11 +377,14 @@ namespace cytnx {
 
     }  // Svd_truncate
 
-    void _svd_truncate_Block_UT(std::vector<UniTensor> &outCyT, const cytnx::UniTensor &Tin,
-                                const cytnx_uint64 &keepdim, std::vector<cytnx_uint64> min_blockdim,
-                                const double &err, const bool &is_UvT, const int &return_err,
-                                const cytnx_uint64 &mindim) {
+    void _svd_truncate_Block_UTs(std::vector<UniTensor> &outCyT, const cytnx::UniTensor &Tin,
+                                 const cytnx_uint64 &keepdim,
+                                 std::vector<cytnx_uint64> min_blockdim, const double &err,
+                                 const bool &is_UvT, const int &return_err,
+                                 const cytnx_uint64 &mindim) {
       // currently, Gesvd is used as a standard for the full SVD before truncation
+      // handles BlockFermionicUniTensor as well: elements of _signflip are removed if blocks are
+      // erased
       cytnx_int64 keep_dim = keepdim;  // these must be signed int, because they can become
                                        // negative!
       cytnx_int64 min_dim = (mindim < 1 ? 1 : mindim);
@@ -654,8 +523,13 @@ namespace cytnx {
         // remove:
         // vec_erase_(S.get_itoi(),to_be_remove);
         S.get_itoi() = new_itoi;
-        vec_erase_(S.get_blocks_(), to_be_remove);
-        vec_erase_(S.bonds()[0].qnums(), to_be_remove);
+        if (!to_be_remove.empty()) {
+          vec_erase_(S.get_blocks_(), to_be_remove);
+          vec_erase_(S.bonds()[0].qnums(), to_be_remove);
+          if (Tin.uten_type() == UTenType.BlockFermionic) {
+            vec_erase_(S.signflip_(), to_be_remove);
+          }
+        }
         S.bonds()[0]._impl->_degs = new_dims;
         S.bonds()[0]._impl->_dim = tot_dim;
         S.bonds()[1] = S.bonds()[0].redirect();
@@ -682,8 +556,13 @@ namespace cytnx {
               U.get_qindices(b).back() = new_qid[U.get_qindices(b).back()];
             }
           }
-          vec_erase_(U.get_itoi(), to_be_remove);
-          vec_erase_(U.get_blocks_(), to_be_remove);
+          if (!to_be_remove.empty()) {
+            vec_erase_(U.get_itoi(), to_be_remove);
+            vec_erase_(U.get_blocks_(), to_be_remove);
+            if (Tin.uten_type() == UTenType.BlockFermionic) {
+              vec_erase_(U.signflip_(), to_be_remove);
+            }
+          }
 
           t++;
         }
@@ -708,12 +587,18 @@ namespace cytnx {
               vT.get_qindices(b)[0] = new_qid[vT.get_qindices(b)[0]];
             }
           }
-          vec_erase_(vT.get_itoi(), to_be_remove);
-          vec_erase_(vT.get_blocks_(), to_be_remove);
+          if (!to_be_remove.empty()) {
+            vec_erase_(vT.get_itoi(), to_be_remove);
+            vec_erase_(vT.get_blocks_(), to_be_remove);
+            if (Tin.uten_type() == UTenType.BlockFermionic) {
+              vec_erase_(vT.signflip_(), to_be_remove);
+            }
+          }
+
           t++;
         }
       }
-    }  // _svd_truncate_Block_UT
+    }  // _svd_truncate_Block_UTs
 
     std::vector<cytnx::UniTensor> Svd_truncate(const cytnx::UniTensor &Tin,
                                                const cytnx_uint64 &keepdim,
@@ -740,17 +625,10 @@ namespace cytnx {
         _svd_truncate_Dense_UT(outCyT, Tin, keepdim, err, is_UvT, return_err,
                                max(mindim, min_blockdim[0]));
 
-      } else if (Tin.uten_type() == UTenType.Block) {
-        _svd_truncate_Block_UT(outCyT, Tin, keepdim, min_blockdim, err, is_UvT, return_err, mindim);
-
-      } else if (Tin.uten_type() == UTenType.BlockFermionic) {
-        // _svd_truncate_BlockFermionic_UT(outCyT, Tin, keepdim, min_blockdim, err, is_UvT,
-        // return_err, mindim);
-        cytnx_error_msg(
-          true,
-          "[ERROR][_svd_truncate_BlockFermionic_UT] with min_blockdim not implemented yet. The "
-          "signflips need to be removed if blocks are deleted in the truncation.%s",
-          "\n");
+      } else if ((Tin.uten_type() == UTenType.Block) ||
+                 (Tin.uten_type() == UTenType.BlockFermionic)) {
+        _svd_truncate_Block_UTs(outCyT, Tin, keepdim, min_blockdim, err, is_UvT, return_err,
+                                mindim);
       } else {
         cytnx_error_msg(
           true, "[ERROR] Svd_truncate only supports Dense/Block/BlockFermionic UniTensors.%s",

--- a/src/linalg/iAdd.cpp
+++ b/src/linalg/iAdd.cpp
@@ -12,10 +12,10 @@ namespace cytnx {
 
     void iAdd(Tensor &Lt, const Tensor &Rt) {
       cytnx_error_msg(Lt.device() != Rt.device(),
-                      "[iAdd] error, two tensor cannot on different devices.%s", "\n");
+                      "[iAdd]  error, the two tensors have to be on the same device.%s", "\n");
       if (!(Rt.shape().size() == 1 && Rt.shape()[0] == 1)) {
         cytnx_error_msg(Lt.shape() != Rt.shape(),
-                        "[iAdd] error, the two tensor does not have the same shape. Lt rank: [%d] "
+                        "[iAdd] error, the two tensors do not have the same shape. Lt rank: [%d] "
                         "Rt rank: [%d] %s",
                         Lt.shape().size(), Rt.shape().size(), "\n");
       }

--- a/src/linalg/iSub.cpp
+++ b/src/linalg/iSub.cpp
@@ -12,11 +12,11 @@ namespace cytnx {
 
     void iSub(Tensor &Lt, const Tensor &Rt) {
       cytnx_error_msg(Lt.device() != Rt.device(),
-                      "[iSub] error, two tensor cannot on different devices.%s", "\n");
+                      "[iSub] error, the two tensors have to be on the same device.%s", "\n");
 
       if (!(Rt.shape().size() == 1 && Rt.shape()[0] == 1)) {
         cytnx_error_msg(Lt.shape() != Rt.shape(),
-                        "[iSub] error, the two tensor does not have the same shape. Lt rank: [%d] "
+                        "[iSub] error, the two tensors do not have the same shape. Lt rank: [%d] "
                         "Rt rank: [%d] %s",
                         Lt.shape().size(), Rt.shape().size(), "\n");
       }
@@ -52,7 +52,7 @@ namespace cytnx {
           if (Lt.dtype() > Rt.dtype()) Lt = tmpo;
 
   #else
-          cytnx_error_msg(true, "[Sub] fatal error, the tensor is on GPU without CUDA support.%s",
+          cytnx_error_msg(true, "[Sub] fatal error, the tensors are on GPU without CUDA support.%s",
                           "\n");
   #endif
         }


### PR DESCRIPTION
`Gesvd` was buggy if used with fermions, and `Svd_truncate` was disabled for fermions. Both works now. I had to add the method `signflip_()` to `UniTensor` to allow for deletion of signflip entries if blocks get erased in `Svd_truncate`