### PR TITLE
Improve conda BuildAndTest robustness and diagnostics

### DIFF
--- a/conda_build/build.sh
+++ b/conda_build/build.sh
@@ -1,16 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 start_time=$(date +%s)
+
+echo "[conda_build] Python: ${PYTHON:-<unset>}"
+echo "[conda_build] CMAKE_PRESET (from conda selector): ${CMAKE_PRESET:-<unset>}"
+echo "[conda_build] CC: ${CC:-<unset>}"
+echo "[conda_build] CXX: ${CXX:-<unset>}"
+
+if [[ -z "${CMAKE_PRESET:-}" ]]; then
+  case "$(uname -m)" in
+    x86_64|amd64)
+      CMAKE_PRESET="mkl-cpu"
+      ;;
+    *)
+      CMAKE_PRESET="openblas-cpu"
+      ;;
+  esac
+  echo "[conda_build] CMAKE_PRESET was unset; using fallback preset: ${CMAKE_PRESET}"
+fi
 
 # By default, scikit-build-core creates separate working directories for each
 # Python version. This prevents ccache from sharing cached objects between
 # versions. Setting the working directory to "build" ensures ccache can reuse
 # the cache across different Python versions.
-# `--config-settings` overwrites the whole list setting, like
-# `skbuild.cmake.args`, so the whole list setting have to be re-assigned even if
-# only one value in the list is changed.
-$PYTHON -m pip install . -vv --no-deps --ignore-installed \
+#
+# Note: `pip --config-settings` can be sensitive to duplicate keys depending on
+# frontend/backend handling. Use CMAKE_ARGS for the generator and a single
+# `skbuild.cmake.args` entry for the preset to avoid list-clobbering.
+export CMAKE_ARGS="-G Unix Makefiles"
+
+echo "[conda_build] Running pip build/install with preset: ${CMAKE_PRESET}"
+"${PYTHON}" -m pip install . -vv --no-deps --ignore-installed \
   --config-settings skbuild.build-dir=build \
-  --config-settings "skbuild.cmake.args=--preset=$CMAKE_PRESET" \
-  --config-settings "skbuild.cmake.args=-G Unix Makefiles"
+  --config-settings "skbuild.cmake.args=--preset=${CMAKE_PRESET}"
 
 end_time=$(date +%s)
 echo "Execution time: $((end_time - start_time)) seconds"


### PR DESCRIPTION
### Motivation
- The conda build job failed with a non-zero exit from the build script without clear diagnostics, making root-cause analysis difficult. 
- The build script relied on selector-injected environment variables and duplicated `--config-settings` keys, which can be fragile across different conda frontends. 
- Adding defensive handling and clearer logs will make CI failures easier to diagnose and reduce failures due to missing env injection or argument clobbering.

### Description
- Enabled strict shell mode with `set -euo pipefail` to fail fast and avoid silent errors in `conda_build/build.sh`.
- Added explicit diagnostic `echo` lines for `PYTHON`, `CMAKE_PRESET`, `CC`, and `CXX` so CI logs show the environment used during the build. 
- Added a fallback selection for `CMAKE_PRESET` when the env var is not present, choosing `mkl-cpu` on `x86_64/amd64` and `openblas-cpu` otherwise, and logging the fallback choice. 
- Avoided possible `--config-settings` list clobbering by exporting `CMAKE_ARGS="-G Unix Makefiles"` and passing a single `skbuild.cmake.args=--preset=${CMAKE_PRESET}` to `pip install`.

### Testing
- Ran shell syntax validation `bash -n conda_build/build.sh`, which completed successfully. 
- Performed a local run of `bash -n` and basic checks to ensure the script is syntactically valid. 
- No full CI `BuildAndTest` run included in this change; please re-run the GitHub Actions workflow to collect the improved diagnostics if failures persist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f177d48e848332a7e59a63ddd42ad8)