### PR TITLE
Fix block Svd_truncate and Gesvd_truncate return_err output

### DIFF
--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -21,6 +21,27 @@
 
 namespace cytnx {
   namespace linalg {
+    namespace {
+      UniTensor BuildBlockDiscardedSingularValues(const Tensor &Sall, const cytnx_uint64 smidx,
+                                                  const unsigned int return_err) {
+        Tensor terr({1}, Sall.dtype());
+        terr.storage().at(0) = 0;
+        if (smidx == 0) {
+          return UniTensor(terr);
+        }
+        if (return_err == 1) {
+          terr.storage().at(0) = Sall.storage()(smidx - 1);
+          return UniTensor(terr);
+        }
+
+        terr = Tensor({smidx}, Sall.dtype());
+        for (cytnx_uint64 i = 0; i < smidx; i++) {
+          terr.storage().at(i) = Sall.storage()(smidx - 1 - i);
+        }
+        return UniTensor(terr);
+      }
+    }  // namespace
+
     std::vector<Tensor> Gesvd_truncate(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                        const double &err, const bool &is_U, const bool &is_vT,
                                        const unsigned int &return_err, const cytnx_uint64 &mindim) {
@@ -357,10 +378,9 @@ namespace cytnx {
 
       // handle return_err!
       if (return_err == 1) {
-        outCyT.push_back(UniTensor(Tensor({1}, Smin.dtype())));
-        outCyT.back().get_block_().storage().at(0) = Smin;
+        outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, smidx, return_err));
       } else if (return_err) {
-        outCyT.push_back(UniTensor(Sall.get({Accessor::tilend(smidx)})));
+        outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, smidx, return_err));
       }
     }  // Gesvd_truncate_Block_UTs_internal
 
