### PR TITLE
feat(symmetry): enforce Zn input-validation semantics (#771)

### DIFF
--- a/include/UniTensor.hpp
+++ b/include/UniTensor.hpp
@@ -1122,7 +1122,7 @@ namespace cytnx {
 
       for (cytnx_int32 i = 0; i < syms.size(); i++) {
         if (this->_bonds[0].type() == BD_BRA)
-          total_qns[i] = syms[0].reverse_rule(this->_bonds[0]._impl->_qnums[loc[0]][i]);
+          total_qns[i] = syms[i].reverse_rule(this->_bonds[0]._impl->_qnums[loc[0]][i]);
         else
           total_qns[i] = this->_bonds[0]._impl->_qnums[loc[0]][i];
 
@@ -1854,7 +1854,7 @@ namespace cytnx {
 
       for (cytnx_int32 i = 0; i < syms.size(); i++) {
         if (this->_bonds[0].type() == BD_BRA)
-          total_qns[i] = syms[0].reverse_rule(this->_bonds[0]._impl->_qnums[loc[0]][i]);
+          total_qns[i] = syms[i].reverse_rule(this->_bonds[0]._impl->_qnums[loc[0]][i]);
         else
           total_qns[i] = this->_bonds[0]._impl->_qnums[loc[0]][i];
 

--- a/pybind/symmetry_py.cpp
+++ b/pybind/symmetry_py.cpp
@@ -1,3 +1,4 @@
+#include <format>
 #include <vector>
 #include <map>
 #include <random>
@@ -16,6 +17,24 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 using namespace cytnx;
+
+namespace {
+  cytnx_int64 NormalizeZnInput(const Symmetry &sym, const cytnx_int64 qnum, const char *fn_name,
+                               const char *arg_name) {
+    if (sym.stype() != SymmetryType::Z) return qnum;
+    const cytnx_int64 n = sym.n();
+    if (qnum >= 0 && qnum < n) return qnum;
+    cytnx_int64 normalized = qnum % n;
+    if (normalized < 0) normalized += n;
+    const std::string message = std::format(
+      "Passing out-of-range Z{} qnum {} to '{}' (argument '{}') is deprecated and will be "
+      "rejected in v2.0.0; pass a canonical representative in [0, {}) instead. Normalizing to "
+      "{} for now.",
+      n, qnum, fn_name, arg_name, n, normalized);
+    if (PyErr_WarnEx(PyExc_FutureWarning, message.c_str(), 2) < 0) throw py::error_already_set();
+    return normalized;
+  }
+}  // namespace
 
 void symmetry_binding(py::module &m) {
   py::enum_<SymmetryType>(m, "SymType")
@@ -55,12 +74,19 @@ void symmetry_binding(py::module &m) {
     .def("check_qnums", &Symmetry::check_qnums, py::arg("qnums"))
     .def(
       "combine_rule",
-      [](Symmetry &self, const cytnx_int64 &inL, const cytnx_int64 &inR, const bool &is_reverse) {
-        return self.combine_rule(inL, inR, is_reverse);
+      [](const Symmetry &self, const cytnx_int64 &inL, const cytnx_int64 &inR,
+         const bool &is_reverse) {
+        const cytnx_int64 normL = NormalizeZnInput(self, inL, "combine_rule", "qnL");
+        const cytnx_int64 normR = NormalizeZnInput(self, inR, "combine_rule", "qnR");
+        return self.combine_rule(normL, normR, is_reverse);
       },
       py::arg("qnL"), py::arg("qnR"), py::arg("is_reverse") = false)
     .def(
-      "reverse_rule", [](Symmetry &self, const cytnx_int64 &qin) { return self.reverse_rule(qin); },
+      "reverse_rule",
+      [](const Symmetry &self, const cytnx_int64 &qin) {
+        const cytnx_int64 norm = NormalizeZnInput(self, qin, "reverse_rule", "qin");
+        return self.reverse_rule(norm);
+      },
       py::arg("qin"))
     .def("get_fermion_parity", &Symmetry::get_fermion_parity, py::arg("qnum"))
     .def("is_fermionic", &Symmetry::is_fermionic)

--- a/pytests/symmetry_test.py
+++ b/pytests/symmetry_test.py
@@ -1,0 +1,85 @@
+import warnings
+
+import pytest
+
+import cytnx
+
+
+def test_zn_combine_rule_canonical_inputs_no_warning():
+    """Canonical qnums in [0, n) must not trigger any deprecation warning."""
+    z3 = cytnx.Symmetry.Zn(3)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        assert z3.combine_rule(1, 2) == 0
+        assert z3.combine_rule(2, 2) == 1
+        assert z3.combine_rule(0, 0) == 0
+        assert z3.combine_rule(1, 1, is_reverse=True) == 1
+        assert z3.reverse_rule(0) == 0
+        assert z3.reverse_rule(1) == 2
+        assert z3.reverse_rule(2) == 1
+
+
+def test_zn_combine_rule_negative_input_warns_and_normalizes():
+    """Out-of-range Zn inputs to combine_rule emit FutureWarning and are normalized."""
+    z2 = cytnx.Symmetry.Zn(2)
+    with pytest.warns(
+            FutureWarning,
+            match=
+            "Passing out-of-range Z2 qnum -1 to 'combine_rule' \\(argument 'qnL'\\) is deprecated"):
+        assert z2.combine_rule(-1, 0) == 1
+
+    with pytest.warns(
+            FutureWarning,
+            match=
+            "Passing out-of-range Z2 qnum -1 to 'combine_rule' \\(argument 'qnR'\\) is deprecated"):
+        assert z2.combine_rule(0, -1) == 1
+
+
+def test_zn_combine_rule_above_range_input_warns_and_normalizes():
+    """qnum >= n is normalized via modulo."""
+    z3 = cytnx.Symmetry.Zn(3)
+    with pytest.warns(FutureWarning,
+                      match="Passing out-of-range Z3 qnum 5"):
+        assert z3.combine_rule(5, 0) == 2
+
+    with pytest.warns(FutureWarning,
+                      match="Passing out-of-range Z3 qnum 4"):
+        assert z3.combine_rule(1, 4) == 2
+
+
+def test_zn_combine_rule_with_is_reverse_warns_and_normalizes():
+    """is_reverse path also warns + normalizes.
+
+    Uses Z3 (N > 2) so the reverse step is non-trivial: in Z2 every qnum
+    is its own inverse, which would let a bug in the reverse path pass
+    silently.
+    """
+    z3 = cytnx.Symmetry.Zn(3)
+    with pytest.warns(FutureWarning, match="out-of-range Z3 qnum -1"):
+        # combine(-1, 0) normalizes to combine(2, 0) = 2; reverse(2) in Z3 = 1.
+        assert z3.combine_rule(-1, 0, is_reverse=True) == 1
+
+
+def test_zn_reverse_rule_out_of_range_warns_and_normalizes():
+    """reverse_rule warns + normalizes for out-of-range inputs."""
+    z3 = cytnx.Symmetry.Zn(3)
+    with pytest.warns(
+            FutureWarning,
+            match=
+            "Passing out-of-range Z3 qnum -1 to 'reverse_rule' \\(argument 'qin'\\) is deprecated"):
+        assert z3.reverse_rule(-1) == 1
+
+    with pytest.warns(FutureWarning,
+                      match="Passing out-of-range Z3 qnum 4"):
+        assert z3.reverse_rule(4) == 2
+
+
+def test_u1_does_not_normalize_or_warn():
+    """U1 accepts arbitrary integers; no warning, no modulo."""
+    u1 = cytnx.Symmetry.U1()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        assert u1.combine_rule(-3, 5) == 2
+        assert u1.combine_rule(7, -10) == -3
+        assert u1.reverse_rule(-4) == 4
+        assert u1.reverse_rule(9) == -9

--- a/src/Symmetry.cpp
+++ b/src/Symmetry.cpp
@@ -11,10 +11,15 @@ using namespace std;
 namespace cytnx {
 
   namespace {
-    cytnx_int64 NormalizeZnQnum(cytnx_int64 qnum, const cytnx_int64 n) {
-      qnum %= n;
-      if (qnum < 0) qnum += n;
-      return qnum;
+    void ValidateZnQnum(const cytnx_int64 qnum, const cytnx_int64 n) {
+      cytnx_error_msg(
+        (qnum < 0) || (qnum >= n),
+        "[ERROR][ZnSymmetry] qnum %lld is out of the valid range [0, %lld) for Z%lld.\n",
+        static_cast<long long>(qnum), static_cast<long long>(n), static_cast<long long>(n));
+    }
+
+    void ValidateZnQnums(const std::vector<cytnx_int64> &qnums, const cytnx_int64 n) {
+      for (const auto &q : qnums) ValidateZnQnum(q, n);
     }
   }  // namespace
 
@@ -123,21 +128,28 @@ namespace cytnx {
   void cytnx::ZnSymmetry::combine_rule_(std::vector<cytnx_int64> &out,
                                         const std::vector<cytnx_int64> &inL,
                                         const std::vector<cytnx_int64> &inR) {
+    ValidateZnQnums(inL, this->n);
+    ValidateZnQnums(inR, this->n);
     out.resize(inL.size() * inR.size());
-    for (cytnx_uint64 i = 0; i < out.size(); i++) {
-      out[i] = NormalizeZnQnum(inL[cytnx_uint64(i / inR.size())] + inR[i % inR.size()], this->n);
+    for (cytnx_uint64 i = 0; i < inL.size(); i++) {
+      for (cytnx_uint64 j = 0; j < inR.size(); j++) {
+        out[i * inR.size() + j] = (inL[i] + inR[j]) % this->n;
+      }
     }
   }
   void cytnx::ZnSymmetry::combine_rule_(cytnx_int64 &out, const cytnx_int64 &inL,
                                         const cytnx_int64 &inR, const bool &is_reverse) {
-    const cytnx_int64 combined = NormalizeZnQnum(inL + inR, this->n);
+    ValidateZnQnum(inL, this->n);
+    ValidateZnQnum(inR, this->n);
+    const cytnx_int64 combined = (inL + inR) % this->n;
     if (is_reverse)
       this->reverse_rule_(out, combined);
     else
       out = combined;
   }
   void cytnx::ZnSymmetry::reverse_rule_(cytnx_int64 &out, const cytnx_int64 &in) {
-    out = NormalizeZnQnum(-in, this->n);
+    ValidateZnQnum(in, this->n);
+    out = (this->n - in) % this->n;
   }
 
   void cytnx::ZnSymmetry::print_info() const {

--- a/tests/BlockUniTensor_test.cpp
+++ b/tests/BlockUniTensor_test.cpp
@@ -89,6 +89,23 @@ TEST_F(BlockUniTensorTest, syms) {
   EXPECT_EQ(BUT3.syms(), std::vector<Symmetry>({Symmetry::Zn(2), Symmetry::U1()}));
 }
 
+// Regression: UniTensor whose first bond is BD_BRA with a non-uniform symmetry
+// list (here {U1, Zn(2)}) used to feed `syms[0].reverse_rule(...)` to every
+// component `i` in `_fx_get_total_fluxs`. For `i = 1` that meant U1's reverse
+// rule was applied to a Zn(2) qnum, producing a negative value that was then
+// passed back into `syms[1].combine_rule` (Zn(2)). The result was silently
+// wrong before strict Zn validation and a hard `std::logic_error` after it.
+TEST_F(BlockUniTensorTest, FxGetTotalFluxsUsesPerComponentSymmetry) {
+  std::vector<Symmetry> syms = {Symmetry::U1(), Symmetry::Zn(2)};
+  Bond bd_bra = Bond(BD_BRA, {{0, 0}, {0, 1}, {1, 0}, {1, 1}}, {1, 1, 1, 1}, syms);
+  Bond bd_ket = Bond(BD_KET, {{0, 0}, {0, 1}, {1, 0}, {1, 1}}, {1, 1, 1, 1}, syms);
+
+  EXPECT_NO_THROW({
+    UniTensor ut = UniTensor({bd_bra, bd_ket});
+    EXPECT_EQ(ut.syms(), syms);
+  });
+}
+
 TEST_F(BlockUniTensorTest, is_contiguous) {
   EXPECT_EQ(Spf.is_contiguous(), true);
   auto Spf_new = Spf.permute({2, 1, 0}, 1);

--- a/tests/Bond_test.cpp
+++ b/tests/Bond_test.cpp
@@ -165,17 +165,41 @@ TEST(Bond, CombindBondSymm_v2) {
   EXPECT_THROW(bd_sym_a.combineBond(bd_sym_g), std::logic_error);
 }
 
-TEST(Bond, ZnSymmetryNormalizesPublicRules) {
+TEST(Bond, ZnSymmetryPublicRulesProduceCanonicalOutputs) {
   Symmetry z2 = Symmetry::Zn(2);
 
-  EXPECT_EQ(z2.combine_rule(-1, 0), 1);
-  EXPECT_EQ(z2.combine_rule(0, -1), 1);
-  EXPECT_EQ(z2.combine_rule(-1, 0, true), 1);
+  EXPECT_EQ(z2.combine_rule(0, 0), 0);
+  EXPECT_EQ(z2.combine_rule(0, 1), 1);
+  EXPECT_EQ(z2.combine_rule(1, 0), 1);
+  EXPECT_EQ(z2.combine_rule(1, 1), 0);
+  EXPECT_EQ(z2.combine_rule(1, 1, /*is_reverse=*/true), 0);
   EXPECT_EQ(z2.reverse_rule(0), 0);
   EXPECT_EQ(z2.reverse_rule(1), 1);
-  EXPECT_TRUE(z2.check_qnum(z2.combine_rule(-1, 0)));
-  EXPECT_TRUE(z2.check_qnum(z2.combine_rule(0, -1)));
-  EXPECT_TRUE(z2.check_qnum(z2.reverse_rule(0)));
+
+  Symmetry z3 = Symmetry::Zn(3);
+  EXPECT_EQ(z3.combine_rule(2, 2), 1);
+  EXPECT_EQ(z3.reverse_rule(0), 0);
+  EXPECT_EQ(z3.reverse_rule(1), 2);
+  EXPECT_EQ(z3.reverse_rule(2), 1);
+}
+
+TEST(Bond, ZnSymmetryRejectsOutOfRangeInputs) {
+  Symmetry z2 = Symmetry::Zn(2);
+
+  EXPECT_THROW(z2.combine_rule(-1, 0), std::logic_error);
+  EXPECT_THROW(z2.combine_rule(0, -1), std::logic_error);
+  EXPECT_THROW(z2.combine_rule(2, 0), std::logic_error);
+  EXPECT_THROW(z2.combine_rule(0, 2), std::logic_error);
+  EXPECT_THROW(z2.combine_rule(-1, 0, /*is_reverse=*/true), std::logic_error);
+  EXPECT_THROW(z2.combine_rule(0, 2, /*is_reverse=*/true), std::logic_error);
+  EXPECT_THROW(z2.reverse_rule(-1), std::logic_error);
+  EXPECT_THROW(z2.reverse_rule(2), std::logic_error);
+
+  Symmetry z3 = Symmetry::Zn(3);
+  EXPECT_THROW(z3.combine_rule(std::vector<cytnx_int64>{0, 3}, std::vector<cytnx_int64>{0}),
+               std::logic_error);
+  EXPECT_THROW(z3.combine_rule(std::vector<cytnx_int64>{0}, std::vector<cytnx_int64>{-1}),
+               std::logic_error);
 }
 
 TEST(Bond, Clear_type) {


### PR DESCRIPTION
Closes #771. Follow-up refactor tracked in #840.

## Summary

Pick a single contract for the Zn arithmetic API: valid quantum numbers are
canonical representatives in `[0, n)`, matching what `check_qnum` /
`check_qnums` already define and what `Bond` construction enforces.

The split policy used here is:

1. **Python binding** — keep accepting out-of-range Zn inputs, but emit a
   `FutureWarning` and normalize into `[0, n)` before forwarding to C++.
   The warning announces removal of the lenient behaviour in v2.0.0.
2. **C++ API** — reject out-of-range Zn inputs. `ZnSymmetry::combine_rule_`
   (scalar and vector overloads) and `reverse_rule_` validate inputs
   against `[0, n)` and throw `std::logic_error` via `cytnx_error_msg`
   on violation.

Tightening the C++ rule surfaced a pre-existing typo in
`UniTensor::_fx_get_total_fluxs`, fixed in the same PR so bisect does
not hit a regression window. See "Latent bug fixed in passing" below.

## Commits

1. `feat(symmetry): warn and normalize out-of-range Zn inputs in Python`
2. `fix(unitensor): use per-component symmetry in _fx_get_total_fluxs`
3. `feat(symmetry): reject out-of-range Zn qnums in C++ arithmetic API`

Ordering matters: (2) must land before (3) so `_fx_get_total_fluxs` is
already correct when the stricter Zn validation goes in.

## Changes

### `src/Symmetry.cpp`
- Replace the defensive `NormalizeZnQnum` helper (introduced in #768) with
  `ValidateZnQnum` / `ValidateZnQnums` validation helpers.
- `ZnSymmetry::combine_rule_` (vector and scalar overloads) and
  `reverse_rule_` validate inputs up front; the bodies simplify to
  `(inL + inR) % n` for combine and `(n - in) % n` for reverse, since
  inputs are now constrained to `[0, n)`. The vector overload uses a
  straightforward double loop instead of a single flat index with
  integer division and modulo.

### `pybind/symmetry_py.cpp`
- Add a `NormalizeZnInput` helper in an anonymous namespace that returns
  the input unchanged for non-Zn symmetries, and for Zn:
  - checks whether the qnum is in `[0, n)`,
  - if not, emits a `FutureWarning` via `PyErr_WarnEx(PyExc_FutureWarning,
    ..., 2)` matching the existing `get_blocks_(slient=...)` pattern in
    `pybind/unitensor_py.cpp`; the message is assembled with
    `std::format` to match other diagnostics in the codebase,
  - returns the positive-modulo normalization of the input.
- Wrap the bound `combine_rule(qnL, qnR, is_reverse)` and
  `reverse_rule(qin)` lambdas to call `NormalizeZnInput` on each
  argument before forwarding to the C++ rule. The lambdas take
  `const Symmetry &self` to match the const-ness of the underlying
  methods.

### `include/UniTensor.hpp` — latent bug fixed in passing
- `_fx_get_total_fluxs` (and its duplicate copy on
  `BlockFermionicUniTensor`) seeded `total_qns[i]` on the BRA-initial
  branch with `syms[0].reverse_rule(...)`. Every other arithmetic step
  in the same function uses `syms[i]`, so this was a typo specific to
  that branch. On uniform symmetry lists (`{U1, U1}`, `{Zn, Zn}`) the
  bug is invisible because `syms[0]` and `syms[i]` are the same type;
  on mixed lists with a BRA first bond (e.g. `{U1, Zn(N)}`) it applied
  `U1::reverse_rule` to a Zn qnum and produced an out-of-range result
  that the rest of the loop then fed back into `Zn::combine_rule`.
  Silent before strict Zn validation, a hard `std::logic_error` after.
  Replace `syms[0]` with `syms[i]` in both copies.

### `tests/Bond_test.cpp`
- Remove `Bond.ZnSymmetryNormalizesPublicRules`, which pinned the old
  lenient behaviour from #768.
- Add `Bond.ZnSymmetryPublicRulesProduceCanonicalOutputs` covering Z2
  and Z3 canonical inputs for `combine_rule`,
  `combine_rule(..., /*is_reverse=*/true)`, and `reverse_rule`.
- Add `Bond.ZnSymmetryRejectsOutOfRangeInputs` covering negative and
  `>= n` inputs on every public arithmetic overload, including the
  vector form and the `is_reverse` branch.

### `tests/BlockUniTensor_test.cpp`
- Add `BlockUniTensorTest.FxGetTotalFluxsUsesPerComponentSymmetry`,
  which constructs `UniTensor({BD_BRA{U1, Zn(2)}, BD_KET{U1, Zn(2)}})`.
  Without the `_fx_get_total_fluxs` fix this constructor would throw
  `std::logic_error` from the strict Zn validation; with the fix it
  completes and reports the expected symmetry list.

### `pytests/symmetry_test.py` (new)
Six tests covering:
- canonical Zn inputs do not emit warnings,
- negative inputs to `combine_rule` warn with the documented message
  and return the canonical combined value,
- `>= n` inputs warn and normalize,
- the `is_reverse` branch warns and normalizes (exercised on Z3 so the
  reverse step is a non-trivial permutation),
- `reverse_rule` warns + normalizes,
- U1 still accepts arbitrary integers without warnings.

## Internal call sites

`src/Bond.cpp` and `src/SparseUniTensor.cpp` are the C++ internal callers
of `combine_rule_` / `reverse_rule_`. They feed qnums that have already
been validated by `Bond` construction (which calls `check_qnum` on every
entry), so they remain compatible with the stricter rule.

## Test plan

Run on both `mkl-cpu` and `openblas-cpu` presets:

```sh
cmake -S . -B build/mkl-cpu -DRUN_TESTS=ON -DUSE_MKL=ON
cmake --build build/mkl-cpu -- -j$(nproc)
ctest --test-dir build/mkl-cpu

cmake -S . -B build/openblas-cpu -DRUN_TESTS=ON
cmake --build build/openblas-cpu -- -j$(nproc)
ctest --test-dir build/openblas-cpu
```

Python tests:

```sh
pytest pytests/symmetry_test.py -v
```

### Results

- `pre-commit run` — clean.
- `ctest --test-dir build/openblas-cpu` — **100% tests passed**, 938 /
  938 (incl. the two new `Bond.ZnSymmetry*` tests and the new
  `BlockUniTensorTest.FxGetTotalFluxsUsesPerComponentSymmetry`
  regression test).
- `ctest --test-dir build/mkl-cpu` — **100% tests passed**, 938 / 938.
- `pytest pytests/symmetry_test.py` — **6 / 6 passed**.