### PR TITLE
cmake: require pybind11 >= 3.0, fall back to FetchContent v3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,7 +332,6 @@ IF(BUILD_PYTHON)
     if(NOT pybind11_sources_POPULATED)
       FetchContent_Populate(pybind11_sources)
 
-      set(PYBIND11_FINDPYTHON ON)
       add_subdirectory(
         ${pybind11_sources_SOURCE_DIR}
         ${pybind11_sources_BINARY_DIR}


### PR DESCRIPTION
## Summary
- Replace `find_package(pybind11 REQUIRED)` with `find_package(pybind11 3.0 QUIET)` to enforce the pybind11 >= 3.0 minimum version while allowing a graceful FetchContent fallback.
- Update FetchContent `GIT_TAG` from `v2.11.1` → `v3.0.0`.
- Add `set(PYBIND11_FINDPYTHON ON)` required by pybind11 3.x to locate Python.

## Test plan
- [ ] Configure with a system pybind11 >= 3.0 installed — verify it is found directly.
- [ ] Configure without pybind11 installed — verify FetchContent downloads v3.0.0 and builds successfully.
- [ ] `BUILD_PYTHON=ON` builds `pycytnx` and Python tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)