### PR TITLE
Add pip install logging and require pip >= 23.1 for skbuild arg handling

### DIFF
--- a/conda_build/build.sh
+++ b/conda_build/build.sh
@@ -7,10 +7,28 @@ start_time=$(date +%s)
 # `--config-settings` overwrites the whole list setting, like
 # `skbuild.cmake.args`, so the whole list setting have to be re-assigned even if
 # only one value in the list is changed.
-$PYTHON -m pip install . -vv --no-deps --ignore-installed \
-  --config-settings skbuild.build-dir=build \
-  --config-settings "skbuild.cmake.args=--preset=$CMAKE_PRESET" \
-  --config-settings "skbuild.cmake.args=-G Unix Makefiles"
+install_log=$(mktemp)
+
+run_pip_install() {
+  set -o pipefail
+  $PYTHON -m pip install . -vv --no-deps --ignore-installed \
+    --config-settings skbuild.build-dir=build \
+    --config-settings "skbuild.cmake.args=--preset=$CMAKE_PRESET" \
+    --config-settings "skbuild.cmake.args=-G Unix Makefiles" 2>&1 | tee "$install_log"
+  local status=$?
+  set +o pipefail
+  return $status
+}
+
+echo "Python version: $($PYTHON -V 2>&1)"
+echo "pip version: $($PYTHON -m pip --version 2>&1)"
+
+if ! run_pip_install; then
+  echo "pip install failed."
+  echo "Last 200 lines of pip install output:"
+  tail -n 200 "$install_log"
+  exit 1
+fi
 
 end_time=$(date +%s)
 echo "Execution time: $((end_time - start_time)) seconds"

--- a/conda_build/meta.yaml
+++ b/conda_build/meta.yaml
@@ -31,6 +31,9 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - python {{ python }}
+    # Ensure pip>=23.1 so repeated
+    # --config-settings keys append correctly for skbuild.cmake.args.
+    - pip >=23.1
     - scikit-build-core
     - pybind11
     - boost >=1.82.0


### PR DESCRIPTION
### Motivation
- Improve diagnostics when `pip install` (for scikit-build-core based builds) fails and ensure consistent behavior when appending `skbuild.cmake.args` via `--config-settings`.

### Description
- Wrap the pip install step in `build.sh` inside a `run_pip_install` function that enables `pipefail`, streams output to a temporary log via `tee`, returns the install status, and prints the last 200 lines on failure.
- Emit `Python` and `pip` version diagnostics before attempting the install to aid debugging.
- Add `pip >=23.1` to `conda_build/meta.yaml` `host` requirements so `--config-settings` handles repeated `skbuild.cmake.args` keys correctly for scikit-build-core.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f177d48e848332a7e59a63ddd42ad8)