### PR TITLE
refactor(trace): pass scalar Trace internal args by value and unify naming

### DIFF
--- a/src/backend/linalg_internal_cpu/Trace_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Trace_internal.cpp
@@ -12,7 +12,7 @@ namespace cytnx {
   namespace linalg_internal {
 
     template <class T>
-    void _trace_2d(Tensor &out, const Tensor &Tn, const cytnx_uint64 &Ndiag) {
+    void _trace_2d(Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag) {
       T a = 0;
       T *rawdata = Tn.storage().data<T>();
       cytnx_uint64 Ldim = Tn.shape()[1];
@@ -21,11 +21,10 @@ namespace cytnx {
     }
 
     template <class T>
-    void _trace_nd(Tensor &out, const Tensor &Tn, const cytnx_uint64 &Ndiag,
-                   const cytnx_uint64 &Nelem, const std::vector<cytnx_uint64> &accu,
+    void _trace_nd(Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag, cytnx_uint64 Nelem,
+                   const std::vector<cytnx_uint64> &accu,
                    const std::vector<cytnx_uint64> &remain_rank_id,
-                   const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                   const cytnx_uint64 &ax2) {
+                   const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1, cytnx_uint64 ax2) {
       cytnx::UniTensor I_UT = cytnx::UniTensor::eye(Ndiag, {}, true, Tn.dtype(), Tn.device());
 
       UniTensor UTn = UniTensor(Tn, false, 2);
@@ -50,12 +49,11 @@ namespace cytnx {
       // }
     }
 
-    void Trace_internal_cd(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                           const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                           const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_cd(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                           cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                            const std::vector<cytnx_uint64> &remain_rank_id,
-                           const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                           const cytnx_uint64 &ax2) {
+                           const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                           cytnx_uint64 ax2) {
       if (is_2d) {
         _trace_2d<cytnx_complex128>(out, Tn, Ndiag);
       } else {
@@ -63,12 +61,11 @@ namespace cytnx {
       }
     }
 
-    void Trace_internal_cf(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                           const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                           const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_cf(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                           cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                            const std::vector<cytnx_uint64> &remain_rank_id,
-                           const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                           const cytnx_uint64 &ax2) {
+                           const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                           cytnx_uint64 ax2) {
       if (is_2d) {
         _trace_2d<cytnx_complex64>(out, Tn, Ndiag);
       } else {
@@ -76,12 +73,11 @@ namespace cytnx {
       }
     }
 
-    void Trace_internal_d(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                          const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                          const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_d(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                          cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                           const std::vector<cytnx_uint64> &remain_rank_id,
-                          const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                          const cytnx_uint64 &ax2) {
+                          const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                          cytnx_uint64 ax2) {
       if (is_2d) {
         _trace_2d<cytnx_double>(out, Tn, Ndiag);
       } else {
@@ -89,12 +85,11 @@ namespace cytnx {
       }
     }
 
-    void Trace_internal_f(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                          const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                          const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_f(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                          cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                           const std::vector<cytnx_uint64> &remain_rank_id,
-                          const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                          const cytnx_uint64 &ax2) {
+                          const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                          cytnx_uint64 ax2) {
       if (is_2d) {
         _trace_2d<cytnx_float>(out, Tn, Ndiag);
       } else {
@@ -102,12 +97,11 @@ namespace cytnx {
       }
     }
 
-    void Trace_internal_u64(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                            const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_u64(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2) {
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2) {
       if (is_2d) {
         _trace_2d<cytnx_uint64>(out, Tn, Ndiag);
       } else {
@@ -115,77 +109,71 @@ namespace cytnx {
       }
     }
 
-    void Trace_internal_i64(const bool &is_2d, Tensor &out, const Tensor &tn,
-                            const cytnx_uint64 &ndiag, const cytnx_uint64 &nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_i64(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2) {
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2) {
       if (is_2d) {
-        _trace_2d<cytnx_int64>(out, tn, ndiag);
+        _trace_2d<cytnx_int64>(out, Tn, Ndiag);
       } else {
-        _trace_nd<cytnx_int64>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
+        _trace_nd<cytnx_int64>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
       }
     }
 
-    void Trace_internal_u32(const bool &is_2d, Tensor &out, const Tensor &tn,
-                            const cytnx_uint64 &ndiag, const cytnx_uint64 &nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_u32(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2) {
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2) {
       if (is_2d) {
-        _trace_2d<cytnx_uint32>(out, tn, ndiag);
+        _trace_2d<cytnx_uint32>(out, Tn, Ndiag);
       } else {
-        _trace_nd<cytnx_uint32>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
+        _trace_nd<cytnx_uint32>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
       }
     }
 
-    void Trace_internal_i32(const bool &is_2d, Tensor &out, const Tensor &tn,
-                            const cytnx_uint64 &ndiag, const cytnx_uint64 &nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_i32(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2) {
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2) {
       if (is_2d) {
-        _trace_2d<cytnx_int32>(out, tn, ndiag);
+        _trace_2d<cytnx_int32>(out, Tn, Ndiag);
       } else {
-        _trace_nd<cytnx_int32>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
+        _trace_nd<cytnx_int32>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
       }
     }
 
-    void Trace_internal_u16(const bool &is_2d, Tensor &out, const Tensor &tn,
-                            const cytnx_uint64 &ndiag, const cytnx_uint64 &nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_u16(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2) {
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2) {
       if (is_2d) {
-        _trace_2d<cytnx_uint16>(out, tn, ndiag);
+        _trace_2d<cytnx_uint16>(out, Tn, Ndiag);
       } else {
-        _trace_nd<cytnx_uint16>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
+        _trace_nd<cytnx_uint16>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
       }
     }
 
-    void Trace_internal_i16(const bool &is_2d, Tensor &out, const Tensor &tn,
-                            const cytnx_uint64 &ndiag, const cytnx_uint64 &nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_i16(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2) {
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2) {
       if (is_2d) {
-        _trace_2d<cytnx_int16>(out, tn, ndiag);
+        _trace_2d<cytnx_int16>(out, Tn, Ndiag);
       } else {
-        _trace_nd<cytnx_int16>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
+        _trace_nd<cytnx_int16>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
       }
     }
 
-    void Trace_internal_b(const bool &is_2d, Tensor &out, const Tensor &tn,
-                          const cytnx_uint64 &ndiag, const cytnx_uint64 &nelem,
-                          const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_b(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                          cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                           const std::vector<cytnx_uint64> &remain_rank_id,
-                          const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                          const cytnx_uint64 &ax2) {
+                          const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                          cytnx_uint64 ax2) {
       cytnx_error_msg(true, "[internal][Trace] bool is not available. %s", "\n");
     }
 

--- a/src/backend/linalg_internal_cpu/Trace_internal.hpp
+++ b/src/backend/linalg_internal_cpu/Trace_internal.hpp
@@ -12,82 +12,71 @@
 namespace cytnx {
   namespace linalg_internal {
 
-    void Trace_internal_cd(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                           const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                           const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_cd(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                           cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                            const std::vector<cytnx_uint64> &remain_rank_id,
-                           const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                           const cytnx_uint64 &ax2);
+                           const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                           cytnx_uint64 ax2);
 
-    void Trace_internal_cf(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                           const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                           const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_cf(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                           cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                            const std::vector<cytnx_uint64> &remain_rank_id,
-                           const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                           const cytnx_uint64 &ax2);
+                           const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                           cytnx_uint64 ax2);
 
-    void Trace_internal_d(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                          const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                          const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_d(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                          cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                           const std::vector<cytnx_uint64> &remain_rank_id,
-                          const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                          const cytnx_uint64 &ax2);
+                          const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                          cytnx_uint64 ax2);
 
-    void Trace_internal_f(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                          const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                          const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_f(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                          cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                           const std::vector<cytnx_uint64> &remain_rank_id,
-                          const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                          const cytnx_uint64 &ax2);
+                          const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                          cytnx_uint64 ax2);
 
-    void Trace_internal_u64(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                            const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_u64(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2);
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2);
 
-    void Trace_internal_i64(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                            const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_i64(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2);
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2);
 
-    void Trace_internal_u32(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                            const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_u32(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2);
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2);
 
-    void Trace_internal_i32(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                            const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_i32(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2);
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2);
 
-    void Trace_internal_u16(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                            const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_u16(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2);
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2);
 
-    void Trace_internal_i16(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                            const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_i16(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2);
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2);
 
-    void Trace_internal_b(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                          const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                          const std::vector<cytnx_uint64> &accu,
+    void Trace_internal_b(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                          cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                           const std::vector<cytnx_uint64> &remain_rank_id,
-                          const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                          const cytnx_uint64 &ax2);
+                          const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                          cytnx_uint64 ax2);
 
   }  // namespace linalg_internal
 

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -13,7 +13,7 @@ namespace cytnx {
   namespace linalg_internal {
 
     template <class T>
-    void _trace_2d_gpu(Tensor &out, const Tensor &Tn, const cytnx_uint64 &Ndiag) {
+    void _trace_2d_gpu(Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag) {
       cytnx::UniTensor I_UT = cytnx::UniTensor::eye(Ndiag, {}, true, Tn.dtype(), Tn.device());
       // similar to _trace_nd_gpu
       UniTensor UTn = UniTensor(Tn, false, 2);
@@ -22,11 +22,10 @@ namespace cytnx {
     }
 
     template <class T>
-    void _trace_nd_gpu(Tensor &out, const Tensor &Tn, const cytnx_uint64 &Ndiag,
-                       const cytnx_uint64 &Nelem, const std::vector<cytnx_uint64> &accu,
+    void _trace_nd_gpu(Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag, cytnx_uint64 Nelem,
+                       const std::vector<cytnx_uint64> &accu,
                        const std::vector<cytnx_uint64> &remain_rank_id,
-                       const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                       const cytnx_uint64 &ax2) {
+                       const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1, cytnx_uint64 ax2) {
       // currently identical to CPU version
       cytnx::UniTensor I_UT = cytnx::UniTensor::eye(Ndiag, {}, true, Tn.dtype(), Tn.device());
 
@@ -36,12 +35,11 @@ namespace cytnx {
       out = Contract(I_UT, UTn).get_block_();
     }
 
-    void cuTrace_internal_cd(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                             const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                             const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_cd(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                             cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                              const std::vector<cytnx_uint64> &remain_rank_id,
-                             const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                             const cytnx_uint64 &ax2) {
+                             const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                             cytnx_uint64 ax2) {
       if (is_2d) {
         _trace_2d_gpu<cytnx_complex128>(out, Tn, Ndiag);
       } else {
@@ -50,12 +48,11 @@ namespace cytnx {
       }
     }
 
-    void cuTrace_internal_cf(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                             const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                             const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_cf(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                             cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                              const std::vector<cytnx_uint64> &remain_rank_id,
-                             const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                             const cytnx_uint64 &ax2) {
+                             const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                             cytnx_uint64 ax2) {
       if (is_2d) {
         _trace_2d_gpu<cytnx_complex64>(out, Tn, Ndiag);
       } else {
@@ -64,12 +61,11 @@ namespace cytnx {
       }
     }
 
-    void cuTrace_internal_d(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                            const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_d(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2) {
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2) {
       if (is_2d) {
         _trace_2d_gpu<cytnx_double>(out, Tn, Ndiag);
       } else {
@@ -77,12 +73,11 @@ namespace cytnx {
       }
     }
 
-    void cuTrace_internal_f(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                            const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_f(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2) {
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2) {
       if (is_2d) {
         _trace_2d_gpu<cytnx_float>(out, Tn, Ndiag);
       } else {
@@ -90,12 +85,11 @@ namespace cytnx {
       }
     }
 
-    void cuTrace_internal_u64(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                              const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                              const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_u64(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                              cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                               const std::vector<cytnx_uint64> &remain_rank_id,
-                              const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                              const cytnx_uint64 &ax2) {
+                              const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                              cytnx_uint64 ax2) {
       if (is_2d) {
         _trace_2d_gpu<cytnx_uint64>(out, Tn, Ndiag);
       } else {
@@ -103,77 +97,71 @@ namespace cytnx {
       }
     }
 
-    void cuTrace_internal_i64(const bool &is_2d, Tensor &out, const Tensor &tn,
-                              const cytnx_uint64 &ndiag, const cytnx_uint64 &nelem,
-                              const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_i64(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                              cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                               const std::vector<cytnx_uint64> &remain_rank_id,
-                              const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                              const cytnx_uint64 &ax2) {
+                              const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                              cytnx_uint64 ax2) {
       if (is_2d) {
-        _trace_2d_gpu<cytnx_int64>(out, tn, ndiag);
+        _trace_2d_gpu<cytnx_int64>(out, Tn, Ndiag);
       } else {
-        _trace_nd_gpu<cytnx_int64>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
+        _trace_nd_gpu<cytnx_int64>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
       }
     }
 
-    void cuTrace_internal_u32(const bool &is_2d, Tensor &out, const Tensor &tn,
-                              const cytnx_uint64 &ndiag, const cytnx_uint64 &nelem,
-                              const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_u32(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                              cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                               const std::vector<cytnx_uint64> &remain_rank_id,
-                              const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                              const cytnx_uint64 &ax2) {
+                              const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                              cytnx_uint64 ax2) {
       if (is_2d) {
-        _trace_2d_gpu<cytnx_uint32>(out, tn, ndiag);
+        _trace_2d_gpu<cytnx_uint32>(out, Tn, Ndiag);
       } else {
-        _trace_nd_gpu<cytnx_uint32>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
+        _trace_nd_gpu<cytnx_uint32>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
       }
     }
 
-    void cuTrace_internal_i32(const bool &is_2d, Tensor &out, const Tensor &tn,
-                              const cytnx_uint64 &ndiag, const cytnx_uint64 &nelem,
-                              const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_i32(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                              cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                               const std::vector<cytnx_uint64> &remain_rank_id,
-                              const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                              const cytnx_uint64 &ax2) {
+                              const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                              cytnx_uint64 ax2) {
       if (is_2d) {
-        _trace_2d_gpu<cytnx_int32>(out, tn, ndiag);
+        _trace_2d_gpu<cytnx_int32>(out, Tn, Ndiag);
       } else {
-        _trace_nd_gpu<cytnx_int32>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
+        _trace_nd_gpu<cytnx_int32>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
       }
     }
 
-    void cuTrace_internal_u16(const bool &is_2d, Tensor &out, const Tensor &tn,
-                              const cytnx_uint64 &ndiag, const cytnx_uint64 &nelem,
-                              const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_u16(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                              cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                               const std::vector<cytnx_uint64> &remain_rank_id,
-                              const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                              const cytnx_uint64 &ax2) {
+                              const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                              cytnx_uint64 ax2) {
       if (is_2d) {
-        _trace_2d_gpu<cytnx_uint16>(out, tn, ndiag);
+        _trace_2d_gpu<cytnx_uint16>(out, Tn, Ndiag);
       } else {
-        _trace_nd_gpu<cytnx_uint16>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
+        _trace_nd_gpu<cytnx_uint16>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
       }
     }
 
-    void cuTrace_internal_i16(const bool &is_2d, Tensor &out, const Tensor &tn,
-                              const cytnx_uint64 &ndiag, const cytnx_uint64 &nelem,
-                              const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_i16(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                              cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                               const std::vector<cytnx_uint64> &remain_rank_id,
-                              const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                              const cytnx_uint64 &ax2) {
+                              const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                              cytnx_uint64 ax2) {
       if (is_2d) {
-        _trace_2d_gpu<cytnx_int16>(out, tn, ndiag);
+        _trace_2d_gpu<cytnx_int16>(out, Tn, Ndiag);
       } else {
-        _trace_nd_gpu<cytnx_int16>(out, tn, ndiag, nelem, accu, remain_rank_id, shape, ax1, ax2);
+        _trace_nd_gpu<cytnx_int16>(out, Tn, Ndiag, Nelem, accu, remain_rank_id, shape, ax1, ax2);
       }
     }
 
-    void cuTrace_internal_b(const bool &is_2d, Tensor &out, const Tensor &tn,
-                            const cytnx_uint64 &ndiag, const cytnx_uint64 &nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_b(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2) {
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2) {
       cytnx_error_msg(true, "[internal][cuTrace] bool is not available. %s", "\n");
     }
 

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.hpp
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.hpp
@@ -12,82 +12,71 @@
 namespace cytnx {
   namespace linalg_internal {
 
-    void cuTrace_internal_cd(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                             const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                             const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_cd(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                             cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                              const std::vector<cytnx_uint64> &remain_rank_id,
-                             const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                             const cytnx_uint64 &ax2);
+                             const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                             cytnx_uint64 ax2);
 
-    void cuTrace_internal_cf(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                             const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                             const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_cf(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                             cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                              const std::vector<cytnx_uint64> &remain_rank_id,
-                             const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                             const cytnx_uint64 &ax2);
+                             const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                             cytnx_uint64 ax2);
 
-    void cuTrace_internal_d(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                            const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_d(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2);
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2);
 
-    void cuTrace_internal_f(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                            const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_f(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2);
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2);
 
-    void cuTrace_internal_u64(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                              const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                              const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_u64(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                              cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                               const std::vector<cytnx_uint64> &remain_rank_id,
-                              const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                              const cytnx_uint64 &ax2);
+                              const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                              cytnx_uint64 ax2);
 
-    void cuTrace_internal_i64(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                              const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                              const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_i64(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                              cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                               const std::vector<cytnx_uint64> &remain_rank_id,
-                              const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                              const cytnx_uint64 &ax2);
+                              const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                              cytnx_uint64 ax2);
 
-    void cuTrace_internal_u32(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                              const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                              const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_u32(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                              cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                               const std::vector<cytnx_uint64> &remain_rank_id,
-                              const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                              const cytnx_uint64 &ax2);
+                              const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                              cytnx_uint64 ax2);
 
-    void cuTrace_internal_i32(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                              const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                              const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_i32(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                              cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                               const std::vector<cytnx_uint64> &remain_rank_id,
-                              const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                              const cytnx_uint64 &ax2);
+                              const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                              cytnx_uint64 ax2);
 
-    void cuTrace_internal_u16(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                              const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                              const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_u16(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                              cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                               const std::vector<cytnx_uint64> &remain_rank_id,
-                              const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                              const cytnx_uint64 &ax2);
+                              const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                              cytnx_uint64 ax2);
 
-    void cuTrace_internal_i16(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                              const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                              const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_i16(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                              cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                               const std::vector<cytnx_uint64> &remain_rank_id,
-                              const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                              const cytnx_uint64 &ax2);
+                              const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                              cytnx_uint64 ax2);
 
-    void cuTrace_internal_b(const bool &is_2d, Tensor &out, const Tensor &Tn,
-                            const cytnx_uint64 &Ndiag, const cytnx_uint64 &Nelem,
-                            const std::vector<cytnx_uint64> &accu,
+    void cuTrace_internal_b(bool is_2d, Tensor &out, const Tensor &Tn, cytnx_uint64 Ndiag,
+                            cytnx_uint64 Nelem, const std::vector<cytnx_uint64> &accu,
                             const std::vector<cytnx_uint64> &remain_rank_id,
-                            const std::vector<cytnx_int64> &shape, const cytnx_uint64 &ax1,
-                            const cytnx_uint64 &ax2);
+                            const std::vector<cytnx_int64> &shape, cytnx_uint64 ax1,
+                            cytnx_uint64 ax2);
 
   }  // namespace linalg_internal
 

--- a/src/backend/linalg_internal_interface.hpp
+++ b/src/backend/linalg_internal_interface.hpp
@@ -178,11 +178,10 @@ namespace cytnx {
     typedef void (*Sumfunc_oii)(boost::intrusive_ptr<Storage_base> &,
                                 const boost::intrusive_ptr<Storage_base> &, const cytnx_uint64 &);
 
-    typedef void (*Tracefunc_oii)(const bool &, Tensor &, const Tensor &, const cytnx_uint64 &,
-                                  const cytnx_uint64 &, const std::vector<cytnx_uint64> &,
+    typedef void (*Tracefunc_oii)(bool, Tensor &, const Tensor &, cytnx_uint64, cytnx_uint64,
                                   const std::vector<cytnx_uint64> &,
-                                  const std::vector<cytnx_int64> &, const cytnx_uint64 &,
-                                  const cytnx_uint64 &);
+                                  const std::vector<cytnx_uint64> &,
+                                  const std::vector<cytnx_int64> &, cytnx_uint64, cytnx_uint64);
 
     typedef void (*Tensordotfunc_oii)(Tensor &out, const Tensor &Lin, const Tensor &Rin,
                                       const std::vector<cytnx_uint64> &idxl,


### PR DESCRIPTION
> **Stacked on #849 → stride_view.** Base is `claude/stride-view` (the new stride_view PR). This PR's diff is only the Trace signature refactor. Review/merge #849 and stride_view first, then this PR retargets to `master`.

## Summary

The Trace internal dispatchers (`Trace_internal_*`, `cuTrace_internal_*`) and the `Tracefunc_oii` function-pointer typedef took their scalar arguments (`is_2d`, `Ndiag`, `Nelem`, `ax1`, `ax2`) by const reference. Passing scalars by const reference adds an indirection without benefit; the convention in this codebase is to take small parameters by value. Vector and Tensor arguments stay by const reference.

Several dispatchers also named the same parameters inconsistently (`tn`, `ndiag`, `nelem` in the integer-typed overloads versus `Tn`, `Ndiag`, `Nelem` elsewhere). Unify on `Tn` / `Ndiag` / `Nelem` across every overload so the signatures read uniformly.

Scope is strictly the Trace API surface: only `Tracefunc_oii` and the eleven Trace dispatcher signatures change. Other `linalg_internal` typedefs are left untouched.

## Why split

This is a pure mechanical refactor that's easy to review on its own; landing it first keeps the follow-up "compute Trace in the container layer" PR focused on the algorithm rather than mixing in cosmetic signature churn.

## Test plan

- [x] `openblas-cpu`: full suite **955/955** passed (includes #849's re-enabled Sum-accuracy tests + new `StrideView` tests from the stride_view PR; no Trace behavior change so the existing `DenseUniTensorTest.Trace` and friends still pass).
- [x] `mkl-cpu`: full suite **955/955** passed.
- [x] `pre-commit` (clang-format-14 + EOF + whitespace) clean.

Draft — opened for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhXYPqttRF669v9f2ek32X)_