### PR TITLE
ci(coverage): build coverage on push to master so Codecov compares the right base

### DIFF
--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -12,7 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -l {0}
+        # Login shell (-l) so conda activation is sourced, plus fail-fast
+        # flags: -e aborts the step on the first failing command and
+        # -o pipefail propagates failures through pipes. Overriding the
+        # shell drops GitHub's default `-eo pipefail`, so set it back here.
+        shell: bash -leo pipefail {0}
     env:
       # Pinned via --config-settings=build-dir=build below so ctest and
       # gcovr know where the build tree (and .gcno / .gcda files) live.

--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -1,5 +1,8 @@
 name: Tests and Codecov
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
## Problem

The `Tests and Codecov` workflow (`.github/workflows/ci-cmake_tests.yml`) ran only on `pull_request` (to `master`) and `workflow_dispatch`. Coverage was therefore uploaded to Codecov **only for PR-head commits** — `master` HEAD (the post-merge state of the default branch) was never built directly, so Codecov never received a coverage report for it.

Because PRs land on `master` via **merge commits**, those PR-head commits sit on the second-parent side of history, off `master`'s first-parent line. When a new PR opens, its base is the current `master` tip — a first-parent merge commit with no coverage report. Codecov then walks back the ancestry to the nearest commit that *does* have a report and uses that as the comparison base, which resolves to an arbitrary old PR-head commit far behind `master`.

Observed on #849: Codecov picked base `98e5842`, which is **194 commits behind** `master` and not on the first-parent line. Its own comment said "Report is 211 commits behind head." The "project" diff then showed `Files +29, Lines +4844, Coverage 37.16% → 28.15% (−9.01%)` — hundreds of commits of drift, not the 3-file / +172−17 change in the PR. The comparison is effectively useless.

## Changes

1. **Add a `push: branches: [master]` trigger** so the full build runs on `master` after every merge and uploads a coverage report for the actual `master` commit. The PR-only "Merge with latest target branch" step is already guarded by `github.event_name == 'pull_request'`, so push builds test `master` directly. With a report attached to each `master` first-parent commit, Codecov can use the true PR base and produce a meaningful diff.

2. **Harden the workflow shell**: `defaults.run.shell` was `bash -l {0}`. Overriding the shell discards GitHub Actions' default `-eo pipefail`, so multi-line `run:` blocks no longer aborted on the first failing command and pipe failures were masked. Switch to `bash -leo pipefail {0}` — keep the login shell (`-l`) for conda activation, add `-e` (fail on first non-zero command) and `-o pipefail` (propagate failures through pipes). This matches the fail-fast behavior `conda-incubator/setup-miniconda` documents (`bash -el {0}`) while also restoring pipefail.

## Note on rollout

This fix takes effect going forward: Codecov gets a usable base for a PR once the `master` commit it is based on has its own coverage report — i.e. after this lands and the next merge fires the new push build. The first PR or two after merge may still show drift until `master` accumulates push-built reports.

## Test plan

- [x] `.github/workflows/ci-cmake_tests.yml` parses as valid YAML; triggers are `push`, `pull_request`, `workflow_dispatch`; job shell is `bash -leo pipefail {0}`.

This is a CI-config-only change; no library code is touched, so the C++/Python test suites are unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XAARrR4qTNWe2XLWeotZAo)_