### PR TITLE
Revert "fix(codecov): mark umbrella project status informational"

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,11 +19,9 @@ coverage:
   status:
     project:
       default:
-        # The per-flag statuses (cpp, python) below are the authoritative
-        # checks. The umbrella default sees a merged view across both flags
-        # and can fail spuriously when coverage is split across uploads;
-        # mark it informational so it reports without blocking.
-        informational: true
+        target: auto
+        threshold: 1%
+        informational: false
       cpp:
         target: auto
         threshold: 1%


### PR DESCRIPTION
## Summary

Reverts commit f206d5e ("fix(codecov): mark umbrella project status informational"), which set `informational: true` on the umbrella `project` coverage status. This restores `informational: false`, so the status check once again **blocks** pull requests whose coverage falls below target.

## Rationale

Blocking on coverage is intentional, as discussed in https://github.com/Cytnx-dev/Cytnx/pull/818#issuecomment-4561404776: it forces pull requests that add new features to also add tests, rather than letting coverage silently decay. Marking the umbrella status as merely informational removes that pressure.

---
_Generated by [Claude Code](https://claude.ai/code/session_019k4bFnTDVh4hL3pyoyJ8we)_