### PR TITLE
Modernize CytnxConfig.cmake.in and re-find PUBLIC imported-target deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,7 +438,7 @@ write_basic_package_version_file(
 
 # CytnxConfig.cmake.in references @USE_CUDA@ / @USE_HPTT@ / @BACKEND_TORCH@
 # directly so the installed Config re-finds the imported-target deps that
-# match the matching cytnx build. See the template for the gating logic.
+# match the options of the cytnx build. See the template for the gating logic.
 configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/cmake/CytnxConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/CytnxConfig.cmake
   INSTALL_DESTINATION ${INSTALL_CONFIGDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,6 +436,9 @@ write_basic_package_version_file(
   COMPATIBILITY AnyNewerVersion
 )
 
+# CytnxConfig.cmake.in references @USE_CUDA@ / @USE_HPTT@ / @BACKEND_TORCH@
+# directly so the installed Config re-finds the imported-target deps that
+# match the matching cytnx build. See the template for the gating logic.
 configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/cmake/CytnxConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/CytnxConfig.cmake
   INSTALL_DESTINATION ${INSTALL_CONFIGDIR}

--- a/CytnxBKNDCMakeLists.cmake
+++ b/CytnxBKNDCMakeLists.cmake
@@ -238,9 +238,14 @@ if(USE_HPTT)
     target_compile_definitions(cytnx PRIVATE UNI_HPTT)
     target_link_libraries(cytnx PUBLIC "${hptt_lib_dir}/libhptt.a")
 
-    # XXX: `cytnx` itself doesn't need this linking flag. Why?
-    #target_link_options(cytnx INTERFACE -fopenmp)
-    #Find OpenMP for HPTT
+    # OpenMP must be PUBLIC even though no cytnx source uses `#pragma omp`
+    # or `<omp.h>`. libcytnx is a STATIC archive
+    # (`add_library(cytnx STATIC)` in the top-level CMakeLists.txt) and
+    # libhptt.a uses OpenMP internally; static linking leaves libhptt's
+    # OpenMP symbol references (`__kmpc_*`, `omp_*`) unresolved until the
+    # consumer's final executable link, so the consumer's link line needs
+    # OpenMP too. PRIVATE here would re-introduce the bug fixed by commit
+    # 5733a441 ("Propagate `-fopenmp` linking flag when using HPTT").
     find_package(OpenMP REQUIRED)
     target_link_libraries(cytnx PUBLIC OpenMP::OpenMP_CXX)
 

--- a/cmake/CytnxConfig.cmake.in
+++ b/cmake/CytnxConfig.cmake.in
@@ -1,7 +1,32 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Boost REQUIRED)
+
+find_dependency(Boost CONFIG REQUIRED)
+
+# Conditional re-find of build-time PUBLIC imported-target deps.
+# Plain absolute-path link entries (e.g. ${LAPACK_LIBRARIES}, ${ARPACK_LIB})
+# do not need this — they were baked into INTERFACE_LINK_LIBRARIES as paths.
+# Imported targets (CUDA::*, OpenMP::*, Torch targets) only exist after the
+# corresponding find_package runs in the consumer's project, so we recreate
+# them here when cytnx was built with the matching flag. The @VAR@ tokens
+# are expanded to the build-time value of each option by
+# configure_package_config_file when CytnxConfig.cmake is emitted.
+if(@USE_CUDA@)
+  find_dependency(CUDAToolkit REQUIRED)
+endif()
+
+if(@USE_HPTT@)
+  # libcytnx is a STATIC archive; libhptt.a (which uses OpenMP internally)
+  # gets pulled in by reference, so the consumer's final executable link
+  # needs OpenMP to resolve libhptt's `__kmpc_*` / `omp_*` symbols. See
+  # commit 5733a441 ("Propagate `-fopenmp` linking flag when using HPTT").
+  find_dependency(OpenMP REQUIRED)
+endif()
+
+if(@BACKEND_TORCH@)
+  find_dependency(Torch REQUIRED)
+endif()
 
 if(NOT TARGET Cytnx::Cytnx)
     include("${CMAKE_CURRENT_LIST_DIR}/CytnxTargets.cmake")
@@ -10,3 +35,5 @@ endif()
 # Legacy alias for consumers still using `target_link_libraries(... ${Cytnx_Libraries})`.
 # Prefer the imported target `Cytnx::Cytnx` in new code.
 set(Cytnx_Libraries Cytnx::Cytnx)
+
+check_required_components(Cytnx)

--- a/cmake/CytnxConfig.cmake.in
+++ b/cmake/CytnxConfig.cmake.in
@@ -1,18 +1,12 @@
-get_filename_component(Cytnx_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+@PACKAGE_INIT@
+
 include(CMakeFindDependencyMacro)
-
-list(APPEND CMAKE_MODULE_PATH ${Cytnx_CMAKE_DIR})
-
-# NOTE Had to use find_package because find_dependency does not support COMPONENTS or MODULE until 3.8.0
-
-#find_dependency(Boost REQUIRED )
-
-find_package(Boost REQUIRED )
-
-list(REMOVE_AT CMAKE_MODULE_PATH -1)
+find_dependency(Boost REQUIRED)
 
 if(NOT TARGET Cytnx::Cytnx)
-    include("${Cytnx_CMAKE_DIR}/CytnxTargets.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/CytnxTargets.cmake")
 endif()
 
+# Legacy alias for consumers still using `target_link_libraries(... ${Cytnx_Libraries})`.
+# Prefer the imported target `Cytnx::Cytnx` in new code.
 set(Cytnx_Libraries Cytnx::Cytnx)

--- a/cmake/CytnxConfig.cmake.in
+++ b/cmake/CytnxConfig.cmake.in
@@ -28,12 +28,8 @@ if(@BACKEND_TORCH@)
   find_dependency(Torch REQUIRED)
 endif()
 
-if(NOT TARGET Cytnx::Cytnx)
+if(NOT TARGET Cytnx::cytnx)
     include("${CMAKE_CURRENT_LIST_DIR}/CytnxTargets.cmake")
 endif()
-
-# Legacy alias for consumers still using `target_link_libraries(... ${Cytnx_Libraries})`.
-# Prefer the imported target `Cytnx::Cytnx` in new code.
-set(Cytnx_Libraries Cytnx::Cytnx)
 
 check_required_components(Cytnx)


### PR DESCRIPTION
## Summary

Three-commit cleanup of `cmake/CytnxConfig.cmake.in` (the package Config template installed via `configure_package_config_file`).

### 1. `Modernize cmake/CytnxConfig.cmake.in`

The Config template had rotted:

- **Missing `@PACKAGE_INIT@`** — the canonical header that supplies `PACKAGE_PREFIX_DIR`, `set_and_check`, and `check_required_components` helpers, letting us drop the hand-rolled `get_filename_component(Cytnx_CMAKE_DIR ...)` in favor of `${CMAKE_CURRENT_LIST_DIR}`.
- **`find_package(Boost)` instead of `find_dependency(Boost CONFIG)`** — the inline comment justified this by citing CMake 3.8.0 limitations on `find_dependency`'s COMPONENTS / MODULE support; cytnx now requires CMake 3.24 (`CMakeLists.txt:10`), so that justification is ~16 minor versions obsolete. `find_dependency` is idiomatic inside a Config file because it forwards the consumer's REQUIRED / QUIET flags. Adding `CONFIG` matches how the main `CMakeLists.txt` finds Boost (`CMakeLists.txt:245 find_package(Boost CONFIG REQUIRED)`).
- **Dead `CMAKE_MODULE_PATH` push/pop** around the Boost find — the workaround pattern for projects shipping `FindXxx.cmake` next to their Config file. Cytnx installs no Find modules into `INSTALL_CONFIGDIR`, so the manipulation is no-op gymnastics.

Also adds `check_required_components(Cytnx)` at the end — canonical with `@PACKAGE_INIT@`. No-op today (cytnx has no components), but it's the standard pairing and validates `find_package(Cytnx COMPONENTS ...)` calls correctly when components are added later.

### 2. `CytnxConfig: re-find PUBLIC imported-target deps (CUDA, OpenMP, Torch)`

Cytnx's installed target references imported targets via `target_link_libraries(... PUBLIC ...)`:

- `CUDA::toolkit`, `CUDA::cudart`, `CUDA::cublas`, `CUDA::cusparse`, `CUDA::curand`, `CUDA::cusolver` — `CytnxBKNDCMakeLists.cmake:155-156`, gated on `USE_CUDA`.
- `OpenMP::OpenMP_CXX` — `CytnxBKNDCMakeLists.cmake:245`, gated on `USE_HPTT`.
- `${TORCH_LIBRARIES}` (modern Torch expands to imported targets) — `CMakeLists.txt:273-275`, gated on `BACKEND_TORCH`.

Without `find_dependency` calls in the Config, a consumer of a CUDA-, HPTT-, or Torch-built install hits the classic `target "CUDA::cudart" not found` error at `target_link_libraries(my_app PRIVATE Cytnx::cytnx)`. This commit adds matching conditional `find_dependency()` lines to the template, using `configure_package_config_file`'s `@VAR@` substitution to read the existing option names directly (`@USE_CUDA@`, `@USE_HPTT@`, `@BACKEND_TORCH@`) — no wrapper variables, no risk of a reader thinking they're a separate user-facing toggle.

#### Why OpenMP needs to be re-found

It's not obvious — no cytnx source uses `#pragma omp` or `<omp.h>`. The dependency exists only because libhptt.a uses OpenMP internally, and `libcytnx` is built as a **static** archive (`CMakeLists.txt:212 add_library(cytnx STATIC)`). With static linking, libhptt's OpenMP symbol references (`__kmpc_*`, `omp_*`) stay unresolved at cytnx build time and have to be satisfied at the consumer's final executable link. See commit `5733a441` ("Propagate `-fopenmp` linking flag when using HPTT") for the original fix. Added an inline comment at the PUBLIC OpenMP link site so this stays explained.

#### Why LAPACK is *not* added

`${LAPACK_LIBRARIES}` is a list of absolute paths — not an imported target name — so the consumer's link line resolves the paths directly without needing `find_dependency(LAPACK)`. If anyone refactors that link line to `LAPACK::LAPACK` (the modern idiom), this Config file will need updating too.

### 3. `CytnxConfig: fix imported-target name and drop dead Cytnx_Libraries alias`

The library is `add_library(cytnx STATIC)` (lowercase) at `CMakeLists.txt:212`, installed via `install(EXPORT cytnx_targets ... NAMESPACE Cytnx::)` at `CMakeLists.txt:421-425`. So the real imported target in `CytnxTargets.cmake` is `Cytnx::cytnx`, not `Cytnx::Cytnx`. The template's stale `Cytnx::Cytnx` references were:

- `if(NOT TARGET Cytnx::Cytnx)` — always true because the target was never created. Fixed to `Cytnx::cytnx` so the guard correctly skips re-inclusion of `CytnxTargets.cmake` on repeated `find_package(Cytnx)` calls.
- `set(Cytnx_Libraries Cytnx::Cytnx)` — pointed at a non-existent target. Any consumer using `target_link_libraries(... ${Cytnx_Libraries})` got "Target ... links to: Cytnx::Cytnx but the target was not found". Since there is no working downstream usage to preserve, removed entirely; consumers should link `Cytnx::cytnx` directly.

## Test plan

- [x] Build cytnx with the `openblas-cuda` preset (`USE_CUDA=ON`, `USE_HPTT=ON`, `USE_CUTENSOR=ON`, `USE_CUQUANTUM=ON`) and `cmake --install` to a prefix. The generated `CytnxConfig.cmake` has `if(ON)` branches around `find_dependency(CUDAToolkit)` and `find_dependency(OpenMP)` and `if(OFF)` around `find_dependency(Torch)`.
- [x] A minimal consumer with `find_package(Cytnx CONFIG REQUIRED)` + `target_link_libraries(... Cytnx::cytnx)` configures, builds, and runs against the install prefix. All `CUDA::*` and `OpenMP::OpenMP_CXX` targets are defined after the `find_package` call; no "target not found", no unresolved `__kmpc_*` / `omp_*` at link.
- [ ] Build cytnx with `BACKEND_TORCH=ON`; consumer `find_package(Cytnx CONFIG REQUIRED)` + link no longer errors with "target torch not found". *Configure succeeds and the generated `CytnxConfig.cmake` shows `if(ON) find_dependency(Torch REQUIRED)`, but the cytnx build itself fails on a pre-existing `BACKEND_TORCH` break: `include/search_tree.hpp:56` references `UniTensor` unconditionally while `include/UniTensor.hpp:22` gates the entire `class UniTensor` behind `#ifndef BACKEND_TORCH`. Same on master; not introduced by this PR. The consumer-link half of this item stays untested until that break is resolved separately. Tracked as #820.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)