### PR TITLE
Remove UNI_ICPC / USE_ICPC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,15 +239,6 @@ endif()
 
 include(GNUInstallDirs)
 
-if(USE_ICPC)
-  target_compile_definitions(cytnx PUBLIC UNI_ICPC)
-  # This option is to disable the warning of icpc
-  target_compile_options(cytnx PUBLIC -diag-disable=10441)
-  # This option is to maintain consistency of the floating point operation, also
-  # try to improve the performance
-  target_compile_options(cytnx PUBLIC -fp-model consistent -fimf-use-svml)
-endif()
-
 # #####################################################################
 
 # ## Boost

--- a/developer_tools/Makefile
+++ b/developer_tools/Makefile
@@ -33,13 +33,8 @@ INCFLAGS +=-I$(CONDA_PREFIX)/include/
 HPTT_PATH=$(CytnxPATH)/thirdparty/hptt
 
 
-ifeq ($(ICPC_Enable),1)
-  CC:= $(ICPC)
-  CCFLAGS:= -DUNI_ICPC
-else
-  CC:= $(GCC)
-  CCFLAGS:=
-endif
+CC:= $(GCC)
+CCFLAGS:=
 
 ifeq ($(MKL_Enable),1)
   CCFLAGS += -std=c++20 ${OPTIM} -Wformat=0 -m64 -fPIC -DUNI_MKL -w -DMKL_LP64 #-DUNI_DEBUG -Wno-c++11-narrowing

--- a/docs/source/adv_install.rst
+++ b/docs/source/adv_install.rst
@@ -15,7 +15,7 @@ Cytnx requires the following minimum dependencies:
 * make
 * Boost v1.53+ [check_deleted, atomicadd, intrusive_ptr]
 * openblas (or mkl, see below)
-* gcc v6+ (or icpc, see below) (recommand latest or equivalent clang on Mac/Linux with C++11 support) (required -std=c++11)
+* gcc v6+ (recommand latest or equivalent clang on Mac/Linux with C++11 support) (required -std=c++11)
 
 In addition, you might want to install the following optional dependencies if you want Cytnx to compile with features like openmp, mkl and/or CUDA support.
 
@@ -202,8 +202,6 @@ The following are the available compiling option flags that you can specify in *
 | -DCMAME_INSTALL_PREFIX | /usr/local/cytnx  | Install destination of the library |
 +------------------------+-------------------+------------------------------------+
 | -DBUILD_PYTHON         |   ON              | Compile and install Python API     |
-+------------------------+-------------------+------------------------------------+
-| -DUSE_ICPC             |   OFF             | Compile using intel icpc compiler  |
 +------------------------+-------------------+------------------------------------+
 | -DUSE_MKL              |   OFF             | Compile Cytnx with intel MKL lib.  |
 |                        |                   | If =off, default link to openblas  |

--- a/include/utils/complex_arithmetic.hpp
+++ b/include/utils/complex_arithmetic.hpp
@@ -5,9 +5,6 @@
 #include "cytnx_error.hpp"
 
 namespace cytnx {
-#ifdef UNI_ICPC
-
-#else
   // operator overload for CPU code. for COMPLEX type arithmic.
   // cytnx_complex128 operator+(const cytnx_complex128 &ln, const cytnx_complex128 &rn);
   cytnx_complex128 operator+(const cytnx_complex128 &ln, const cytnx_complex64 &rn);
@@ -253,7 +250,6 @@ namespace cytnx {
   bool operator==(const cytnx_int16 &rn, const cytnx_complex64 &ln);
   bool operator==(const cytnx_uint16 &rn, const cytnx_complex64 &ln);
   bool operator==(const cytnx_bool &rn, const cytnx_complex64 &ln);
-#endif
 
 #if defined(UNI_GPU)
   //__host__ __device__ bool operator==(const cuDoubleComplex &ln, const cuDoubleComplex &rn);

--- a/src/utils/complex_arithmetic.cpp
+++ b/src/utils/complex_arithmetic.cpp
@@ -2,9 +2,6 @@
 #include "utils/complex_arithmetic.hpp"
 namespace cytnx {
 
-#ifdef UNI_ICPC
-
-#else
   cytnx_complex128 operator+(const cytnx_complex128 &ln, const cytnx_complex64 &rn) {
     return cytnx_complex128(ln.real() + rn.real(), ln.imag() + rn.imag());
   }
@@ -637,6 +634,5 @@ namespace cytnx {
   bool operator==(const cytnx_bool &rn, const cytnx_complex64 &ln) {
     return cytnx_complex64(rn, 0) == ln;
   }
-#endif
 
 }  // namespace cytnx


### PR DESCRIPTION
## Summary
- The classic Intel C++ compiler (`icpc`) is deprecated; its replacement `icpx` (oneAPI / LLVM-based) uses the standard `libstdc++` / `libc++` `<complex>` headers, which do **not** provide the mixed-type complex arithmetic overloads. The `UNI_ICPC` guards therefore hide overloads `icpx` actually needs (potential build break) and add no value for any supported toolchain.
- Removes the `USE_ICPC` CMake option, the `UNI_ICPC` `#ifdef` guards in `complex_arithmetic.hpp`/`.cpp`, the `ICPC_Enable` branch in `developer_tools/Makefile`, and the docs table row + parenthetical in `docs/source/adv_install.rst`.
- The language support of Intel C++ compiler is behind GCC and Clang. Just drop the support of Intel C++ compiler.

Closes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)