@@ -500,10 +520,9 @@ namespace cytnx {
           }
           // handle return_err!
           if (return_err == 1) {
-            outCyT.push_back(UniTensor(Tensor({1}, Smin.dtype())));
-            outCyT.back().get_block_().storage().at(0) = Smin;
+            outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, smidx, return_err));
           } else if (return_err) {
-            outCyT.push_back(UniTensor(Sall.get({Accessor::tilend(smidx)})));
+            outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, smidx, return_err));
           }
         } else {
           // keep_dim < 1: per-block min_blockdim guarantees already cover the global cap, so

--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -7,6 +7,7 @@
 #include "Tensor.hpp"
 #include "UniTensor.hpp"
 #include "algo.hpp"
+#include "block_truncation_helpers.hpp"
 
 #ifdef BACKEND_TORCH
 #else
@@ -21,26 +22,6 @@
 
 namespace cytnx {
   namespace linalg {
-    namespace {
-      UniTensor BuildBlockDiscardedSingularValues(const Tensor &Sall, const cytnx_uint64 smidx,
-                                                  const unsigned int return_err) {
-        Tensor terr({1}, Sall.dtype());
-        terr.storage().at(0) = 0;
-        if (smidx == 0) {
-          return UniTensor(terr);
-        }
-        if (return_err == 1) {
-          terr.storage().at(0) = Sall.storage()(smidx - 1);
-          return UniTensor(terr);
-        }
-
-        terr = Tensor({smidx}, Sall.dtype());
-        for (cytnx_uint64 i = 0; i < smidx; i++) {
-          terr.storage().at(i) = Sall.storage()(smidx - 1 - i);
-        }
-        return UniTensor(terr);
-      }
-    }  // namespace
 
     std::vector<Tensor> Gesvd_truncate(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                        const double &err, const bool &is_U, const bool &is_vT,

--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -504,11 +504,10 @@ namespace cytnx {
         } else {
           // keep_dim < 1: per-block min_blockdim guarantees already cover the global cap, so
           // every value in Sall is dropped.
-          if (return_err == 1) {
-            // largest dropped singular value
-            outCyT.push_back(UniTensor(linalg::Max(Sall)));
-          } else if (return_err) {
-            outCyT.push_back(UniTensor(Sall));
+          if (return_err) {
+            Sall = algo::Sort(Sall);  // ascending; BuildBlockDiscardedSingularValues expects this
+            outCyT.push_back(
+              BuildBlockDiscardedSingularValues(Sall, Sall.shape()[0], return_err));
           }
         }
 

--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -358,9 +358,7 @@ namespace cytnx {
       }
 
       // handle return_err!
-      if (return_err == 1) {
-        outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, smidx, return_err));
-      } else if (return_err) {
+      if (return_err) {
         outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, smidx, return_err));
       }
     }  // Gesvd_truncate_Block_UTs_internal
@@ -469,7 +467,7 @@ namespace cytnx {
       if (!anySall) {
         // no truncation; return_err is tensor with one element, set to 0
         if (return_err >= 1) {
-          outCyT.push_back(UniTensor(Tensor({1}, Tin.dtype())));
+          outCyT.push_back(UniTensor(Tensor({1}, outCyT[0].dtype())));
         }
       } else {
         Scalar Smin;
@@ -500,9 +498,7 @@ namespace cytnx {
             Smin = Sall.storage()(smidx);
           }
           // handle return_err!
-          if (return_err == 1) {
-            outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, smidx, return_err));
-          } else if (return_err) {
+          if (return_err) {
             outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, smidx, return_err));
           }
         } else {

--- a/src/linalg/Svd_truncate.cpp
+++ b/src/linalg/Svd_truncate.cpp
@@ -8,6 +8,7 @@
 #include "UniTensor.hpp"
 #include "algo.hpp"
 #include "Accessor.hpp"
+#include "block_truncation_helpers.hpp"
 
 #ifdef BACKEND_TORCH
 #else
@@ -15,26 +16,6 @@
   #include "backend/linalg_internal_interface.hpp"
 namespace cytnx {
   namespace linalg {
-    namespace {
-      UniTensor BuildBlockDiscardedSingularValues(const Tensor &Sall, const cytnx_uint64 smidx,
-                                                  const unsigned int return_err) {
-        Tensor terr({1}, Sall.dtype());
-        terr.storage().at(0) = 0;
-        if (smidx == 0) {
-          return UniTensor(terr);
-        }
-        if (return_err == 1) {
-          terr.storage().at(0) = Sall.storage()(smidx - 1);
-          return UniTensor(terr);
-        }
-
-        terr = Tensor({smidx}, Sall.dtype());
-        for (cytnx_uint64 i = 0; i < smidx; i++) {
-          terr.storage().at(i) = Sall.storage()(smidx - 1 - i);
-        }
-        return UniTensor(terr);
-      }
-    }  // namespace
 
     std::vector<Tensor> Svd_truncate(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                      const double &err, const bool &is_UvT,

--- a/src/linalg/Svd_truncate.cpp
+++ b/src/linalg/Svd_truncate.cpp
@@ -309,9 +309,7 @@ namespace cytnx {
       }
 
       // handle return_err!
-      if (return_err == 1) {
-        outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, smidx, return_err));
-      } else if (return_err) {
+      if (return_err) {
         outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, smidx, return_err));
       }
     }  // Svd_truncate_Block_UTs_internal
