### PR TITLE
Fixing bugs in truncated Svd functions with mindim

### DIFF
--- a/include/linalg.hpp
+++ b/include/linalg.hpp
@@ -842,7 +842,9 @@ namespace cytnx {
     the largest error will be pushed back to the vector (The smallest singular value in the return
     singular values matrix \f$ S \f$.) If \p return_err is > 1, then the full list of truncated
     singular values will be returned.
-    @param[in] mindim at least this amount of singular values are kept in each block.
+    @param[in] mindim at least this many singular values are kept in total. For a per-block lower
+    bound (which also acts as the per-block sampling floor of the randomized SVD), use the
+    overload that takes a \p min_blockdim vector.
     @param[in] oversampling_summand the randomized SVD computes [(1 + oversampling_factor) *
     keepdim*d/D + oversampling_summand] singular values in each block before further truncating,
     where d is the block dimension and D the full tensor dimension (each being the minimum of row
@@ -1878,7 +1880,7 @@ namespace cytnx {
     the largest error will be pushed back to the vector (The smallest singular value in the return
     singular values matrix \f$ S \f$.) If \p return_err is a \em positive int, then the
     full list of truncated singular values will be returned.
-    @param[in] mindim at least this amount of singular values are kept in each block.
+    @param[in] mindim at least this many singular values are kept in total.
     @param[in] oversampling_summand the randomized SVD computes [(1 + oversampling_factor) *
     keepdim*d/D + oversampling_summand] singular values in each block before further truncating,
     where d is the block dimension and D the full tensor dimension (each being the minimum of row

--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -418,6 +418,10 @@ namespace cytnx {
       cytnx_int64 keep_dim = keepdim;  // these must be signed int, because they can become
                                        // negative!
       cytnx_int64 min_dim = (mindim < 1 ? 1 : mindim);
+      cytnx_error_msg(min_blockdim.empty(),
+                      "[ERROR][Gesvd_truncate] min_blockdim must not be empty; use the overload "
+                      "without min_blockdim if no per-block floor is needed.%s",
+                      "\n");
 
       outCyT = linalg::Gesvd(Tin, is_U, is_vT);
       if (min_blockdim.size() == 1)  // if only one element given, make it a vector
@@ -508,8 +512,9 @@ namespace cytnx {
             // largest dropped singular value
             Sall = algo::Sort(Sall);  // ascending; largest dropped is the last element
             Scalar Smax = Sall.storage()(Sall.shape()[0] - 1);
-            outCyT.push_back(UniTensor(Tensor({1}, Smax.dtype())));
-            outCyT.back().get_block_().storage().at(0) = Smax;
+            Tensor terr({1}, Sall.dtype());
+            terr.storage().at(0) = Smax;
+            outCyT.push_back(UniTensor(terr));
           } else if (return_err) {
             outCyT.push_back(UniTensor(Sall));
           }

--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -504,8 +504,16 @@ namespace cytnx {
             outCyT.push_back(UniTensor(Sall.get({Accessor::tilend(smidx)})));
           }
         } else {
-          if (return_err >= 1) {
-            outCyT.push_back(UniTensor(Tensor({1}, Tin.dtype())));
+          // keep_dim < 1: per-block min_blockdim guarantees already cover the global cap, so
+          // every value in Sall is dropped.
+          if (return_err == 1) {
+            // largest dropped singular value
+            Sall = algo::Sort(Sall);  // ascending; largest dropped is the last element
+            Scalar Smax = Sall.storage()(Sall.shape()[0] - 1);
+            outCyT.push_back(UniTensor(Tensor({1}, Smax.dtype())));
+            outCyT.back().get_block_().storage().at(0) = Smax;
+          } else if (return_err) {
+            outCyT.push_back(UniTensor(Sall));
           }
         }
 

--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -510,11 +510,7 @@ namespace cytnx {
           // every value in Sall is dropped.
           if (return_err == 1) {
             // largest dropped singular value
-            Sall = algo::Sort(Sall);  // ascending; largest dropped is the last element
-            Scalar Smax = Sall.storage()(Sall.shape()[0] - 1);
-            Tensor terr({1}, Sall.dtype());
-            terr.storage().at(0) = Smax;
-            outCyT.push_back(UniTensor(terr));
+            outCyT.push_back(UniTensor(linalg::Max(Sall)));
           } else if (return_err) {
             outCyT.push_back(UniTensor(Sall));
           }

--- a/src/linalg/Rsvd.cpp
+++ b/src/linalg/Rsvd.cpp
@@ -971,11 +971,7 @@ namespace cytnx {
             // every value in Sall is dropped.
             if (return_err == 1) {
               // largest dropped singular value
-              Sall = algo::Sort(Sall);  // ascending; largest dropped is the last element
-              Scalar Smax = Sall.storage()(Sall.shape()[0] - 1);
-              Tensor terr({1}, Sall.dtype());
-              terr.storage().at(0) = Smax;
-              outCyT.push_back(UniTensor(terr));
+              outCyT.push_back(UniTensor(linalg::Max(Sall)));
             } else if (return_err) {
               outCyT.push_back(UniTensor(Sall));
             }

--- a/src/linalg/Rsvd.cpp
+++ b/src/linalg/Rsvd.cpp
@@ -948,8 +948,16 @@ namespace cytnx {
               outCyT.push_back(UniTensor(Sall.get({Accessor::tilend(smidx)})));
             }
           } else {
-            if (return_err >= 1) {
-              outCyT.push_back(UniTensor(Tensor({1}, Tin.dtype())));
+            // keep_dim < 1: per-block min_blockdim guarantees already cover the global cap, so
+            // every value in Sall is dropped.
+            if (return_err == 1) {
+              // largest dropped singular value
+              Sall = algo::Sort(Sall);  // ascending; largest dropped is the last element
+              Scalar Smax = Sall.storage()(Sall.shape()[0] - 1);
+              outCyT.push_back(UniTensor(Tensor({1}, Smax.dtype())));
+              outCyT.back().get_block_().storage().at(0) = Smax;
+            } else if (return_err) {
+              outCyT.push_back(UniTensor(Sall));
             }
           }
 

--- a/src/linalg/Rsvd.cpp
+++ b/src/linalg/Rsvd.cpp
@@ -225,6 +225,15 @@ namespace cytnx {
           mgrp[BdLeft.qnums()[new_itoi[b][0]]].push_back(b);
         }
 
+        // Validate min_blockdim against the number of blocks (mgrp.size())
+        cytnx_error_msg(
+          !(min_blockdim.empty() || (min_blockdim.size() == 1) ||
+            (min_blockdim.size() == mgrp.size())),
+          "[ERROR][Rsvd] min_blockdim must be empty, size 1, or have one entry per symmetry "
+          "sector (%llu); got %llu.%s",
+          static_cast<unsigned long long>(mgrp.size()),
+          static_cast<unsigned long long>(min_blockdim.size()), "\n");
+
         // 4) for each qcharge in key, combining the blocks into a big chunk!
         // ->a initialize an empty shell of UniTensors!
         vec2d<cytnx_int64> aux_qnums;  // for sharing bond
@@ -864,6 +873,10 @@ namespace cytnx {
         cytnx_int64 keep_dim = keepdim;  // these must be signed int, because they can become
                                          // negative!
         cytnx_int64 min_dim = (mindim < 1 ? 1 : mindim);
+        cytnx_error_msg(min_blockdim.empty(),
+                        "[ERROR][Rsvd] min_blockdim must not be empty; use the overload without "
+                        "min_blockdim if no per-block floor is needed.%s",
+                        "\n");
 
         // Set sampling target to max(keepdim, mindim) so the global mindim contract is satisfiable
         const cytnx_uint64 sample_target = std::max(keepdim, mindim);
@@ -878,11 +891,6 @@ namespace cytnx {
         }
         if (min_blockdim.size() == 1)  // if only one element given, make it a vector
           min_blockdim.resize(outCyT[0].Nblocks(), min_blockdim.front());
-        cytnx_error_msg(
-          min_blockdim.size() != outCyT[0].Nblocks(),
-          "[ERROR][Gesvd_truncate] min_blockdim must have the same number of elements as "
-          "blocks in the singular value UniTensor%s",
-          "\n");
 
         // process truncation:
         // 1) concate all S vals from all blk but exclude the first min_blockdim Svals in each block
@@ -965,8 +973,9 @@ namespace cytnx {
               // largest dropped singular value
               Sall = algo::Sort(Sall);  // ascending; largest dropped is the last element
               Scalar Smax = Sall.storage()(Sall.shape()[0] - 1);
-              outCyT.push_back(UniTensor(Tensor({1}, Smax.dtype())));
-              outCyT.back().get_block_().storage().at(0) = Smax;
+              Tensor terr({1}, Sall.dtype());
+              terr.storage().at(0) = Smax;
+              outCyT.push_back(UniTensor(terr));
             } else if (return_err) {
               outCyT.push_back(UniTensor(Sall));
             }

--- a/src/linalg/Rsvd.cpp
+++ b/src/linalg/Rsvd.cpp
@@ -134,7 +134,10 @@ namespace cytnx {
       oversampling.
       @param[in] is_U if \em true, the left-unitary UniTensor U (isometry) is returned.
       @param[in] is_vT if \em true, the right-unitary UniTensor vT (isometry) is returned.
-      @param[in] mindim at least this amount of singular values are kept in each block.
+      @param[in] min_blockdim per-block lower bound on the number of singular values: each block's
+      randomized SVD computes at least \p min_blockdim[b] singular values, and the subsequent
+      truncation also keeps at least \p min_blockdim[b] per block. May be empty for no per-block
+      floor; a single-element vector is broadcast to every block.
       @param[in] oversampling_summand the randomized SVD computes [(1 + oversampling_factor) *
       keepdim*d/D + oversampling_summand] singular values in each block before further truncating,
       where d is the block dimension and D the full tensor dimension (each being the minimum of row
@@ -148,7 +151,7 @@ namespace cytnx {
       @see Rsvd()
       @see Gesvd()
       @note At least one singular value per symmetry sector is always kept.
-      @note More than keepdim singular values might be returned (depending on mindim,
+      @note More than keepdim singular values might be returned (depending on min_blockdim,
       oversampling_summand, oversampling_factor, and symmetry sector sizes).
       @warning No truncation of the singular values is performed, and the smaller ones will be
       inaccurate. Use Rsvd() for a truncated version that drops small singular values.
@@ -158,7 +161,8 @@ namespace cytnx {
       template <typename BUT>
       void Rsvd_notruncate_BlockUT_internal(std::vector<cytnx::UniTensor> &outCyT,
                                             const cytnx::UniTensor &Tin, cytnx_uint64 keepdim,
-                                            bool is_U, bool is_vT, cytnx_uint64 mindim,
+                                            bool is_U, bool is_vT,
+                                            const std::vector<cytnx_uint64> &min_blockdim,
                                             cytnx_uint64 oversampling_summand,
                                             double oversampling_factor,
                                             cytnx_uint64 power_iteration, unsigned int seed) {
@@ -234,6 +238,7 @@ namespace cytnx {
         std::vector<Tensor> vT_blocks;
 
         int tr;
+        cytnx_uint64 block_idx = 0;  // tracks the position of the current sector in S/U/vT
         for (auto const &x : mgrp) {
           vec2d<cytnx_uint64> itoi_indicators(x.second.size());
           for (int i = 0; i < x.second.size(); i++) {
@@ -274,8 +279,14 @@ namespace cytnx {
           // Now we can perform linalg!
           aux_qnums.push_back(x.first);
           auto BlockDim = std::min(BTen.shape()[0], BTen.shape()[1]);
+          // per-block sampling floor: ensure each block's randomized SVD computes at least as
+          // many singular values as min_blockdim asks to keep. Empty -> 0; size 1 -> broadcast.
+          const cytnx_uint64 block_floor =
+            min_blockdim.empty()
+              ? 0u
+              : (min_blockdim.size() == 1 ? min_blockdim.front() : min_blockdim[block_idx]);
           cytnx::cytnx_uint64 svalnum =
-            std::max(static_cast<cytnx_int64>(mindim),
+            std::max(static_cast<cytnx_int64>(block_floor),
                      static_cast<cytnx_int64>(
                        std::ceil((1. + oversampling_factor) * keepdim * BlockDim / TenDim) +
                        static_cast<cytnx_int64>(oversampling_summand)));
@@ -341,6 +352,7 @@ namespace cytnx {
 
             tr++;
           }  // is_vT
+          ++block_idx;
         }
 
         // process S:
@@ -682,14 +694,18 @@ namespace cytnx {
         // from Gesvd_truncate, but using Rsvd_notruncate_BlockUT_internal for the SVD
         cytnx_uint64 keep_dim = keepdim;
 
+        // no min_blockdim was passed by the caller -> empty vector, per-block sampling floor is 0
+        const std::vector<cytnx_uint64> empty_min_blockdim;
+        // Set sampling target to max(keepdim, mindim) so the global mindim contract is satisfiable
+        const cytnx_uint64 sample_target = std::max(keepdim, mindim);
         if (Tin.uten_type() == UTenType.Block) {
           Rsvd_notruncate_BlockUT_internal<BlockUniTensor>(
-            outCyT, Tin, keepdim, is_U, is_vT, mindim, oversampling_summand, oversampling_factor,
-            power_iteration, seed);
+            outCyT, Tin, sample_target, is_U, is_vT, empty_min_blockdim, oversampling_summand,
+            oversampling_factor, power_iteration, seed);
         } else {  // BlockFermionic
           Rsvd_notruncate_BlockUT_internal<BlockFermionicUniTensor>(
-            outCyT, Tin, keepdim, is_U, is_vT, mindim, oversampling_summand, oversampling_factor,
-            power_iteration, seed);
+            outCyT, Tin, sample_target, is_U, is_vT, empty_min_blockdim, oversampling_summand,
+            oversampling_factor, power_iteration, seed);
         }
 
         // process truncation:
@@ -856,14 +872,16 @@ namespace cytnx {
                                          // negative!
         cytnx_int64 min_dim = (mindim < 1 ? 1 : mindim);
 
+        // Set sampling target to max(keepdim, mindim) so the global mindim contract is satisfiable
+        const cytnx_uint64 sample_target = std::max(keepdim, mindim);
         if (Tin.uten_type() == UTenType.Block) {
           Rsvd_notruncate_BlockUT_internal<BlockUniTensor>(
-            outCyT, Tin, keepdim, is_U, is_vT, mindim, oversampling_summand, oversampling_factor,
-            power_iteration, seed);
+            outCyT, Tin, sample_target, is_U, is_vT, min_blockdim, oversampling_summand,
+            oversampling_factor, power_iteration, seed);
         } else {  // BlockFermionic
           Rsvd_notruncate_BlockUT_internal<BlockFermionicUniTensor>(
-            outCyT, Tin, keepdim, is_U, is_vT, mindim, oversampling_summand, oversampling_factor,
-            power_iteration, seed);
+            outCyT, Tin, sample_target, is_U, is_vT, min_blockdim, oversampling_summand,
+            oversampling_factor, power_iteration, seed);
         }
         if (min_blockdim.size() == 1)  // if only one element given, make it a vector
           min_blockdim.resize(outCyT[0].Nblocks(), min_blockdim.front());

--- a/src/linalg/Svd_truncate.cpp
+++ b/src/linalg/Svd_truncate.cpp
@@ -471,8 +471,16 @@ namespace cytnx {
             outCyT.push_back(UniTensor(Sall.get({Accessor::tilend(smidx)})));
           }
         } else {
-          if (return_err >= 1) {
-            outCyT.push_back(UniTensor(Tensor({1}, Tin.dtype())));
+          // keep_dim < 1: per-block min_blockdim guarantees already cover the global cap, so
+          // every value in Sall is dropped.
+          if (return_err == 1) {
+            // largest dropped singular value
+            Sall = algo::Sort(Sall);  // ascending; largest dropped is the last element
+            Scalar Smax = Sall.storage()(Sall.shape()[0] - 1);
+            outCyT.push_back(UniTensor(Tensor({1}, Smax.dtype())));
+            outCyT.back().get_block_().storage().at(0) = Smax;
+          } else if (return_err) {
+            outCyT.push_back(UniTensor(Sall));
           }
         }
 

--- a/src/linalg/Svd_truncate.cpp
+++ b/src/linalg/Svd_truncate.cpp
@@ -366,6 +366,10 @@ namespace cytnx {
       cytnx_int64 keep_dim = keepdim;  // these must be signed int, because they can become
                                        // negative!
       cytnx_int64 min_dim = (mindim < 1 ? 1 : mindim);
+      cytnx_error_msg(min_blockdim.empty(),
+                      "[ERROR][Svd_truncate] min_blockdim must not be empty; use the overload "
+                      "without min_blockdim if no per-block floor is needed.%s",
+                      "\n");
 
       outCyT = linalg::Gesvd(Tin, is_UvT, is_UvT);
       if (min_blockdim.size() == 1)  // if only one element given, make it a vector
@@ -456,8 +460,9 @@ namespace cytnx {
             // largest dropped singular value
             Sall = algo::Sort(Sall);  // ascending; largest dropped is the last element
             Scalar Smax = Sall.storage()(Sall.shape()[0] - 1);
-            outCyT.push_back(UniTensor(Tensor({1}, Smax.dtype())));
-            outCyT.back().get_block_().storage().at(0) = Smax;
+            Tensor terr({1}, Sall.dtype());
+            terr.storage().at(0) = Smax;
+            outCyT.push_back(UniTensor(terr));
           } else if (return_err) {
             outCyT.push_back(UniTensor(Sall));
           }

--- a/src/linalg/Svd_truncate.cpp
+++ b/src/linalg/Svd_truncate.cpp
@@ -458,11 +458,7 @@ namespace cytnx {
           // every value in Sall is dropped.
           if (return_err == 1) {
             // largest dropped singular value
-            Sall = algo::Sort(Sall);  // ascending; largest dropped is the last element
-            Scalar Smax = Sall.storage()(Sall.shape()[0] - 1);
-            Tensor terr({1}, Sall.dtype());
-            terr.storage().at(0) = Smax;
-            outCyT.push_back(UniTensor(terr));
+            outCyT.push_back(UniTensor(linalg::Max(Sall)));
           } else if (return_err) {
             outCyT.push_back(UniTensor(Sall));
           }

--- a/tests/linalg_test/Gesvd_truncate_test.cpp
+++ b/tests/linalg_test/Gesvd_truncate_test.cpp
@@ -295,4 +295,87 @@ namespace GesvdTruncateTest {
 
     return true;
   }
+
+  /*=====test info=====
+  describe:When per-block min_blockdim guarantees already meet or exceed the global keepdim cap
+  (keep_dim<=0 internally) but there are further singular values, the return_err path must report
+  the actually dropped singular values, not a 1-element zero tensor.
+  ====================*/
+  TEST(Gesvd_truncate, return_err_when_min_blockdim_exhausts_keepdim) {
+    // 2-leg U(1) BlockUT, 3 sectors of size 3x3 each. With min_blockdim=[2,2,2] every block
+    // keeps its top 2 SVs and contributes its 3rd to Sall (3 dropped values total);
+    // keep_dim = 3 - 6 = -3 < 0, so all 3 are dropped via the keep_dim<=0 branch.
+    auto syms = std::vector<Symmetry>{Symmetry(SymmetryType::U)};
+    Bond bk = Bond(BD_KET, {{0}, {1}, {2}}, {3, 3, 3}, syms);
+    UniTensor src_T({bk, bk.redirect()}, {"l", "r"}, 1, Type.Double, Device.cpu, false);
+    InitUniTensorUniform(src_T, 23);
+
+    const cytnx_uint64 keepdim = 3;
+    const std::vector<cytnx_uint64> min_blockdim = {2, 2, 2};
+
+    // return_err = 2: terr holds every dropped singular value (3 total)
+    std::vector<UniTensor> gsvds_all =
+      linalg::Gesvd_truncate(src_T, keepdim, min_blockdim, 0., true, true, 2, 1);
+    Tensor terr_all = gsvds_all.back().get_block_();
+    ASSERT_EQ(terr_all.shape(), std::vector<cytnx_uint64>({3}))
+      << "terr must hold all 3 dropped singular values, not a 1-element zero";
+    double max_abs = 0.0;
+    for (cytnx_uint64 i = 0; i < terr_all.storage().size(); ++i)
+      max_abs = std::max(max_abs, std::abs(terr_all.storage().at<double>(i)));
+    EXPECT_GT(max_abs, 0.0) << "terr values are all zero (previous bug)";
+
+    // return_err = 1: terr is a single element = largest dropped singular value
+    std::vector<UniTensor> gsvds_max =
+      linalg::Gesvd_truncate(src_T, keepdim, min_blockdim, 0., true, true, 1, 1);
+    Tensor terr_max = gsvds_max.back().get_block_();
+    ASSERT_EQ(terr_max.shape(), std::vector<cytnx_uint64>({1}));
+    EXPECT_NEAR(std::abs(terr_max.storage().at<double>(0)), max_abs, 1e-10 * (1.0 + max_abs));
+  }
+
+  /*=====test info=====
+  describe:Setting min_blockdim must keep at least the requested number of singular values per
+  sector. With a small keepdim, the baseline (no min_blockdim) drops entire sectors; with
+  min_blockdim={1,1,1} every sector keeps at least one singular value.
+  ====================*/
+  TEST(Gesvd_truncate, min_blockdim_keeps_each_sector) {
+    auto syms = std::vector<Symmetry>{Symmetry(SymmetryType::U)};
+    Bond bk = Bond(BD_KET, {{0}, {1}, {2}}, {3, 3, 3}, syms);
+    UniTensor src_T({bk, bk.redirect()}, {"l", "r"}, 1, Type.Double, Device.cpu, false);
+    InitUniTensorUniform(src_T, 29);
+    const cytnx_uint64 keepdim = 1;
+
+    // baseline: only the single largest singular value is kept, so most sectors disappear
+    std::vector<UniTensor> base = linalg::Gesvd_truncate(src_T, keepdim);
+    const auto base_degs = base[0].bonds()[0].getDegeneracies();
+    EXPECT_LT(base_degs.size(), 3u)
+      << "baseline should drop some sectors; pick a smaller keepdim or larger blocks";
+
+    // with min_blockdim={1,1,1}: every sector must keep at least 1
+    std::vector<UniTensor> withf = linalg::Gesvd_truncate(src_T, keepdim, {1, 1, 1});
+    const auto withf_degs = withf[0].bonds()[0].getDegeneracies();
+    ASSERT_EQ(withf_degs.size(), 3u);
+    for (cytnx_uint64 b = 0; b < 3; ++b) EXPECT_GE(withf_degs[b], 1u) << "block " << b;
+  }
+
+  /*=====test info=====
+  describe:With err larger than every singular value, the truncation loop would otherwise cut
+  down to 1. mindim must restrict the kept count to at least mindim, and the kept values must be
+  the mindim largest ones of the full SVD.
+  ====================*/
+  TEST(Gesvd_truncate, mindim_floor) {
+    Tensor T = Tensor({6, 5}, Type.Double);
+    InitTensorUniform(T, 17);
+    const cytnx_uint64 full = 5;
+    const cytnx_uint64 floor = 3;
+    std::vector<Tensor> ref = linalg::Gesvd(T, /*is_U=*/true, /*is_vT=*/true);
+
+    std::vector<Tensor> out = linalg::Gesvd_truncate(T, /*keepdim=*/full, /*err=*/1e9,
+                                                     /*is_U=*/true, /*is_vT=*/true, 0, floor);
+    ASSERT_EQ(out[0].shape(), std::vector<cytnx_uint64>({floor}));
+    for (cytnx_uint64 i = 0; i < floor; ++i) {
+      const double got = out[0].astype(Type.Double).storage().at<double>(i);
+      const double exp = ref[0].astype(Type.Double).storage().at<double>(i);
+      EXPECT_NEAR(got, exp, 1e-12 * (1.0 + std::abs(exp))) << "S[" << i << "]";
+    }
+  }
 }  // namespace GesvdTruncateTest

--- a/tests/linalg_test/Rsvd_test.cpp
+++ b/tests/linalg_test/Rsvd_test.cpp
@@ -243,6 +243,25 @@ namespace RsvdTest {
   }
 
   /*=====test info=====
+  describe:On a Block UniTensor, with err larger than every singular value, the truncation loop
+  would otherwise cut down to 1; mindim must clamp the kept count to at least mindim. Exercises
+  the sample_target=max(keepdim,mindim) path on the Block route.
+  ====================*/
+  TEST(Rsvd, mindim_floor_blockut) {
+    auto syms = std::vector<Symmetry>{Symmetry(SymmetryType::U)};
+    Bond bk = Bond(BD_KET, {{0}, {1}, {2}}, {3, 3, 3}, syms);
+    UniTensor src_T({bk, bk.redirect()}, {"l", "r"}, 1, Type.Double, Device.cpu, false);
+    InitUniTensorUniform(src_T, 31);
+    const cytnx_uint64 keepdim = 6, mindim = 4;
+
+    std::vector<UniTensor> out =
+      linalg::Rsvd(src_T, keepdim, /*err=*/1e9, true, true, 0, mindim, 0, 0., 2, 0);
+    cytnx_uint64 total_kept = 0;
+    for (auto d : out[0].bonds()[0].getDegeneracies()) total_kept += d;
+    EXPECT_GE(total_kept, mindim);
+  }
+
+  /*=====test info=====
   describe:Setting min_blockdim must keep at least the requested number of singular values per
   sector. With a small keepdim, the baseline (no min_blockdim) drops entire sectors; with
   min_blockdim={1,1,1} every sector keeps at least one singular value.

--- a/tests/linalg_test/Rsvd_test.cpp
+++ b/tests/linalg_test/Rsvd_test.cpp
@@ -177,6 +177,97 @@ namespace RsvdTest {
     // EXPECT_TRUE(ReComposeCheck(src_T, rsvds)) << fail_msg.TraceFailMsgs();
   }
 
+  /*=====test info=====
+  describe:When per-block min_blockdim guarantees already meet or exceed the global keepdim cap
+  (keep_dim<=0 internally) but there are further singular values, the return_err path must report
+  the actually dropped singular values.
+  ====================*/
+  TEST(Rsvd, return_err_when_min_blockdim_exhausts_keepdim) {
+    // 2-leg U(1) BlockUT, 3 sectors of size 3x3 each. With min_blockdim=[2,2,2] every block
+    // keeps its top 2 SVs and contributes its 3rd to Sall (3 dropped values total);
+    // oversampling_summand=2 makes the per-block sampling formula ask for the full 3 SVs per
+    // block (the default ceil(keepdim*BlockDim/TenDim)=1 would otherwise leave only 1 SV per
+    // block and the min_blockdim cut would never see anything to put into Sall).
+    auto syms = std::vector<Symmetry>{Symmetry(SymmetryType::U)};
+    Bond bk = Bond(BD_KET, {{0}, {1}, {2}}, {3, 3, 3}, syms);
+    UniTensor src_T({bk, bk.redirect()}, {"l", "r"}, 1, Type.Double, Device.cpu, false);
+    InitUniTensorUniform(src_T, 23);
+
+    const cytnx_uint64 keepdim = 3;
+    const std::vector<cytnx_uint64> min_blockdim = {2, 2, 2};
+    const cytnx_uint64 oversampling_summand = 2;
+
+    // return_err = 2: terr holds every dropped singular value (3 total)
+    std::vector<UniTensor> rsvd_all = linalg::Rsvd(src_T, keepdim, min_blockdim, 0., true, true, 2,
+                                                   1, oversampling_summand, 0., 2, 0);
+    Tensor terr_all = rsvd_all.back().get_block_();
+    ASSERT_EQ(terr_all.shape(), std::vector<cytnx_uint64>({3}))
+      << "terr must hold all 3 dropped singular values, not a 1-element zero";
+    double max_abs = 0.0;
+    for (cytnx_uint64 i = 0; i < terr_all.storage().size(); ++i)
+      max_abs = std::max(max_abs, std::abs(terr_all.storage().at<double>(i)));
+    EXPECT_GT(max_abs, 0.0) << "terr values are all zero (previous bug)";
+
+    // return_err = 1: terr is a single element = largest dropped singular value
+    std::vector<UniTensor> rsvd_max = linalg::Rsvd(src_T, keepdim, min_blockdim, 0., true, true, 1,
+                                                   1, oversampling_summand, 0., 2, 0);
+    Tensor terr_max = rsvd_max.back().get_block_();
+    ASSERT_EQ(terr_max.shape(), std::vector<cytnx_uint64>({1}));
+    EXPECT_NEAR(std::abs(terr_max.storage().at<double>(0)), max_abs, 1e-10 * (1.0 + max_abs));
+  }
+
+  /*=====test info=====
+  describe:With err larger than every singular value, the truncation loop would otherwise cut
+  down to 1. mindim must restrict the kept count to at least mindim, and the kept values must be
+  the mindim largest ones of the full SVD. Uses samplenum = min(m,n) so Rsvd matches a full SVD.
+  ====================*/
+  TEST(Rsvd, mindim_floor) {
+    Tensor T = Tensor({8, 6}, Type.Double);
+    InitTensorUniform(T, 19);
+    const cytnx_uint64 keepdim = 6;  // == min(m, n) so the randomized projection is full rank
+    const cytnx_uint64 floor = 3;
+    const cytnx_uint64 oversampling_summand = 0;
+    const double oversampling_factor = 0.;
+    const cytnx_uint64 power_it = 4;
+    std::vector<Tensor> ref = linalg::Gesvd(T, /*is_U=*/true, /*is_vT=*/true);
+
+    std::vector<Tensor> out =
+      linalg::Rsvd(T, keepdim, /*err=*/1e9, /*is_U=*/true, /*is_vT=*/true, 0, floor,
+                   oversampling_summand, oversampling_factor, power_it, 0);
+    ASSERT_EQ(out[0].shape(), std::vector<cytnx_uint64>({floor}));
+    for (cytnx_uint64 i = 0; i < floor; ++i) {
+      const double got = out[0].astype(Type.Double).storage().at<double>(i);
+      const double exp = ref[0].astype(Type.Double).storage().at<double>(i);
+      EXPECT_NEAR(got, exp, 1e-8 * (1.0 + std::abs(exp))) << "S[" << i << "]";
+    }
+  }
+
+  /*=====test info=====
+  describe:Setting min_blockdim must keep at least the requested number of singular values per
+  sector. With a small keepdim, the baseline (no min_blockdim) drops entire sectors; with
+  min_blockdim={1,1,1} every sector keeps at least one singular value.
+  ====================*/
+  TEST(Rsvd, min_blockdim_keeps_each_sector) {
+    auto syms = std::vector<Symmetry>{Symmetry(SymmetryType::U)};
+    Bond bk = Bond(BD_KET, {{0}, {1}, {2}}, {3, 3, 3}, syms);
+    UniTensor src_T({bk, bk.redirect()}, {"l", "r"}, 1, Type.Double, Device.cpu, false);
+    InitUniTensorUniform(src_T, 29);
+    const cytnx_uint64 keepdim = 1;
+
+    // baseline: only the single largest singular value is kept, so most sectors disappear
+    std::vector<UniTensor> base = linalg::Rsvd(src_T, keepdim, 0., true, true, 0, 1, 0, 0., 2, 0);
+    const auto base_degs = base[0].bonds()[0].getDegeneracies();
+    EXPECT_LT(base_degs.size(), 3u)
+      << "baseline should drop some sectors; pick a smaller keepdim or larger blocks";
+
+    // with min_blockdim={1,1,1}: every sector must keep at least 1
+    std::vector<UniTensor> withf =
+      linalg::Rsvd(src_T, keepdim, {1, 1, 1}, 0., true, true, 0, 1, 0, 0., 2, 0);
+    const auto withf_degs = withf[0].bonds()[0].getDegeneracies();
+    ASSERT_EQ(withf_degs.size(), 3u);
+    for (cytnx_uint64 b = 0; b < 3; ++b) EXPECT_GE(withf_degs[b], 1u) << "block " << b;
+  }
+
   bool ReComposeCheck(const UniTensor& Tin, const std::vector<UniTensor>& Tout) {
     bool is_double_float_acc = true;
     auto dtype = Tin.dtype();

--- a/tests/linalg_test/Svd_truncate_test.cpp
+++ b/tests/linalg_test/Svd_truncate_test.cpp
@@ -276,4 +276,87 @@ namespace SvdTruncateTest {
 
     return true;
   }
+
+  /*=====test info=====
+  describe:When per-block min_blockdim guarantees already meet or exceed the global keepdim cap
+  (keep_dim<=0 internally) but there are further singular values, the return_err path must report
+  the actually dropped singular values, not a 1-element zero tensor.
+  ====================*/
+  TEST(Svd_truncate, return_err_when_min_blockdim_exhausts_keepdim) {
+    // 2-leg U(1) BlockUT, 3 sectors of size 3x3 each. With min_blockdim=[2,2,2] every block
+    // keeps its top 2 SVs and contributes its 3rd to Sall (3 dropped values total);
+    // keep_dim = 3 - 6 = -3 < 0, so all 3 are dropped via the keep_dim<=0 branch.
+    auto syms = std::vector<Symmetry>{Symmetry(SymmetryType::U)};
+    Bond bk = Bond(BD_KET, {{0}, {1}, {2}}, {3, 3, 3}, syms);
+    UniTensor src_T({bk, bk.redirect()}, {"l", "r"}, 1, Type.Double, Device.cpu, false);
+    InitUniTensorUniform(src_T, 23);
+
+    const cytnx_uint64 keepdim = 3;
+    const std::vector<cytnx_uint64> min_blockdim = {2, 2, 2};
+
+    // return_err = 2: terr holds every dropped singular value (3 total)
+    std::vector<UniTensor> svds_all =
+      linalg::Svd_truncate(src_T, keepdim, min_blockdim, 0., true, 2, 1);
+    Tensor terr_all = svds_all.back().get_block_();
+    ASSERT_EQ(terr_all.shape(), std::vector<cytnx_uint64>({3}))
+      << "terr must hold all 3 dropped singular values, not a 1-element zero";
+    double max_abs = 0.0;
+    for (cytnx_uint64 i = 0; i < terr_all.storage().size(); ++i)
+      max_abs = std::max(max_abs, std::abs(terr_all.storage().at<double>(i)));
+    EXPECT_GT(max_abs, 0.0) << "terr values are all zero (previous bug)";
+
+    // return_err = 1: terr is a single element = largest dropped singular value
+    std::vector<UniTensor> svds_max =
+      linalg::Svd_truncate(src_T, keepdim, min_blockdim, 0., true, 1, 1);
+    Tensor terr_max = svds_max.back().get_block_();
+    ASSERT_EQ(terr_max.shape(), std::vector<cytnx_uint64>({1}));
+    EXPECT_NEAR(std::abs(terr_max.storage().at<double>(0)), max_abs, 1e-10 * (1.0 + max_abs));
+  }
+
+  /*=====test info=====
+  describe:Setting min_blockdim must keep at least the requested number of singular values per
+  sector. With a small keepdim, the baseline (no min_blockdim) drops entire sectors; with
+  min_blockdim={1,1,1} every sector keeps at least one singular value.
+  ====================*/
+  TEST(Svd_truncate, min_blockdim_keeps_each_sector) {
+    auto syms = std::vector<Symmetry>{Symmetry(SymmetryType::U)};
+    Bond bk = Bond(BD_KET, {{0}, {1}, {2}}, {3, 3, 3}, syms);
+    UniTensor src_T({bk, bk.redirect()}, {"l", "r"}, 1, Type.Double, Device.cpu, false);
+    InitUniTensorUniform(src_T, 29);
+    const cytnx_uint64 keepdim = 1;
+
+    // baseline: only the single largest singular value is kept, so most sectors disappear
+    std::vector<UniTensor> base = linalg::Svd_truncate(src_T, keepdim);
+    const auto base_degs = base[0].bonds()[0].getDegeneracies();
+    EXPECT_LT(base_degs.size(), 3u)
+      << "baseline should drop some sectors; pick a smaller keepdim or larger blocks";
+
+    // with min_blockdim={1,1,1}: every sector must keep at least 1
+    std::vector<UniTensor> withf = linalg::Svd_truncate(src_T, keepdim, {1, 1, 1});
+    const auto withf_degs = withf[0].bonds()[0].getDegeneracies();
+    ASSERT_EQ(withf_degs.size(), 3u);
+    for (cytnx_uint64 b = 0; b < 3; ++b) EXPECT_GE(withf_degs[b], 1u) << "block " << b;
+  }
+
+  /*=====test info=====
+  describe:With err larger than every singular value, the truncation loop would otherwise cut
+  down to 1. mindim must restrict the kept count to at least mindim, and the kept values must be
+  the mindim largest ones of the full SVD.
+  ====================*/
+  TEST(Svd_truncate, mindim_floor) {
+    Tensor T = Tensor({6, 5}, Type.Double);
+    InitTensorUniform(T, 13);
+    const cytnx_uint64 full = 5;
+    const cytnx_uint64 floor = 3;
+    std::vector<Tensor> ref = linalg::Svd(T, /*is_UvT=*/true);
+
+    std::vector<Tensor> out =
+      linalg::Svd_truncate(T, /*keepdim=*/full, /*err=*/1e9, /*is_UvT=*/true, 0, floor);
+    ASSERT_EQ(out[0].shape(), std::vector<cytnx_uint64>({floor}));
+    for (cytnx_uint64 i = 0; i < floor; ++i) {
+      const double got = out[0].astype(Type.Double).storage().at<double>(i);
+      const double exp = ref[0].astype(Type.Double).storage().at<double>(i);
+      EXPECT_NEAR(got, exp, 1e-12 * (1.0 + std::abs(exp))) << "S[" << i << "]";
+    }
+  }
 }  // namespace SvdTruncateTest


### PR DESCRIPTION
`Svd_truncate`, `Gesvd_truncate`, `Rsvd` returned wrong error values when `mindim` <= `keepdim`.
`Rsvd` behaved differently with respect to `mindim` and `min_blockdim` compared to the other truncated SVD functions.
The behavior of `mindim` and `min_blockdim` is checked in all 3 functions by unit tests.