### PR TITLE
Use TARGET_DIRECTORY for Kron.cpp CUDA property

### DIFF
--- a/src/linalg/CMakeLists.txt
+++ b/src/linalg/CMakeLists.txt
@@ -1,7 +1,8 @@
 
-# This must be before the target_sources_local(), so that the target is added as CUDA
+# Set Kron.cpp to compile with CUDA compiler when USE_CUDA is enabled
+# Use TARGET_DIRECTORY to explicitly specify the target scope (requires CMake 3.18+)
 if(USE_CUDA)
-  set_source_files_properties(Kron.cpp DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTIES LANGUAGE CUDA)
+  set_source_files_properties(Kron.cpp TARGET_DIRECTORY cytnx PROPERTIES LANGUAGE CUDA)
 endif()
 
 target_sources_local(cytnx


### PR DESCRIPTION
Building `src/linalg/Kron.cpp` for GPU should be handled by `nvcc` (or another CUDA-family compiler).
However, under the current configuration, the `LANGUAGE CUDA` property does not propagate to the top-level CMake configuration, causing the file to be compiled incorrectly with a C++ compiler such as `g++`.
This PR corrects the issue by using `TARGET_DIRECTORY`, enabling `Kron.cpp` to be built properly with `nvcc`.
This fix may also resolve the ordering issue mentioned in the comment.