@@ -417,7 +415,7 @@ namespace cytnx {
       if (!anySall) {
         // no truncation; return_err is tensor with one element, set to 0
         if (return_err >= 1) {
-          outCyT.push_back(UniTensor(Tensor({1}, Tin.dtype())));
+          outCyT.push_back(UniTensor(Tensor({1}, outCyT[0].dtype())));
         }
       } else {
         Scalar Smin;
@@ -448,9 +446,7 @@ namespace cytnx {
             Smin = Sall.storage()(smidx);
           }
           // handle return_err!
-          if (return_err == 1) {
-            outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, smidx, return_err));
-          } else if (return_err) {
+          if (return_err) {
             outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, smidx, return_err));
           }
         } else {

--- a/src/linalg/Svd_truncate.cpp
+++ b/src/linalg/Svd_truncate.cpp
@@ -15,6 +15,27 @@
   #include "backend/linalg_internal_interface.hpp"
 namespace cytnx {
   namespace linalg {
+    namespace {
+      UniTensor BuildBlockDiscardedSingularValues(const Tensor &Sall, const cytnx_uint64 smidx,
+                                                  const unsigned int return_err) {
+        Tensor terr({1}, Sall.dtype());
+        terr.storage().at(0) = 0;
+        if (smidx == 0) {
+          return UniTensor(terr);
+        }
+        if (return_err == 1) {
+          terr.storage().at(0) = Sall.storage()(smidx - 1);
+          return UniTensor(terr);
+        }
+
+        terr = Tensor({smidx}, Sall.dtype());
+        for (cytnx_uint64 i = 0; i < smidx; i++) {
+          terr.storage().at(i) = Sall.storage()(smidx - 1 - i);
+        }
+        return UniTensor(terr);
+      }
+    }  // namespace
+
     std::vector<Tensor> Svd_truncate(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                      const double &err, const bool &is_UvT,
                                      const unsigned int &return_err, const cytnx_uint64 &mindim) {
@@ -308,10 +329,9 @@ namespace cytnx {
 
       // handle return_err!
       if (return_err == 1) {
-        outCyT.push_back(UniTensor(Tensor({1}, Smin.dtype())));
-        outCyT.back().get_block_().storage().at(0) = Smin;
+        outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, smidx, return_err));
       } else if (return_err) {
-        outCyT.push_back(UniTensor(Sall.get({Accessor::tilend(smidx)})));
+        outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, smidx, return_err));
       }
     }  // Svd_truncate_Block_UTs_internal
 
