### PR TITLE
Change intrusive_ptr_add_ref/release signatures so ADL can find them

### DIFF
--- a/include/intrusive_ptr_base.hpp
+++ b/include/intrusive_ptr_base.hpp
@@ -9,6 +9,11 @@
 
 namespace cytnx {
   /// @cond
+  class Storage_base;  // forward, defined in backend/Storage.hpp
+  // The following two declarations are necessary for ADL.
+  void intrusive_ptr_add_ref(Storage_base *);
+  void intrusive_ptr_release(Storage_base *);
+
   template <class T>
   class intrusive_ptr_base {
    public:
@@ -30,21 +35,20 @@ namespace cytnx {
     }
 
     // hook boost::intrusive_ptr add
-    friend void intrusive_ptr_add_ref(intrusive_ptr_base<T> const *s) {
+    friend void intrusive_ptr_add_ref(T *s) {
       // add ref
-      // std::cout << "add" << std::endl;
-      assert(s->ref_count >= 0);
-      assert(s != 0);
-      ++s->ref_count;
+      assert(s != nullptr);
+      auto &base = static_cast<const intrusive_ptr_base<T> &>(*s);
+      assert(base.ref_count >= 0);
+      ++base.ref_count;
     }
-
     // hook boost::intrusive_ptr release
-    friend void intrusive_ptr_release(intrusive_ptr_base<T> const *s) {
+    friend void intrusive_ptr_release(T *s) {
       // release ref
-      // std::cout << "release" << std::endl;
-      assert(s->ref_count > 0);
-      assert(s != 0);
-      if (--s->ref_count == 0) boost::checked_delete(static_cast<T const *>(s));
+      assert(s != nullptr);
+      auto &base = static_cast<const intrusive_ptr_base<T> &>(*s);
+      assert(base.ref_count > 0);
+      if (--base.ref_count == 0) boost::checked_delete(static_cast<T const *>(s));
     }
 
     boost::intrusive_ptr<T> self() { return boost::intrusive_ptr<T>((T *)this); }


### PR DESCRIPTION
I encountered a build failure in my environment (macOS on Apple Silicon with Homebrew).
The functions `intrusive_ptr_add_ref` and `intrusive_ptr_release` did not match Boost’s expected signatures (see the [reference](https://www.boost.org/doc/libs/latest/boost/smart_ptr/intrusive_ptr.hpp)), so the unqualified calls were not found by ADL. 
They now follow

```C++
void intrusive_ptr_add_ref(T* p);
void intrusive_ptr_release(T* p);
```

A forward declaration of `Storage_base` is also added so these functions are found by ADL. 
This resolves the build in my environment.

The coupling the `intrusive_ptr_base` code to the concrete `Storage_base` type isn't ideal. 
If you have a cleaner way to decouple this, I'm happy to revise.