### PR TITLE
Refactor sort internal implementation

### DIFF
--- a/src/backend/algo_internal_cpu/Sort_internal.cpp
+++ b/src/backend/algo_internal_cpu/Sort_internal.cpp
@@ -1,93 +1,55 @@
 #include "Sort_internal.hpp"
-#include "backend/algo_internal_interface.hpp"
-#include <iostream>
+
 #include <algorithm>
+#include <iostream>
+
+#include "backend/algo_internal_interface.hpp"
+
+// Macro to generate complex number sorting functions.
+// Creates a comparison function and sort implementation for complex types.
+#define CYTNX_INTERNAL_COMPLEX_SORT(Device, DType, CytnxDType)                                \
+  bool Device##_compare_##DType(CytnxDType a, CytnxDType b) {                                 \
+    if (real(a) == real(b)) return imag(a) < imag(b);                                         \
+    return real(a) < real(b);                                                                 \
+  }                                                                                           \
+  void Device##Sort_internal_##DType(boost::intrusive_ptr<Storage_base>& out,                 \
+                                     const cytnx_uint64& stride, const cytnx_uint64& Nelem) { \
+    auto* p = reinterpret_cast<CytnxDType*>(out->data());                                     \
+    cytnx_uint64 num_iterations = Nelem / stride;                                             \
+    for (cytnx_uint64 i = 0; i < num_iterations; ++i) {                                       \
+      std::sort(p + i * stride, p + i * stride + stride, Device##_compare_##DType);           \
+    }                                                                                         \
+  }
+
+// Macro to generate standard sorting functions.
+#define CYTNX_INTERNAL_SORT(Device, DType, CytnxDType)                                        \
+  void Device##Sort_internal_##DType(boost::intrusive_ptr<Storage_base>& out,                 \
+                                     const cytnx_uint64& stride, const cytnx_uint64& Nelem) { \
+    auto* p = reinterpret_cast<CytnxDType*>(out->data());                                     \
+    cytnx_uint64 num_iterations = Nelem / stride;                                             \
+    for (cytnx_uint64 i = 0; i < num_iterations; ++i) {                                       \
+      std::sort(p + i * stride, p + i * stride + stride);                                     \
+    }                                                                                         \
+  }
 
 namespace cytnx {
 
   namespace algo_internal {
 
-    bool _compare_c128(cytnx_complex128 a, cytnx_complex128 b) {
-      if (real(a) == real(b)) return imag(a) < imag(b);
-      return real(a) < real(b);
-    }
-    void Sort_internal_cd(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                          const cytnx_uint64 &Nelem) {
-      cytnx_complex128 *p = (cytnx_complex128 *)out->data();
-      cytnx_uint64 Niter = Nelem / stride;
-      for (cytnx_uint64 i = 0; i < Niter; i++)
-        std::sort(p + i * stride, p + i * stride + stride, _compare_c128);
-    }
-    bool _compare_c64(cytnx_complex64 a, cytnx_complex64 b) {
-      if (real(a) == real(b)) return imag(a) < imag(b);
-      return real(a) < real(b);
-    }
-    void Sort_internal_cf(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                          const cytnx_uint64 &Nelem) {
-      cytnx_complex64 *p = (cytnx_complex64 *)out->data();
-      cytnx_uint64 Niter = Nelem / stride;
-      for (cytnx_uint64 i = 0; i < Niter; i++)
-        std::sort(p + i * stride, p + i * stride + stride, _compare_c64);
-    }
+    // Generate sorting functions for all supported data types.
+    CYTNX_INTERNAL_COMPLEX_SORT(/*cpu*/, ComplexDouble, cytnx_complex128)
+    CYTNX_INTERNAL_COMPLEX_SORT(/*cpu*/, ComplexFloat, cytnx_complex64)
+    CYTNX_INTERNAL_SORT(/*cpu*/, Double, double)
+    CYTNX_INTERNAL_SORT(/*cpu*/, Float, float)
+    CYTNX_INTERNAL_SORT(/*cpu*/, Uint64, cytnx_uint64)
+    CYTNX_INTERNAL_SORT(/*cpu*/, Int64, cytnx_int64)
+    CYTNX_INTERNAL_SORT(/*cpu*/, Uint32, cytnx_uint32)
+    CYTNX_INTERNAL_SORT(/*cpu*/, Int32, cytnx_int32)
+    CYTNX_INTERNAL_SORT(/*cpu*/, Uint16, cytnx_uint16)
+    CYTNX_INTERNAL_SORT(/*cpu*/, Int16, cytnx_int16)
 
-    void Sort_internal_d(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                         const cytnx_uint64 &Nelem) {
-      double *p = (double *)out->data();
-      cytnx_uint64 Niter = Nelem / stride;
-      for (cytnx_uint64 i = 0; i < Niter; i++) std::sort(p + i * stride, p + i * stride + stride);
-    }
-
-    void Sort_internal_f(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                         const cytnx_uint64 &Nelem) {
-      float *p = (float *)out->data();
-      cytnx_uint64 Niter = Nelem / stride;
-      for (cytnx_uint64 i = 0; i < Niter; i++) std::sort(p + i * stride, p + i * stride + stride);
-    }
-
-    void Sort_internal_u64(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                           const cytnx_uint64 &Nelem) {
-      cytnx_uint64 *p = (cytnx_uint64 *)out->data();
-      cytnx_uint64 Niter = Nelem / stride;
-      for (cytnx_uint64 i = 0; i < Niter; i++) std::sort(p + i * stride, p + i * stride + stride);
-    }
-
-    void Sort_internal_i64(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                           const cytnx_uint64 &Nelem) {
-      cytnx_int64 *p = (cytnx_int64 *)out->data();
-      cytnx_uint64 Niter = Nelem / stride;
-      for (cytnx_uint64 i = 0; i < Niter; i++) std::sort(p + i * stride, p + i * stride + stride);
-    }
-
-    void Sort_internal_u32(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                           const cytnx_uint64 &Nelem) {
-      cytnx_uint32 *p = (cytnx_uint32 *)out->data();
-      cytnx_uint64 Niter = Nelem / stride;
-      for (cytnx_uint64 i = 0; i < Niter; i++) std::sort(p + i * stride, p + i * stride + stride);
-    }
-
-    void Sort_internal_i32(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                           const cytnx_uint64 &Nelem) {
-      cytnx_int32 *p = (cytnx_int32 *)out->data();
-      cytnx_uint64 Niter = Nelem / stride;
-      for (cytnx_uint64 i = 0; i < Niter; i++) std::sort(p + i * stride, p + i * stride + stride);
-    }
-
-    void Sort_internal_u16(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                           const cytnx_uint64 &Nelem) {
-      cytnx_uint16 *p = (cytnx_uint16 *)out->data();
-      cytnx_uint64 Niter = Nelem / stride;
-      for (cytnx_uint64 i = 0; i < Niter; i++) std::sort(p + i * stride, p + i * stride + stride);
-    }
-
-    void Sort_internal_i16(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                           const cytnx_uint64 &Nelem) {
-      cytnx_int16 *p = (cytnx_int16 *)out->data();
-      cytnx_uint64 Niter = Nelem / stride;
-      for (cytnx_uint64 i = 0; i < Niter; i++) std::sort(p + i * stride, p + i * stride + stride);
-    }
-
-    void Sort_internal_b(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                         const cytnx_uint64 &Nelem) {
+    void Sort_internal_Bool(boost::intrusive_ptr<Storage_base>& out, const cytnx_uint64& stride,
+                            const cytnx_uint64& Nelem) {
       /*
       cytnx_bool *p = (cytnx_bool*)out->Mem;
       cytnx_uint64 Niter = Nelem/stride;

--- a/src/backend/algo_internal_cpu/Sort_internal.hpp
+++ b/src/backend/algo_internal_cpu/Sort_internal.hpp
@@ -1,49 +1,34 @@
 #ifndef CYTNX_BACKEND_ALGO_INTERNAL_CPU_SORT_INTERNAL_H_
 #define CYTNX_BACKEND_ALGO_INTERNAL_CPU_SORT_INTERNAL_H_
 
-#include <assert.h>
-#include <iostream>
-#include <iomanip>
-#include <vector>
-#include "backend/Storage.hpp"
+#include <algorithm>
+#include <cstdint>
+
+#include <boost/intrusive_ptr.hpp>
+
 #include "Type.hpp"
+#include "backend/Storage.hpp"
+
+// Macro to declare sorting functions for different data types.
+#define CYTNX_SORT_INTERNAL_FUNC(Device, DType)                                                   \
+  void Sort_internal_##DType(boost::intrusive_ptr<Storage_base>& out, const cytnx_uint64& stride, \
+                             const cytnx_uint64& Nelem)
 
 namespace cytnx {
 
   namespace algo_internal {
 
-    void Sort_internal_cd(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                          const cytnx_uint64 &Nelem);
-
-    void Sort_internal_cf(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                          const cytnx_uint64 &Nelem);
-
-    void Sort_internal_d(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                         const cytnx_uint64 &Nelem);
-
-    void Sort_internal_f(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                         const cytnx_uint64 &Nelem);
-
-    void Sort_internal_u64(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                           const cytnx_uint64 &Nelem);
-
-    void Sort_internal_i64(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                           const cytnx_uint64 &Nelem);
-
-    void Sort_internal_u32(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                           const cytnx_uint64 &Nelem);
-
-    void Sort_internal_i32(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                           const cytnx_uint64 &Nelem);
-
-    void Sort_internal_u16(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                           const cytnx_uint64 &Nelem);
-
-    void Sort_internal_i16(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                           const cytnx_uint64 &Nelem);
-
-    void Sort_internal_b(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                         const cytnx_uint64 &Nelem);
+    CYTNX_SORT_INTERNAL_FUNC(/*cpu*/, ComplexDouble);
+    CYTNX_SORT_INTERNAL_FUNC(/*cpu*/, ComplexFloat);
+    CYTNX_SORT_INTERNAL_FUNC(/*cpu*/, Double);
+    CYTNX_SORT_INTERNAL_FUNC(/*cpu*/, Float);
+    CYTNX_SORT_INTERNAL_FUNC(/*cpu*/, Uint64);
+    CYTNX_SORT_INTERNAL_FUNC(/*cpu*/, Int64);
+    CYTNX_SORT_INTERNAL_FUNC(/*cpu*/, Uint32);
+    CYTNX_SORT_INTERNAL_FUNC(/*cpu*/, Int32);
+    CYTNX_SORT_INTERNAL_FUNC(/*cpu*/, Uint16);
+    CYTNX_SORT_INTERNAL_FUNC(/*cpu*/, Int16);
+    CYTNX_SORT_INTERNAL_FUNC(/*cpu*/, Bool);
 
   }  // namespace algo_internal
 

--- a/src/backend/algo_internal_gpu/cuSort_internal.hpp
+++ b/src/backend/algo_internal_gpu/cuSort_internal.hpp
@@ -1,49 +1,33 @@
 #ifndef CYTNX_BACKEND_ALGO_INTERNAL_GPU_CUSORT_INTERNAL_H_
 #define CYTNX_BACKEND_ALGO_INTERNAL_GPU_CUSORT_INTERNAL_H_
 
-#include <assert.h>
-#include <iostream>
-#include <iomanip>
-#include <vector>
-#include "backend/Storage.hpp"
+#include <cstdint>
+
+#include <boost/intrusive_ptr.hpp>
+
 #include "Type.hpp"
+#include "backend/Storage.hpp"
+
+// Macro to declare sorting functions for different data types.
+#define CYTNX_SORT_INTERNAL_FUNC(Device, DType)                               \
+  void Device##Sort_internal_##DType(boost::intrusive_ptr<Storage_base>& out, \
+                                     const cytnx_uint64& stride, const cytnx_uint64& Nelem)
 
 namespace cytnx {
 
   namespace algo_internal {
 
-    void cuSort_internal_cd(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                            const cytnx_uint64 &Nelem);
-
-    void cuSort_internal_cf(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                            const cytnx_uint64 &Nelem);
-
-    void cuSort_internal_d(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                           const cytnx_uint64 &Nelem);
-
-    void cuSort_internal_f(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                           const cytnx_uint64 &Nelem);
-
-    void cuSort_internal_u64(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                             const cytnx_uint64 &Nelem);
-
-    void cuSort_internal_i64(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                             const cytnx_uint64 &Nelem);
-
-    void cuSort_internal_u32(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                             const cytnx_uint64 &Nelem);
-
-    void cuSort_internal_i32(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                             const cytnx_uint64 &Nelem);
-
-    void cuSort_internal_u16(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                             const cytnx_uint64 &Nelem);
-
-    void cuSort_internal_i16(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                             const cytnx_uint64 &Nelem);
-
-    void cuSort_internal_b(boost::intrusive_ptr<Storage_base> &out, const cytnx_uint64 &stride,
-                           const cytnx_uint64 &Nelem);
+    CYTNX_SORT_INTERNAL_FUNC(cuda, ComplexDouble);
+    CYTNX_SORT_INTERNAL_FUNC(cuda, ComplexFloat);
+    CYTNX_SORT_INTERNAL_FUNC(cuda, Double);
+    CYTNX_SORT_INTERNAL_FUNC(cuda, Float);
+    CYTNX_SORT_INTERNAL_FUNC(cuda, Uint64);
+    CYTNX_SORT_INTERNAL_FUNC(cuda, Int64);
+    CYTNX_SORT_INTERNAL_FUNC(cuda, Uint32);
+    CYTNX_SORT_INTERNAL_FUNC(cuda, Int32);
+    CYTNX_SORT_INTERNAL_FUNC(cuda, Uint16);
+    CYTNX_SORT_INTERNAL_FUNC(cuda, Int16);
+    CYTNX_SORT_INTERNAL_FUNC(cuda, Bool);
 
   }  // namespace algo_internal
 

--- a/src/backend/algo_internal_interface.cpp
+++ b/src/backend/algo_internal_interface.cpp
@@ -1,6 +1,22 @@
 #include "algo_internal_interface.hpp"
 
-using namespace std;
+// Macro to assign a device-specific sort function to a function table.
+#define CYTNX_ASSIGN_SORT_FUNC(Device, Table, DataType) \
+  Table[Type.DataType] = Device##Sort_internal_##DataType
+
+// Macro to assign all supported data type sort functions for a specific device.
+#define CYTNX_ASSIGN_ALL_DTYPE_SORT_FUNC(Device, Table) \
+  CYTNX_ASSIGN_SORT_FUNC(Device, Table, ComplexDouble); \
+  CYTNX_ASSIGN_SORT_FUNC(Device, Table, ComplexFloat);  \
+  CYTNX_ASSIGN_SORT_FUNC(Device, Table, Double);        \
+  CYTNX_ASSIGN_SORT_FUNC(Device, Table, Float);         \
+  CYTNX_ASSIGN_SORT_FUNC(Device, Table, Uint64);        \
+  CYTNX_ASSIGN_SORT_FUNC(Device, Table, Int64);         \
+  CYTNX_ASSIGN_SORT_FUNC(Device, Table, Uint32);        \
+  CYTNX_ASSIGN_SORT_FUNC(Device, Table, Int32);         \
+  CYTNX_ASSIGN_SORT_FUNC(Device, Table, Uint16);        \
+  CYTNX_ASSIGN_SORT_FUNC(Device, Table, Int16);         \
+  CYTNX_ASSIGN_SORT_FUNC(Device, Table, Bool);
 
 namespace cytnx {
   namespace algo_internal {
@@ -8,35 +24,14 @@ namespace cytnx {
     algo_internal_interface aii;
 
     algo_internal_interface::algo_internal_interface() {
-      Sort_ii.assign(N_Type, NULL);
+      Sort_ii.assign(N_Type, nullptr);
 #ifdef UNI_GPU
-      cuSort_ii.assign(N_Type, NULL);
+      cuSort_ii.assign(N_Type, nullptr);
 #endif
-
-      Sort_ii[Type.ComplexDouble] = Sort_internal_cd;
-      Sort_ii[Type.ComplexFloat] = Sort_internal_cf;
-      Sort_ii[Type.Double] = Sort_internal_d;
-      Sort_ii[Type.Float] = Sort_internal_f;
-      Sort_ii[Type.Uint64] = Sort_internal_u64;
-      Sort_ii[Type.Int64] = Sort_internal_i64;
-      Sort_ii[Type.Uint32] = Sort_internal_u32;
-      Sort_ii[Type.Int32] = Sort_internal_i32;
-      Sort_ii[Type.Uint16] = Sort_internal_u16;
-      Sort_ii[Type.Int16] = Sort_internal_i16;
-      Sort_ii[Type.Bool] = Sort_internal_b;
+      CYTNX_ASSIGN_ALL_DTYPE_SORT_FUNC(/*cpu*/, Sort_ii)
 
 #ifdef UNI_GPU
-      cuSort_ii[Type.ComplexDouble] = cuSort_internal_cd;
-      cuSort_ii[Type.ComplexFloat] = cuSort_internal_cf;
-      cuSort_ii[Type.Double] = cuSort_internal_d;
-      cuSort_ii[Type.Float] = cuSort_internal_f;
-      cuSort_ii[Type.Uint64] = cuSort_internal_u64;
-      cuSort_ii[Type.Int64] = cuSort_internal_i64;
-      cuSort_ii[Type.Uint32] = cuSort_internal_u32;
-      cuSort_ii[Type.Int32] = cuSort_internal_i32;
-      cuSort_ii[Type.Uint16] = cuSort_internal_u16;
-      cuSort_ii[Type.Int16] = cuSort_internal_i16;
-      cuSort_ii[Type.Bool] = cuSort_internal_b;
+      CYTNX_ASSIGN_ALL_DTYPE_SORT_FUNC(cuda, cuSort_ii)
 #endif
     }
 

--- a/src/backend/algo_internal_interface.hpp
+++ b/src/backend/algo_internal_interface.hpp
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <vector>
+#include <functional>
 
 #include "Type.hpp"
 #include "backend/Storage.hpp"
@@ -19,8 +20,8 @@
 namespace cytnx {
 
   namespace algo_internal {
-    typedef void (*Sort_internal_ii)(boost::intrusive_ptr<Storage_base> &, const cytnx_uint64 &,
-                                     const cytnx_uint64 &);
+    using Sort_internal_ii = std::function<void(boost::intrusive_ptr<Storage_base> &,
+                                                const cytnx_uint64 &, const cytnx_uint64 &)>;
     class algo_internal_interface {
      public:
       std::vector<Sort_internal_ii> Sort_ii;


### PR DESCRIPTION
- Use macros to eliminate duplicated code
- Fix include order according to google c++ style guide
- Replace NULL with `nullptr` for modern C++ compliance
- Replace function pointers with `std::function` for type safety