### PR TITLE
fixed bug in ExpH when a == 0 and b != 0

### DIFF
--- a/src/linalg/ExpH.cpp
+++ b/src/linalg/ExpH.cpp
@@ -26,9 +26,9 @@ namespace cytnx {
 
       if (a == 0) {
         if (b == 0)
-          return cytnx::linalg::Diag(cytnx::ones(Tin.shape()[0]));
+          return cytnx::identity(Tin.shape()[0], Tin.dtype(), Tin.device());
         else
-          return cytnx::linalg::Diag(cytnx::ones(Tin.shape()[0])) * exp(b);
+          return cytnx::identity(Tin.shape()[0], Tin.dtype(), Tin.device()) * exp(b);
       }
 
       vector<Tensor> su = cytnx::linalg::Eigh(Tin, true);


### PR DESCRIPTION
This was wrong, b was assumed to be 0 if a == 0; also, the eigensolver is not needed if a == 0