### PR TITLE
Fix conda-build installation and shell activation in GitHub Actions

### DIFF
--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest, macos-15-intel, macos-latest]
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el {0}
 
     steps:
     - uses: actions/checkout@v4
@@ -41,13 +41,14 @@ jobs:
         python-version: "3.10"
         # Using miniforge to the enable conda-forge channel only.
         miniforge-version: latest
+        # Install conda-build in base so `conda build` command is available.
+        conda-build-version: "*"
 
     - name: Config Conda
       run: |
         echo "Config Conda---------------------------------"
         conda info
         conda config --set anaconda_upload no
-        conda install conda-build
 
     - name: Cache Ccache Directory (push)
       if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/conda_build_release.yml
+++ b/.github/workflows/conda_build_release.yml
@@ -14,6 +14,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-15-intel, macos-latest]
+    defaults:
+      run:
+        shell: bash -el {0}
 
     steps:
     - uses: actions/checkout@v4
@@ -24,13 +27,14 @@ jobs:
         python-version: "3.10"
         # Using miniforge to the enable conda-forge channel only.
         miniforge-version: latest
+        # Install conda-build in base so `conda build` command is available.
+        conda-build-version: "*"
 
     - name: Config Conda
       run: |
         echo "Config Conda---------------------------------"
         conda info
         conda config --set anaconda_upload no
-        conda install conda-build
 
     - name: Cache Ccache Directory
       uses: actions/cache@v4


### PR DESCRIPTION
### Motivation
- The `setup-miniconda@v3` action does not install `conda-build` by default and creates a non-base environment by default, which can leave `conda build` unavailable or registered in the wrong environment. 
- GitHub Actions bash steps should use `bash -el {0}` to ensure proper Conda activation in non-interactive runs.

### Description
- Changed run-shell defaults from `bash -l {0}` to `bash -el {0}` in `.github/workflows/conda_build.yml` and `.github/workflows/conda_build_release.yml` to improve Conda activation behavior. 
- Added `conda-build-version: "*"` to the `conda-incubator/setup-miniconda@v3` `with:` block in both workflows so `conda-build` is installed into the base environment by the action. 
- Removed the manual `conda install conda-build` step from the `Config Conda` step to avoid installing into an ambiguous environment. 
- Added `defaults.run.shell` to the release workflow so its steps use the same `bash -el {0}` behavior.

### Testing
- Verified the YAML changes with `git diff -- .github/workflows/conda_build.yml .github/workflows/conda_build_release.yml` and the diff matched the intended edits (success). 
- Confirmed only the intended workflow files were modified using `git status --short` (success).
- Committed the changes with `git commit -m "Fix conda-build setup in GitHub Actions"` and the commit completed successfully (success).
- Inspected the resulting workflow files with `nl` to verify the inserted `conda-build-version` and `bash -el {0}` lines (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d71bef908332bdfd5a0602943d81)