### PR TITLE
pybind11 3.0.0 required.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,14 +317,14 @@ endif()
 # #######
 IF(BUILD_PYTHON)
   find_package (Python COMPONENTS Interpreter Development)
-  find_package(pybind11 REQUIRED)
+  find_package(pybind11 3.0.0 REQUIRED)
 
   if(NOT pybind11_FOUND)
     include(FetchContent)
     FetchContent_Declare(
       pybind11_sources
       GIT_REPOSITORY https://github.com/pybind/pybind11.git
-      GIT_TAG v2.11.1
+      GIT_TAG v3.0.1
     )
 
     FetchContent_GetProperties(pybind11_sources)


### PR DESCRIPTION
pybind11>=3.0.0 is required after PR #672 .