@@ -448,10 +468,9 @@ namespace cytnx {
           }
           // handle return_err!
           if (return_err == 1) {
-            outCyT.push_back(UniTensor(Tensor({1}, Smin.dtype())));
-            outCyT.back().get_block_().storage().at(0) = Smin;
+            outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, smidx, return_err));
           } else if (return_err) {
-            outCyT.push_back(UniTensor(Sall.get({Accessor::tilend(smidx)})));
+            outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, smidx, return_err));
           }
         } else {
           // keep_dim < 1: per-block min_blockdim guarantees already cover the global cap, so

--- a/src/linalg/Svd_truncate.cpp
+++ b/src/linalg/Svd_truncate.cpp
@@ -452,11 +452,10 @@ namespace cytnx {
         } else {
           // keep_dim < 1: per-block min_blockdim guarantees already cover the global cap, so
           // every value in Sall is dropped.
-          if (return_err == 1) {
-            // largest dropped singular value
-            outCyT.push_back(UniTensor(linalg::Max(Sall)));
-          } else if (return_err) {
-            outCyT.push_back(UniTensor(Sall));
+          if (return_err) {
+            Sall = algo::Sort(Sall);  // ascending; BuildBlockDiscardedSingularValues expects this
+            outCyT.push_back(
+              BuildBlockDiscardedSingularValues(Sall, Sall.shape()[0], return_err));
           }
         }
 

--- a/src/linalg/block_truncation_helpers.hpp
+++ b/src/linalg/block_truncation_helpers.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include "Tensor.hpp"
+#include "UniTensor.hpp"
+
+namespace cytnx {
+  namespace linalg {
+
+    // Returns a UniTensor holding the discarded singular values for the return_err path of
+    // block truncated SVD functions (Svd_truncate, Gesvd_truncate).
+    //
+    // Sall      : ascending-sorted tensor of singular values that were candidates for dropping
+    //             (indices 0..smidx-1 were dropped, smidx..end were kept).
+    // smidx     : number of dropped values (== 0 when nothing was dropped).
+    // return_err: 1 → return largest dropped value; >1 → return all dropped values descending.
+    //
+    // When smidx == 0 (no truncation), returns a one-element zero tensor regardless of return_err.
+    inline UniTensor BuildBlockDiscardedSingularValues(const Tensor &Sall,
+                                                       const cytnx_uint64 smidx,
+                                                       const unsigned int return_err) {
+      Tensor terr({1}, Sall.dtype());
+      terr.storage().at(0) = 0;
+      if (smidx == 0) {
+        return UniTensor(terr);
+      }
+      if (return_err == 1) {
+        terr.storage().at(0) = Sall.storage()(smidx - 1);
+        return UniTensor(terr);
+      }
+
+      terr = Tensor({smidx}, Sall.dtype());
+      for (cytnx_uint64 i = 0; i < smidx; i++) {
+        terr.storage().at(i) = Sall.storage()(smidx - 1 - i);
+      }
+      return UniTensor(terr);
+    }
+
+  }  // namespace linalg
+}  // namespace cytnx

--- a/tests/linalg_test/linalg_test.cpp
+++ b/tests/linalg_test/linalg_test.cpp
@@ -92,6 +92,29 @@ TEST_F(linalg_Test, BkUt_Gesvd_truncate_return_err_one_returns_first_discarded_v
   EXPECT_EQ(all_svals.at({all_svals.shape()[0] - trunc[0].shape()[0] - 1}), trunc[3].at({0}));
 }
 
+/*=====test info=====
+describe:When keepdim >= total singular values (smidx == 0), nothing is dropped. return_err
+must still return a one-element zero tensor rather than crashing or returning garbage.
+====================*/
+TEST_F(linalg_Test, BkUt_Svd_truncate_return_err_no_truncation) {
+  // keepdim=999 keeps everything; both return_err=1 and return_err=2 must produce {1} x {0.0}
+  for (unsigned int re : {1u, 2u}) {
+    std::vector<UniTensor> res = linalg::Svd_truncate(svd_T, 999, 0, true, re);
+    ASSERT_EQ(res.size(), 4u) << "return_err=" << re;
+    ASSERT_EQ(res[3].shape()[0], 1u) << "return_err=" << re;
+    EXPECT_EQ(res[3].at({0}), Scalar(0.0)) << "return_err=" << re;
+  }
+}
+
+TEST_F(linalg_Test, BkUt_Gesvd_truncate_return_err_no_truncation) {
+  for (unsigned int re : {1u, 2u}) {
+    std::vector<UniTensor> res = linalg::Gesvd_truncate(svd_T, 999, 0, true, true, re);
+    ASSERT_EQ(res.size(), 4u) << "return_err=" << re;
+    ASSERT_EQ(res[3].shape()[0], 1u) << "return_err=" << re;
+    EXPECT_EQ(res[3].at({0}), Scalar(0.0)) << "return_err=" << re;
+  }
+}
+
 // TEST_F(linalg_Test, BkUt_Svd_truncate3) {
 //   Bond I = Bond(BD_IN, {Qs(-5), Qs(-3), Qs(-1), Qs(1), Qs(3), Qs(5)}, {1, 4, 10, 9, 5, 1});
 //   Bond J = Bond(BD_OUT, {Qs(1), Qs(-1)}, {1, 1});

--- a/tests/linalg_test/linalg_test.cpp
+++ b/tests/linalg_test/linalg_test.cpp
@@ -5,6 +5,16 @@ using namespace cytnx;
 using namespace testing;
 using namespace TestTools;
 
+namespace {
+  Tensor SortedBlockSingularValues(const UniTensor &S) {
+    Tensor all_svals = S.get_block_(0);
+    for (cytnx_int64 i = 1; i < S.Nblocks(); i++) {
+      all_svals = algo::Concatenate(all_svals, S.get_block_(i));
+    }
+    return algo::Sort(all_svals);
+  }
+}  // namespace
+
 TEST_F(linalg_Test, BkUt_Svd_truncate1) {
   std::vector<UniTensor> res = linalg::Svd_truncate(svd_T, 200, 0, true);
   std::vector<double> vnm_S;
@@ -26,6 +36,60 @@ TEST_F(linalg_Test, BkUt_Svd_truncate2) {
   for (size_t i = 0; i < vnm_S.size(); i++) EXPECT_TRUE(vnm_S[i] > 1e-1);
   auto con_T1 = Contract(Contract(res[2], res[0]), res[1]);
   auto con_T2 = Contract(Contract(res[1], res[0]), res[2]);
+}
+
+TEST_F(linalg_Test, BkUt_Svd_truncate_return_err_returns_discarded_values) {
+  std::vector<UniTensor> full = linalg::Svd_truncate(svd_T, 999, 0, true, 0);
+  std::vector<UniTensor> trunc = linalg::Svd_truncate(svd_T, 5, 0, true, 999);
+  Tensor all_svals = SortedBlockSingularValues(full[0]);
+
+  ASSERT_EQ(full.size(), 3);
+  ASSERT_EQ(trunc.size(), 4);
+  ASSERT_EQ(trunc[0].shape()[0], 5);
+  ASSERT_EQ(all_svals.shape()[0], 400);
+  ASSERT_EQ(trunc[3].shape()[0], all_svals.shape()[0] - trunc[0].shape()[0]);
+
+  for (cytnx_uint64 i = 0; i < trunc[3].shape()[0]; i++) {
+    EXPECT_EQ(all_svals.at({trunc[3].shape()[0] - 1 - i}), trunc[3].at({i}));
+  }
+}
+
+TEST_F(linalg_Test, BkUt_Gesvd_truncate_return_err_returns_discarded_values) {
+  std::vector<UniTensor> full = linalg::Gesvd_truncate(svd_T, 999, 0, true, true, 0);
+  std::vector<UniTensor> trunc = linalg::Gesvd_truncate(svd_T, 5, 0, true, true, 999);
+  Tensor all_svals = SortedBlockSingularValues(full[0]);
+
+  ASSERT_EQ(full.size(), 3);
+  ASSERT_EQ(trunc.size(), 4);
+  ASSERT_EQ(trunc[0].shape()[0], 5);
+  ASSERT_EQ(all_svals.shape()[0], 400);
+  ASSERT_EQ(trunc[3].shape()[0], all_svals.shape()[0] - trunc[0].shape()[0]);
+
+  for (cytnx_uint64 i = 0; i < trunc[3].shape()[0]; i++) {
+    EXPECT_EQ(all_svals.at({trunc[3].shape()[0] - 1 - i}), trunc[3].at({i}));
+  }
+}
+
+TEST_F(linalg_Test, BkUt_Svd_truncate_return_err_one_returns_first_discarded_value) {
+  std::vector<UniTensor> full = linalg::Svd_truncate(svd_T, 999, 0, true, 0);
+  std::vector<UniTensor> trunc = linalg::Svd_truncate(svd_T, 5, 0, true, 1);
+  Tensor all_svals = SortedBlockSingularValues(full[0]);
+
+  ASSERT_EQ(full.size(), 3);
+  ASSERT_EQ(trunc.size(), 4);
+  ASSERT_EQ(trunc[3].shape()[0], 1);
+  EXPECT_EQ(all_svals.at({all_svals.shape()[0] - trunc[0].shape()[0] - 1}), trunc[3].at({0}));
+}
+
+TEST_F(linalg_Test, BkUt_Gesvd_truncate_return_err_one_returns_first_discarded_value) {
+  std::vector<UniTensor> full = linalg::Gesvd_truncate(svd_T, 999, 0, true, true, 0);
+  std::vector<UniTensor> trunc = linalg::Gesvd_truncate(svd_T, 5, 0, true, true, 1);
+  Tensor all_svals = SortedBlockSingularValues(full[0]);
+
+  ASSERT_EQ(full.size(), 3);
+  ASSERT_EQ(trunc.size(), 4);
+  ASSERT_EQ(trunc[3].shape()[0], 1);
+  EXPECT_EQ(all_svals.at({all_svals.shape()[0] - trunc[0].shape()[0] - 1}), trunc[3].at({0}));
 }
 
 // TEST_F(linalg_Test, BkUt_Svd_truncate3) {

--- a/tests/linalg_test/linalg_test.cpp
+++ b/tests/linalg_test/linalg_test.cpp
@@ -115,6 +115,53 @@ TEST_F(linalg_Test, BkUt_Gesvd_truncate_return_err_no_truncation) {
   }
 }
 
+/*=====test info=====
+describe:BlockFermionic truncated SVD: return_err must return the discarded singular values
+in descending order (return_err>1) or just the largest discarded value (return_err==1),
+matching the same contract as the Block (non-fermionic) path.
+====================*/
+TEST_F(linalg_Test, BkFermionicUt_Svd_truncate_return_err_returns_discarded_values) {
+  UniTensor fermi_T = make_square_fermionic({"a", "b"});
+  random::uniform_(fermi_T, -1.0, 1.0, 42);
+  ASSERT_EQ(fermi_T.uten_type(), UTenType.BlockFermionic);
+
+  std::vector<UniTensor> full = linalg::Svd_truncate(fermi_T, 999, 0, true, 0);
+  std::vector<UniTensor> trunc = linalg::Svd_truncate(fermi_T, 1, 0, true, 999);
+  Tensor all_svals = SortedBlockSingularValues(full[0]);
+
+  ASSERT_GE(trunc.size(), 4u);
+  ASSERT_GE(all_svals.shape()[0], trunc[0].shape()[0] + trunc[3].shape()[0]);
+  for (cytnx_uint64 i = 0; i < trunc[3].shape()[0]; i++) {
+    EXPECT_EQ(all_svals.at({trunc[3].shape()[0] - 1 - i}), trunc[3].at({i}));
+  }
+
+  // return_err=1: single element equal to largest discarded
+  std::vector<UniTensor> trunc1 = linalg::Svd_truncate(fermi_T, 1, 0, true, 1);
+  ASSERT_EQ(trunc1.back().shape()[0], 1u);
+  EXPECT_EQ(trunc1.back().at({0}), trunc[3].at({0}));
+}
+
+TEST_F(linalg_Test, BkFermionicUt_Gesvd_truncate_return_err_returns_discarded_values) {
+  UniTensor fermi_T = make_square_fermionic({"a", "b"});
+  random::uniform_(fermi_T, -1.0, 1.0, 42);
+  ASSERT_EQ(fermi_T.uten_type(), UTenType.BlockFermionic);
+
+  std::vector<UniTensor> full = linalg::Gesvd_truncate(fermi_T, 999, 0, true, true, 0);
+  std::vector<UniTensor> trunc = linalg::Gesvd_truncate(fermi_T, 1, 0, true, true, 999);
+  Tensor all_svals = SortedBlockSingularValues(full[0]);
+
+  ASSERT_GE(trunc.size(), 4u);
+  ASSERT_GE(all_svals.shape()[0], trunc[0].shape()[0] + trunc[3].shape()[0]);
+  for (cytnx_uint64 i = 0; i < trunc[3].shape()[0]; i++) {
+    EXPECT_EQ(all_svals.at({trunc[3].shape()[0] - 1 - i}), trunc[3].at({i}));
+  }
+
+  // return_err=1: single element equal to largest discarded
+  std::vector<UniTensor> trunc1 = linalg::Gesvd_truncate(fermi_T, 1, 0, true, true, 1);
+  ASSERT_EQ(trunc1.back().shape()[0], 1u);
+  EXPECT_EQ(trunc1.back().at({0}), trunc[3].at({0}));
+}
+
 // TEST_F(linalg_Test, BkUt_Svd_truncate3) {
 //   Bond I = Bond(BD_IN, {Qs(-5), Qs(-3), Qs(-1), Qs(1), Qs(3), Qs(5)}, {1, 4, 10, 9, 5, 1});
 //   Bond J = Bond(BD_OUT, {Qs(1), Qs(-1)}, {1, 1});


### PR DESCRIPTION
Fixes #762.

## Summary
- make block `Svd_truncate` and `Gesvd_truncate` return discarded singular values in the `return_err` path
- make `return_err == 1` return the first discarded singular value instead of the smallest kept value
- keep block output ordering consistent with the dense truncation path
- add regressions for both block APIs and the `return_err == 1` edge case

## Verification
- `./build/openblas-cpu/tests/test_main --gtest_filter="linalg_Test.BkUt_Svd_truncate_return_err_returns_discarded_values:linalg_Test.BkUt_Gesvd_truncate_return_err_returns_discarded_values:linalg_Test.BkUt_Svd_truncate_return_err_one_returns_first_discarded_value:linalg_Test.BkUt_Gesvd_truncate_return_err_one_returns_first_discarded_value"`
- `./build/openblas-cpu/tests/test_main --gtest_filter="Svd_truncate.*:Gesvd_truncate.*:linalg_Test.BkUt_Svd_truncate1:linalg_Test.BkUt_Svd_truncate2:DenseUt_Svd_truncate:DenseUt_Gesvd_truncate"`