### PR TITLE
refactor(trace): implement the GPU Tensor trace as CUDA kernels

### DIFF
--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -206,19 +206,23 @@ namespace cytnx {
         // Ship the two surviving_rank-sized layout arrays the multi-index decode
         // needs; the rank-2 case (surviving_rank == 0) needs neither, so the
         // kernel reads nullptr only where the decode loop never runs.
+        //
+        // Allocated with cudaMallocAsync (stream-ordered) rather than cudaMalloc
+        // so they can be released with cudaFreeAsync below -- cudaFreeAsync only
+        // accepts pointers allocated by cudaMallocAsync/cudaMallocFromPoolAsync.
         cytnx_uint64 *device_surviving_shape = nullptr;
         cytnx_uint64 *device_surviving_input_stride = nullptr;
         if (surviving_rank > 0) {
+          checkCudaErrors(cudaMallocAsync((void **)&device_surviving_shape,
+                                          sizeof(cytnx_uint64) * surviving_rank, 0));
+          checkCudaErrors(cudaMallocAsync((void **)&device_surviving_input_stride,
+                                          sizeof(cytnx_uint64) * surviving_rank, 0));
+          checkCudaErrors(cudaMemcpyAsync(device_surviving_shape, host_surviving_shape.data(),
+                                          sizeof(cytnx_uint64) * surviving_rank,
+                                          cudaMemcpyHostToDevice, 0));
           checkCudaErrors(
-            cudaMalloc((void **)&device_surviving_shape, sizeof(cytnx_uint64) * surviving_rank));
-          checkCudaErrors(cudaMalloc((void **)&device_surviving_input_stride,
-                                     sizeof(cytnx_uint64) * surviving_rank));
-          checkCudaErrors(cudaMemcpy(device_surviving_shape, host_surviving_shape.data(),
-                                     sizeof(cytnx_uint64) * surviving_rank,
-                                     cudaMemcpyHostToDevice));
-          checkCudaErrors(
-            cudaMemcpy(device_surviving_input_stride, host_surviving_input_stride.data(),
-                       sizeof(cytnx_uint64) * surviving_rank, cudaMemcpyHostToDevice));
+            cudaMemcpyAsync(device_surviving_input_stride, host_surviving_input_stride.data(),
+                            sizeof(cytnx_uint64) * surviving_rank, cudaMemcpyHostToDevice, 0));
         }
 
         // Size each block to its diagonal: diagonal_length is known here, so the
