### PR TITLE
Fix typo "defualt"

### DIFF
--- a/tests/common_data_generator.cpp
+++ b/tests/common_data_generator.cpp
@@ -48,7 +48,7 @@ namespace CommonDataGen {
         return "U16";
       case Type.Bool:
         return "Bool";
-      defualt:
+      default:
         assert(false);
     }
   }

--- a/tests/gpu/common_data_generator.cpp
+++ b/tests/gpu/common_data_generator.cpp
@@ -48,7 +48,7 @@ namespace CommonDataGen {
         return "U16";
       case Type.Bool:
         return "Bool";
-      defualt:
+      default:
         assert(false);
     }
   }


### PR DESCRIPTION
Some default cases in switch statements are broken due to the typo "defualt".