### PR TITLE
Make version.cmake the single source of truth for the project version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,9 +70,6 @@ message(STATUS " Version: ${CYTNX_VERSION}")
 FILE(WRITE "${CMAKE_BINARY_DIR}/linkflags.tmp" "" "")
 FILE(WRITE "${CMAKE_BINARY_DIR}/cxxflags.tmp" "" "")
 
-FILE(WRITE "${CMAKE_BINARY_DIR}/version.tmp" "" "")
-FILE(APPEND "${CMAKE_BINARY_DIR}/version.tmp" "${CYTNX_VERSION}" "")
-
 FILE(WRITE "${CMAKE_BINARY_DIR}/vinfo.tmp" "" "")
 FILE(APPEND "${CMAKE_BINARY_DIR}/vinfo.tmp" "${CYTNX_VARIANT_INFO}" "")
 
@@ -356,6 +353,7 @@ IF(BUILD_PYTHON)
     pybind/ncon_py.cpp
   )
   target_link_libraries(pycytnx PUBLIC cytnx)
+  target_compile_definitions(pycytnx PRIVATE CYTNX_VERSION="${CYTNX_VERSION}")
 
   # On macOS, Python extensions should NOT link to libpython
   # Use -undefined dynamic_lookup to resolve symbols from the running interpreter
@@ -523,7 +521,6 @@ message(STATUS "")
 
 install(FILES ${CMAKE_BINARY_DIR}/linkflags.tmp DESTINATION ${CMAKE_INSTALL_PREFIX}/cytnx)
 install(FILES ${CMAKE_BINARY_DIR}/cxxflags.tmp DESTINATION ${CMAKE_INSTALL_PREFIX}/cytnx)
-install(FILES ${CMAKE_BINARY_DIR}/version.tmp DESTINATION ${CMAKE_INSTALL_PREFIX}/cytnx)
 install(FILES ${CMAKE_BINARY_DIR}/vinfo.tmp DESTINATION ${CMAKE_INSTALL_PREFIX}/cytnx)
 
 if(BUILD_PACKAGES)

--- a/cytnx/__init__.py
+++ b/cytnx/__init__.py
@@ -1,5 +1,7 @@
 import os,sys,warnings
+from . import cytnx
 from .cytnx import *
+from .cytnx import __version__
 
 if cytnx.__cytnx_backend__ == "torch":
     import numpy, torch
@@ -165,13 +167,6 @@ def _find_hptt__():
 
 
 
-def _get_version__():
-    f = open(os.path.join(os.path.dirname(os.path.abspath(__file__)),"version.tmp"))
-    line = f.readline()
-    f.close()
-    line = line.strip()
-    return line
-
 def _resolve_cpp_compileflags__():
     f = open(os.path.join(os.path.dirname(os.path.abspath(__file__)),"cxxflags.tmp"))
     lines = f.readlines()
@@ -219,5 +214,4 @@ def _get_variant_info__():
 
 __cpp_linkflags__ = _resolve_cpp_linkflags__()
 __cpp_flags__ = _resolve_cpp_compileflags__()
-__version__ = _get_version__()
 __variant_info__ = _get_variant_info__()

--- a/cytnx/version.tmp
+++ b/cytnx/version.tmp
@@ -1,1 +1,0 @@
-test_version

--- a/docs/source/adv_install.rst
+++ b/docs/source/adv_install.rst
@@ -286,6 +286,17 @@ In the case that Cytnx is installed locally from binary build, not from anaconda
     CYTNX_ROOT is the path where Cytnx is installed from binary build.
 
 
+Check Cytnx version
+*************************************
+The current version of the library can be printed by:
+
+* In Python:
+
+.. code-block:: python
+    :linenos:
+
+    print("Cytnx version = ", cytnx.__version__)
+
 Generate API documentation
 *************************************
 An API documentation can be generated from the source code of Cytnx by using doxygen. The documentation is accessible online at <https://kaihsinwu.gitlab.io/cytnx_api/>. To create it locally, make sure that doxygen is installed:

--- a/pybind/cytnx.cpp
+++ b/pybind/cytnx.cpp
@@ -51,7 +51,7 @@ void ncon_binding(py::module &m);
 #endif
 
 PYBIND11_MODULE(cytnx, m) {
-  m.attr("__version__") = "0.7";
+  m.attr("__version__") = CYTNX_VERSION;
   m.attr("__blasINTsize__") = cytnx::__blasINTsize__;
   m.attr("User_debug") = cytnx::User_debug;
 

--- a/pytests/version_test.py
+++ b/pytests/version_test.py
@@ -1,0 +1,19 @@
+import re
+from pathlib import Path
+
+import cytnx
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _read_version_cmake():
+    text = (_REPO_ROOT / "version.cmake").read_text()
+    parts = {
+        key: re.search(rf"set\(CYTNX_VERSION_{key}\s+(\d+)\)", text).group(1)
+        for key in ("MAJOR", "MINOR", "PATCH")
+    }
+    return f"{parts['MAJOR']}.{parts['MINOR']}.{parts['PATCH']}"
+
+
+def test_version_matches_version_cmake():
+    assert cytnx.__version__ == _read_version_cmake()


### PR DESCRIPTION
## Summary
Fixes #812.

`pybind/cytnx.cpp` hard-coded `__version__ = "0.7"`, which was stale; the package version was being patched at import time by reading `version.tmp` in `cytnx/__init__.py`. This PR collapses the layers so `version.cmake` is the only place the project version is authored.

- Pass `CYTNX_VERSION` to the `pycytnx` target via `target_compile_definitions` and use it in `pybind/cytnx.cpp`.
- Import `__version__` from the C extension in `cytnx/__init__.py` and drop the `_get_version__()` / `version.tmp` indirection.
- Stop generating and installing `version.tmp`.

Existing version sources that already derive from `version.cmake` (`pyproject.toml` regex via scikit-build, `setup_macos.py` regex, `conda_build/meta.yaml`) were left untouched. `CITATION.cff` is intentionally left alone — its `version:` represents a citable released version (paired with `date-released:`), not the current dev version.

## Test plan
- [ ] After a full build, verify `python -c "import cytnx; print(cytnx.__version__)"` reports the version from `version.cmake`.