### PR TITLE
cibuildwheel: pin macOS targets, unify ccache handling, add macOS minos probe and validation

### DIFF
--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -11,8 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, macos-15-intel]
-        # os: [ubuntu-latest]
+        # We intentionally pin specific macOS runners; do not blindly move to
+        # newer images because Homebrew dylib minos can force a higher wheel
+        # deployment target and break delocate compatibility for lower targets.
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-14, macos-15-intel]
+        # os: [ubuntu-24.04]
     defaults:
       run:
         shell: bash -l {0}
@@ -45,16 +48,19 @@ jobs:
     - name: Set Ccache Directory
       run: |
         echo "Start building---------------------------------"
-        export CCACHE_DIR="${HOME}/.ccache"
+        echo "CCACHE_DIR=${HOME}/.ccache" >> "$GITHUB_ENV"
 
-    - name: Setup macOS
-      if: matrix.os == 'macos-15-intel' || matrix.os == 'macos-14'
-      run: |
-        if [[ ${{ matrix.os }} == 'macos-15-intel' ]]; then
-          echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> "$GITHUB_ENV"
-        elif [[ ${{ matrix.os }} == 'macos-14' ]]; then
-          echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> "$GITHUB_ENV"
-        fi
+    # NOTE: Setup macOS step is temporarily disabled.
+    # Deployment target is now computed from Homebrew dylib minos metadata in
+    # tools/cibuildwheel_before_all_macos.sh and injected via pyproject.toml.
+    # - name: Setup macOS
+    #   if: matrix.os == 'macos-15-intel' || matrix.os == 'macos-14'
+    #   run: |
+    #     if [[ ${{ matrix.os }} == 'macos-15-intel' ]]; then
+    #       echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> "$GITHUB_ENV"
+    #     elif [[ ${{ matrix.os }} == 'macos-14' ]]; then
+    #       echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> "$GITHUB_ENV"
+    #     fi
 
     - name: Build Wheels
       uses: pypa/cibuildwheel@v3.3.0
@@ -62,15 +68,16 @@ jobs:
         CMAKE_C_COMPILER_LAUNCHER: ccache
         CMAKE_CXX_COMPILER_LAUNCHER: ccache
         CMAKE_CUDA_COMPILER_LAUNCHER: ccache
-        # DO NOT enable this line because the script for conda build is not
-        # executed in a interactive shell, and "~" will not be expanded to the
-        # home directory. Export CCACHE_DIR in the run command instead.
-        # CCACHE_DIR: ~/.ccache
+        CCACHE_COMPILERCHECK: content
         CCACHE_MAXSIZE: 1G  # The limit of actions/cache is 10GB
         # Pass environment variables into cibuildwheel build environments
         # This is only needed on Linux becuase the wheels are built in docker
         # images only on Linux.
-        CIBW_ENVIRONMENT_PASS_LINUX: CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER CMAKE_CUDA_COMPILER_LAUNCHER CCACHE_MAXSIZE
+        CIBW_CONTAINER_ENGINE: "docker; create_args: --volume ${{ env.CCACHE_DIR }}:/host_ccache"
+        CIBW_ENVIRONMENT_LINUX: CCACHE_DIR=/host_ccache CCACHE_BASEDIR=/project/build
+        CIBW_ENVIRONMENT_PASS_LINUX: CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER CMAKE_CUDA_COMPILER_LAUNCHER CCACHE_COMPILERCHECK CCACHE_MAXSIZE
+        CIBW_TEST_COMMAND: "python {project}/tools/validate_ccache_stats.py"
+
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ dev_test
 *.e
 *.o
 *.so
