### PR TITLE
feat(stride_view): add a strided random-access range adaptor

### DIFF
--- a/src/backend/linalg_internal_cpu/stride_view.hpp
+++ b/src/backend/linalg_internal_cpu/stride_view.hpp
@@ -163,6 +163,10 @@ namespace cytnx {
     /// @code
     /// std::span<const T>(data, extent) | stride(diag_stride)
     /// @endcode
+    ///
+    /// TODO(C++23): replace this whole header with @c std::views::stride. The
+    /// pipe form @c r | stride(k) is chosen to match @c std::views::stride so
+    /// call sites stay unchanged across the swap.
     inline stride_closure stride(std::size_t step) { return stride_closure{step}; }
 
   }  // namespace linalg_internal

--- a/src/backend/linalg_internal_cpu/stride_view.hpp
+++ b/src/backend/linalg_internal_cpu/stride_view.hpp
@@ -10,27 +10,36 @@
 namespace cytnx {
   namespace linalg_internal {
 
-    // A view over every step-th element of a random-access, sized range, e.g. the
-    // diagonal of a matrix laid out with a fixed stride. It lets a single
-    // reduction routine (PairwiseSum) consume both contiguous and strided
-    // sequences.
-    //
-    // The iterator stores the underlying range's iterator rather than a pointer
-    // to the view, so iterators stay valid for as long as the underlying data
-    // lives, independent of the stride_view object's lifetime.
+    /// @brief A view over every @p step -th element of a random-access, sized range.
+    ///
+    /// Wraps any sized random-access range @p V (e.g. `std::span<const T>`) and
+    /// presents a fresh random-access, sized range whose @c i -th element is the
+    /// @p step*i -th element of the underlying range. This lets a single
+    /// reduction routine (e.g. `PairwiseSum`) consume both contiguous and
+    /// strided sequences uniformly -- the diagonal of a matrix laid out with a
+    /// fixed stride being the motivating use case.
+    ///
+    /// The iterator stores the underlying range's iterator rather than a
+    /// pointer back to the view, so iterators stay valid for as long as the
+    /// underlying data lives, independent of the @c stride_view object's
+    /// lifetime.
+    ///
+    /// @par Example
+    /// @code
+    /// std::vector<double> v(30);
+    /// // every third element: 0, 3, 6, ..., 27
+    /// auto s = PairwiseSum(std::span<const double>(v) | stride(3));
+    /// @endcode
+    ///
+    /// @tparam V An underlying view modelling @c std::ranges::view,
+    ///           @c std::ranges::random_access_range, and
+    ///           @c std::ranges::sized_range.
     template <std::ranges::view V>
     requires std::ranges::random_access_range<V> && std::ranges::sized_range<V>
     class stride_view : public std::ranges::view_interface<stride_view<V>> {
-      V base_{};
-      std::size_t step_ = 1;
-
      public:
+      /// @brief Random-access iterator over a @c stride_view.
       class iterator {
-        using BaseIter = std::ranges::iterator_t<const V>;
-        BaseIter base_{};
-        std::size_t step_ = 1;
-        std::size_t index_ = 0;
-
        public:
         using value_type = std::ranges::range_value_t<V>;
         using difference_type = std::ptrdiff_t;
@@ -39,13 +48,13 @@ namespace cytnx {
         using reference = std::ranges::range_reference_t<const V>;
 
         iterator() = default;
-        iterator(BaseIter base, std::size_t step, std::size_t index)
+        iterator(std::ranges::iterator_t<const V> base, std::size_t step, std::size_t index)
             : base_(base), step_(step), index_(index) {}
 
         reference operator*() const { return base_[static_cast<difference_type>(index_ * step_)]; }
         reference operator[](difference_type n) const {
-          return base_[static_cast<difference_type>((index_ + static_cast<std::size_t>(n)) *
-                                                    step_)];
+          return base_[(static_cast<difference_type>(index_) + n) *
+                       static_cast<difference_type>(step_)];
         }
 
         iterator& operator++() {
@@ -71,7 +80,13 @@ namespace cytnx {
           index_ = static_cast<std::size_t>(static_cast<difference_type>(index_) + n);
           return *this;
         }
-        iterator& operator-=(difference_type n) { return *this += -n; }
+        iterator& operator-=(difference_type n) {
+          // Direct subtraction; computing `*this += -n` would invoke UB when
+          // n == std::numeric_limits<difference_type>::min() (the negation
+          // cannot be represented in difference_type).
+          index_ = static_cast<std::size_t>(static_cast<difference_type>(index_) - n);
+          return *this;
+        }
 
         friend iterator operator+(iterator it, difference_type n) {
           it += n;
@@ -95,26 +110,45 @@ namespace cytnx {
         friend auto operator<=>(const iterator& a, const iterator& b) {
           return a.index_ <=> b.index_;
         }
+
+       private:
+        std::ranges::iterator_t<const V> base_{};
+        std::size_t step_ = 1;
+        std::size_t index_ = 0;
       };
 
       stride_view() = default;
+
+      /// @brief Construct a view that selects every @p step -th element of @p base.
+      /// @param base The underlying random-access, sized range.
+      /// @param step Positive stride; @p step == 0 is rejected.
+      /// @throws std::invalid_argument if @p step is zero.
       stride_view(V base, std::size_t step) : base_(std::move(base)), step_(step) {
         if (step_ == 0) throw std::invalid_argument("stride_view: stride must be positive");
       }
 
+      /// @brief Number of elements produced by this view.
+      ///
+      /// Equal to @c ceil(size(base) / step). An empty base or any base whose
+      /// length is shorter than @c step yields a well-formed view that selects
+      /// at most one element.
       std::size_t size() const {
         const auto n = static_cast<std::size_t>(std::ranges::size(base_));
         return n / step_ + (n % step_ != 0);
       }
       iterator begin() const { return iterator(std::ranges::begin(base_), step_, 0); }
       iterator end() const { return iterator(std::ranges::begin(base_), step_, size()); }
+
+     private:
+      V base_{};
+      std::size_t step_ = 1;
     };
 
     template <class R>
     stride_view(R&&, std::size_t) -> stride_view<std::views::all_t<R>>;
 
-    // Range-adaptor closure so a strided view can be written as
-    // `range | stride(step)`, e.g. `std::span<const T>(data, extent) | stride(k)`.
+    /// @brief Range-adaptor closure for the pipe form `r | stride(k)`.
+    /// @see stride
     struct stride_closure {
       std::size_t step;
       template <std::ranges::viewable_range R>
@@ -122,6 +156,13 @@ namespace cytnx {
         return stride_view(std::views::all(std::forward<R>(range)), closure.step);
       }
     };
+
+    /// @brief Build a closure that pipes a range through @c stride_view.
+    /// @param step Positive stride forwarded to @c stride_view's constructor.
+    /// @par Example
+    /// @code
+    /// std::span<const T>(data, extent) | stride(diag_stride)
+    /// @endcode
     inline stride_closure stride(std::size_t step) { return stride_closure{step}; }
 
   }  // namespace linalg_internal

--- a/src/backend/linalg_internal_cpu/stride_view.hpp
+++ b/src/backend/linalg_internal_cpu/stride_view.hpp
@@ -1,0 +1,130 @@
+#ifndef CYTNX_BACKEND_LINALG_INTERNAL_CPU_STRIDE_VIEW_H_
+#define CYTNX_BACKEND_LINALG_INTERNAL_CPU_STRIDE_VIEW_H_
+
+#include <cstddef>
+#include <iterator>
+#include <ranges>
+#include <stdexcept>
+#include <utility>
+
+namespace cytnx {
+  namespace linalg_internal {
+
+    // A view over every step-th element of a random-access, sized range, e.g. the
+    // diagonal of a matrix laid out with a fixed stride. It lets a single
+    // reduction routine (PairwiseSum) consume both contiguous and strided
+    // sequences.
+    //
+    // The iterator stores the underlying range's iterator rather than a pointer
+    // to the view, so iterators stay valid for as long as the underlying data
+    // lives, independent of the stride_view object's lifetime.
+    template <std::ranges::view V>
+    requires std::ranges::random_access_range<V> && std::ranges::sized_range<V>
+    class stride_view : public std::ranges::view_interface<stride_view<V>> {
+      V base_{};
+      std::size_t step_ = 1;
+
+     public:
+      class iterator {
+        using BaseIter = std::ranges::iterator_t<const V>;
+        BaseIter base_{};
+        std::size_t step_ = 1;
+        std::size_t index_ = 0;
+
+       public:
+        using value_type = std::ranges::range_value_t<V>;
+        using difference_type = std::ptrdiff_t;
+        using iterator_concept = std::random_access_iterator_tag;
+        using iterator_category = std::random_access_iterator_tag;
+        using reference = std::ranges::range_reference_t<const V>;
+
+        iterator() = default;
+        iterator(BaseIter base, std::size_t step, std::size_t index)
+            : base_(base), step_(step), index_(index) {}
+
+        reference operator*() const { return base_[static_cast<difference_type>(index_ * step_)]; }
+        reference operator[](difference_type n) const {
+          return base_[static_cast<difference_type>((index_ + static_cast<std::size_t>(n)) *
+                                                    step_)];
+        }
+
+        iterator& operator++() {
+          ++index_;
+          return *this;
+        }
+        iterator operator++(int) {
+          iterator t = *this;
+          ++index_;
+          return t;
+        }
+        iterator& operator--() {
+          --index_;
+          return *this;
+        }
+        iterator operator--(int) {
+          iterator t = *this;
+          --index_;
+          return t;
+        }
+
+        iterator& operator+=(difference_type n) {
+          index_ = static_cast<std::size_t>(static_cast<difference_type>(index_) + n);
+          return *this;
+        }
+        iterator& operator-=(difference_type n) { return *this += -n; }
+
+        friend iterator operator+(iterator it, difference_type n) {
+          it += n;
+          return it;
+        }
+        friend iterator operator+(difference_type n, iterator it) {
+          it += n;
+          return it;
+        }
+        friend iterator operator-(iterator it, difference_type n) {
+          it -= n;
+          return it;
+        }
+        friend difference_type operator-(const iterator& a, const iterator& b) {
+          return static_cast<difference_type>(a.index_) - static_cast<difference_type>(b.index_);
+        }
+
+        friend bool operator==(const iterator& a, const iterator& b) {
+          return a.index_ == b.index_;
+        }
+        friend auto operator<=>(const iterator& a, const iterator& b) {
+          return a.index_ <=> b.index_;
+        }
+      };
+
+      stride_view() = default;
+      stride_view(V base, std::size_t step) : base_(std::move(base)), step_(step) {
+        if (step_ == 0) throw std::invalid_argument("stride_view: stride must be positive");
+      }
+
+      std::size_t size() const {
+        const auto n = static_cast<std::size_t>(std::ranges::size(base_));
+        return n / step_ + (n % step_ != 0);
+      }
+      iterator begin() const { return iterator(std::ranges::begin(base_), step_, 0); }
+      iterator end() const { return iterator(std::ranges::begin(base_), step_, size()); }
+    };
+
+    template <class R>
+    stride_view(R&&, std::size_t) -> stride_view<std::views::all_t<R>>;
+
+    // Range-adaptor closure so a strided view can be written as
+    // `range | stride(step)`, e.g. `std::span<const T>(data, extent) | stride(k)`.
+    struct stride_closure {
+      std::size_t step;
+      template <std::ranges::viewable_range R>
+      friend auto operator|(R&& range, stride_closure closure) {
+        return stride_view(std::views::all(std::forward<R>(range)), closure.step);
+      }
+    };
+    inline stride_closure stride(std::size_t step) { return stride_closure{step}; }
+
+  }  // namespace linalg_internal
+}  // namespace cytnx
+
+#endif  // CYTNX_BACKEND_LINALG_INTERNAL_CPU_STRIDE_VIEW_H_

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(
   linalg_test/Rsvd_test.cpp
   linalg_test/Gemm_Batch_test.cpp
   linalg_test/linalg_test.cpp
+  linalg_test/stride_view_test.cpp
   linalg_test/sum_test.cpp
   linalg_test/Vectordot_test.cpp
   algo_test/Hsplit_test.cpp
@@ -60,6 +61,10 @@ target_include_directories(
   test_main
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
+  # Internal backend headers (e.g. linalg_internal_cpu/stride_view.hpp) live
+  # under src/ and are PRIVATE to the cytnx target; expose them to the test
+  # binary so internal utilities can be unit-tested directly.
+  ${CMAKE_SOURCE_DIR}/src
 )
 target_link_libraries(
   test_main

--- a/tests/linalg_test/stride_view_test.cpp
+++ b/tests/linalg_test/stride_view_test.cpp
@@ -1,0 +1,95 @@
+#include <gtest/gtest.h>
+
+#include <complex>
+#include <ranges>
+#include <span>
+#include <vector>
+
+#include "backend/linalg_internal_cpu/pairwise_sum.hpp"
+#include "backend/linalg_internal_cpu/stride_view.hpp"
+
+namespace {
+
+  using cytnx::linalg_internal::PairwiseSum;
+  using cytnx::linalg_internal::stride;
+  using cytnx::linalg_internal::stride_view;
+
+  using DoubleView = stride_view<std::span<const double>>;
+
+  // stride_view must model a sized random-access range so PairwiseSum (and any
+  // other range algorithm) can consume it.
+  static_assert(std::random_access_iterator<DoubleView::iterator>);
+  static_assert(std::ranges::random_access_range<DoubleView>);
+  static_assert(std::ranges::sized_range<DoubleView>);
+
+  TEST(StrideViewTest, SelectsEveryStepThElement) {
+    std::vector<double> v(30);
+    for (int i = 0; i < 30; ++i) v[i] = i;
+    stride_view sv(std::span<const double>(v), 3);
+    ASSERT_EQ(sv.size(), 10u);
+    std::vector<double> got(sv.begin(), sv.end());
+    ASSERT_EQ(got.size(), 10u);
+    for (int k = 0; k < 10; ++k) EXPECT_DOUBLE_EQ(got[k], 3.0 * k);
+  }
+
+  TEST(StrideViewTest, NonDividingRangeRoundsUp) {
+    // size 10 with stride 3 -> 4 elements at offsets 0, 3, 6, 9 (exercises the
+    // n % step != 0 branch of size(), which is the shape produced by Trace's
+    // extent = (Ndiag - 1) * step + 1 contract).
+    std::vector<double> v(10);
+    for (int i = 0; i < 10; ++i) v[i] = i;
+    stride_view sv(std::span<const double>(v), 3);
+    ASSERT_EQ(sv.size(), 4u);
+    std::vector<double> got(sv.begin(), sv.end());
+    ASSERT_EQ(got.size(), 4u);
+    for (int k = 0; k < 4; ++k) EXPECT_DOUBLE_EQ(got[k], 3.0 * k);
+  }
+
+  TEST(StrideViewTest, RejectsZeroStride) {
+    std::vector<double> v(4);
+    EXPECT_THROW(stride_view(std::span<const double>(v), 0), std::invalid_argument);
+  }
+
+  TEST(StrideViewTest, PipeAdaptorFeedsPairwiseSum) {
+    std::vector<double> v(30);
+    for (int i = 0; i < 30; ++i) v[i] = i;
+    // 0 + 3 + 6 + ... + 27 = 135
+    double s = PairwiseSum(std::span<const double>(v) | stride(3));
+    EXPECT_DOUBLE_EQ(s, 135.0);
+  }
+
+  TEST(StrideViewTest, IteratorsOutliveTheView) {
+    // The iterator stores the underlying base iterator, not a pointer to the
+    // stride_view, so iterators stay valid after the view is destroyed as long
+    // as the underlying data lives.
+    std::vector<double> w(10, 2.0);
+    DoubleView::iterator b, e;
+    {
+      stride_view sv(std::span<const double>(w), 2);
+      b = sv.begin();
+      e = sv.end();
+    }
+    double s = 0;
+    for (auto it = b; it != e; ++it) s += *it;
+    EXPECT_DOUBLE_EQ(s, 10.0);  // 5 selected elements * 2.0
+  }
+
+  TEST(StrideViewTest, RandomAccessOps) {
+    std::vector<double> v(20);
+    for (int i = 0; i < 20; ++i) v[i] = i;
+    stride_view sv(std::span<const double>(v), 2);  // 0,2,4,...,18
+    auto it = sv.begin();
+    EXPECT_DOUBLE_EQ(*(it + 3), 6.0);
+    EXPECT_DOUBLE_EQ(it[4], 8.0);
+    EXPECT_EQ(sv.end() - sv.begin(), 10);
+    EXPECT_TRUE(sv.begin() < sv.end());
+  }
+
+  TEST(StrideViewTest, ComplexStridedSum) {
+    std::vector<std::complex<double>> v(12, std::complex<double>(1.0, -1.0));
+    auto s = PairwiseSum(std::span<const std::complex<double>>(v) | stride(2));  // 6 elements
+    EXPECT_DOUBLE_EQ(s.real(), 6.0);
+    EXPECT_DOUBLE_EQ(s.imag(), -6.0);
+  }
+
+}  // namespace

--- a/tests/linalg_test/stride_view_test.cpp
+++ b/tests/linalg_test/stride_view_test.cpp
@@ -22,32 +22,59 @@ namespace {
   static_assert(std::ranges::random_access_range<DoubleView>);
   static_assert(std::ranges::sized_range<DoubleView>);
 
-  TEST(StrideViewTest, SelectsEveryStepThElement) {
-    std::vector<double> v(30);
-    for (int i = 0; i < 30; ++i) v[i] = i;
-    stride_view sv(std::span<const double>(v), 3);
-    ASSERT_EQ(sv.size(), 10u);
-    std::vector<double> got(sv.begin(), sv.end());
-    ASSERT_EQ(got.size(), 10u);
-    for (int k = 0; k < 10; ++k) EXPECT_DOUBLE_EQ(got[k], 3.0 * k);
-  }
-
-  TEST(StrideViewTest, NonDividingRangeRoundsUp) {
-    // size 10 with stride 3 -> 4 elements at offsets 0, 3, 6, 9 (exercises the
-    // n % step != 0 branch of size(), which is the shape produced by Trace's
-    // extent = (Ndiag - 1) * step + 1 contract).
-    std::vector<double> v(10);
-    for (int i = 0; i < 10; ++i) v[i] = i;
-    stride_view sv(std::span<const double>(v), 3);
+  TEST(StrideViewTest, SelectsEveryStepthElement) {
+    std::vector<double> v(12);
+    for (int i = 0; i < 12; ++i) v[i] = i;
+    auto sv = stride_view(std::span<const double>(v), 3);
     ASSERT_EQ(sv.size(), 4u);
     std::vector<double> got(sv.begin(), sv.end());
     ASSERT_EQ(got.size(), 4u);
     for (int k = 0; k < 4; ++k) EXPECT_DOUBLE_EQ(got[k], 3.0 * k);
   }
 
+  TEST(StrideViewTest, SizeRoundsUpWhenLengthNotMultipleOfStride) {
+    // When the range length is not an exact multiple of the stride, size() must
+    // round up: a 10-element range with stride 3 yields indices 0, 3, 6, 9. This
+    // exercises the (n + step - 1) / step branch in size() and end().
+    std::vector<double> v(10);
+    for (int i = 0; i < 10; ++i) v[i] = i;
+    auto sv = stride_view(std::span<const double>(v), 3);
+    ASSERT_EQ(sv.size(), 4u);
+    EXPECT_EQ(sv.end() - sv.begin(), 4);
+    std::vector<double> got(sv.begin(), sv.end());
+    ASSERT_EQ(got.size(), 4u);
+    EXPECT_DOUBLE_EQ(got[0], 0.0);
+    EXPECT_DOUBLE_EQ(got[1], 3.0);
+    EXPECT_DOUBLE_EQ(got[2], 6.0);
+    EXPECT_DOUBLE_EQ(got[3], 9.0);
+  }
+
   TEST(StrideViewTest, RejectsZeroStride) {
     std::vector<double> v(4);
     EXPECT_THROW(stride_view(std::span<const double>(v), 0), std::invalid_argument);
+  }
+
+  TEST(StrideViewTest, EmptyBaseYieldsEmptyView) {
+    // An empty underlying range must yield size()==0 and begin()==end(); a
+    // sum/reduce algorithm consuming it must produce the identity.
+    std::vector<double> empty;
+    auto sv = stride_view(std::span<const double>(empty), 4);
+    EXPECT_EQ(sv.size(), 0u);
+    EXPECT_EQ(sv.begin(), sv.end());
+    double s = PairwiseSum(std::span<const double>(empty) | stride(4));
+    EXPECT_DOUBLE_EQ(s, 0.0);
+  }
+
+  TEST(StrideViewTest, StrideLargerThanBaseSelectsFirstElement) {
+    // When step exceeds the underlying length, the view selects exactly one
+    // element (the first). This is the (n + step - 1) / step formula's
+    // single-element regime and keeps the view well-formed for short inputs.
+    std::vector<double> v = {7.0, 8.0, 9.0};
+    auto sv = stride_view(std::span<const double>(v), 10);
+    EXPECT_EQ(sv.size(), 1u);
+    std::vector<double> got(sv.begin(), sv.end());
+    ASSERT_EQ(got.size(), 1u);
+    EXPECT_DOUBLE_EQ(got[0], 7.0);
   }
 
   TEST(StrideViewTest, PipeAdaptorFeedsPairwiseSum) {
@@ -63,24 +90,30 @@ namespace {
     // stride_view, so iterators stay valid after the view is destroyed as long
     // as the underlying data lives.
     std::vector<double> w(10, 2.0);
-    DoubleView::iterator b, e;
+    DoubleView::iterator it;
+    DoubleView::iterator end;
     {
-      stride_view sv(std::span<const double>(w), 2);
-      b = sv.begin();
-      e = sv.end();
+      auto sv = stride_view(std::span<const double>(w), 2);
+      it = sv.begin();
+      end = sv.end();
     }
     double s = 0;
-    for (auto it = b; it != e; ++it) s += *it;
-    EXPECT_DOUBLE_EQ(s, 10.0);  // 5 selected elements * 2.0
+    for (; it != end; ++it) s += *it;
+    EXPECT_DOUBLE_EQ(s, 10.0);
   }
 
   TEST(StrideViewTest, RandomAccessOps) {
     std::vector<double> v(20);
     for (int i = 0; i < 20; ++i) v[i] = i;
-    stride_view sv(std::span<const double>(v), 2);  // 0,2,4,...,18
+    auto sv = stride_view(std::span<const double>(v), 2);
     auto it = sv.begin();
     EXPECT_DOUBLE_EQ(*(it + 3), 6.0);
     EXPECT_DOUBLE_EQ(it[4], 8.0);
+    // Negative offsets must step backwards: step_ is the signed difference_type,
+    // so n * step_ stays signed and a negative index does not wrap around.
+    auto mid = sv.begin() + 5;
+    EXPECT_DOUBLE_EQ(mid[-2], 6.0);
+    EXPECT_DOUBLE_EQ(*(sv.end() - 1), 18.0);
     EXPECT_EQ(sv.end() - sv.begin(), 10);
     EXPECT_TRUE(sv.begin() < sv.end());
   }


### PR DESCRIPTION
> **Stacked on master.** Direct child of `master` (#849 has merged). The CPU trace consumer lives in #862; #850 builds on top of that for GPU.

## Summary

Adds `cytnx::linalg_internal::stride_view`, a strided random-access range adaptor that wraps any sized random-access range `V` and exposes every `step`-th element as a fresh random-access range. The `r | stride(k)` pipe form lets range algorithms consume strided slices directly.

The iterator stores the underlying base iterator (not a pointer back to the view), so iterators stay valid as long as the underlying data lives — independent of the view's lifetime.

## Why now

The next Trace refactor needs to reduce a tensor diagonal in place without first cloning the data into a contiguous buffer. Landing `stride_view` as its own change makes the iterator semantics reviewable in isolation and lets the diagonal-sum step in #862 focus on the trace algorithm itself.

## Tests

`tests/linalg_test/stride_view_test.cpp` covers:

- Random-access iterator concept model via `static_assert(std::random_access_iterator<...>)` / `std::ranges::random_access_range<...>` / `std::ranges::sized_range<...>`.
- Strided element selection (dividing and non-dividing sizes — the `n % step != 0` branch of `size()`).
- `step == 0` precondition (`EXPECT_THROW(stride_view(..., 0), std::invalid_argument)`).
- Pipe adaptor (`r | stride(k)`) fed into `PairwiseSum` to exercise the integration point.
- Iterator-outlives-view regression case.
- Random-access operations (`+ n`, `[n]`, `end - begin`, `<`, negative offsets).
- Complex strided sum.
- Empty base + step > size edge cases.

The test reaches into the internal header through a `${CMAKE_SOURCE_DIR}/src` PRIVATE include on the test binary, so internal utilities can be unit-tested directly.

## Test plan

- [x] `openblas-cpu`: full suite **1064/1064** passed.
- [x] `pre-commit` (clang-format-14 + EOF + whitespace) clean.