### PR TITLE
Guard execinfo include and stacktrace logic on unsupported toolchains

### DIFF
--- a/include/cytnx_error.hpp
+++ b/include/cytnx_error.hpp
@@ -9,7 +9,16 @@
 #include <iostream>
 #include <stdexcept>
 
-#include <execinfo.h>
+#if defined(__has_include)
+  #if __has_include(<execinfo.h>)
+    #include <execinfo.h>
+    #define CYTNX_HAS_EXECINFO 1
+  #endif
+#endif
+
+#ifndef CYTNX_HAS_EXECINFO
+  #define CYTNX_HAS_EXECINFO 0
+#endif
 
 #ifdef _MSC_VER
   #define __PRETTY_FUNCTION__ __FUNCTION__
@@ -34,6 +43,7 @@ static inline void error_msg(char const *const func, const char *const file, int
     va_end(args);
     // std::cerr << output_str << std::endl;
     std::cerr << output_str << std::endl;
+#if CYTNX_HAS_EXECINFO
     std::cerr << "Stack trace:" << std::endl;
     void *array[10];
     size_t size;
@@ -43,6 +53,9 @@ static inline void error_msg(char const *const func, const char *const file, int
       std::cerr << strings[i] << std::endl;
     }
     free(strings);
+#else
+    std::cerr << "Stack trace is unavailable on this platform/compiler." << std::endl;
+#endif
     throw std::logic_error(output_str);
   }
   // } catch (const char *output_msg) {


### PR DESCRIPTION
### Motivation
- Prevent build failures on platforms or compilers that do not provide `<execinfo.h>` or the `backtrace` APIs, such as MSVC or non-glibc environments.
- Keep error reporting functional while avoiding compilation errors on unsupported toolchains.

### Description
- Use `__has_include` to conditionally include `<execinfo.h>` and define a compile-time `CYTNX_HAS_EXECINFO` flag in `include/cytnx_error.hpp`.
- Provide a fallback definition `#define CYTNX_HAS_EXECINFO 0` when the header is not available.
- Wrap the `backtrace`/`backtrace_symbols` stack-trace code inside `#if CYTNX_HAS_EXECINFO` and emit a clear runtime message when stack traces are unavailable.

### Testing
- Committed the change with `git commit` and the commit succeeded (`Guard execinfo usage for unsupported platforms`).
- Verified the updated file contents with `nl -ba include/cytnx_error.hpp` and confirmed the conditional include and guarded stack-trace logic were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f170c4c5288332813ed63b6aaa6677)