### PR TITLE
avoid function names starting with `_`

### DIFF
--- a/src/BlockFermionicUniTensor.cpp
+++ b/src/BlockFermionicUniTensor.cpp
@@ -2760,7 +2760,7 @@ namespace cytnx {
     this->combineBonds(idx_mapper, force);
   }
 
-  void _BKF_from_DN(BlockFermionicUniTensor *ths, DenseUniTensor *rhs, const bool &force) {
+  void _bkf_from_dn(BlockFermionicUniTensor *ths, DenseUniTensor *rhs, const bool &force) {
     if (!force) {
       // more checking:
       if (int(rhs->bond_(0).type()) != bondType::BD_NONE) {
@@ -2799,11 +2799,11 @@ namespace cytnx {
     }
   }
 
-  void _BKF_from_BK(BlockFermionicUniTensor *ths, BlockUniTensor *rhs, const bool &force) {
+  void _bkf_from_bk(BlockFermionicUniTensor *ths, BlockUniTensor *rhs, const bool &force) {
     cytnx_error_msg(true, "[ERROR] BlockFermionicUT-> BlockUT not implemented.%s", "\n");
   }
 
-  void _BKF_from_BKF(BlockFermionicUniTensor *ths, BlockFermionicUniTensor *rhs,
+  void _bkf_from_bkF(BlockFermionicUniTensor *ths, BlockFermionicUniTensor *rhs,
                      const bool &force) {
     cytnx_error_msg(true, "[ERROR] BlockFermionicUT-> BlockFermionicUT not implemented.%s", "\n");
   }
@@ -2814,11 +2814,11 @@ namespace cytnx {
     cytnx_error_msg(this->shape() != rhs->shape(), "[ERROR][from_] shape does not match.%s", "\n");
 
     if (rhs->uten_type() == UTenType.Dense) {
-      _BKF_from_DN(this, (DenseUniTensor *)(rhs.get()), force);
+      _bkf_from_dn(this, (DenseUniTensor *)(rhs.get()), force);
     } else if (rhs->uten_type() == UTenType.Block) {
-      _BKF_from_BK(this, (BlockUniTensor *)(rhs.get()), force);
+      _bkf_from_bk(this, (BlockUniTensor *)(rhs.get()), force);
     } else if (rhs->uten_type() == UTenType.BlockFermionic) {
-      _BKF_from_BKF(this, (BlockFermionicUniTensor *)(rhs.get()), force);
+      _bkf_from_bkF(this, (BlockFermionicUniTensor *)(rhs.get()), force);
     } else {
       cytnx_error_msg(
         true, "[ERROR] unsupport conversion of UniTensor from %s => BlockFermionicUniTensor\n",

--- a/src/BlockUniTensor.cpp
+++ b/src/BlockUniTensor.cpp
@@ -2013,7 +2013,7 @@ namespace cytnx {
     this->combineBonds(idx_mapper, force);
   }
 
-  void _BK_from_DN(BlockUniTensor *ths, DenseUniTensor *rhs, const bool &force) {
+  void _bk_from_dn(BlockUniTensor *ths, DenseUniTensor *rhs, const bool &force) {
     if (!force) {
       // more checking:
       if (int(rhs->bond_(0).type()) != bondType::BD_NONE) {
@@ -2051,7 +2051,7 @@ namespace cytnx {
     }
   }
 
-  void _BK_from_BK(BlockUniTensor *ths, BlockUniTensor *rhs, const bool &force) {
+  void _bk_from_bk(BlockUniTensor *ths, BlockUniTensor *rhs, const bool &force) {
     cytnx_error_msg(true, "[ERROR] BlockUT-> BlockUT not implemented.%s", "\n");
   }
 
@@ -2060,9 +2060,9 @@ namespace cytnx {
     cytnx_error_msg(this->shape() != rhs->shape(), "[ERROR][from_] shape does not match.%s", "\n");
 
     if (rhs->uten_type() == UTenType.Dense) {
-      _BK_from_DN(this, (DenseUniTensor *)(rhs.get()), force);
+      _bk_from_dn(this, (DenseUniTensor *)(rhs.get()), force);
     } else if (rhs->uten_type() == UTenType.Block) {
-      _BK_from_BK(this, (BlockUniTensor *)(rhs.get()), force);
+      _bk_from_bk(this, (BlockUniTensor *)(rhs.get()), force);
     } else {
       cytnx_error_msg(true, "[ERROR] unsupport conversion of UniTensor from %s => BlockUniTensor\n",
                       UTenType.getname(rhs->uten_type()).c_str());


### PR DESCRIPTION
Function names starting with `-` are reserved in C++. We use them to mimick the Python convention, but this could possibly cause conflicts with certain compilers (in the future).


Here is the previous discussion on this:

@IvanaGyro 
Following the coding style we applied. Function names should be upper camel case. C++ doesn't need to imply internal on the method name because all functions declared in .cpp (source) files and in internal namespaces are internal in the language semantics. In contrast Python doesn't have access control, but developers feel they need to indicate a method is "private" as other languages like C++. As a result, there is the underscore convention.

See: https://google.github.io/styleguide/cppguide.html#Function_Names


@ianmccul  ianmccul [Jun 26, 2025](https://github.com/Cytnx-dev/Cytnx/pull/619#discussion_r2168002462)

The google coding conventions implicitly assume that you don't use leading underscores, because for most purposes they are banned by the C++ standard:

    All identifiers that begin with an underscore followed by an uppercase letter, or that contain a double underscore, are reserved to the implementation for any use.

    All identifiers that begin with an underscore are reserved in the global namespace.

If you are going to use a leading underscore, it must be followed by a lowercase letter, and it must be in some namespace or function scope, it cannot be in the global namespace.

In practice it will probably just work, compilers don't check identifier names, but don't be surprised if there is some conflict.Following the coding style we applied. Function names should be upper camel case. C++ doesn't need to imply internal on the method name because all functions declared in .cpp (source) files and in internal namespaces are internal in the language semantics. In contrast Python doesn't have access control, but developers feel they need to indicate a method is "private" as other languages like C++. As a result, there is the underscore convention.

See: https://google.github.io/styleguide/cppguide.html#Function_Names

Additionally, could you cherry-pick this commit to another branch and open a new PR? It seems that this commit is not related to this PR. This PR is growing and the workload on reviewing this PR become heavier 😂.
Member
@[ianmccul](https://github.com/ianmccul) ianmccul [Jun 26, 2025](https://github.com/Cytnx-dev/Cytnx/pull/619#discussion_r2168002462)

The google coding conventions implicitly assume that you don't use leading underscores, because for most purposes they are banned by the C++ standard:

    All identifiers that begin with an underscore followed by an uppercase letter, or that contain a double underscore, are reserved to the implementation for any use.

    All identifiers that begin with an underscore are reserved in the global namespace.

If you are going to use a leading underscore, it must be followed by a lowercase letter, and it must be in some namespace or function scope, it cannot be in the global namespace.

In practice it will probably just work, compilers don't check identifier names, but don't be surprised if there is some conflict.