@@ -254,11 +258,21 @@ namespace cytnx {
         checkCudaErrors(cudaGetLastError());
 
         if (surviving_rank > 0) {
-          // cudaFree synchronizes the device, but that wait is already bounded
-          // by the TraceKernel launch above on this same in-order stream, so it
-          // adds no additional stall beyond the kernel's own completion.
-          checkCudaErrors(cudaFree(device_surviving_shape));
-          checkCudaErrors(cudaFree(device_surviving_input_stride));
+          // cudaEventSynchronize waits only for TraceKernel (recorded on this
+          // same stream), not the whole device; cudaFreeAsync then enqueues the
+          // release into the stream-ordered memory pool without the host
+          // blocking on the free itself. This is groundwork for a future where
+          // GPU work runs across multiple concurrent streams -- today, with
+          // every op on the default stream, it costs the same as a direct
+          // cudaFree, but it stops scaling into a device-wide stall once that
+          // stops being true.
+          cudaEvent_t kernel_done;
+          checkCudaErrors(cudaEventCreate(&kernel_done));
+          checkCudaErrors(cudaEventRecord(kernel_done, 0));
+          checkCudaErrors(cudaEventSynchronize(kernel_done));
+          checkCudaErrors(cudaFreeAsync(device_surviving_shape, 0));
+          checkCudaErrors(cudaFreeAsync(device_surviving_input_stride, 0));
+          checkCudaErrors(cudaEventDestroy(kernel_done));
         }
 
         return ComposeTraceOutput(output_storage, output_shape, output_is_scalar);

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -153,6 +153,18 @@ namespace cytnx {
         if (threadIdx.x == 0) output_data[output_index] = sum;
       }
 
+      // Composes the output Tensor from its already-filled storage, reshaping to
+      // output_shape unless the trace is a rank-2 scalar. Tensor::from_storage
+      // keeps the storage on its current device, so no host round-trip is
+      // involved.
+      Tensor ComposeTraceOutput(Storage &output_storage,
+                                const std::vector<cytnx_int64> &output_shape,
+                                bool output_is_scalar) {
+        Tensor out = Tensor::from_storage(output_storage);
+        if (!output_is_scalar) out.reshape_(output_shape);
+        return out;
+      }
+
       template <class T>
       Tensor TraceImplGpu(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {
         using CudaT = typename utils_internal::ToCudaDType<T>::type;
@@ -183,16 +195,12 @@ namespace cytnx {
         for (auto dim : host_surviving_shape) output_size *= dim;
         const bool output_is_scalar = surviving_rank == 0;
 
-        // Fill a device-resident result Storage, then compose the output Tensor
-        // from it; Tensor::from_storage keeps the storage on its current device, so
-        // no host round-trip is involved.
+        // Fill a device-resident result Storage.
         Storage output_storage(output_is_scalar ? cytnx_uint64{1} : output_size, Tn.dtype(),
                                Tn.device());
         if (diagonal_length == 0 || output_size == 0) {
           output_storage.set_zeros();
-          Tensor out = Tensor::from_storage(output_storage);
-          if (!output_is_scalar) out.reshape_(output_shape);
-          return out;
+          return ComposeTraceOutput(output_storage, output_shape, output_is_scalar);
         }
 
         // Ship the two surviving_rank-sized layout arrays the multi-index decode
@@ -252,9 +260,7 @@ namespace cytnx {
           checkCudaErrors(cudaFree(device_surviving_input_stride));
         }
 
-        Tensor out = Tensor::from_storage(output_storage);
-        if (!output_is_scalar) out.reshape_(output_shape);
-        return out;
+        return ComposeTraceOutput(output_storage, output_shape, output_is_scalar);
       }
 
     }  // namespace

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -2,9 +2,10 @@
 #include "cytnx_error.hpp"
 #include "Tensor.hpp"
 #include "backend/Storage.hpp"
-#include "backend/utils_internal_gpu/cuFill_gpu.hpp"
+#include "backend/utils_internal_gpu/cuTypeTraits_gpu.hpp"
 
 #include <algorithm>
+#include <iterator>
 #include <limits>
 #include <vector>
 

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -12,11 +12,22 @@ namespace cytnx {
   namespace linalg_internal {
     namespace {
 
-      constexpr int kTraceThreadsPerBlock = 512;
-      // The single-block tree reduction below halves the active thread count each
-      // step, which only covers every element when the block size is a power of two.
-      static_assert((kTraceThreadsPerBlock & (kTraceThreadsPerBlock - 1)) == 0,
-                    "kTraceThreadsPerBlock must be a power of two for the tree reduction.");
+      // Number of threads a GPU executes in lockstep (warpSize in the CUDA
+      // runtime). Fixed at 32 on every current NVIDIA architecture; the
+      // __shfl_down_sync reductions below assume this value.
+      constexpr int kWarpSize = 32;
+      // Cap on threads per block for the trace kernel. Each block is sized to
+      // its diagonal (rounded up to a whole warp) and saturates at this cap.
+      constexpr int kMaxTraceThreadsPerBlock = 256;
+      // Capacity of the shared array of per-warp partial sums: one slot per
+      // warp of a maximum-size block.
+      constexpr int kMaxTraceWarpsPerBlock = kMaxTraceThreadsPerBlock / kWarpSize;
+      static_assert(kMaxTraceThreadsPerBlock % kWarpSize == 0,
+                    "Blocks are sized in whole warps, so the cap must be a warp multiple.");
+      // The per-warp tree reduction below halves the active lane count each step,
+      // which only covers every lane when the warp size is a power of two.
+      static_assert((kWarpSize & (kWarpSize - 1)) == 0,
+                    "kWarpSize must be a power of two for the tree reduction.");
 
       // Maps a cytnx storage type to the device arithmetic type used inside the
       // kernels. Complex storage is bit-compatible with cuda::std::complex, which
@@ -37,50 +48,31 @@ namespace cytnx {
       template <class T>
       using TraceCudaTypeT = typename TraceCudaType<T>::type;
 
-      // Sums one diagonal: every thread strides over the diagonal_length entries
-      // starting at diagonal_start_offset (step diagonal_stride), then a
-      // shared-memory tree reduction combines the per-thread partials into the
-      // single *output_element. This is the whole computation for a rank-2 trace
-      // (one diagonal -> one scalar); the trace of higher-rank inputs runs one
-      // block per output element and calls this with that element's offset.
+      // value + (the value `reduction_stride` lanes higher in the warp). For real
+      // types this is a single __shfl_down_sync; complex storage is shuffled
+      // component-wise since __shfl_down_sync only moves scalar lanes. (Small
+      // integer types promote to int through the shuffle and truncate back, which
+      // preserves the modular-sum semantics the trace already has.)
       template <class T>
-      __device__ void TraceDiagonalBlock(T *output_element, const T *input_data,
-                                         cytnx_uint64 diagonal_start_offset,
-                                         cytnx_uint64 diagonal_length,
-                                         cytnx_uint64 diagonal_stride) {
-        __shared__ T block_partial_sums[kTraceThreadsPerBlock];
-        T thread_partial_sum = T(0);
-        for (cytnx_uint64 i = threadIdx.x; i < diagonal_length; i += blockDim.x)
-          thread_partial_sum += input_data[diagonal_start_offset + i * diagonal_stride];
-        block_partial_sums[threadIdx.x] = thread_partial_sum;
-        __syncthreads();
-
-        for (unsigned int reduction_stride = blockDim.x >> 1; reduction_stride > 0;
-             reduction_stride >>= 1) {
-          if (threadIdx.x < reduction_stride)
-            block_partial_sums[threadIdx.x] += block_partial_sums[threadIdx.x + reduction_stride];
-          __syncthreads();
-        }
-
-        if (threadIdx.x == 0) *output_element = block_partial_sums[0];
+      __device__ T WarpShuffleDownAdd(T value, int reduction_stride) {
+        return value + __shfl_down_sync(0xffffffff, value, reduction_stride);
+      }
+      template <class F>
+      __device__ cuda::std::complex<F> WarpShuffleDownAdd(cuda::std::complex<F> value,
+                                                          int reduction_stride) {
+        return cuda::std::complex<F>(
+          value.real() + __shfl_down_sync(0xffffffff, value.real(), reduction_stride),
+          value.imag() + __shfl_down_sync(0xffffffff, value.imag(), reduction_stride));
       }
 
-      // One block per output element. The block decodes its flat index into the
-      // surviving-axis multi-index, accumulating the input base offset from
-      // surviving_input_stride (the input stride of each surviving axis), then
-      // sums that element's diagonal via TraceDiagonalBlock. A rank-2 trace is
-      // the special case surviving_rank == 0 / output_size == 1: the decode loop
-      // is empty and the diagonal starts at offset 0, so the single block traces
-      // the whole matrix diagonal.
-      template <class T>
-      __global__ void TraceKernel(T *output_data, const T *input_data,
-                                  const cytnx_uint64 *surviving_shape,
-                                  const cytnx_uint64 *surviving_input_stride,
-                                  cytnx_uint64 surviving_rank, cytnx_uint64 output_size,
-                                  cytnx_uint64 diagonal_length, cytnx_uint64 diagonal_stride) {
-        cytnx_uint64 output_index = blockIdx.x;
-        if (output_index >= output_size) return;
-
+      // Decodes a flat output index into the input storage offset of that output
+      // element's diagonal start: walk the surviving axes, accumulating
+      // (index_along_axis * input_stride_of_axis). For a rank-2 trace
+      // (surviving_rank == 0) the loop is empty and the offset is 0.
+      __device__ cytnx_uint64 DecodeDiagonalStartOffset(cytnx_uint64 output_index,
+                                                        const cytnx_uint64 *surviving_shape,
+                                                        const cytnx_uint64 *surviving_input_stride,
+                                                        cytnx_uint64 surviving_rank) {
         cytnx_uint64 remaining_flat_index = output_index;
         cytnx_uint64 diagonal_start_offset = 0;
         for (cytnx_uint64 axis = surviving_rank; axis-- > 0;) {
@@ -88,8 +80,71 @@ namespace cytnx {
             (remaining_flat_index % surviving_shape[axis]) * surviving_input_stride[axis];
           remaining_flat_index /= surviving_shape[axis];
         }
-        TraceDiagonalBlock<T>(&output_data[output_index], input_data, diagonal_start_offset,
-                              diagonal_length, diagonal_stride);
+        return diagonal_start_offset;
+      }
+
+      // Sums one diagonal with the whole block (blockDim.x threads): each thread
+      // strides over the diagonal, each warp reduces its lanes with a warp-shuffle
+      // tree, the per-warp sums land in shared memory, and the first warp reduces
+      // those. Thread 0 returns the result. The reduction adapts to whatever
+      // blockDim.x the kernel was launched with -- the caller sizes blockDim per
+      // call to diagonal_length so a short diagonal never spawns idle warps.
+      template <class T>
+      __device__ T BlockTraceDiagonal(const T *input_data, cytnx_uint64 diagonal_start_offset,
+                                      cytnx_uint64 diagonal_length, cytnx_uint64 diagonal_stride) {
+        T thread_partial_sum = T(0);
+        for (cytnx_uint64 i = threadIdx.x; i < diagonal_length; i += blockDim.x)
+          thread_partial_sum += input_data[diagonal_start_offset + i * diagonal_stride];
+
+        // Reduce within each warp.
+        for (int reduction_stride = kWarpSize / 2; reduction_stride > 0; reduction_stride /= 2)
+          thread_partial_sum = WarpShuffleDownAdd(thread_partial_sum, reduction_stride);
+
+        const unsigned int warps_in_block = (blockDim.x + kWarpSize - 1) / kWarpSize;
+        if (warps_in_block == 1) {
+          // Single-warp launch: thread_partial_sum on lane 0 already holds the
+          // total. No shared memory or barrier needed.
+          return thread_partial_sum;
+        }
+
+        // Lane 0 of each warp publishes its warp's sum; the first warp reduces them.
+        __shared__ T warp_sums[kMaxTraceWarpsPerBlock];
+        const unsigned int lane = threadIdx.x % kWarpSize;
+        const unsigned int warp_in_block = threadIdx.x / kWarpSize;
+        if (lane == 0) warp_sums[warp_in_block] = thread_partial_sum;
+        __syncthreads();
+
+        T block_sum = T(0);
+        if (warp_in_block == 0) {
+          T v = (lane < warps_in_block) ? warp_sums[lane] : T(0);
+          for (int reduction_stride = kWarpSize / 2; reduction_stride > 0; reduction_stride /= 2)
+            v = WarpShuffleDownAdd(v, reduction_stride);
+          block_sum = v;
+        }
+        return block_sum;  // valid on thread 0
+      }
+
+      // One block per output element (blockIdx.x is the output index). The caller
+      // sizes blockDim per call so each block has roughly diagonal_length threads
+      // (rounded up to a warp, capped at kMaxTraceThreadsPerBlock): a short
+      // diagonal launches a small block (no idle warps), a long diagonal launches
+      // the maximum-size block (all threads working). A rank-2 trace
+      // (output_size == 1) is just one such block; many short-diagonal outputs
+      // launch many small blocks running concurrently across SMs.
+      template <class T>
+      __global__ void TraceKernel(T *output_data, const T *input_data,
+                                  const cytnx_uint64 *surviving_shape,
+                                  const cytnx_uint64 *surviving_input_stride,
+                                  cytnx_uint64 surviving_rank, cytnx_uint64 output_size,
+                                  cytnx_uint64 diagonal_length, cytnx_uint64 diagonal_stride) {
+        const cytnx_uint64 output_index = blockIdx.x;
+        if (output_index >= output_size) return;
+
+        const cytnx_uint64 diagonal_start_offset = DecodeDiagonalStartOffset(
+          output_index, surviving_shape, surviving_input_stride, surviving_rank);
+        T sum = BlockTraceDiagonal<T>(input_data, diagonal_start_offset, diagonal_length,
+                                      diagonal_stride);
+        if (threadIdx.x == 0) output_data[output_index] = sum;
       }
 
       template <class T>
@@ -152,8 +207,17 @@ namespace cytnx {
                        sizeof(cytnx_uint64) * surviving_rank, cudaMemcpyHostToDevice));
         }
 
-        // One block per output element (output_size == 1 for the rank-2 case).
-        TraceKernel<CudaT><<<output_size, kTraceThreadsPerBlock>>>(
+        // Size each block to its diagonal: diagonal_length is known here, so the
+        // block gets just enough threads to cover it (rounded up to a whole warp,
+        // capped at kMaxTraceThreadsPerBlock). A short diagonal launches a small
+        // block with no idle warps; a long diagonal gets the full-size block and
+        // each thread strides. One block per output element, so many short
+        // diagonals still reduce concurrently across SMs, and the rank-2 trace
+        // (output_size == 1) puts every thread of its single block on the one
+        // diagonal.
+        const cytnx_uint64 threads_per_block = std::min<cytnx_uint64>(
+          ((diagonal_length + kWarpSize - 1) / kWarpSize) * kWarpSize, kMaxTraceThreadsPerBlock);
+        TraceKernel<CudaT><<<output_size, threads_per_block>>>(
           reinterpret_cast<CudaT *>(output_storage.data()),
           reinterpret_cast<const CudaT *>(Tn.storage().data()), device_surviving_shape,
           device_surviving_input_stride, surviving_rank, output_size, diagonal_length,

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -38,8 +38,8 @@ namespace cytnx {
       // <<<...>>> launch's first argument would implicitly narrow to dim3.x
       // (32-bit) and silently truncate the grid -- see the 2-D grid dispatch in
       // TraceImplGpu below.
-      constexpr cytnx_uint64 kMaxGridDimX = 2147483647ULL;
-      constexpr cytnx_uint64 kMaxGridDimY = 65535ULL;
+      constexpr cytnx_int64 kMaxGridDimX = 2147483647LL;
+      constexpr cytnx_int64 kMaxGridDimY = 65535LL;
 
       // Narrows a shape/stride extent (mathematically non-negative, stored as
       // cytnx_uint64) to cytnx_int64, rejecting values that would overflow.
@@ -75,13 +75,17 @@ namespace cytnx {
       // element's diagonal start: walk the surviving axes, accumulating
       // (index_along_axis * input_stride_of_axis). For a rank-2 trace
       // (surviving_rank == 0) the loop is empty and the offset is 0.
-      __device__ cytnx_uint64 DecodeDiagonalStartOffset(cytnx_uint64 output_index,
-                                                        const cytnx_uint64 *surviving_shape,
-                                                        const cytnx_uint64 *surviving_input_stride,
-                                                        cytnx_uint64 surviving_rank) {
-        cytnx_uint64 remaining_flat_index = output_index;
-        cytnx_uint64 diagonal_start_offset = 0;
-        for (cytnx_uint64 axis = surviving_rank; axis-- > 0;) {
+      //
+      // Every index/extent here is a single signed type (cytnx_int64), mirroring
+      // the CPU TraceImpl (Trace_internal.cpp) so this arithmetic needs no casts
+      // between calls.
+      __device__ cytnx_int64 DecodeDiagonalStartOffset(cytnx_int64 output_index,
+                                                       const cytnx_int64 *surviving_shape,
+                                                       const cytnx_int64 *surviving_input_stride,
+                                                       cytnx_int64 surviving_rank) {
+        cytnx_int64 remaining_flat_index = output_index;
+        cytnx_int64 diagonal_start_offset = 0;
+        for (cytnx_int64 axis = surviving_rank; axis-- > 0;) {
           diagonal_start_offset +=
             (remaining_flat_index % surviving_shape[axis]) * surviving_input_stride[axis];
           remaining_flat_index /= surviving_shape[axis];
@@ -96,10 +100,12 @@ namespace cytnx {
       // blockDim.x the kernel was launched with -- the caller sizes blockDim per
       // call to diagonal_length so a short diagonal never spawns idle warps.
       template <class T>
-      __device__ T BlockTraceDiagonal(const T *input_data, cytnx_uint64 diagonal_start_offset,
-                                      cytnx_uint64 diagonal_length, cytnx_uint64 diagonal_stride) {
+      __device__ T BlockTraceDiagonal(const T *input_data, cytnx_int64 diagonal_start_offset,
+                                      cytnx_int64 diagonal_length, cytnx_int64 diagonal_stride) {
         T thread_partial_sum = T(0);
-        for (cytnx_uint64 i = threadIdx.x; i < diagonal_length; i += blockDim.x)
+        // threadIdx.x/blockDim.x are CUDA's native unsigned int; cast once here at
+        // that boundary and keep the stride math in cytnx_int64 from then on.
+        for (cytnx_int64 i = threadIdx.x; i < diagonal_length; i += blockDim.x)
           thread_partial_sum += input_data[diagonal_start_offset + i * diagonal_stride];
 
         // Reduce within each warp.
@@ -139,15 +145,17 @@ namespace cytnx {
       // launch many small blocks running concurrently across SMs.
       template <class T>
       __global__ void TraceKernel(T *output_data, const T *input_data,
-                                  const cytnx_uint64 *surviving_shape,
-                                  const cytnx_uint64 *surviving_input_stride,
-                                  cytnx_uint64 surviving_rank, cytnx_uint64 output_size,
-                                  cytnx_uint64 diagonal_length, cytnx_uint64 diagonal_stride) {
-        const cytnx_uint64 output_index =
-          static_cast<cytnx_uint64>(blockIdx.y) * gridDim.x + blockIdx.x;
+                                  const cytnx_int64 *surviving_shape,
+                                  const cytnx_int64 *surviving_input_stride,
+                                  cytnx_int64 surviving_rank, cytnx_int64 output_size,
+                                  cytnx_int64 diagonal_length, cytnx_int64 diagonal_stride) {
+        // blockIdx/gridDim are CUDA's native unsigned int; cast once here at that
+        // boundary, then the rest of the decode stays in cytnx_int64.
+        const cytnx_int64 output_index =
+          static_cast<cytnx_int64>(blockIdx.y) * gridDim.x + blockIdx.x;
         if (output_index >= output_size) return;
 
-        const cytnx_uint64 diagonal_start_offset = DecodeDiagonalStartOffset(
+        const cytnx_int64 diagonal_start_offset = DecodeDiagonalStartOffset(
           output_index, surviving_shape, surviving_input_stride, surviving_rank);
         T sum = BlockTraceDiagonal<T>(input_data, diagonal_start_offset, diagonal_length,
                                       diagonal_stride);
@@ -169,36 +177,47 @@ namespace cytnx {
       template <class T>
       Tensor TraceImplGpu(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {
         using CudaT = typename utils_internal::ToCudaDType<T>::type;
+        // Every cudaXxxAsync call and the kernel launch below share this one
+        // stream, named rather than passed as a bare 0, so the whole function
+        // only has to change in one place if this ever moves off the default
+        // stream.
+        const cudaStream_t stream = 0;
         // Trace() validates upstream that ax1 != ax2 and shape[ax1] == shape[ax2],
         // so their order is irrelevant: the diagonal stride and the set of
         // surviving axes are symmetric in (ax1, ax2).
+        // Every index/extent below is kept as a single signed type (cytnx_int64),
+        // mirroring the CPU TraceImpl (Trace_internal.cpp) -- input_shape's
+        // elements and surviving_rank are the only values that start out
+        // unsigned (Tn.shape() and std::vector::size()), so those are the only
+        // two places a cast is needed at all.
         const auto &input_shape = Tn.shape();
         const std::vector<cytnx_int64> input_strides = Tn.strides();
-        const cytnx_uint64 diagonal_length = input_shape[ax1];
-        const cytnx_uint64 diagonal_stride =
-          static_cast<cytnx_uint64>(input_strides[ax1] + input_strides[ax2]);
+        const cytnx_int64 diagonal_length =
+          CheckedCastToInt64Gpu(input_shape[ax1], "input_shape[ax1]");
+        const cytnx_int64 diagonal_stride = input_strides[ax1] + input_strides[ax2];
 
         // Build the reduced output shape and the matching per-surviving-axis input
         // strides in a single pass over the surviving axes (no separate surviving-
-        // axis index list).
-        std::vector<cytnx_int64> output_shape;  // for Tensor::reshape_
-        std::vector<cytnx_uint64> host_surviving_shape;  // same dims, device-bound
-        std::vector<cytnx_uint64> host_surviving_input_stride;
+        // axis index list). output_shape doubles as the surviving-axis extent
+        // array shipped to the device below -- it already holds exactly those
+        // values, so there is no separate host_surviving_shape.
+        std::vector<cytnx_int64> output_shape;  // for Tensor::reshape_ and device upload
+        std::vector<cytnx_int64> surviving_input_stride;
         for (cytnx_uint64 axis = 0; axis < input_shape.size(); ++axis) {
           if (axis != ax1 && axis != ax2) {
             output_shape.push_back(CheckedCastToInt64Gpu(input_shape[axis], "input_shape[axis]"));
-            host_surviving_shape.push_back(input_shape[axis]);
-            host_surviving_input_stride.push_back(static_cast<cytnx_uint64>(input_strides[axis]));
+            surviving_input_stride.push_back(input_strides[axis]);
           }
         }
-        const cytnx_uint64 surviving_rank = host_surviving_shape.size();
-        cytnx_uint64 output_size = 1;
-        for (auto dim : host_surviving_shape) output_size *= dim;
+        const cytnx_int64 surviving_rank = std::ssize(surviving_input_stride);
+        cytnx_int64 output_size = 1;
+        for (cytnx_int64 dim : output_shape) output_size *= dim;
         const bool output_is_scalar = surviving_rank == 0;
 
         // Fill a device-resident result Storage.
-        Storage output_storage(output_is_scalar ? cytnx_uint64{1} : output_size, Tn.dtype(),
-                               Tn.device());
+        Storage output_storage(
+          output_is_scalar ? cytnx_uint64{1} : static_cast<cytnx_uint64>(output_size), Tn.dtype(),
+          Tn.device());
         if (diagonal_length == 0 || output_size == 0) {
           output_storage.set_zeros();
           return ComposeTraceOutput(output_storage, output_shape, output_is_scalar);
@@ -211,19 +230,19 @@ namespace cytnx {
         // Allocated with cudaMallocAsync (stream-ordered) rather than cudaMalloc
         // so they can be released with cudaFreeAsync below -- cudaFreeAsync only
         // accepts pointers allocated by cudaMallocAsync/cudaMallocFromPoolAsync.
-        cytnx_uint64 *device_surviving_shape = nullptr;
-        cytnx_uint64 *device_surviving_input_stride = nullptr;
+        cytnx_int64 *device_surviving_shape = nullptr;
+        cytnx_int64 *device_surviving_input_stride = nullptr;
         if (surviving_rank > 0) {
           checkCudaErrors(cudaMallocAsync((void **)&device_surviving_shape,
-                                          sizeof(cytnx_uint64) * surviving_rank, 0));
+                                          sizeof(cytnx_int64) * surviving_rank, stream));
           checkCudaErrors(cudaMallocAsync((void **)&device_surviving_input_stride,
-                                          sizeof(cytnx_uint64) * surviving_rank, 0));
-          checkCudaErrors(cudaMemcpyAsync(device_surviving_shape, host_surviving_shape.data(),
-                                          sizeof(cytnx_uint64) * surviving_rank,
-                                          cudaMemcpyHostToDevice, 0));
+                                          sizeof(cytnx_int64) * surviving_rank, stream));
+          checkCudaErrors(cudaMemcpyAsync(device_surviving_shape, output_shape.data(),
+                                          sizeof(cytnx_int64) * surviving_rank,
+                                          cudaMemcpyHostToDevice, stream));
           checkCudaErrors(
-            cudaMemcpyAsync(device_surviving_input_stride, host_surviving_input_stride.data(),
-                            sizeof(cytnx_uint64) * surviving_rank, cudaMemcpyHostToDevice, 0));
+            cudaMemcpyAsync(device_surviving_input_stride, surviving_input_stride.data(),
+                            sizeof(cytnx_int64) * surviving_rank, cudaMemcpyHostToDevice, stream));
         }
 
         // Size each block to its diagonal: diagonal_length is known here, so the
@@ -234,22 +253,26 @@ namespace cytnx {
         // diagonals still reduce concurrently across SMs, and the rank-2 trace
         // (output_size == 1) puts every thread of its single block on the one
         // diagonal.
-        const cytnx_uint64 threads_per_block = std::min<cytnx_uint64>(
+        const cytnx_int64 threads_per_block = std::min<cytnx_int64>(
           ((diagonal_length + kWarpSize - 1) / kWarpSize) * kWarpSize, kMaxTraceThreadsPerBlock);
 
         // One block per output element. output_size can exceed dim3::x's 32-bit
         // range, so it is spread across grid.x and grid.y instead of being passed
         // directly as the <<<...>>> launch's first argument (which would
         // implicitly narrow to dim3 and silently truncate to the low 32 bits).
+        // The final casts to unsigned int here are the actual CUDA API boundary
+        // (dim3's fields), not a signed/unsigned bookkeeping cast.
         cytnx_error_msg(output_size > kMaxGridDimX * kMaxGridDimY,
-                        "[internal][cuTrace] output_size=%llu exceeds the maximum grid size "
-                        "(%llu) this launch can address.\n",
-                        static_cast<unsigned long long>(output_size),
-                        static_cast<unsigned long long>(kMaxGridDimX * kMaxGridDimY));
+                        "[internal][cuTrace] output_size=%lld exceeds the maximum grid size "
+                        "(%lld) this launch can address.\n",
+                        static_cast<long long>(output_size),
+                        static_cast<long long>(kMaxGridDimX * kMaxGridDimY));
         const dim3 grid_dim(
           static_cast<unsigned int>(std::min(output_size, kMaxGridDimX)),
           static_cast<unsigned int>((output_size + kMaxGridDimX - 1) / kMaxGridDimX));
-        TraceKernel<CudaT><<<grid_dim, threads_per_block>>>(
+        // 0 below is the dynamic shared-memory size in bytes (the kernel uses
+        // none; its __shared__ warp_sums array is statically sized).
+        TraceKernel<CudaT><<<grid_dim, threads_per_block, /* shared_mem_bytes */ 0, stream>>>(
           reinterpret_cast<CudaT *>(output_storage.data()),
           reinterpret_cast<const CudaT *>(Tn.storage().data()), device_surviving_shape,
           device_surviving_input_stride, surviving_rank, output_size, diagonal_length,
@@ -269,10 +292,10 @@ namespace cytnx {
           // stops being true.
           cudaEvent_t kernel_done;
           checkCudaErrors(cudaEventCreate(&kernel_done));
-          checkCudaErrors(cudaEventRecord(kernel_done, 0));
+          checkCudaErrors(cudaEventRecord(kernel_done, stream));
           checkCudaErrors(cudaEventSynchronize(kernel_done));
-          checkCudaErrors(cudaFreeAsync(device_surviving_shape, 0));
-          checkCudaErrors(cudaFreeAsync(device_surviving_input_stride, 0));
+          checkCudaErrors(cudaFreeAsync(device_surviving_shape, stream));
+          checkCudaErrors(cudaFreeAsync(device_surviving_input_stride, stream));
           checkCudaErrors(cudaEventDestroy(kernel_done));
         }
 

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -2,6 +2,7 @@
 #include "cytnx_error.hpp"
 #include "Tensor.hpp"
 #include "backend/Storage.hpp"
+#include "backend/utils_internal_gpu/cuFill_gpu.hpp"
 
 #include <algorithm>
 #include <limits>
@@ -51,25 +52,6 @@ namespace cytnx {
                         static_cast<unsigned long long>(value));
         return static_cast<cytnx_int64>(value);
       }
-
-      // Maps a cytnx storage type to the device arithmetic type used inside the
-      // kernels. Complex storage is bit-compatible with cuda::std::complex, which
-      // provides device operator+ / construction-from-zero, so the kernels stay
-      // type-generic.
-      template <class T>
-      struct TraceCudaType {
-        using type = T;
-      };
-      template <>
-      struct TraceCudaType<cytnx_complex128> {
-        using type = cuda::std::complex<double>;
-      };
-      template <>
-      struct TraceCudaType<cytnx_complex64> {
-        using type = cuda::std::complex<float>;
-      };
-      template <class T>
-      using TraceCudaTypeT = typename TraceCudaType<T>::type;
 
       // value + (the value `reduction_stride` lanes higher in the warp). For real
       // types this is a single __shfl_down_sync; complex storage is shuffled
@@ -173,7 +155,7 @@ namespace cytnx {
 
       template <class T>
       Tensor TraceImplGpu(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {
-        using CudaT = TraceCudaTypeT<T>;
+        using CudaT = typename utils_internal::ToCudaDType<T>::type;
         // Trace() validates upstream that ax1 != ax2 and shape[ax1] == shape[ax2],
         // so their order is irrelevant: the diagonal stride and the set of
         // surviving axes are symmetric in (ax1, ax2).

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -5,6 +5,7 @@
 #include "backend/utils_internal_gpu/cuTypeTraits_gpu.hpp"
 
 #include <algorithm>
+#include <iterator>
 #include <limits>
 #include <vector>
 
@@ -40,23 +41,28 @@ namespace cytnx {
       constexpr cytnx_int64 kMaxGridDimX = 2147483647LL;
       constexpr cytnx_int64 kMaxGridDimY = 65535LL;
 
-      // Cap on the surviving (non-traced) rank TraceKernel handles via its
-      // stack-resident TraceLayout. Every surviving axis has extent >= 2 (a
-      // size-1 axis contributes nothing to a diagonal decode and would be
-      // squeezed away, not kept as a surviving axis), so a tensor with
-      // surviving_rank axes plus the two traced axes has at least
-      // 2^(surviving_rank + 2) elements. x86-64 addresses at most 2^52 bytes,
-      // so even a 1-byte-per-element dtype caps surviving_rank at 50 on any
-      // physically constructible machine -- there is no dtype/hardware
-      // combination that can reach 51. 50 costs nothing extra against CUDA's
-      // per-launch parameter/constant-memory budget, so there is no reason to
-      // size this any tighter, and no fallback path is needed: the case this
-      // constant would guard against cannot occur.
+      // Cap on the number of surviving (non-traced) axes with extent > 1 that
+      // TraceKernel handles via its stack-resident TraceLayout. Axes with
+      // extent 1 are not counted here and are never stored in TraceLayout at
+      // all (see TraceImplGpu) -- a size-1 axis's decode step is always a
+      // no-op, so it can be dropped from the layout without affecting any
+      // other axis's computed offset, and a tensor can carry an unbounded
+      // number of them regardless of this cap. For the axes that ARE counted
+      // (extent >= 2 each), a tensor with that many of them plus the two
+      // traced axes has at least 2^(non_trivial_rank + 2) elements. x86-64
+      // addresses at most 2^52 bytes, so even a 1-byte-per-element dtype caps
+      // non_trivial_rank at 50 on any physically constructible machine --
+      // there is no dtype/hardware combination that can reach 51. 50 costs
+      // nothing extra against CUDA's per-launch parameter/constant-memory
+      // budget, so there is no reason to size this any tighter.
       constexpr cytnx_int64 kMaxTraceRank = 50;
 
-      // Surviving-axis shape/stride, sized to kMaxTraceRank so it can be
-      // passed to TraceKernel by value as a __grid_constant__ parameter
-      // instead of two separate device allocations.
+      // Non-trivial (extent > 1) surviving-axis shape/stride, sized to
+      // kMaxTraceRank so it can be passed to TraceKernel by value as a
+      // __grid_constant__ parameter instead of two separate device
+      // allocations. rank here is the count of non-trivial axes, which can be
+      // smaller than the tensor's actual surviving rank if any surviving axis
+      // has extent 1 (see TraceImplGpu).
       struct TraceLayout {
         cytnx_int64 rank;
         cytnx_int64 shape[kMaxTraceRank];
@@ -93,24 +99,31 @@ namespace cytnx {
           value.imag() + __shfl_down_sync(0xffffffff, value.imag(), reduction_stride));
       }
 
-      // Decodes a flat output index into the input storage offset of that output
-      // element's diagonal start: walk the surviving axes, accumulating
+      // Decodes a flat output index into the input storage offset of that
+      // output element's diagonal start: walk the given axes, accumulating
       // (index_along_axis * input_stride_of_axis). For a rank-2 trace
-      // (surviving_rank == 0) the loop is empty and the offset is 0.
+      // (axis_count == 0) the loop is empty and the offset is 0.
+      //
+      // axis_count may be smaller than the tensor's actual surviving rank:
+      // TraceImplGpu omits surviving axes of extent 1 from these arrays
+      // entirely, since such an axis's step here is always a no-op
+      // (remaining_flat_index % 1 == 0, /= 1 leaves it unchanged, and its
+      // stride contributes * 0) -- skipping it changes nothing about the
+      // offsets this computes for the remaining axes.
       //
       // Every index/extent here is a single signed type (cytnx_int64), mirroring
       // the CPU TraceImpl (Trace_internal.cpp) so this arithmetic needs no casts
       // between calls.
       __device__ cytnx_int64 DecodeDiagonalStartOffset(cytnx_int64 output_index,
-                                                       const cytnx_int64 *surviving_shape,
-                                                       const cytnx_int64 *surviving_input_stride,
-                                                       cytnx_int64 surviving_rank) {
+                                                       const cytnx_int64 *axis_shape,
+                                                       const cytnx_int64 *axis_input_stride,
+                                                       cytnx_int64 axis_count) {
         cytnx_int64 remaining_flat_index = output_index;
         cytnx_int64 diagonal_start_offset = 0;
-        for (cytnx_int64 axis = surviving_rank; axis-- > 0;) {
+        for (cytnx_int64 axis = axis_count; axis-- > 0;) {
           diagonal_start_offset +=
-            (remaining_flat_index % surviving_shape[axis]) * surviving_input_stride[axis];
-          remaining_flat_index /= surviving_shape[axis];
+            (remaining_flat_index % axis_shape[axis]) * axis_input_stride[axis];
+          remaining_flat_index /= axis_shape[axis];
         }
         return diagonal_start_offset;
       }
@@ -167,15 +180,15 @@ namespace cytnx {
       // block; many short-diagonal outputs launch many small blocks running
       // concurrently across SMs.
       //
-      // The surviving-axis layout is a small fixed-size struct (TraceLayout)
-      // passed by value as a __grid_constant__ parameter rather than two
-      // device pointers, so a trace call needs no cudaMalloc/cudaMemcpy/
-      // cudaFree at all -- kMaxTraceRank comfortably covers every surviving
-      // rank reachable on any physically constructible machine (see its
-      // definition above), so there is no larger-rank fallback to dispatch
-      // to. __grid_constant__ places the parameter in read-only per-grid
-      // constant memory rather than copying it into every thread's local
-      // memory.
+      // The non-trivial surviving-axis layout is a small fixed-size struct
+      // (TraceLayout) passed by value as a __grid_constant__ parameter rather
+      // than two device pointers, so a trace call needs no cudaMalloc/
+      // cudaMemcpy/cudaFree at all -- kMaxTraceRank comfortably covers every
+      // non-trivial surviving rank reachable on any physically constructible
+      // machine (see its definition above), so there is no larger-rank
+      // fallback to dispatch to. __grid_constant__ places the parameter in
+      // read-only per-grid constant memory rather than copying it into every
+      // thread's local memory.
       template <class T>
       __global__ void TraceKernel(T *output_data, const T *input_data,
                                   const __grid_constant__ TraceLayout layout,
@@ -226,35 +239,39 @@ namespace cytnx {
         const cytnx_int64 diagonal_stride = input_strides[ax1] + input_strides[ax2];
 
         // Build the reduced output shape (needed for Tensor::reshape_ on every
-        // path) and, in the same pass, write directly into a stack-resident
-        // TraceLayout wherever it still fits (idx < kMaxTraceRank) -- the
-        // common case needs no heap allocation or host->device copy at all
-        // for the surviving-axis layout; see the dispatch below.
+        // path, and covers every surviving axis regardless of extent -- a
+        // size-1 surviving axis is a legitimate part of the output shape, not
+        // droppable there). In the same pass, write only the *non-trivial*
+        // (extent > 1) surviving axes into a stack-resident TraceLayout: a
+        // size-1 axis's odometer step in DecodeDiagonalStartOffset is always
+        // (remaining_flat_index % 1 == 0, remaining_flat_index /= 1 == itself,
+        // stride * 0 == 0) -- a no-op -- so omitting it from the decode array
+        // entirely changes nothing about the offsets it computes for the
+        // other axes. This is what makes kMaxTraceRank's derivation (every
+        // axis counted there has extent >= 2) actually true of what's stored,
+        // rather than merely assumed of the input: a tensor can carry an
+        // unbounded number of size-1 surviving axes without ever touching
+        // TraceLayout's fixed capacity.
         TraceLayout layout;
         std::vector<cytnx_int64> output_shape;  // for Tensor::reshape_
-        cytnx_int64 idx = 0;
+        cytnx_int64 non_trivial_rank = 0;
         for (cytnx_uint64 axis = 0; axis < input_shape.size(); ++axis) {
           if (axis != ax1 && axis != ax2) {
             const cytnx_int64 dim = CheckedCastToInt64Gpu(input_shape[axis], "input_shape[axis]");
             output_shape.push_back(dim);
-            if (idx < kMaxTraceRank) {
-              layout.shape[idx] = dim;
-              layout.stride[idx] = input_strides[axis];
+            if (dim > 1) {
+              cytnx_error_msg(non_trivial_rank >= kMaxTraceRank,
+                              "[internal][cuTrace] more than %lld surviving axes with extent > 1; "
+                              "exceeds kMaxTraceRank.\n",
+                              static_cast<long long>(kMaxTraceRank));
+              layout.shape[non_trivial_rank] = dim;
+              layout.stride[non_trivial_rank] = input_strides[axis];
+              ++non_trivial_rank;
             }
-            ++idx;
           }
         }
-        const cytnx_int64 surviving_rank = idx;
-        // Defensive, not a supported case: kMaxTraceRank's derivation above
-        // shows no physically constructible tensor can reach this. If it were
-        // ever hit anyway, layout.shape/stride beyond kMaxTraceRank weren't
-        // populated by the loop above, so proceeding would read uninitialized
-        // stack memory on the device.
-        cytnx_error_msg(surviving_rank > kMaxTraceRank,
-                        "[internal][cuTrace] surviving_rank=%lld exceeds kMaxTraceRank (%lld).\n",
-                        static_cast<long long>(surviving_rank),
-                        static_cast<long long>(kMaxTraceRank));
-        layout.rank = surviving_rank;
+        const cytnx_int64 surviving_rank = std::ssize(output_shape);
+        layout.rank = non_trivial_rank;
         cytnx_int64 output_size = 1;
         for (cytnx_int64 dim : output_shape) output_size *= dim;
         const bool output_is_scalar = surviving_rank == 0;

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -4,6 +4,7 @@
 #include "backend/Storage.hpp"
 
 #include <algorithm>
+#include <limits>
 #include <vector>
 
 #include "cuda/std/complex"
@@ -37,6 +38,19 @@ namespace cytnx {
       // TraceImplGpu below.
       constexpr cytnx_uint64 kMaxGridDimX = 2147483647ULL;
       constexpr cytnx_uint64 kMaxGridDimY = 65535ULL;
+
+      // Narrows a shape/stride extent (mathematically non-negative, stored as
+      // cytnx_uint64) to cytnx_int64, rejecting values that would overflow.
+      // internal::CheckedCastToInt64 (utils/checked_cast.hpp) does the same
+      // check on the CPU path, but its std::source_location::current() default
+      // argument does not compile under nvcc's host-code frontend, so the GPU
+      // path checks inline instead.
+      cytnx_int64 CheckedCastToInt64Gpu(cytnx_uint64 value, const char *name) {
+        cytnx_error_msg(value > static_cast<cytnx_uint64>(std::numeric_limits<cytnx_int64>::max()),
+                        "[internal][cuTrace] %s=%llu exceeds cytnx_int64 max.\n", name,
+                        static_cast<unsigned long long>(value));
+        return static_cast<cytnx_int64>(value);
+      }
 
       // Maps a cytnx storage type to the device arithmetic type used inside the
       // kernels. Complex storage is bit-compatible with cuda::std::complex, which
@@ -177,7 +191,7 @@ namespace cytnx {
         std::vector<cytnx_uint64> host_surviving_input_stride;
         for (cytnx_uint64 axis = 0; axis < input_shape.size(); ++axis) {
           if (axis != ax1 && axis != ax2) {
-            output_shape.push_back(static_cast<cytnx_int64>(input_shape[axis]));
+            output_shape.push_back(CheckedCastToInt64Gpu(input_shape[axis], "input_shape[axis]"));
             host_surviving_shape.push_back(input_shape[axis]);
             host_surviving_input_stride.push_back(static_cast<cytnx_uint64>(input_strides[axis]));
           }

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <limits>
-#include <thread>
 #include <vector>
 
 #include "cuda/std/complex"
@@ -255,24 +254,11 @@ namespace cytnx {
         checkCudaErrors(cudaGetLastError());
 
         if (surviving_rank > 0) {
-          // A direct cudaFree here would synchronize the whole device, stalling
-          // the host on every trace call. Instead, record an event right after
-          // the launch and hand the wait-then-free off to a detached background
-          // thread, so this call returns as soon as the kernel is queued.
-          //
-          // This must be a detached std::thread, not std::async: a std::future
-          // returned by std::async blocks in its own destructor until the task
-          // completes, so an unstored std::async result would reintroduce the
-          // same stall synchronously at the end of this expression.
-          cudaEvent_t free_ready;
-          checkCudaErrors(cudaEventCreate(&free_ready));
-          checkCudaErrors(cudaEventRecord(free_ready, 0));
-          std::thread([device_surviving_shape, device_surviving_input_stride, free_ready]() {
-            checkCudaErrors(cudaEventSynchronize(free_ready));
-            checkCudaErrors(cudaFree(device_surviving_shape));
-            checkCudaErrors(cudaFree(device_surviving_input_stride));
-            checkCudaErrors(cudaEventDestroy(free_ready));
-          }).detach();
+          // cudaFree synchronizes the device, but that wait is already bounded
+          // by the TraceKernel launch above on this same in-order stream, so it
+          // adds no additional stall beyond the kernel's own completion.
+          checkCudaErrors(cudaFree(device_surviving_shape));
+          checkCudaErrors(cudaFree(device_surviving_input_stride));
         }
 
         return ComposeTraceOutput(output_storage, output_shape, output_is_scalar);

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -1,76 +1,210 @@
 #include "cuTrace_internal.hpp"
 #include "cytnx_error.hpp"
-#include "backend/lapack_wrapper.hpp"
-#include "utils/cucomplex_arithmetic.hpp"
+#include "Tensor.hpp"
+#include "backend/Storage.hpp"
 
-#include "Generator.hpp"
-#include "utils/utils.hpp"
-
-#include "UniTensor.hpp"
+#include <algorithm>
 #include <vector>
+
+#include "cuda/std/complex"
 
 namespace cytnx {
   namespace linalg_internal {
     namespace {
 
+      constexpr int kTraceThreadsPerBlock = 512;
+      // The single-block tree reduction below halves the active thread count each
+      // step, which only covers every element when the block size is a power of two.
+      static_assert((kTraceThreadsPerBlock & (kTraceThreadsPerBlock - 1)) == 0,
+                    "kTraceThreadsPerBlock must be a power of two for the tree reduction.");
+
+      // Maps a cytnx storage type to the device arithmetic type used inside the
+      // kernels. Complex storage is bit-compatible with cuda::std::complex, which
+      // provides device operator+ / construction-from-zero, so the kernels stay
+      // type-generic.
       template <class T>
-      Tensor _trace_2d_gpu(const Tensor &Tn, cytnx_uint64 Ndiag) {
-        cytnx::UniTensor I_UT = cytnx::UniTensor::eye(Ndiag, {}, true, Tn.dtype(), Tn.device());
-        UniTensor UTn = UniTensor(Tn, false, 2);
-        I_UT.relabel_({UTn._impl->_labels[0], UTn._impl->_labels[1]});
-        return Contract(I_UT, UTn).get_block_();
+      struct TraceCudaType {
+        using type = T;
+      };
+      template <>
+      struct TraceCudaType<cytnx_complex128> {
+        using type = cuda::std::complex<double>;
+      };
+      template <>
+      struct TraceCudaType<cytnx_complex64> {
+        using type = cuda::std::complex<float>;
+      };
+      template <class T>
+      using TraceCudaTypeT = typename TraceCudaType<T>::type;
+
+      // Sums one diagonal: every thread strides over the diagonal_length entries
+      // starting at diagonal_start_offset (step diagonal_stride), then a
+      // shared-memory tree reduction combines the per-thread partials into the
+      // single *output_element. This is the whole computation for a rank-2 trace
+      // (one diagonal -> one scalar); the trace of higher-rank inputs runs one
+      // block per output element and calls this with that element's offset.
+      template <class T>
+      __device__ void TraceDiagonalBlock(T *output_element, const T *input_data,
+                                         cytnx_uint64 diagonal_start_offset,
+                                         cytnx_uint64 diagonal_length,
+                                         cytnx_uint64 diagonal_stride) {
+        __shared__ T block_partial_sums[kTraceThreadsPerBlock];
+        T thread_partial_sum = T(0);
+        for (cytnx_uint64 i = threadIdx.x; i < diagonal_length; i += blockDim.x)
+          thread_partial_sum += input_data[diagonal_start_offset + i * diagonal_stride];
+        block_partial_sums[threadIdx.x] = thread_partial_sum;
+        __syncthreads();
+
+        for (unsigned int reduction_stride = blockDim.x >> 1; reduction_stride > 0;
+             reduction_stride >>= 1) {
+          if (threadIdx.x < reduction_stride)
+            block_partial_sums[threadIdx.x] += block_partial_sums[threadIdx.x + reduction_stride];
+          __syncthreads();
+        }
+
+        if (threadIdx.x == 0) *output_element = block_partial_sums[0];
+      }
+
+      // One block per output element. The block decodes its flat index into the
+      // surviving-axis multi-index, accumulating the input base offset from
+      // surviving_input_stride (the input stride of each surviving axis), then
+      // sums that element's diagonal via TraceDiagonalBlock. A rank-2 trace is
+      // the special case surviving_rank == 0 / output_size == 1: the decode loop
+      // is empty and the diagonal starts at offset 0, so the single block traces
+      // the whole matrix diagonal.
+      template <class T>
+      __global__ void TraceKernel(T *output_data, const T *input_data,
+                                  const cytnx_uint64 *surviving_shape,
+                                  const cytnx_uint64 *surviving_input_stride,
+                                  cytnx_uint64 surviving_rank, cytnx_uint64 output_size,
+                                  cytnx_uint64 diagonal_length, cytnx_uint64 diagonal_stride) {
+        cytnx_uint64 output_index = blockIdx.x;
+        if (output_index >= output_size) return;
+
+        cytnx_uint64 remaining_flat_index = output_index;
+        cytnx_uint64 diagonal_start_offset = 0;
+        for (cytnx_uint64 axis = surviving_rank; axis-- > 0;) {
+          diagonal_start_offset +=
+            (remaining_flat_index % surviving_shape[axis]) * surviving_input_stride[axis];
+          remaining_flat_index /= surviving_shape[axis];
+        }
+        TraceDiagonalBlock<T>(&output_data[output_index], input_data, diagonal_start_offset,
+                              diagonal_length, diagonal_stride);
       }
 
       template <class T>
-      Tensor _trace_nd_gpu(const Tensor &Tn, cytnx_uint64 Ndiag, cytnx_uint64 ax1,
-                           cytnx_uint64 ax2) {
-        cytnx::UniTensor I_UT = cytnx::UniTensor::eye(Ndiag, {}, true, Tn.dtype(), Tn.device());
-        UniTensor UTn = UniTensor(Tn, false, 2);
-        I_UT.relabel_({UTn._impl->_labels[ax1], UTn._impl->_labels[ax2]});
-        return Contract(I_UT, UTn).get_block_();
-      }
+      Tensor TraceImplGpu(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {
+        using CudaT = TraceCudaTypeT<T>;
+        // Trace() validates upstream that ax1 != ax2 and shape[ax1] == shape[ax2],
+        // so their order is irrelevant: the diagonal stride and the set of
+        // surviving axes are symmetric in (ax1, ax2).
+        const auto &input_shape = Tn.shape();
+        const std::vector<cytnx_int64> input_strides = Tn.strides();
+        const cytnx_uint64 diagonal_length = input_shape[ax1];
+        const cytnx_uint64 diagonal_stride =
+          static_cast<cytnx_uint64>(input_strides[ax1] + input_strides[ax2]);
 
-      // Dispatches to the rank-2 or rank-N helper. The two helpers existed before
-      // the dispatcher API was simplified to (Tn, ax1, ax2); this trampoline
-      // derives is_2d / Ndiag from the input so callers do not have to.
-      template <class T>
-      Tensor TraceDispatchGpu(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {
-        const cytnx_uint64 Ndiag = Tn.shape()[ax1];
-        if (Tn.shape().size() == 2) return _trace_2d_gpu<T>(Tn, Ndiag);
-        return _trace_nd_gpu<T>(Tn, Ndiag, ax1, ax2);
+        // Build the reduced output shape and the matching per-surviving-axis input
+        // strides in a single pass over the surviving axes (no separate surviving-
+        // axis index list).
+        std::vector<cytnx_int64> output_shape;  // for Tensor::reshape_
+        std::vector<cytnx_uint64> host_surviving_shape;  // same dims, device-bound
+        std::vector<cytnx_uint64> host_surviving_input_stride;
+        for (cytnx_uint64 axis = 0; axis < input_shape.size(); ++axis) {
+          if (axis != ax1 && axis != ax2) {
+            output_shape.push_back(static_cast<cytnx_int64>(input_shape[axis]));
+            host_surviving_shape.push_back(input_shape[axis]);
+            host_surviving_input_stride.push_back(static_cast<cytnx_uint64>(input_strides[axis]));
+          }
+        }
+        const cytnx_uint64 surviving_rank = host_surviving_shape.size();
+        cytnx_uint64 output_size = 1;
+        for (auto dim : host_surviving_shape) output_size *= dim;
+        const bool output_is_scalar = surviving_rank == 0;
+
+        // Fill a device-resident result Storage, then compose the output Tensor
+        // from it; Tensor::from_storage keeps the storage on its current device, so
+        // no host round-trip is involved.
+        Storage output_storage(output_is_scalar ? cytnx_uint64{1} : output_size, Tn.dtype(),
+                               Tn.device());
+        if (diagonal_length == 0 || output_size == 0) {
+          output_storage.set_zeros();
+          Tensor out = Tensor::from_storage(output_storage);
+          if (!output_is_scalar) out.reshape_(output_shape);
+          return out;
+        }
+
+        // Ship the two surviving_rank-sized layout arrays the multi-index decode
+        // needs; the rank-2 case (surviving_rank == 0) needs neither, so the
+        // kernel reads nullptr only where the decode loop never runs.
+        cytnx_uint64 *device_surviving_shape = nullptr;
+        cytnx_uint64 *device_surviving_input_stride = nullptr;
+        if (surviving_rank > 0) {
+          checkCudaErrors(
+            cudaMalloc((void **)&device_surviving_shape, sizeof(cytnx_uint64) * surviving_rank));
+          checkCudaErrors(cudaMalloc((void **)&device_surviving_input_stride,
+                                     sizeof(cytnx_uint64) * surviving_rank));
+          checkCudaErrors(cudaMemcpy(device_surviving_shape, host_surviving_shape.data(),
+                                     sizeof(cytnx_uint64) * surviving_rank,
+                                     cudaMemcpyHostToDevice));
+          checkCudaErrors(
+            cudaMemcpy(device_surviving_input_stride, host_surviving_input_stride.data(),
+                       sizeof(cytnx_uint64) * surviving_rank, cudaMemcpyHostToDevice));
+        }
+
+        // One block per output element (output_size == 1 for the rank-2 case).
+        TraceKernel<CudaT><<<output_size, kTraceThreadsPerBlock>>>(
+          reinterpret_cast<CudaT *>(output_storage.data()),
+          reinterpret_cast<const CudaT *>(Tn.storage().data()), device_surviving_shape,
+          device_surviving_input_stride, surviving_rank, output_size, diagonal_length,
+          diagonal_stride);
+        // Surface a launch/configuration failure at the trace call rather than at
+        // the next, unrelated CUDA call.
+        checkCudaErrors(cudaGetLastError());
+
+        if (surviving_rank > 0) {
+          // cudaFree synchronizes the device, so the kernel is guaranteed complete
+          // (and its reads of the layout arrays done) before the buffers are freed.
+          checkCudaErrors(cudaFree(device_surviving_shape));
+          checkCudaErrors(cudaFree(device_surviving_input_stride));
+        }
+
+        Tensor out = Tensor::from_storage(output_storage);
+        if (!output_is_scalar) out.reshape_(output_shape);
+        return out;
       }
 
     }  // namespace
 
     Tensor cuTrace_internal_cd(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {
-      return TraceDispatchGpu<cytnx_complex128>(Tn, ax1, ax2);
+      return TraceImplGpu<cytnx_complex128>(Tn, ax1, ax2);
     }
     Tensor cuTrace_internal_cf(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {
-      return TraceDispatchGpu<cytnx_complex64>(Tn, ax1, ax2);
+      return TraceImplGpu<cytnx_complex64>(Tn, ax1, ax2);
     }
     Tensor cuTrace_internal_d(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {
-      return TraceDispatchGpu<cytnx_double>(Tn, ax1, ax2);
+      return TraceImplGpu<cytnx_double>(Tn, ax1, ax2);
     }
     Tensor cuTrace_internal_f(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {
-      return TraceDispatchGpu<cytnx_float>(Tn, ax1, ax2);
+      return TraceImplGpu<cytnx_float>(Tn, ax1, ax2);
     }
     Tensor cuTrace_internal_u64(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {
-      return TraceDispatchGpu<cytnx_uint64>(Tn, ax1, ax2);
+      return TraceImplGpu<cytnx_uint64>(Tn, ax1, ax2);
     }
     Tensor cuTrace_internal_i64(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {
-      return TraceDispatchGpu<cytnx_int64>(Tn, ax1, ax2);
+      return TraceImplGpu<cytnx_int64>(Tn, ax1, ax2);
     }
     Tensor cuTrace_internal_u32(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {
-      return TraceDispatchGpu<cytnx_uint32>(Tn, ax1, ax2);
+      return TraceImplGpu<cytnx_uint32>(Tn, ax1, ax2);
     }
     Tensor cuTrace_internal_i32(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {
-      return TraceDispatchGpu<cytnx_int32>(Tn, ax1, ax2);
+      return TraceImplGpu<cytnx_int32>(Tn, ax1, ax2);
     }
     Tensor cuTrace_internal_u16(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {
-      return TraceDispatchGpu<cytnx_uint16>(Tn, ax1, ax2);
+      return TraceImplGpu<cytnx_uint16>(Tn, ax1, ax2);
     }
     Tensor cuTrace_internal_i16(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {
-      return TraceDispatchGpu<cytnx_int16>(Tn, ax1, ax2);
+      return TraceImplGpu<cytnx_int16>(Tn, ax1, ax2);
     }
 
     Tensor cuTrace_internal_b(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -252,6 +252,12 @@ namespace cytnx {
         // rather than merely assumed of the input: a tensor can carry an
         // unbounded number of size-1 surviving axes without ever touching
         // TraceLayout's fixed capacity.
+        //
+        // non_trivial_rank can exceed kMaxTraceRank here without harm: writes
+        // into layout.shape/stride simply stop once the fixed arrays are
+        // full. Whether that matters at all depends on output_size, which
+        // isn't known until after this loop -- see the kMaxTraceRank check
+        // below, deliberately placed after the zero-extent early return.
         TraceLayout layout;
         std::vector<cytnx_int64> output_shape;  // for Tensor::reshape_
         cytnx_int64 non_trivial_rank = 0;
@@ -260,18 +266,15 @@ namespace cytnx {
             const cytnx_int64 dim = CheckedCastToInt64Gpu(input_shape[axis], "input_shape[axis]");
             output_shape.push_back(dim);
             if (dim > 1) {
-              cytnx_error_msg(non_trivial_rank >= kMaxTraceRank,
-                              "[internal][cuTrace] more than %lld surviving axes with extent > 1; "
-                              "exceeds kMaxTraceRank.\n",
-                              static_cast<long long>(kMaxTraceRank));
-              layout.shape[non_trivial_rank] = dim;
-              layout.stride[non_trivial_rank] = input_strides[axis];
+              if (non_trivial_rank < kMaxTraceRank) {
+                layout.shape[non_trivial_rank] = dim;
+                layout.stride[non_trivial_rank] = input_strides[axis];
+              }
               ++non_trivial_rank;
             }
           }
         }
         const cytnx_int64 surviving_rank = std::ssize(output_shape);
-        layout.rank = non_trivial_rank;
         cytnx_int64 output_size = 1;
         for (cytnx_int64 dim : output_shape) output_size *= dim;
         const bool output_is_scalar = surviving_rank == 0;
@@ -281,9 +284,22 @@ namespace cytnx {
           output_is_scalar ? cytnx_uint64{1} : static_cast<cytnx_uint64>(output_size), Tn.dtype(),
           Tn.device());
         if (diagonal_length == 0 || output_size == 0) {
+          // No kernel launch on this path, so TraceLayout's capacity is
+          // irrelevant here -- a surviving axis of extent 0 makes output_size
+          // 0 regardless of how many other (possibly non-trivial) surviving
+          // axes exist, and this must match the CPU path's empty-tensor
+          // result rather than reject on non_trivial_rank alone.
           output_storage.set_zeros();
           return ComposeTraceOutput(output_storage, output_shape, output_is_scalar);
         }
+
+        // Only reachable with a real kernel launch ahead, so this is the
+        // first point non_trivial_rank actually needs to fit TraceLayout.
+        cytnx_error_msg(non_trivial_rank > kMaxTraceRank,
+                        "[internal][cuTrace] more than %lld surviving axes with extent > 1; "
+                        "exceeds kMaxTraceRank.\n",
+                        static_cast<long long>(kMaxTraceRank));
+        layout.rank = non_trivial_rank;
 
         // Size each block to its diagonal: diagonal_length is known here, so the
         // block gets just enough threads to cover it (rounded up to a whole warp,

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <thread>
 #include <vector>
 
 #include "cuda/std/complex"
@@ -254,10 +255,24 @@ namespace cytnx {
         checkCudaErrors(cudaGetLastError());
 
         if (surviving_rank > 0) {
-          // cudaFree synchronizes the device, so the kernel is guaranteed complete
-          // (and its reads of the layout arrays done) before the buffers are freed.
-          checkCudaErrors(cudaFree(device_surviving_shape));
-          checkCudaErrors(cudaFree(device_surviving_input_stride));
+          // A direct cudaFree here would synchronize the whole device, stalling
+          // the host on every trace call. Instead, record an event right after
+          // the launch and hand the wait-then-free off to a detached background
+          // thread, so this call returns as soon as the kernel is queued.
+          //
+          // This must be a detached std::thread, not std::async: a std::future
+          // returned by std::async blocks in its own destructor until the task
+          // completes, so an unstored std::async result would reintroduce the
+          // same stall synchronously at the end of this expression.
+          cudaEvent_t free_ready;
+          checkCudaErrors(cudaEventCreate(&free_ready));
+          checkCudaErrors(cudaEventRecord(free_ready, 0));
+          std::thread([device_surviving_shape, device_surviving_input_stride, free_ready]() {
+            checkCudaErrors(cudaEventSynchronize(free_ready));
+            checkCudaErrors(cudaFree(device_surviving_shape));
+            checkCudaErrors(cudaFree(device_surviving_input_stride));
+            checkCudaErrors(cudaEventDestroy(free_ready));
+          }).detach();
         }
 
         return ComposeTraceOutput(output_storage, output_shape, output_is_scalar);

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -41,6 +41,25 @@ namespace cytnx {
       constexpr cytnx_int64 kMaxGridDimX = 2147483647LL;
       constexpr cytnx_int64 kMaxGridDimY = 65535LL;
 
+      // Cap on the surviving (non-traced) rank the fast, allocation-free
+      // kernel path below handles. 32 mirrors NumPy's historical NPY_MAXDIMS:
+      // generous relative to real tensor-network tensors (MPS/MPO rank 2-4,
+      // PEPS rank 4-6, MERA/TTN rank 3-4; even unusually complex ncon
+      // intermediates rarely exceed ~15 legs before their element count is
+      // infeasible regardless of Trace), while costing nothing extra against
+      // CUDA's per-launch parameter/constant-memory budget. Ranks above this
+      // fall back to the heap-allocated path (see TraceImplGpu).
+      constexpr cytnx_int64 kMaxTraceRank = 32;
+
+      // Surviving-axis shape/stride, sized to kMaxTraceRank so it can be
+      // passed to TraceKernelFast by value as a __grid_constant__ parameter
+      // instead of two separate device allocations.
+      struct TraceLayout {
+        cytnx_int64 rank;
+        cytnx_int64 shape[kMaxTraceRank];
+        cytnx_int64 stride[kMaxTraceRank];
+      };
+
       // Narrows a shape/stride extent (mathematically non-negative, stored as
       // cytnx_uint64) to cytnx_int64, rejecting values that would overflow.
       // internal::CheckedCastToInt64 (utils/checked_cast.hpp) does the same
@@ -162,6 +181,29 @@ namespace cytnx {
         if (threadIdx.x == 0) output_data[output_index] = sum;
       }
 
+      // Same per-output decode and block reduction as TraceKernel, but the
+      // surviving-axis layout is a small fixed-size struct passed by value as
+      // a __grid_constant__ parameter instead of two device pointers -- no
+      // cudaMalloc/cudaMemcpy/cudaFree needed for surviving_rank <=
+      // kMaxTraceRank (the common case; see the dispatch in TraceImplGpu).
+      // __grid_constant__ places the parameter in read-only per-grid constant
+      // memory rather than copying it into every thread's local memory.
+      template <class T>
+      __global__ void TraceKernelFast(T *output_data, const T *input_data,
+                                      const __grid_constant__ TraceLayout layout,
+                                      cytnx_int64 output_size, cytnx_int64 diagonal_length,
+                                      cytnx_int64 diagonal_stride) {
+        const cytnx_int64 output_index =
+          static_cast<cytnx_int64>(blockIdx.y) * gridDim.x + blockIdx.x;
+        if (output_index >= output_size) return;
+
+        const cytnx_int64 diagonal_start_offset =
+          DecodeDiagonalStartOffset(output_index, layout.shape, layout.stride, layout.rank);
+        T sum = BlockTraceDiagonal<T>(input_data, diagonal_start_offset, diagonal_length,
+                                      diagonal_stride);
+        if (threadIdx.x == 0) output_data[output_index] = sum;
+      }
+
       // Composes the output Tensor from its already-filled storage, reshaping to
       // output_shape unless the trace is a rank-2 scalar. Tensor::from_storage
       // keeps the storage on its current device, so no host round-trip is
@@ -196,20 +238,27 @@ namespace cytnx {
           CheckedCastToInt64Gpu(input_shape[ax1], "input_shape[ax1]");
         const cytnx_int64 diagonal_stride = input_strides[ax1] + input_strides[ax2];
 
-        // Build the reduced output shape and the matching per-surviving-axis input
-        // strides in a single pass over the surviving axes (no separate surviving-
-        // axis index list). output_shape doubles as the surviving-axis extent
-        // array shipped to the device below -- it already holds exactly those
-        // values, so there is no separate host_surviving_shape.
-        std::vector<cytnx_int64> output_shape;  // for Tensor::reshape_ and device upload
-        std::vector<cytnx_int64> surviving_input_stride;
+        // Build the reduced output shape (needed for Tensor::reshape_ on every
+        // path) and, in the same pass, write directly into a stack-resident
+        // TraceLayout wherever it still fits (idx < kMaxTraceRank) -- the
+        // common case needs no heap allocation or host->device copy at all
+        // for the surviving-axis layout; see the dispatch below.
+        TraceLayout layout;
+        std::vector<cytnx_int64> output_shape;  // for Tensor::reshape_
+        cytnx_int64 idx = 0;
         for (cytnx_uint64 axis = 0; axis < input_shape.size(); ++axis) {
           if (axis != ax1 && axis != ax2) {
-            output_shape.push_back(CheckedCastToInt64Gpu(input_shape[axis], "input_shape[axis]"));
-            surviving_input_stride.push_back(input_strides[axis]);
+            const cytnx_int64 dim = CheckedCastToInt64Gpu(input_shape[axis], "input_shape[axis]");
+            output_shape.push_back(dim);
+            if (idx < kMaxTraceRank) {
+              layout.shape[idx] = dim;
+              layout.stride[idx] = input_strides[axis];
+            }
+            ++idx;
           }
         }
-        const cytnx_int64 surviving_rank = std::ssize(surviving_input_stride);
+        const cytnx_int64 surviving_rank = idx;
+        layout.rank = surviving_rank;
         cytnx_int64 output_size = 1;
         for (cytnx_int64 dim : output_shape) output_size *= dim;
         const bool output_is_scalar = surviving_rank == 0;
@@ -221,28 +270,6 @@ namespace cytnx {
         if (diagonal_length == 0 || output_size == 0) {
           output_storage.set_zeros();
           return ComposeTraceOutput(output_storage, output_shape, output_is_scalar);
-        }
-
-        // Ship the two surviving_rank-sized layout arrays the multi-index decode
-        // needs; the rank-2 case (surviving_rank == 0) needs neither, so the
-        // kernel reads nullptr only where the decode loop never runs.
-        //
-        // Allocated with cudaMallocAsync (stream-ordered) rather than cudaMalloc
-        // so they can be released with cudaFreeAsync below -- cudaFreeAsync only
-        // accepts pointers allocated by cudaMallocAsync/cudaMallocFromPoolAsync.
-        cytnx_int64 *device_surviving_shape = nullptr;
-        cytnx_int64 *device_surviving_input_stride = nullptr;
-        if (surviving_rank > 0) {
-          checkCudaErrors(cudaMallocAsync((void **)&device_surviving_shape,
-                                          sizeof(cytnx_int64) * surviving_rank, stream));
-          checkCudaErrors(cudaMallocAsync((void **)&device_surviving_input_stride,
-                                          sizeof(cytnx_int64) * surviving_rank, stream));
-          checkCudaErrors(cudaMemcpyAsync(device_surviving_shape, output_shape.data(),
-                                          sizeof(cytnx_int64) * surviving_rank,
-                                          cudaMemcpyHostToDevice, stream));
-          checkCudaErrors(
-            cudaMemcpyAsync(device_surviving_input_stride, surviving_input_stride.data(),
-                            sizeof(cytnx_int64) * surviving_rank, cudaMemcpyHostToDevice, stream));
         }
 
         // Size each block to its diagonal: diagonal_length is known here, so the
@@ -270,26 +297,68 @@ namespace cytnx {
         const dim3 grid_dim(
           static_cast<unsigned int>(std::min(output_size, kMaxGridDimX)),
           static_cast<unsigned int>((output_size + kMaxGridDimX - 1) / kMaxGridDimX));
-        // 0 below is the dynamic shared-memory size in bytes (the kernel uses
-        // none; its __shared__ warp_sums array is statically sized).
-        TraceKernel<CudaT><<<grid_dim, threads_per_block, /* shared_mem_bytes */ 0, stream>>>(
-          reinterpret_cast<CudaT *>(output_storage.data()),
-          reinterpret_cast<const CudaT *>(Tn.storage().data()), device_surviving_shape,
-          device_surviving_input_stride, surviving_rank, output_size, diagonal_length,
-          diagonal_stride);
-        // Surface a launch/configuration failure at the trace call rather than at
-        // the next, unrelated CUDA call.
-        checkCudaErrors(cudaGetLastError());
 
-        if (surviving_rank > 0) {
+        if (surviving_rank <= kMaxTraceRank) {
+          // layout is already fully populated above -- launch directly, no
+          // cudaMalloc/cudaMemcpy/cudaFree at all. 0 below is the dynamic
+          // shared-memory size in bytes (the kernel uses none; its __shared__
+          // warp_sums array is statically sized).
+          TraceKernelFast<CudaT><<<grid_dim, threads_per_block, /* shared_mem_bytes */ 0, stream>>>(
+            reinterpret_cast<CudaT *>(output_storage.data()),
+            reinterpret_cast<const CudaT *>(Tn.storage().data()), layout, output_size,
+            diagonal_length, diagonal_stride);
+          // Surface a launch/configuration failure at the trace call rather
+          // than at the next, unrelated CUDA call.
+          checkCudaErrors(cudaGetLastError());
+        } else {
+          // Rare (surviving_rank > kMaxTraceRank), but not free to be sloppy
+          // about: rebuild the full stride list as three contiguous
+          // range-copies around ax1/ax2 instead of a per-element branch,
+          // since this path is only reached when rank is large enough for
+          // that branch to actually cost something. output_shape already has
+          // every entry and is reused as-is for the device shape array.
+          const cytnx_uint64 lo = std::min(ax1, ax2);
+          const cytnx_uint64 hi = std::max(ax1, ax2);
+          std::vector<cytnx_int64> surviving_input_stride;
+          surviving_input_stride.reserve(surviving_rank);
+          std::copy(input_strides.begin(), input_strides.begin() + lo,
+                    std::back_inserter(surviving_input_stride));
+          std::copy(input_strides.begin() + lo + 1, input_strides.begin() + hi,
+                    std::back_inserter(surviving_input_stride));
+          std::copy(input_strides.begin() + hi + 1, input_strides.end(),
+                    std::back_inserter(surviving_input_stride));
+
+          // Ship the two surviving_rank-sized layout arrays the multi-index
+          // decode needs. Allocated with cudaMallocAsync (stream-ordered)
+          // rather than cudaMalloc so they can be released with cudaFreeAsync
+          // below -- cudaFreeAsync only accepts pointers allocated by
+          // cudaMallocAsync/cudaMallocFromPoolAsync.
+          cytnx_int64 *device_surviving_shape = nullptr;
+          cytnx_int64 *device_surviving_input_stride = nullptr;
+          checkCudaErrors(cudaMallocAsync((void **)&device_surviving_shape,
+                                          sizeof(cytnx_int64) * surviving_rank, stream));
+          checkCudaErrors(cudaMallocAsync((void **)&device_surviving_input_stride,
+                                          sizeof(cytnx_int64) * surviving_rank, stream));
+          checkCudaErrors(cudaMemcpyAsync(device_surviving_shape, output_shape.data(),
+                                          sizeof(cytnx_int64) * surviving_rank,
+                                          cudaMemcpyHostToDevice, stream));
+          checkCudaErrors(
+            cudaMemcpyAsync(device_surviving_input_stride, surviving_input_stride.data(),
+                            sizeof(cytnx_int64) * surviving_rank, cudaMemcpyHostToDevice, stream));
+
+          TraceKernel<CudaT><<<grid_dim, threads_per_block, /* shared_mem_bytes */ 0, stream>>>(
+            reinterpret_cast<CudaT *>(output_storage.data()),
+            reinterpret_cast<const CudaT *>(Tn.storage().data()), device_surviving_shape,
+            device_surviving_input_stride, surviving_rank, output_size, diagonal_length,
+            diagonal_stride);
+          // Surface a launch/configuration failure at the trace call rather
+          // than at the next, unrelated CUDA call.
+          checkCudaErrors(cudaGetLastError());
+
           // cudaEventSynchronize waits only for TraceKernel (recorded on this
           // same stream), not the whole device; cudaFreeAsync then enqueues the
           // release into the stream-ordered memory pool without the host
-          // blocking on the free itself. This is groundwork for a future where
-          // GPU work runs across multiple concurrent streams -- today, with
-          // every op on the default stream, it costs the same as a direct
-          // cudaFree, but it stops scaling into a device-wide stall once that
-          // stops being true.
+          // blocking on the free itself.
           cudaEvent_t kernel_done;
           checkCudaErrors(cudaEventCreate(&kernel_done));
           checkCudaErrors(cudaEventRecord(kernel_done, stream));

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -5,7 +5,6 @@
 #include "backend/utils_internal_gpu/cuTypeTraits_gpu.hpp"
 
 #include <algorithm>
-#include <iterator>
 #include <limits>
 #include <vector>
 
@@ -41,18 +40,22 @@ namespace cytnx {
       constexpr cytnx_int64 kMaxGridDimX = 2147483647LL;
       constexpr cytnx_int64 kMaxGridDimY = 65535LL;
 
-      // Cap on the surviving (non-traced) rank the fast, allocation-free
-      // kernel path below handles. 32 mirrors NumPy's historical NPY_MAXDIMS:
-      // generous relative to real tensor-network tensors (MPS/MPO rank 2-4,
-      // PEPS rank 4-6, MERA/TTN rank 3-4; even unusually complex ncon
-      // intermediates rarely exceed ~15 legs before their element count is
-      // infeasible regardless of Trace), while costing nothing extra against
-      // CUDA's per-launch parameter/constant-memory budget. Ranks above this
-      // fall back to the heap-allocated path (see TraceImplGpu).
-      constexpr cytnx_int64 kMaxTraceRank = 32;
+      // Cap on the surviving (non-traced) rank TraceKernel handles via its
+      // stack-resident TraceLayout. Every surviving axis has extent >= 2 (a
+      // size-1 axis contributes nothing to a diagonal decode and would be
+      // squeezed away, not kept as a surviving axis), so a tensor with
+      // surviving_rank axes plus the two traced axes has at least
+      // 2^(surviving_rank + 2) elements. x86-64 addresses at most 2^52 bytes,
+      // so even a 1-byte-per-element dtype caps surviving_rank at 50 on any
+      // physically constructible machine -- there is no dtype/hardware
+      // combination that can reach 51. 50 costs nothing extra against CUDA's
+      // per-launch parameter/constant-memory budget, so there is no reason to
+      // size this any tighter, and no fallback path is needed: the case this
+      // constant would guard against cannot occur.
+      constexpr cytnx_int64 kMaxTraceRank = 50;
 
       // Surviving-axis shape/stride, sized to kMaxTraceRank so it can be
-      // passed to TraceKernelFast by value as a __grid_constant__ parameter
+      // passed to TraceKernel by value as a __grid_constant__ parameter
       // instead of two separate device allocations.
       struct TraceLayout {
         cytnx_int64 rank;
@@ -155,44 +158,29 @@ namespace cytnx {
         return block_sum;  // valid on thread 0
       }
 
-      // One block per output element (blockIdx.x is the output index). The caller
-      // sizes blockDim per call so each block has roughly diagonal_length threads
-      // (rounded up to a warp, capped at kMaxTraceThreadsPerBlock): a short
-      // diagonal launches a small block (no idle warps), a long diagonal launches
-      // the maximum-size block (all threads working). A rank-2 trace
-      // (output_size == 1) is just one such block; many short-diagonal outputs
-      // launch many small blocks running concurrently across SMs.
+      // One block per output element (blockIdx.x is the output index). The
+      // caller sizes blockDim per call so each block has roughly
+      // diagonal_length threads (rounded up to a warp, capped at
+      // kMaxTraceThreadsPerBlock): a short diagonal launches a small block (no
+      // idle warps), a long diagonal launches the maximum-size block (all
+      // threads working). A rank-2 trace (output_size == 1) is just one such
+      // block; many short-diagonal outputs launch many small blocks running
+      // concurrently across SMs.
+      //
+      // The surviving-axis layout is a small fixed-size struct (TraceLayout)
+      // passed by value as a __grid_constant__ parameter rather than two
+      // device pointers, so a trace call needs no cudaMalloc/cudaMemcpy/
+      // cudaFree at all -- kMaxTraceRank comfortably covers every surviving
+      // rank reachable on any physically constructible machine (see its
+      // definition above), so there is no larger-rank fallback to dispatch
+      // to. __grid_constant__ places the parameter in read-only per-grid
+      // constant memory rather than copying it into every thread's local
+      // memory.
       template <class T>
       __global__ void TraceKernel(T *output_data, const T *input_data,
-                                  const cytnx_int64 *surviving_shape,
-                                  const cytnx_int64 *surviving_input_stride,
-                                  cytnx_int64 surviving_rank, cytnx_int64 output_size,
-                                  cytnx_int64 diagonal_length, cytnx_int64 diagonal_stride) {
-        // blockIdx/gridDim are CUDA's native unsigned int; cast once here at that
-        // boundary, then the rest of the decode stays in cytnx_int64.
-        const cytnx_int64 output_index =
-          static_cast<cytnx_int64>(blockIdx.y) * gridDim.x + blockIdx.x;
-        if (output_index >= output_size) return;
-
-        const cytnx_int64 diagonal_start_offset = DecodeDiagonalStartOffset(
-          output_index, surviving_shape, surviving_input_stride, surviving_rank);
-        T sum = BlockTraceDiagonal<T>(input_data, diagonal_start_offset, diagonal_length,
-                                      diagonal_stride);
-        if (threadIdx.x == 0) output_data[output_index] = sum;
-      }
-
-      // Same per-output decode and block reduction as TraceKernel, but the
-      // surviving-axis layout is a small fixed-size struct passed by value as
-      // a __grid_constant__ parameter instead of two device pointers -- no
-      // cudaMalloc/cudaMemcpy/cudaFree needed for surviving_rank <=
-      // kMaxTraceRank (the common case; see the dispatch in TraceImplGpu).
-      // __grid_constant__ places the parameter in read-only per-grid constant
-      // memory rather than copying it into every thread's local memory.
-      template <class T>
-      __global__ void TraceKernelFast(T *output_data, const T *input_data,
-                                      const __grid_constant__ TraceLayout layout,
-                                      cytnx_int64 output_size, cytnx_int64 diagonal_length,
-                                      cytnx_int64 diagonal_stride) {
+                                  const __grid_constant__ TraceLayout layout,
+                                  cytnx_int64 output_size, cytnx_int64 diagonal_length,
+                                  cytnx_int64 diagonal_stride) {
         const cytnx_int64 output_index =
           static_cast<cytnx_int64>(blockIdx.y) * gridDim.x + blockIdx.x;
         if (output_index >= output_size) return;
@@ -219,10 +207,9 @@ namespace cytnx {
       template <class T>
       Tensor TraceImplGpu(const Tensor &Tn, cytnx_uint64 ax1, cytnx_uint64 ax2) {
         using CudaT = typename utils_internal::ToCudaDType<T>::type;
-        // Every cudaXxxAsync call and the kernel launch below share this one
-        // stream, named rather than passed as a bare 0, so the whole function
-        // only has to change in one place if this ever moves off the default
-        // stream.
+        // The kernel launch below runs on this stream, named rather than
+        // passed as a bare 0 so the whole function only has to change in one
+        // place if this ever moves off the default stream.
         const cudaStream_t stream = 0;
         // Trace() validates upstream that ax1 != ax2 and shape[ax1] == shape[ax2],
         // so their order is irrelevant: the diagonal stride and the set of
@@ -258,6 +245,15 @@ namespace cytnx {
           }
         }
         const cytnx_int64 surviving_rank = idx;
+        // Defensive, not a supported case: kMaxTraceRank's derivation above
+        // shows no physically constructible tensor can reach this. If it were
+        // ever hit anyway, layout.shape/stride beyond kMaxTraceRank weren't
+        // populated by the loop above, so proceeding would read uninitialized
+        // stack memory on the device.
+        cytnx_error_msg(surviving_rank > kMaxTraceRank,
+                        "[internal][cuTrace] surviving_rank=%lld exceeds kMaxTraceRank (%lld).\n",
+                        static_cast<long long>(surviving_rank),
+                        static_cast<long long>(kMaxTraceRank));
         layout.rank = surviving_rank;
         cytnx_int64 output_size = 1;
         for (cytnx_int64 dim : output_shape) output_size *= dim;
@@ -298,75 +294,17 @@ namespace cytnx {
           static_cast<unsigned int>(std::min(output_size, kMaxGridDimX)),
           static_cast<unsigned int>((output_size + kMaxGridDimX - 1) / kMaxGridDimX));
 
-        if (surviving_rank <= kMaxTraceRank) {
-          // layout is already fully populated above -- launch directly, no
-          // cudaMalloc/cudaMemcpy/cudaFree at all. 0 below is the dynamic
-          // shared-memory size in bytes (the kernel uses none; its __shared__
-          // warp_sums array is statically sized).
-          TraceKernelFast<CudaT><<<grid_dim, threads_per_block, /* shared_mem_bytes */ 0, stream>>>(
-            reinterpret_cast<CudaT *>(output_storage.data()),
-            reinterpret_cast<const CudaT *>(Tn.storage().data()), layout, output_size,
-            diagonal_length, diagonal_stride);
-          // Surface a launch/configuration failure at the trace call rather
-          // than at the next, unrelated CUDA call.
-          checkCudaErrors(cudaGetLastError());
-        } else {
-          // Rare (surviving_rank > kMaxTraceRank), but not free to be sloppy
-          // about: rebuild the full stride list as three contiguous
-          // range-copies around ax1/ax2 instead of a per-element branch,
-          // since this path is only reached when rank is large enough for
-          // that branch to actually cost something. output_shape already has
-          // every entry and is reused as-is for the device shape array.
-          const cytnx_uint64 lo = std::min(ax1, ax2);
-          const cytnx_uint64 hi = std::max(ax1, ax2);
-          std::vector<cytnx_int64> surviving_input_stride;
-          surviving_input_stride.reserve(surviving_rank);
-          std::copy(input_strides.begin(), input_strides.begin() + lo,
-                    std::back_inserter(surviving_input_stride));
-          std::copy(input_strides.begin() + lo + 1, input_strides.begin() + hi,
-                    std::back_inserter(surviving_input_stride));
-          std::copy(input_strides.begin() + hi + 1, input_strides.end(),
-                    std::back_inserter(surviving_input_stride));
-
-          // Ship the two surviving_rank-sized layout arrays the multi-index
-          // decode needs. Allocated with cudaMallocAsync (stream-ordered)
-          // rather than cudaMalloc so they can be released with cudaFreeAsync
-          // below -- cudaFreeAsync only accepts pointers allocated by
-          // cudaMallocAsync/cudaMallocFromPoolAsync.
-          cytnx_int64 *device_surviving_shape = nullptr;
-          cytnx_int64 *device_surviving_input_stride = nullptr;
-          checkCudaErrors(cudaMallocAsync((void **)&device_surviving_shape,
-                                          sizeof(cytnx_int64) * surviving_rank, stream));
-          checkCudaErrors(cudaMallocAsync((void **)&device_surviving_input_stride,
-                                          sizeof(cytnx_int64) * surviving_rank, stream));
-          checkCudaErrors(cudaMemcpyAsync(device_surviving_shape, output_shape.data(),
-                                          sizeof(cytnx_int64) * surviving_rank,
-                                          cudaMemcpyHostToDevice, stream));
-          checkCudaErrors(
-            cudaMemcpyAsync(device_surviving_input_stride, surviving_input_stride.data(),
-                            sizeof(cytnx_int64) * surviving_rank, cudaMemcpyHostToDevice, stream));
-
-          TraceKernel<CudaT><<<grid_dim, threads_per_block, /* shared_mem_bytes */ 0, stream>>>(
-            reinterpret_cast<CudaT *>(output_storage.data()),
-            reinterpret_cast<const CudaT *>(Tn.storage().data()), device_surviving_shape,
-            device_surviving_input_stride, surviving_rank, output_size, diagonal_length,
-            diagonal_stride);
-          // Surface a launch/configuration failure at the trace call rather
-          // than at the next, unrelated CUDA call.
-          checkCudaErrors(cudaGetLastError());
-
-          // cudaEventSynchronize waits only for TraceKernel (recorded on this
-          // same stream), not the whole device; cudaFreeAsync then enqueues the
-          // release into the stream-ordered memory pool without the host
-          // blocking on the free itself.
-          cudaEvent_t kernel_done;
-          checkCudaErrors(cudaEventCreate(&kernel_done));
-          checkCudaErrors(cudaEventRecord(kernel_done, stream));
-          checkCudaErrors(cudaEventSynchronize(kernel_done));
-          checkCudaErrors(cudaFreeAsync(device_surviving_shape, stream));
-          checkCudaErrors(cudaFreeAsync(device_surviving_input_stride, stream));
-          checkCudaErrors(cudaEventDestroy(kernel_done));
-        }
+        // layout is already fully populated above -- launch directly, no
+        // cudaMalloc/cudaMemcpy/cudaFree at all. 0 below is the dynamic
+        // shared-memory size in bytes (the kernel uses none; its __shared__
+        // warp_sums array is statically sized).
+        TraceKernel<CudaT><<<grid_dim, threads_per_block, /* shared_mem_bytes */ 0, stream>>>(
+          reinterpret_cast<CudaT *>(output_storage.data()),
+          reinterpret_cast<const CudaT *>(Tn.storage().data()), layout, output_size,
+          diagonal_length, diagonal_stride);
+        // Surface a launch/configuration failure at the trace call rather than
+        // at the next, unrelated CUDA call.
+        checkCudaErrors(cudaGetLastError());
 
         return ComposeTraceOutput(output_storage, output_shape, output_is_scalar);
       }

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -28,6 +28,15 @@ namespace cytnx {
       // which only covers every lane when the warp size is a power of two.
       static_assert((kWarpSize & (kWarpSize - 1)) == 0,
                     "kWarpSize must be a power of two for the tree reduction.");
+      // Max extent of grid.x on every architecture this project targets (CUDA
+      // compute capability >= 3.0). One block is launched per output element;
+      // output counts at or below this fit in a 1-D grid. Above it, the launch
+      // spills into grid.y (max 65535), so passing output_size directly as the
+      // <<<...>>> launch's first argument would implicitly narrow to dim3.x
+      // (32-bit) and silently truncate the grid -- see the 2-D grid dispatch in
+      // TraceImplGpu below.
+      constexpr cytnx_uint64 kMaxGridDimX = 2147483647ULL;
+      constexpr cytnx_uint64 kMaxGridDimY = 65535ULL;
 
       // Maps a cytnx storage type to the device arithmetic type used inside the
       // kernels. Complex storage is bit-compatible with cuda::std::complex, which
@@ -137,7 +146,8 @@ namespace cytnx {
                                   const cytnx_uint64 *surviving_input_stride,
                                   cytnx_uint64 surviving_rank, cytnx_uint64 output_size,
                                   cytnx_uint64 diagonal_length, cytnx_uint64 diagonal_stride) {
-        const cytnx_uint64 output_index = blockIdx.x;
+        const cytnx_uint64 output_index =
+          static_cast<cytnx_uint64>(blockIdx.y) * gridDim.x + blockIdx.x;
         if (output_index >= output_size) return;
 
         const cytnx_uint64 diagonal_start_offset = DecodeDiagonalStartOffset(
@@ -217,7 +227,20 @@ namespace cytnx {
         // diagonal.
         const cytnx_uint64 threads_per_block = std::min<cytnx_uint64>(
           ((diagonal_length + kWarpSize - 1) / kWarpSize) * kWarpSize, kMaxTraceThreadsPerBlock);
-        TraceKernel<CudaT><<<output_size, threads_per_block>>>(
+
+        // One block per output element. output_size can exceed dim3::x's 32-bit
+        // range, so it is spread across grid.x and grid.y instead of being passed
+        // directly as the <<<...>>> launch's first argument (which would
+        // implicitly narrow to dim3 and silently truncate to the low 32 bits).
+        cytnx_error_msg(output_size > kMaxGridDimX * kMaxGridDimY,
+                        "[internal][cuTrace] output_size=%llu exceeds the maximum grid size "
+                        "(%llu) this launch can address.\n",
+                        static_cast<unsigned long long>(output_size),
+                        static_cast<unsigned long long>(kMaxGridDimX * kMaxGridDimY));
+        const dim3 grid_dim(
+          static_cast<unsigned int>(std::min(output_size, kMaxGridDimX)),
+          static_cast<unsigned int>((output_size + kMaxGridDimX - 1) / kMaxGridDimX));
+        TraceKernel<CudaT><<<grid_dim, threads_per_block>>>(
           reinterpret_cast<CudaT *>(output_storage.data()),
           reinterpret_cast<const CudaT *>(Tn.storage().data()), device_surviving_shape,
           device_surviving_input_stride, surviving_rank, output_size, diagonal_length,

--- a/src/backend/utils_internal_gpu/CMakeLists.txt
+++ b/src/backend/utils_internal_gpu/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(cytnx
     cuAlloc_gpu.hpp
     cuCast_gpu.hpp
     cuFill_gpu.hpp
+    cuTypeTraits_gpu.hpp
     cuGetElems_gpu.hpp
     cuGetElems_contiguous_gpu.hpp
     cuMovemem_gpu.hpp

--- a/src/backend/utils_internal_gpu/cuFill_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuFill_gpu.cu
@@ -17,26 +17,6 @@ namespace cytnx {
     }
 
     template <typename DType>
-    struct ToCudaDType {
-      typedef DType type;
-    };
-
-    template <typename DType>
-    struct ToCudaDType<std::complex<DType>> {
-      typedef cuda::std::complex<DType> type;
-    };
-
-    template <>
-    struct ToCudaDType<cytnx_complex128> {
-      typedef cuda::std::complex<double> type;
-    };
-
-    template <>
-    struct ToCudaDType<cytnx_complex64> {
-      typedef cuda::std::complex<float> type;
-    };
-
-    template <typename DType>
     void FillGpu(void* first, const DType& value, cytnx_uint64 count) {
       using CudaDType = typename ToCudaDType<DType>::type;
 

--- a/src/backend/utils_internal_gpu/cuFill_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuFill_gpu.cu
@@ -1,4 +1,5 @@
 #include "backend/utils_internal_gpu/cuFill_gpu.hpp"
+#include "backend/utils_internal_gpu/cuTypeTraits_gpu.hpp"
 
 #include <complex>
 

--- a/src/backend/utils_internal_gpu/cuFill_gpu.hpp
+++ b/src/backend/utils_internal_gpu/cuFill_gpu.hpp
@@ -1,10 +1,38 @@
 #ifndef CYTNX_BACKEND_UTILS_INTERNAL_GPU_CUFILL_GPU_H_
 #define CYTNX_BACKEND_UTILS_INTERNAL_GPU_CUFILL_GPU_H_
 
+#include <complex>
+
+#include "cuda/std/complex"
+
 #include "Type.hpp"
 
 namespace cytnx {
   namespace utils_internal {
+
+    /// @brief Maps a cytnx/std scalar type to the device arithmetic type used
+    /// inside CUDA kernels. Complex types map to the bit-compatible
+    /// cuda::std::complex, which provides device operator+ /
+    /// construction-from-zero; every other type passes through unchanged.
+    template <typename DType>
+    struct ToCudaDType {
+      typedef DType type;
+    };
+
+    template <typename DType>
+    struct ToCudaDType<std::complex<DType>> {
+      typedef cuda::std::complex<DType> type;
+    };
+
+    template <>
+    struct ToCudaDType<cytnx_complex128> {
+      typedef cuda::std::complex<double> type;
+    };
+
+    template <>
+    struct ToCudaDType<cytnx_complex64> {
+      typedef cuda::std::complex<float> type;
+    };
 
     /**
      * @brief Assign the given value to the first `count` elements in the range beginning at

--- a/src/backend/utils_internal_gpu/cuFill_gpu.hpp
+++ b/src/backend/utils_internal_gpu/cuFill_gpu.hpp
@@ -1,15 +1,18 @@
 #ifndef CYTNX_BACKEND_UTILS_INTERNAL_GPU_CUFILL_GPU_H_
 #define CYTNX_BACKEND_UTILS_INTERNAL_GPU_CUFILL_GPU_H_
 
-#include <complex>
-
-#include "cuda/std/complex"
-
 #include "Type.hpp"
+
+#ifdef UNI_GPU
+  #include <complex>
+
+  #include "cuda/std/complex"
+#endif
 
 namespace cytnx {
   namespace utils_internal {
 
+#ifdef UNI_GPU
     /// @brief Maps a cytnx/std scalar type to the device arithmetic type used
     /// inside CUDA kernels. Complex types map to the bit-compatible
     /// cuda::std::complex, which provides device operator+ /
@@ -33,6 +36,7 @@ namespace cytnx {
     struct ToCudaDType<cytnx_complex64> {
       typedef cuda::std::complex<float> type;
     };
+#endif
 
     /**
      * @brief Assign the given value to the first `count` elements in the range beginning at

--- a/src/backend/utils_internal_gpu/cuFill_gpu.hpp
+++ b/src/backend/utils_internal_gpu/cuFill_gpu.hpp
@@ -3,40 +3,8 @@
 
 #include "Type.hpp"
 
-#ifdef UNI_GPU
-  #include <complex>
-
-  #include "cuda/std/complex"
-#endif
-
 namespace cytnx {
   namespace utils_internal {
-
-#ifdef UNI_GPU
-    /// @brief Maps a cytnx/std scalar type to the device arithmetic type used
-    /// inside CUDA kernels. Complex types map to the bit-compatible
-    /// cuda::std::complex, which provides device operator+ /
-    /// construction-from-zero; every other type passes through unchanged.
-    template <typename DType>
-    struct ToCudaDType {
-      typedef DType type;
-    };
-
-    template <typename DType>
-    struct ToCudaDType<std::complex<DType>> {
-      typedef cuda::std::complex<DType> type;
-    };
-
-    template <>
-    struct ToCudaDType<cytnx_complex128> {
-      typedef cuda::std::complex<double> type;
-    };
-
-    template <>
-    struct ToCudaDType<cytnx_complex64> {
-      typedef cuda::std::complex<float> type;
-    };
-#endif
 
     /**
      * @brief Assign the given value to the first `count` elements in the range beginning at

--- a/src/backend/utils_internal_gpu/cuTypeTraits_gpu.hpp
+++ b/src/backend/utils_internal_gpu/cuTypeTraits_gpu.hpp
@@ -1,0 +1,44 @@
+#ifndef CYTNX_BACKEND_UTILS_INTERNAL_GPU_CUTYPETRAITS_GPU_H_
+#define CYTNX_BACKEND_UTILS_INTERNAL_GPU_CUTYPETRAITS_GPU_H_
+
+#include "Type.hpp"
+
+#ifdef UNI_GPU
+  #include <complex>
+
+  #include "cuda/std/complex"
+#endif
+
+namespace cytnx {
+  namespace utils_internal {
+
+#ifdef UNI_GPU
+    /// @brief Maps a cytnx/std scalar type to the device arithmetic type used
+    /// inside CUDA kernels. Complex types map to the bit-compatible
+    /// cuda::std::complex, which provides device operator+ /
+    /// construction-from-zero; every other type passes through unchanged.
+    template <typename DType>
+    struct ToCudaDType {
+      typedef DType type;
+    };
+
+    template <typename DType>
+    struct ToCudaDType<std::complex<DType>> {
+      typedef cuda::std::complex<DType> type;
+    };
+
+    template <>
+    struct ToCudaDType<cytnx_complex128> {
+      typedef cuda::std::complex<double> type;
+    };
+
+    template <>
+    struct ToCudaDType<cytnx_complex64> {
+      typedef cuda::std::complex<float> type;
+    };
+#endif
+
+  }  // namespace utils_internal
+}  // namespace cytnx
+
+#endif  // CYTNX_BACKEND_UTILS_INTERNAL_GPU_CUTYPETRAITS_GPU_H_

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(
   linalg_test/GeSvd_test.cpp
   linalg_test/Rsvd_test.cpp
   linalg_test/truncate_test.cpp
+  linalg_test/Trace_test.cpp
   linalg_test/linalg_test.cpp
   linalg_test/sum_test.cpp
   algo_test/Hsplit_test.cpp

--- a/tests/gpu/linalg_test/Trace_test.cpp
+++ b/tests/gpu/linalg_test/Trace_test.cpp
@@ -1,0 +1,153 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+#include "gpu_test_tools.h"
+#include "Device.hpp"
+#include "Tensor.hpp"
+#include "Type.hpp"
+#include "linalg.hpp"
+#include "random.hpp"
+
+// GPU counterpart of tests/linalg_test/Trace_test.cpp. Each case builds the
+// input on the GPU, traces it with the CUDA kernels, and compares against the
+// trace of a contiguous CPU clone of the same data -- so the kernels' stride
+// handling, per-dtype accumulation, and the 2D-vs-ND branch are all exercised
+// against an independent reference. The GPU result is moved to the CPU before
+// the comparison since AreNearlyEqTensor compares host-side.
+
+namespace {
+
+  using cytnx::cytnx_uint64;
+  using cytnx::Device;
+  using cytnx::Tensor;
+  using cytnx::Type;
+
+  // Reference: trace a contiguous CPU clone of the (possibly permuted) GPU
+  // tensor through the same public API, then keep it on the CPU.
+  static Tensor ContiguousCpuReferenceTrace(const Tensor& gpu_t, cytnx_uint64 a, cytnx_uint64 b) {
+    return cytnx::linalg::Trace(gpu_t.to(Device.cpu).contiguous(), a, b);
+  }
+
+  static Tensor TraceOnGpuToCpu(const Tensor& gpu_t, cytnx_uint64 a, cytnx_uint64 b) {
+    return cytnx::linalg::Trace(gpu_t, a, b).to(Device.cpu);
+  }
+
+  TEST(LinalgGpuTraceTest, PermutedRank3MatchesContiguous) {
+    auto t = cytnx::random::random_tensor({4, 3, 4}, -1.0, 1.0, Device.cpu, 0, Type.Double)
+               .to(Device.cuda);
+    auto p = t.permute({2, 1, 0});  // shape {4, 3, 4} but non-contiguous
+    ASSERT_FALSE(p.is_contiguous());
+    auto gpu = TraceOnGpuToCpu(p, 0, 2);
+    auto reference = ContiguousCpuReferenceTrace(p, 0, 2);
+    EXPECT_TRUE(cytnx::TestTools::AreNearlyEqTensor(gpu, reference, 1e-12));
+  }
+
+  TEST(LinalgGpuTraceTest, PermutedTracesAcrossRanksAndDtypes) {
+    struct Case {
+      std::vector<cytnx_uint64> shape;
+      std::vector<cytnx_uint64> perm;
+      cytnx_uint64 ax1, ax2;
+    };
+    // Each case picks two equal-sized logical axes after a non-trivial permute.
+    const std::vector<Case> cases = {
+      // rank 3
+      {{4, 3, 4}, {1, 0, 2}, 1, 2},
+      // rank 4 with non-adjacent traced axes (permuted shape = {4, 4, 5, 3})
+      {{4, 3, 4, 5}, {2, 0, 3, 1}, 0, 1},
+      // rank 5
+      {{3, 4, 3, 2, 3}, {4, 1, 0, 3, 2}, 0, 2},
+    };
+    for (unsigned int dtype : {Type.Double, Type.ComplexDouble, Type.Int32}) {
+      for (const auto& c : cases) {
+        auto t =
+          cytnx::random::random_tensor(c.shape, -2.0, 2.0, Device.cpu, 0, dtype).to(Device.cuda);
+        auto p = t.permute(c.perm);
+        EXPECT_FALSE(p.is_contiguous());
+        auto gpu = TraceOnGpuToCpu(p, c.ax1, c.ax2);
+        auto reference = ContiguousCpuReferenceTrace(p, c.ax1, c.ax2);
+        EXPECT_TRUE(cytnx::TestTools::AreNearlyEqTensor(gpu, reference, 1e-10))
+          << "dtype=" << dtype << " rank=" << c.shape.size();
+      }
+    }
+  }
+
+  TEST(LinalgGpuTraceTest, Rank2Path) {
+    // Exercises the rank-2 branch (out_rank == 0 / n_elem == 1): the single
+    // block traces the whole matrix diagonal.
+    auto t =
+      cytnx::random::random_tensor({6, 6}, -1.0, 1.0, Device.cpu, 0, Type.Double).to(Device.cuda);
+    auto p = t.permute({1, 0});
+    ASSERT_FALSE(p.is_contiguous());
+    auto out_p = TraceOnGpuToCpu(p, 0, 1);
+    auto out_c = ContiguousCpuReferenceTrace(t, 0, 1);  // tr(A) == tr(A^T)
+    ASSERT_EQ(out_p.shape().size(), 1u);
+    ASSERT_EQ(out_p.shape()[0], 1u);
+    EXPECT_TRUE(cytnx::TestTools::AreNearlyEqTensor(out_p, out_c, 1e-12));
+  }
+
+  TEST(LinalgGpuTraceTest, OutputRankIsInputMinusTwo) {
+    // tr(rank-N) -> rank-(N-2); tr(rank-2) -> a 1-element rank-1 tensor.
+    auto r4 = cytnx::random::random_tensor({2, 3, 2, 4}, -1.0, 1.0, Device.cpu, 0, Type.Double)
+                .to(Device.cuda);
+    auto out4 = TraceOnGpuToCpu(r4, 0, 2);
+    EXPECT_EQ(out4.shape().size(), 2u);
+    EXPECT_EQ(out4.shape()[0], 3u);
+    EXPECT_EQ(out4.shape()[1], 4u);
+
+    auto r3 = cytnx::random::random_tensor({3, 4, 3}, -1.0, 1.0, Device.cpu, 0, Type.Double)
+                .to(Device.cuda);
+    auto out3 = TraceOnGpuToCpu(r3, 0, 2);
+    EXPECT_EQ(out3.shape().size(), 1u);
+    EXPECT_EQ(out3.shape()[0], 4u);
+
+    auto r2 =
+      cytnx::random::random_tensor({5, 5}, -1.0, 1.0, Device.cpu, 0, Type.Double).to(Device.cuda);
+    auto out2 = TraceOnGpuToCpu(r2, 0, 1);
+    EXPECT_EQ(out2.shape().size(), 1u);
+    EXPECT_EQ(out2.shape()[0], 1u);
+  }
+
+  TEST(LinalgGpuTraceTest, SwappedAxisOrderMatches) {
+    // Trace(T, a, b) == Trace(T, b, a) (the kernels are symmetric in the axes).
+    auto t = cytnx::random::random_tensor({3, 4, 3, 2}, -1.0, 1.0, Device.cpu, 0, Type.Double)
+               .to(Device.cuda);
+    auto ab = TraceOnGpuToCpu(t, 0, 2);
+    auto ba = TraceOnGpuToCpu(t, 2, 0);
+    EXPECT_TRUE(cytnx::TestTools::AreNearlyEqTensor(ab, ba, 1e-12));
+  }
+
+  TEST(LinalgGpuTraceTest, MatchesCpuTraceOnContiguousInput) {
+    // The headline cross-device equivalence: the GPU kernel result equals the
+    // CPU pairwise result on identical contiguous data, across dtypes.
+    for (unsigned int dtype : {Type.Double, Type.ComplexDouble, Type.Int32}) {
+      auto cpu = cytnx::random::random_tensor({8, 5, 8}, -2.0, 2.0, Device.cpu, 0, dtype);
+      auto gpu = TraceOnGpuToCpu(cpu.to(Device.cuda), 0, 2);
+      auto reference = cytnx::linalg::Trace(cpu, 0, 2);
+      EXPECT_TRUE(cytnx::TestTools::AreNearlyEqTensor(gpu, reference, 1e-10)) << "dtype=" << dtype;
+    }
+  }
+
+  TEST(LinalgGpuTraceTest, LargeDiagonalAccuracyBound) {
+    // Upper bound the GPU's diagonal-sum accuracy at a large diagonal_length.
+    // The current TraceDiagonalBlock accumulates serially per thread; a future
+    // intra-block tree reduction would tighten the bound. The assertion is on
+    // the *exact* sum (a fully homogeneous input, so the math is closed-form)
+    // with a slack proportional to diagonal_length * eps * |value|. That bound
+    // is generous enough to hold for the present serial accumulation, and is
+    // also satisfied by any more accurate replacement -- so the test pins
+    // correctness without freezing the current implementation's error regime.
+    const cytnx::cytnx_int64 n = 4096;
+    const cytnx::cytnx_double value = 0.5;
+    auto t =
+      cytnx::Tensor({static_cast<cytnx::cytnx_uint64>(n), static_cast<cytnx::cytnx_uint64>(n)},
+                    Type.Double, Device.cuda, /*init_zero=*/false);
+    t.fill(value);
+    auto gpu = cytnx::linalg::Trace(t, 0, 1).to(Device.cpu);
+    const double expected = value * static_cast<double>(n);
+    const double slack = static_cast<double>(n) * 1e-15 * std::abs(value) + 1e-9;
+    EXPECT_NEAR(gpu.at<cytnx::cytnx_double>({0}), expected, slack);
+  }
+
+}  // namespace

--- a/tests/gpu/linalg_test/Trace_test.cpp
+++ b/tests/gpu/linalg_test/Trace_test.cpp
@@ -270,4 +270,21 @@ namespace {
     EXPECT_EQ(out.shape()[0], 0u);
   }
 
+  TEST(LinalgGpuTraceTest, ManyNonTrivialSurvivingAxesWithZeroExtentReturnsEmptyOutput) {
+    // Regression test: a surviving axis of extent 0 must take the
+    // empty-output early return before TraceImplGpu's kMaxTraceRank guard is
+    // ever consulted, even when the tensor also has more non-trivial
+    // (extent > 1) surviving axes than kMaxTraceRank (50) -- output_size is 0
+    // regardless of how many other axes exist, so the kernel launch (and
+    // thus TraceLayout's capacity) is never reached. Built via
+    // ZeroExtentGpuTensor since one axis is 0, so the tensor has 0 elements
+    // despite its rank.
+    std::vector<cytnx_int64> shape = {2, 2, 0};
+    shape.insert(shape.end(), 51, 2);
+    auto t = ZeroExtentGpuTensor(shape, Type.Double);
+    auto out = cytnx::linalg::Trace(t, 0, 1).to(Device.cpu);
+    ASSERT_EQ(out.shape().size(), 52u);
+    EXPECT_EQ(out.shape()[0], 0u);
+  }
+
 }  // namespace

--- a/tests/gpu/linalg_test/Trace_test.cpp
+++ b/tests/gpu/linalg_test/Trace_test.cpp
@@ -129,6 +129,47 @@ namespace {
     }
   }
 
+  TEST(LinalgGpuTraceTest, BlockSizeBoundaries) {
+    // The launch sizes each block to its diagonal:
+    //   threads_per_block = min(round_up_to_warp(diagonal_length), 256).
+    // Walk diagonal lengths that straddle every sizing boundary -- sub-warp
+    // (1, 31 -> a 32-thread block), exactly one warp (32), one past a warp
+    // boundary (33 -> 64 threads), the 256-thread cap (255, 256), one past the
+    // cap (257 -> capped block, threads stride), and a multi-stride length
+    // (1024 -> 4 strides per thread). Each is a rank-2 trace, so it is a single
+    // block whose result must match the CPU pairwise reference exactly within
+    // tolerance; an off-by-one in the warp rounding, the per-warp shared-memory
+    // hand-off, or the single-warp early-return path would show up here.
+    for (cytnx_uint64 diagonal_length : {1u, 31u, 32u, 33u, 64u, 255u, 256u, 257u, 1024u}) {
+      auto cpu = cytnx::random::random_tensor({diagonal_length, diagonal_length}, -2.0, 2.0,
+                                              Device.cpu, 0, Type.Double);
+      auto gpu = TraceOnGpuToCpu(cpu.to(Device.cuda), 0, 1);
+      auto reference = cytnx::linalg::Trace(cpu, 0, 1);
+      EXPECT_TRUE(cytnx::TestTools::AreNearlyEqTensor(gpu, reference, 1e-9))
+        << "diagonal_length=" << diagonal_length;
+    }
+  }
+
+  TEST(LinalgGpuTraceTest, ShortDiagonalsManyOutputs) {
+    // The many-blocks regime: {n, middle, n} traced over (0, 2) launches
+    // `middle` blocks, each sized to the short diagonal n. Covers a sub-warp
+    // diagonal (n = 2 -> 32-thread blocks), an exact warp (n = 32), and one
+    // past a warp boundary (n = 33 -> 64-thread blocks), each with enough
+    // output elements that block indexing -- not just the reduction -- is
+    // exercised.
+    struct Case {
+      cytnx_uint64 n, middle;
+    };
+    for (const auto& c : {Case{2, 1000}, Case{32, 500}, Case{33, 100}}) {
+      auto cpu =
+        cytnx::random::random_tensor({c.n, c.middle, c.n}, -2.0, 2.0, Device.cpu, 0, Type.Double);
+      auto gpu = TraceOnGpuToCpu(cpu.to(Device.cuda), 0, 2);
+      auto reference = cytnx::linalg::Trace(cpu, 0, 2);
+      EXPECT_TRUE(cytnx::TestTools::AreNearlyEqTensor(gpu, reference, 1e-9))
+        << "n=" << c.n << " middle=" << c.middle;
+    }
+  }
+
   TEST(LinalgGpuTraceTest, LargeDiagonalAccuracyBound) {
     // Upper bound the GPU's diagonal-sum accuracy at a large diagonal_length.
     // The current TraceDiagonalBlock accumulates serially per thread; a future

--- a/tests/gpu/linalg_test/Trace_test.cpp
+++ b/tests/gpu/linalg_test/Trace_test.cpp
@@ -7,6 +7,7 @@
 #include "Device.hpp"
 #include "Tensor.hpp"
 #include "Type.hpp"
+#include "backend/Storage.hpp"
 #include "linalg.hpp"
 #include "random.hpp"
 
@@ -19,8 +20,11 @@
 
 namespace {
 
+  using cytnx::cytnx_double;
+  using cytnx::cytnx_int64;
   using cytnx::cytnx_uint64;
   using cytnx::Device;
+  using cytnx::Storage;
   using cytnx::Tensor;
   using cytnx::Type;
 
@@ -28,6 +32,16 @@ namespace {
   // tensor through the same public API, then keep it on the CPU.
   static Tensor ContiguousCpuReferenceTrace(const Tensor& gpu_t, cytnx_uint64 a, cytnx_uint64 b) {
     return cytnx::linalg::Trace(gpu_t.to(Device.cpu).contiguous(), a, b);
+  }
+
+  // Tensor's own constructor and Tensor::get() (slicing) both reject a 0 in any
+  // shape dimension, so a zero-extent Tensor can only be built by composing a
+  // zero-element Storage directly and reshaping it onto the target shape.
+  static Tensor ZeroExtentGpuTensor(const std::vector<cytnx_int64>& shape, unsigned int dtype) {
+    Storage s(0, dtype, Device.cuda);
+    Tensor t = Tensor::from_storage(s);
+    t.reshape_(shape);
+    return t;
   }
 
   static Tensor TraceOnGpuToCpu(const Tensor& gpu_t, cytnx_uint64 a, cytnx_uint64 b) {
@@ -189,6 +203,40 @@ namespace {
     const double expected = value * static_cast<double>(n);
     const double slack = static_cast<double>(n) * 1e-15 * std::abs(value) + 1e-9;
     EXPECT_NEAR(gpu.at<cytnx::cytnx_double>({0}), expected, slack);
+  }
+
+  // The following three cases mirror tests/linalg_test/Trace_test.cpp's CPU
+  // zero-extent coverage. cuTraceImpl's zero-extent early-out (the GPU
+  // counterpart of TraceImpl's `diagonal_length == 0 || output_size == 0`
+  // branch) returns before any cudaMalloc/kernel launch, so these pin that
+  // path -- and its NumPy-matching output -- against regression independently
+  // of the CPU implementation.
+
+  TEST(LinalgGpuTraceTest, Rank2ZeroExtentReturnsZeroScalar) {
+    auto t = ZeroExtentGpuTensor({0, 0}, Type.Double);
+    auto out = cytnx::linalg::Trace(t, 0, 1).to(Device.cpu);
+    ASSERT_EQ(out.shape().size(), 1u);
+    EXPECT_EQ(out.shape()[0], 1u);
+    EXPECT_DOUBLE_EQ(out.at<cytnx_double>({0}), 0.0);
+  }
+
+  TEST(LinalgGpuTraceTest, ZeroTracedAxisReturnsZeroFilledOutput) {
+    // shape {3, 0, 0} traced over (1, 2): the diagonal is empty for every one of
+    // the 3 surviving indices, so each sums to 0 -> output shape {3}, all zero.
+    auto t = ZeroExtentGpuTensor({3, 0, 0}, Type.Double);
+    auto out = cytnx::linalg::Trace(t, 1, 2).to(Device.cpu);
+    ASSERT_EQ(out.shape().size(), 1u);
+    EXPECT_EQ(out.shape()[0], 3u);
+    for (cytnx_uint64 i = 0; i < 3; i++) EXPECT_DOUBLE_EQ(out.at<cytnx_double>({i}), 0.0);
+  }
+
+  TEST(LinalgGpuTraceTest, ZeroRemainingAxisReturnsEmptyOutput) {
+    // shape {3, 0, 3} traced over (0, 2): the surviving axis (1) is zero-length,
+    // so the output is an empty tensor of shape {0}.
+    auto t = ZeroExtentGpuTensor({3, 0, 3}, Type.Double);
+    auto out = cytnx::linalg::Trace(t, 0, 2).to(Device.cpu);
+    ASSERT_EQ(out.shape().size(), 1u);
+    EXPECT_EQ(out.shape()[0], 0u);
   }
 
 }  // namespace

--- a/tests/gpu/linalg_test/Trace_test.cpp
+++ b/tests/gpu/linalg_test/Trace_test.cpp
@@ -205,32 +205,20 @@ namespace {
     EXPECT_NEAR(gpu.at<cytnx::cytnx_double>({0}), expected, slack);
   }
 
-  TEST(LinalgGpuTraceTest, SurvivingRankAtFastPathCapMatchesReference) {
-    // TraceImplGpu's stack-resident TraceLayout fast path (a __grid_constant__
-    // kernel parameter, no cudaMalloc/cudaFree) handles surviving_rank <=
-    // kMaxTraceRank (32); this pins correctness exactly at that boundary.
-    // shape = {5, 5, 1x32}: 32 size-1 axes beyond the two traced ones keep the
-    // tensor -- and its element count -- tiny even at rank 34.
+  TEST(LinalgGpuTraceTest, SurvivingRankAtTraceLayoutCapMatchesReference) {
+    // TraceImplGpu's stack-resident TraceLayout is sized to kMaxTraceRank
+    // (50); this pins correctness exactly at that array-bound edge -- not a
+    // realistic tensor (every surviving axis here has extent 1, so a real
+    // caller would never keep them rather than squeeze them away), just a
+    // cheap way to construct a maximal-rank tensor and catch a fencepost bug
+    // in the fixed-size shape/stride arrays. shape = {5, 5, 1x50}.
     std::vector<cytnx_uint64> shape = {5, 5};
-    shape.insert(shape.end(), 32, 1);
+    shape.insert(shape.end(), 50, 1);
     auto cpu = cytnx::random::random_tensor(shape, -2.0, 2.0, Device.cpu, 0, Type.Double);
     auto gpu = TraceOnGpuToCpu(cpu.to(Device.cuda), 0, 1);
     auto reference = cytnx::linalg::Trace(cpu, 0, 1);
     EXPECT_TRUE(cytnx::TestTools::AreNearlyEqTensor(gpu, reference, 1e-10));
-    EXPECT_EQ(gpu.shape().size(), 32u);
-  }
-
-  TEST(LinalgGpuTraceTest, SurvivingRankAboveFastPathCapUsesFallback) {
-    // One more surviving axis than kMaxTraceRank forces TraceImplGpu's
-    // heap-allocated cudaMallocAsync/cudaFreeAsync fallback path -- pins that
-    // path's correctness independently of the fast path above.
-    std::vector<cytnx_uint64> shape = {5, 5};
-    shape.insert(shape.end(), 33, 1);
-    auto cpu = cytnx::random::random_tensor(shape, -2.0, 2.0, Device.cpu, 0, Type.Double);
-    auto gpu = TraceOnGpuToCpu(cpu.to(Device.cuda), 0, 1);
-    auto reference = cytnx::linalg::Trace(cpu, 0, 1);
-    EXPECT_TRUE(cytnx::TestTools::AreNearlyEqTensor(gpu, reference, 1e-10));
-    EXPECT_EQ(gpu.shape().size(), 33u);
+    EXPECT_EQ(gpu.shape().size(), 50u);
   }
 
   // The following three cases mirror tests/linalg_test/Trace_test.cpp's CPU

--- a/tests/gpu/linalg_test/Trace_test.cpp
+++ b/tests/gpu/linalg_test/Trace_test.cpp
@@ -205,6 +205,34 @@ namespace {
     EXPECT_NEAR(gpu.at<cytnx::cytnx_double>({0}), expected, slack);
   }
 
+  TEST(LinalgGpuTraceTest, SurvivingRankAtFastPathCapMatchesReference) {
+    // TraceImplGpu's stack-resident TraceLayout fast path (a __grid_constant__
+    // kernel parameter, no cudaMalloc/cudaFree) handles surviving_rank <=
+    // kMaxTraceRank (32); this pins correctness exactly at that boundary.
+    // shape = {5, 5, 1x32}: 32 size-1 axes beyond the two traced ones keep the
+    // tensor -- and its element count -- tiny even at rank 34.
+    std::vector<cytnx_uint64> shape = {5, 5};
+    shape.insert(shape.end(), 32, 1);
+    auto cpu = cytnx::random::random_tensor(shape, -2.0, 2.0, Device.cpu, 0, Type.Double);
+    auto gpu = TraceOnGpuToCpu(cpu.to(Device.cuda), 0, 1);
+    auto reference = cytnx::linalg::Trace(cpu, 0, 1);
+    EXPECT_TRUE(cytnx::TestTools::AreNearlyEqTensor(gpu, reference, 1e-10));
+    EXPECT_EQ(gpu.shape().size(), 32u);
+  }
+
+  TEST(LinalgGpuTraceTest, SurvivingRankAboveFastPathCapUsesFallback) {
+    // One more surviving axis than kMaxTraceRank forces TraceImplGpu's
+    // heap-allocated cudaMallocAsync/cudaFreeAsync fallback path -- pins that
+    // path's correctness independently of the fast path above.
+    std::vector<cytnx_uint64> shape = {5, 5};
+    shape.insert(shape.end(), 33, 1);
+    auto cpu = cytnx::random::random_tensor(shape, -2.0, 2.0, Device.cpu, 0, Type.Double);
+    auto gpu = TraceOnGpuToCpu(cpu.to(Device.cuda), 0, 1);
+    auto reference = cytnx::linalg::Trace(cpu, 0, 1);
+    EXPECT_TRUE(cytnx::TestTools::AreNearlyEqTensor(gpu, reference, 1e-10));
+    EXPECT_EQ(gpu.shape().size(), 33u);
+  }
+
   // The following three cases mirror tests/linalg_test/Trace_test.cpp's CPU
   // zero-extent coverage. cuTraceImpl's zero-extent early-out (the GPU
   // counterpart of TraceImpl's `diagonal_length == 0 || output_size == 0`

--- a/tests/gpu/linalg_test/Trace_test.cpp
+++ b/tests/gpu/linalg_test/Trace_test.cpp
@@ -205,20 +205,35 @@ namespace {
     EXPECT_NEAR(gpu.at<cytnx::cytnx_double>({0}), expected, slack);
   }
 
-  TEST(LinalgGpuTraceTest, SurvivingRankAtTraceLayoutCapMatchesReference) {
-    // TraceImplGpu's stack-resident TraceLayout is sized to kMaxTraceRank
-    // (50); this pins correctness exactly at that array-bound edge -- not a
-    // realistic tensor (every surviving axis here has extent 1, so a real
-    // caller would never keep them rather than squeeze them away), just a
-    // cheap way to construct a maximal-rank tensor and catch a fencepost bug
-    // in the fixed-size shape/stride arrays. shape = {5, 5, 1x50}.
-    std::vector<cytnx_uint64> shape = {5, 5};
-    shape.insert(shape.end(), 50, 1);
+  TEST(LinalgGpuTraceTest, SingletonSurvivingAxesDoNotCountTowardTraceLayoutCap) {
+    // Regression test: a surviving axis of extent 1 must not count toward
+    // TraceImplGpu's kMaxTraceRank cap, since it contributes nothing to the
+    // kernel's per-output decode (its odometer step is always a no-op -- see
+    // DecodeDiagonalStartOffset) and TraceImplGpu omits it from TraceLayout
+    // entirely. Uses more singleton axes than kMaxTraceRank (50) to pin that
+    // the cap applies to non-trivial (extent > 1) axes only -- this tensor
+    // has just 4 elements total despite the rank, so it stays cheap.
+    std::vector<cytnx_uint64> shape = {2, 2};
+    shape.insert(shape.end(), 60, 1);
     auto cpu = cytnx::random::random_tensor(shape, -2.0, 2.0, Device.cpu, 0, Type.Double);
     auto gpu = TraceOnGpuToCpu(cpu.to(Device.cuda), 0, 1);
     auto reference = cytnx::linalg::Trace(cpu, 0, 1);
     EXPECT_TRUE(cytnx::TestTools::AreNearlyEqTensor(gpu, reference, 1e-10));
-    EXPECT_EQ(gpu.shape().size(), 50u);
+    EXPECT_EQ(gpu.shape().size(), 60u);
+  }
+
+  TEST(LinalgGpuTraceTest, MixedSingletonAndNonTrivialSurvivingAxesPreserveShape) {
+    // Non-trivial (extent > 1) surviving axes interleaved with singleton
+    // ones: pins that TraceImplGpu counts and stores only the non-trivial
+    // axes in TraceLayout for the decode, while still keeping every
+    // surviving axis -- trivial or not -- in the output shape, in its
+    // original order.
+    std::vector<cytnx_uint64> shape = {3, 3, 1, 4, 1, 1, 2, 1};
+    auto cpu = cytnx::random::random_tensor(shape, -2.0, 2.0, Device.cpu, 0, Type.Double);
+    auto gpu = TraceOnGpuToCpu(cpu.to(Device.cuda), 0, 1);
+    auto reference = cytnx::linalg::Trace(cpu, 0, 1);
+    EXPECT_TRUE(cytnx::TestTools::AreNearlyEqTensor(gpu, reference, 1e-10));
+    EXPECT_EQ(gpu.shape().size(), 6u);
   }
 
   // The following three cases mirror tests/linalg_test/Trace_test.cpp's CPU


### PR DESCRIPTION
Fixes #834.

> **Stacked on #862 (CPU trace) → #860 (stride_view).** This PR's diff is only the GPU CUDA implementation. Each prerequisite PR retargets up the chain as it merges.

## Summary

Implements the GPU Tensor trace as native CUDA kernels reading storage directly via `Tensor::strides()`, replacing the previous `Contract`-based path that built an identity `UniTensor` per call.

## Change

- **`BlockTraceDiagonal<T>`**: sums one diagonal with the whole block. Each thread strides over the diagonal, each warp reduces its lanes with a `__shfl_down_sync` tree, the per-warp sums land in shared memory, and the first warp reduces those. A single-warp launch returns directly after the warp shuffle (no shared memory or barrier).
- **`TraceKernel<T>`**: one block per output element. The block decodes its flat index into the surviving-axis multi-index using `DecodeDiagonalStartOffset`, then reduces the corresponding diagonal via `BlockTraceDiagonal`. The rank-2 trace is the `output_size == 1` / `surviving_rank == 0` case — the decode loop is empty, the diagonal starts at offset 0, and a single full block reduces the whole matrix diagonal.
- **Block sized per call from `diagonal_length`**: `threads_per_block = min(round_up_to_warp(diagonal_length), 256)`. A short diagonal launches a small block (no idle warps; many such blocks run concurrently across SMs); a long diagonal gets the full 256-thread block with each thread striding. The rank-2 trace puts every thread of its single block on the one diagonal.
- **`WarpShuffleDownAdd`** wraps `__shfl_down_sync`, overloaded for `cuda::std::complex` (shuffled component-wise since `__shfl_down_sync` only moves scalar lanes). Small integer types promote to `int` through the shuffle and truncate back, preserving the modular-sum semantics the trace already has.
- **`TraceImplGpu<T>`** mirrors the CPU `TraceImpl<T>`: derives the reduced output shape and per-surviving-axis input strides in a single pass; fills a device-resident `Storage` and promotes it via `Tensor::from_storage` (no host round-trip).
- **`diagonal_length == 0` / `output_size == 0`** guards skip the kernel launch; `checkCudaErrors(cudaGetLastError())` after launch surfaces any launch/configuration failure at the trace call rather than the next unrelated CUDA call.
- Only the two `surviving_rank`-sized layout arrays (shape + per-axis input stride) are shipped to the device; the kernel decodes each element's offset itself rather than the host materializing an `output_size`-sized offset table.
- Type-generic over `T` via `T(0)` / `+=`; complex storage is `reinterpret_cast` to `cuda::std::complex<{float,double}>`, which provides device `operator+` / zero-construction (CUDA ≥ 12.6).

## Tests

`tests/gpu/linalg_test/Trace_test.cpp` as `LinalgGpuTraceTest` mirrors the CPU `LinalgTraceTest` matrix:

- `PermutedRank3MatchesContiguous` / `PermutedTracesAcrossRanksAndDtypes`: permuted (non-contiguous) inputs over non-adjacent axes across ranks 3–5 and Double/ComplexDouble/Int32, compared against the trace of a contiguous CPU clone.
- `Rank2Path`: the `surviving_rank == 0` single-block path.
- `OutputRankIsInputMinusTwo`, `SwappedAxisOrderMatches`: rank and axis-order invariants.
- `MatchesCpuTraceOnContiguousInput`: GPU result equals the CPU pairwise result on identical contiguous data across dtypes.
- `BlockSizeBoundaries`: rank-2 traces at diagonal lengths {1, 31, 32, 33, 64, 255, 256, 257, 1024} — straddles every block-sizing boundary (sub-warp, exact-warp, warp+1, the 256 cap and one past it, multi-stride).
- `ShortDiagonalsManyOutputs`: `{n, middle, n}` traced over (0, 2) for `(n, middle) = (2, 1000), (32, 500), (33, 100)` — many small blocks per launch, exercises block indexing across a large output together with sub-warp / exact-warp / warp+1 block sizes.
- `LargeDiagonalAccuracyBound`: upper bounds the diagonal-sum accuracy at `diagonal_length = 4096` with a slack proportional to `n · ε · |value|` — generous enough that the current serial intra-thread accumulation passes, and any future intra-block tree reduction also passes (locks correctness, not the current error regime).

## Benchmark

`benchmarks/linalg/Trace_bm.cpp`, `BM_gpu_Trace_*` (Google Benchmark, release `openblas-cuda` build, `-DRUN_BENCHMARKS=ON`, GTX 1660 SUPER):

| Trace pattern | shape params | Double | ComplexDouble |
|---|---|---|---|
| `Strided_3D` | 256/64 | 72.3us | 86.0us |
| `Strided_3D` | 1024/16 | 77.4us | 86.6us |
| `Strided_3D` | 2048/16 | 79.1us | 83.7us |
| `Strided_3D` | 4096/8 | 83.0us | 88.1us |
| `Matvec_3D` | 256/64 | 4603us | 7179us |
| `Matvec_3D` | 1024/16 | 12190us | 22461us |
| `Matvec_3D` | 2048/16 | 42026us | 83319us |
| `Matvec_3D` | 4096/8 | 80809us | 164402us |
| `Strided_2D` | 256 | 16.8us | 17.2us |
| `Strided_2D` | 1024 | 17.5us | 18.0us |
| `Strided_2D` | 4096 | 19.3us | 20.2us |
| `Strided_2D` | 8192 | 21.9us | 23.6us |
| `Vecdot_2D` | 256 | 289us | 293us |
| `Vecdot_2D` | 1024 | 321us | 360us |
| `Vecdot_2D` | 4096 | 882us | 1362us |
| `Vecdot_2D` | 8192 | 2216us | 4040us |
| `Reshape_2D` | 256 | 2026us | 2239us |
| `Reshape_2D` | 1024 | 2926us | 3503us |
| `Reshape_2D` | 4096 | 13274us | 22613us |
| `Reshape_2D` | 8192 | 46304us | 80679us |

`Strided_3D`/`Strided_2D` (this PR's new kernel path, traced over non-adjacent/permuted axes) stay roughly flat regardless of size — dominated by launch overhead rather than diagonal length. `Matvec_3D`, `Vecdot_2D`, and `Reshape_2D` are reference/comparison shapes that do proportionally more work and scale with size as expected. `ComplexDouble` tracks `Double` at roughly 1.0–1.5x throughout, consistent with the `cuda::std::complex` reinterpret-cast path.

## Test plan

- [x] CPU: `openblas-cpu` full suite **1072/1072** passed (the GPU TU is excluded; no CPU regressions from the GPU patch).
- [x] `nvcc 12.6` compile-check of `cuTrace_internal.cu`: 0 errors.
- [x] Adaptive block reduction verified against exact sums for every combination of block sizes {32, 64, 96, 128, 256} × diagonal lengths {1, 5, 31, 32, 33, 64, 100, 255, 256, 257, 4096} via host simulation of the shuffle semantics.
- [ ] **GPU CI** — the `.cu` runtime can't be exercised locally; relying on CI to run `tests/gpu/`.

Draft — opened for review.