+
+.ccache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 message(STATUS " Generator: ${CMAKE_GENERATOR}")
 message(STATUS " Build Target: ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
 message(STATUS " Installation Prefix: ${CMAKE_INSTALL_PREFIX}")
+message(STATUS " CMAKE_BINARY_DIR: ${CMAKE_BINARY_DIR}")
+message(STATUS " PROJECT_BINARY_DIR: ${PROJECT_BINARY_DIR}")
 
 # #####################################################################
 # ## DISABLING IN-SOURCE BUILD

--- a/CytnxBKNDCMakeLists.cmake
+++ b/CytnxBKNDCMakeLists.cmake
@@ -43,7 +43,8 @@ if( NOT (DEFINED BLAS_LIBRARIES AND DEFINED LAPACK_LIBRARIES AND DEFINED LAPACKE
     find_package( LAPACK REQUIRED)
     find_package( LAPACKE REQUIRED)
     target_link_libraries(cytnx PUBLIC ${LAPACK_LIBRARIES} ${LAPACKE_LIBRARIES})
-    set(LAPACKE_INCLUDE_DIRS ${LAPACKE_DIR_FOUND}/include)
+    # Use include dirs resolved by FindLAPACKE instead of overriding with
+    # an internal/non-standard variable.
     target_include_directories(cytnx PUBLIC ${LAPACKE_INCLUDE_DIRS})
     message( STATUS "LAPACK found: ${LAPACK_LIBRARIES}" )
     message( STATUS "LAPACKE Header found: ${LAPACKE_INCLUDE_DIRS}" )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,15 +57,17 @@ result = "{major}.{minor}.{patch}"
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux_2_28"
 before-build = "python ./tools/cibuildwheel_before_build.py"
+environment = { CMAKE_C_COMPILER_LAUNCHER = "ccache", CMAKE_CXX_COMPILER_LAUNCHER = "ccache", CMAKE_CUDA_COMPILER_LAUNCHER = "ccache", CCACHE_DIR = "${PWD}/.ccache", CCACHE_BASEDIR = "${PWD}" }
 
 [tool.cibuildwheel.config-settings]
 "build-dir" = "build"
 
 [tool.cibuildwheel.linux]
 before-all = "bash ./tools/cibuildwheel_before_all.sh"
-environment = { CMAKE_PREFIX_PATH = "/usr/include/openblas", CPATH = "/usr/include/openblas", CCACHE_CONFIGPATH = "~/ccache.conf", CCACHE_BASEDIR = "/project/build" }
+environment = { CMAKE_PREFIX_PATH = "/usr/include/openblas", CCACHE_DIR = "/host${PWD}/.ccache", CCACHE_BASEDIR = "/host${PWD}" }
 
 [tool.cibuildwheel.macos]
-before-all = "brew update; brew install arpack boost ccache libomp openblas"
-environment = { CMAKE_PREFIX_PATH = "$(brew --prefix arpack):$(brew --prefix boost):$(brew --prefix libomp):$(brew --prefix openblas)", PATH = "$(brew --prefix ccache)/libexec:$PATH", CCACHE_CONFIGPATH = "~/ccache.conf" }
+before-all = "bash ./tools/cibuildwheel_before_all_macos.sh"
+# `.cibw_macos_deployment_target.txt` is generated in tools/cibuildwheel_before_all_macos.sh.
+environment = { CMAKE_PREFIX_PATH = "$(brew --prefix arpack):$(brew --prefix boost):$(brew --prefix libomp):$(brew --prefix openblas)", PATH = "$(brew --prefix ccache)/libexec:$PATH", MACOSX_DEPLOYMENT_TARGET = "$(cat .cibw_macos_deployment_target.txt 2>/dev/null || echo 14.0)" }
 

--- a/tools/cibuildwheel_before_all.sh
+++ b/tools/cibuildwheel_before_all.sh
@@ -1,13 +1,27 @@
 set -xe
 
-# Install required packages for manylinux_2_28+ (AlmaLinux/RHEL)
-dnf install -y boost-devel openblas-devel arpack-devel ccache
-
-# Create symlinks for OpenBLAS headers if available
-if [ -d /usr/include/openblas ]; then
-    ln -sf /usr/include/openblas/lapacke.h /usr/include/lapacke.h
-    ln -sf /usr/include/openblas/lapack.h /usr/include/lapack.h
-    ln -sf /usr/include/openblas/lapacke_mangling.h /usr/include/lapacke_mangling.h
-    ln -sf /usr/include/openblas/cblas.h /usr/include/cblas.h
-    ln -sf /usr/include/openblas/openblas_config.h /usr/include/openblas_config.h
+# Install required packages for manylinux_2_28+ (AlmaLinux/RHEL).
+if command -v dnf >/dev/null 2>&1; then
+    dnf install -y boost-devel openblas-devel arpack-devel ccache
+# musllinux_1_2 images are Alpine-based, so use apk there.
+elif command -v apk >/dev/null 2>&1; then
+    apk update
+    apk add boost-dev openblas-dev arpack-dev ccache
+else
+    echo "Unsupported package manager: expected dnf or apk" >&2
+    exit 1
 fi
+
+# Kept disabled by request since CMAKE_PREFIX_PATH already points to openblas.
+# if [ -d /usr/include/openblas ]; then
+#     ln -sf /usr/include/openblas/lapacke.h /usr/include/lapacke.h
+#     ln -sf /usr/include/openblas/lapack.h /usr/include/lapack.h
+#     ln -sf /usr/include/openblas/lapacke_mangling.h /usr/include/lapacke_mangling.h
+#     ln -sf /usr/include/openblas/cblas.h /usr/include/cblas.h
+#     ln -sf /usr/include/openblas/openblas_config.h /usr/include/openblas_config.h
+#     if ls /usr/include/openblas/openblas_config-*.h >/dev/null 2>&1; then
+#         for f in /usr/include/openblas/openblas_config-*.h; do
+#             ln -sf "${f}" "/usr/include/$(basename "${f}")"
+#         done
+#     fi
+# fi

--- a/tools/cibuildwheel_before_all_macos.sh
+++ b/tools/cibuildwheel_before_all_macos.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# NOTE:
+# We intentionally install dependencies via Homebrew here. Their dylibs may
+# encode a minimum supported macOS version (minos). We inspect that metadata
+# and persist both a report and an effective deployment target for cibuildwheel.
+
+probe_packages=(arpack boost openblas)
+install_only_packages=(ccache libomp)
+install_packages=("${probe_packages[@]}" "${install_only_packages[@]}")
+
+brew update
+brew install "${install_packages[@]}"
+
+report_file="${PWD}/.cibw_macos_brew_minos_report.txt"
+target_file="${PWD}/.cibw_macos_deployment_target.txt"
+
+# Truncate/create report file before appending package diagnostics.
+: > "${report_file}"
+
+max_minos="0.0"
+
+for pkg in "${probe_packages[@]}"; do
+  echo "### ${pkg} ###" | tee -a "${report_file}"
+  prefix="$(brew --prefix "${pkg}")"
+  if [[ -d "${prefix}/lib" ]]; then
+    while IFS= read -r dylib; do
+      minos="$(vtool -show-build "${dylib}" 2>/dev/null | awk '/minos/ {print $2; exit}')"
+      minos="${minos:-unknown}"
+      echo "  ${minos}  $(basename "${dylib}")" | tee -a "${report_file}"
+
+      if [[ "${minos}" != "unknown" ]]; then
+        if [[ "$(printf '%s\n' "${max_minos}" "${minos}" | sort -V | tail -n1)" == "${minos}" ]]; then
+          max_minos="${minos}"
+        fi
+      fi
+    done < <(find "${prefix}/lib" -maxdepth 2 -name "*.dylib" -type f)
+  fi
+  echo | tee -a "${report_file}"
+done
+
+# Use the highest minos observed to avoid building wheels that reference
+# brewed dylibs requiring a newer macOS than the deployment target.
+echo "${max_minos}" > "${target_file}"
+echo "Computed MACOSX_DEPLOYMENT_TARGET=${max_minos}" | tee -a "${report_file}"
+echo "Wrote minos report: ${report_file}"
+echo "Wrote deployment target: ${target_file}"

--- a/tools/cibuildwheel_before_build.py
+++ b/tools/cibuildwheel_before_build.py
@@ -2,27 +2,11 @@ import os
 import pathlib
 import platform
 
-ccache_config_path = os.getenv('CCACHE_CONFIGPATH')
-if not ccache_config_path:
-    raise RuntimeError('The CCACHE_CONFIGPATH environment variable must be set.')
-
-# Expand ~ to actual home directory before writing config.
-ccache_config_abspath = pathlib.Path(os.path.expanduser(ccache_config_path)).resolve()
-ccache_config_abspath.parent.mkdir(parents=True, exist_ok=True)
-
-# cibuildwheel mounts Linux sources at /project inside manylinux containers.
-# On macOS/local runs, use the repository build directory instead.
-if platform.system() == 'Linux':
-    ccache_base_dir = '/project/build'
-else:
-    ccache_base_dir = str(pathlib.Path.cwd().joinpath('build').resolve())
-
-print('ccache_config_path:', ccache_config_path)
-print('ccache_config_path_absolute:', ccache_config_abspath)
-print('ccache_base_dir:', ccache_base_dir)
-
-with open(ccache_config_abspath, 'w', encoding='utf-8') as f:
-    f.writelines([
-        f'base_dir = {ccache_base_dir}\n',
-        'hash_dir = false\n',
-    ])
+print('platform_system:', platform.system())
+print('current_working_directory:', pathlib.Path.cwd())
+print('build_dir_guess:', pathlib.Path.cwd().joinpath('build').resolve())
+print('CMAKE_C_COMPILER_LAUNCHER:', os.getenv('CMAKE_C_COMPILER_LAUNCHER', ''))
+print('CMAKE_CXX_COMPILER_LAUNCHER:', os.getenv('CMAKE_CXX_COMPILER_LAUNCHER', ''))
+print('CCACHE_COMPILERCHECK:', os.getenv('CCACHE_COMPILERCHECK', ''))
+print('CCACHE_BASEDIR:', os.getenv('CCACHE_BASEDIR', ''))
+print('CCACHE_DIR:', os.getenv('CCACHE_DIR', ''))

--- a/tools/validate_ccache_stats.py
+++ b/tools/validate_ccache_stats.py
@@ -1,0 +1,32 @@
+import subprocess
+
+raw = subprocess.check_output(['ccache', '--print-stats'], text=True)
+stats = {}
+for line in raw.splitlines():
+    if '\t' not in line:
+        continue
+    key, value = line.split('\t', 1)
+    stats[key.strip()] = value.strip()
+
+
+def to_num(v: str) -> float:
+    token = v.split()[0] if v else '0'
+    try:
+        return float(token)
+    except Exception:
+        return 0.0
+
+
+direct = to_num(stats.get('direct_cache_hit', stats.get('cache_hit_direct', '0')))
+preprocessed = to_num(stats.get('preprocessed_cache_hit', stats.get('cache_hit_preprocessed', '0')))
+total = direct + preprocessed
+
+print(f'cache_hit_direct={direct}')
+print(f'cache_hit_preprocessed={preprocessed}')
+print(f'cache_hit_total={total}')
+
+# Reset counters so the next Python-version build observes fresh, per-build stats.
+subprocess.check_call(['ccache', '--zero-stats'])
+
+if total <= 0:
+    raise SystemExit('No ccache hits detected for this python-version build.')


### PR DESCRIPTION
### Motivation
- Ensure macOS wheels use a deployment target compatible with brewed dylibs to avoid delocate/minos breakage.
- Make ccache usable inside cibuildwheel (manylinux containers and macOS) and validate that it is effective for each Python-version build.
- Improve portability of pre-build scripts to Alpine-based musllinux images and clean up LAPACKE include handling.

### Description
- Updated `.github/workflows/release_pypi.yml` to pin runner images to specific Ubuntu/macOS variants, set `CCACHE_DIR` via `GITHUB_ENV`, disable the old macOS setup step, and configure cibuildwheel to mount the host ccache directory with `CIBW_CONTAINER_ENGINE`, pass ccache env into Linux builds, set `CCACHE_COMPILERCHECK`, and run `tools/validate_ccache_stats.py` as `CIBW_TEST_COMMAND`.
- Added `.ccache/` to `.gitignore`.
- Added CMake status prints for `CMAKE_BINARY_DIR` and `PROJECT_BINARY_DIR` in `CMakeLists.txt` to aid debugging.
- Fixed LAPACKE include handling in `CytnxBKNDCMakeLists.cmake` to use `FindLAPACKE`-provided `LAPACKE_INCLUDE_DIRS` instead of an internal override.
- Extended `pyproject.toml` cibuildwheel configuration to set ccache-related environment variables, adjust Linux path mappings for container mounts, and replace macOS `before-all` inline brew commands with `tools/cibuildwheel_before_all_macos.sh` while exporting `MACOSX_DEPLOYMENT_TARGET` from a generated file.
- Modified `tools/cibuildwheel_before_all.sh` to support `dnf` and `apk` package managers and kept manual OpenBLAS symlink logic disabled.
- Added `tools/cibuildwheel_before_all_macos.sh` which installs brew deps, inspects brewed dylib minos using `vtool`, writes a minos report, and emits an effective `MACOSX_DEPLOYMENT_TARGET` for cibuildwheel.
- Replaced the previous `tools/cibuildwheel_before_build.py` ccache-config writer with a diagnostic debug-printing version.
- Added `tools/validate_ccache_stats.py` that parses `ccache --print-stats`, zeroes stats, and fails the build if no ccache hits are observed for the Python-version build.

### Testing
- No automated CI runs were executed as part of this PR; CI is expected to run `cibuildwheel` which will execute `tools/validate_ccache_stats.py` via the configured `CIBW_TEST_COMMAND` to enforce ccache hits in build jobs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a2d4d6148332b318a7a9e2bb917f)