### PR TITLE
ci: unified release_pypi.yml — stable to PyPI on tag, nightly .devN to anaconda.org on master push

### DIFF
--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -1,11 +1,37 @@
-name: Release to PyPI
+name: Release wheels
 
-# Production release pipeline for the `cytnx` PyPI project. cibuildwheel
-# builds the wheels on every pull request and every push to
-# master/tags as a build-health check, but the wheels are only
-# published to production PyPI on `v*` tag pushes and manual
-# workflow_dispatch. Pull-request and master-push runs build and
-# discard the wheels.
+# Single release pipeline for cytnx. cibuildwheel builds the wheels on
+# every pull request and every push as a build-health check; what
+# happens to the wheels afterwards depends on the resolved channel:
+#
+#   - **stable** — a `v*` tag push (or a dispatch resolving to stable)
+#     publishes `cytnx X.Y.Z` to production PyPI via OIDC trusted
+#     publishing. pyproject.toml is consumed as-is (numeric version
+#     from version.cmake).
+#
+#   - **nightly** — a push to `master` (or a dispatch resolving to
+#     nightly) stamps a PEP 440 dev version
+#     (`MAJOR.MINOR.PATCH.devYYYYMMDDHHMM`) into pyproject.toml via
+#     tools/prepare_nightly_release.py and uploads the wheels to the
+#     `cytnx-nightly-wheels` organisation channel on anaconda.org. The
+#     official `cytnx` PyPI project is never touched by this path, so
+#     production PyPI only ever holds tagged stable releases.
+#
+# Pull requests always resolve to the nightly channel with publishing
+# disabled: the PR is merged with its target branch and the nightly
+# wheels are built (validating the nightly release path) but never
+# uploaded.
+#
+# Manual `workflow_dispatch` runs default to auto-detection (tag →
+# stable, anything else → nightly) and expose a `channel` input that
+# can force either path.
+#
+# Install commands:
+#   stable:   pip install cytnx
+#   nightly:  pip install --pre \
+#               --extra-index-url \
+#                 https://pypi.anaconda.org/cytnx-nightly-wheels/simple \
+#               cytnx
 
 on:
   pull_request:
@@ -15,10 +41,78 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      channel:
+        description: "Release channel"
+        type: choice
+        options:
+          - auto
+          - stable
+          - nightly
+        default: auto
 
 jobs:
+  DetermineChannel:
+    # Resolves a single source of truth for the rest of the workflow:
+    #   * channel — `stable` or `nightly`, selecting the build/publish path
+    #   * publish — whether the resolved channel's publish job may run
+    #   * dev_tag — the PEP 440 dev suffix (`.devYYYYMMDDHHMM`, UTC)
+    #     for nightly builds; empty string for stable. Computed in
+    #     this single job and forwarded to every BuildWheel matrix
+    #     entry so all wheels for one workflow run carry the same
+    #     version, even when the matrix runners start across a
+    #     minute boundary.
+    # Concentrating the decision here keeps the BuildWheel matrix
+    # and the publish jobs from re-deriving the trigger logic.
+    name: DetermineChannel
+    runs-on: ubuntu-24.04
+    outputs:
+      channel: ${{ steps.pick.outputs.channel }}
+      publish: ${{ steps.pick.outputs.publish }}
+      dev_tag: ${{ steps.pick.outputs.dev_tag }}
+    steps:
+    - id: pick
+      run: |
+        event="${{ github.event_name }}"
+        ref="${{ github.ref }}"
+        if [[ "$event" == "pull_request" ]]; then
+          # PRs validate the nightly build path but never upload.
+          channel=nightly
+          publish=false
+        elif [[ "$event" == "push" ]]; then
+          if [[ "$ref" == refs/tags/v* ]]; then
+            channel=stable
+          else
+            channel=nightly
+          fi
+          publish=true
+        else
+          # workflow_dispatch
+          requested="${{ inputs.channel }}"
+          if [[ "$requested" == "auto" ]]; then
+            if [[ "$ref" == refs/tags/v* ]]; then
+              channel=stable
+            else
+              channel=nightly
+            fi
+          else
+            channel="$requested"
+          fi
+          publish=true
+        fi
+        if [[ "$channel" == "nightly" ]]; then
+          dev_tag=".dev$(date -u +%Y%m%d%H%M)"
+        else
+          dev_tag=""
+        fi
+        echo "channel=$channel" >> "$GITHUB_OUTPUT"
+        echo "publish=$publish" >> "$GITHUB_OUTPUT"
+        echo "dev_tag=$dev_tag" >> "$GITHUB_OUTPUT"
+        echo "event=$event ref=$ref -> channel=$channel publish=$publish dev_tag=$dev_tag"
+
   BuildWheel:
     name: BuildWheel-${{ matrix.os }}
+    needs: DetermineChannel
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -49,6 +143,36 @@ jobs:
         # Refresh submodules in case the merge moved any gitlinks
         # (e.g. cmake_modules/morse_cmake).
         git submodule update --init --recursive
+
+    - name: Install nightly stamping helper
+      if: needs.DetermineChannel.outputs.channel == 'nightly'
+      # Installs the `release-tools` PEP 735 dependency-group from
+      # pyproject.toml (currently just `tomlkit`). Using `--group`
+      # rather than `pip install .[release-tools]` keeps the source
+      # of truth for build-pipeline deps in pyproject.toml without
+      # triggering scikit-build-core to compile cytnx itself before
+      # cibuildwheel does so under its own isolated environment.
+      # `--group` requires pip 25.1+; the runner-bundled pip is
+      # upgraded first to make the requirement portable across
+      # runner image versions.
+      run: |
+        python -m pip install --upgrade pip
+        pip install --group release-tools
+
+    - name: Stamp pyproject.toml for nightly release
+      if: needs.DetermineChannel.outputs.channel == 'nightly'
+      # Rewrites pyproject.toml to set a static
+      # MAJOR.MINOR.PATCH.devYYYYMMDDHHMM version. The dev suffix is
+      # supplied through the CYTNX_VERSION_TAG env var, sourced from
+      # the DetermineChannel job's output so every matrix entry uses
+      # the same value (each matrix runner reaching this step at a
+      # different minute would otherwise stamp a different version
+      # for the same source commit). The stable path skips this step
+      # entirely so production wheels keep the numeric version
+      # straight from version.cmake.
+      env:
+        CYTNX_VERSION_TAG: ${{ needs.DetermineChannel.outputs.dev_tag }}
+      run: python tools/prepare_nightly_release.py
 
     - name: Cache Ccache Directory
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
@@ -89,6 +213,14 @@ jobs:
         CCACHE_BASEDIR: ${{ runner.os == 'Linux' && '/project/build' || github.workspace }}
         CIBW_CONTAINER_ENGINE: "docker; create_args: --volume ${{ env.HOST_CCACHE_DIR }}:/host_ccache"
         CIBW_TEST_COMMAND: "python {project}/tools/validate_ccache_stats.py"
+        # CYTNX_VERSION_TAG is sourced from the DetermineChannel job
+        # output so every matrix entry sees the same dev tag for one
+        # workflow run. It is the empty string for stable builds, in
+        # which case CMakeLists.txt leaves CYTNX_VERSION_FULL equal
+        # to the numeric CYTNX_VERSION. On Linux it is forwarded
+        # into the manylinux container via
+        # [tool.cibuildwheel.linux].environment-pass.
+        CYTNX_VERSION_TAG: ${{ needs.DetermineChannel.outputs.dev_tag }}
 
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
       with:
@@ -97,11 +229,8 @@ jobs:
 
   ReleasePyPI:
     name: ReleasePyPI
-    needs: BuildWheel
-    # BuildWheel runs on every trigger (PR and master push included) as a
-    # build-health check, but publishing to production PyPI happens only
-    # for `v*` tag pushes and manual dispatch.
-    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch' }}
+    needs: [DetermineChannel, BuildWheel]
+    if: needs.DetermineChannel.outputs.channel == 'stable' && needs.DetermineChannel.outputs.publish == 'true'
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
@@ -116,3 +245,28 @@ jobs:
       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
       with:
         packages-dir: dist
+
+  PublishNightlyAnaconda:
+    name: PublishNightlyAnaconda
+    needs: [DetermineChannel, BuildWheel]
+    if: needs.DetermineChannel.outputs.channel == 'nightly' && needs.DetermineChannel.outputs.publish == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+      with:
+        pattern: cibw-wheels-*
+        path: dist
+        merge-multiple: true
+
+    - name: Upload nightly wheels to anaconda.org
+      # Uploads dist/*.whl to the cytnx-nightly-wheels org channel with
+      # `anaconda upload --force` (so workflow re-runs overwrite the
+      # same-named file safely). Authenticated with an anaconda.org
+      # API token stored as the ANACONDA_ORG_UPLOAD_TOKEN repository
+      # secret; no OIDC / id-token permission is required.
+      uses: scientific-python/upload-nightly-action@e76cfec8a4611fd02808a801b0ff5a7d7c1b2d99  # 0.6.4
+      with:
+        artifacts_path: dist
+        anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
+        anaconda_nightly_upload_organization: cytnx-nightly-wheels
+        anaconda_nightly_upload_labels: main

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -1,5 +1,12 @@
 name: Release to PyPI
 
+# Production release pipeline for the `cytnx` PyPI project. cibuildwheel
+# builds the wheels on every pull request and every push to
+# master/tags as a build-health check, but the wheels are only
+# published to production PyPI on `v*` tag pushes and manual
+# workflow_dispatch. Pull-request and master-push runs build and
+# discard the wheels.
+
 on:
   pull_request:
   push:
@@ -20,58 +27,48 @@ jobs:
         # newer images because Homebrew dylib minos can force a higher wheel
         # deployment target and break delocate compatibility for lower targets.
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-14, macos-15-intel]
-    defaults:
-      run:
-        shell: bash -el {0}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       with:
         fetch-depth: 0
         submodules: recursive
 
-    # When re-running a PR job, GitHub Actions uses the merge commit created at
-    # the time of the original run, not a fresh merge with the latest target branch.
-    # This step ensures we always test against the most recent target branch.
     - name: Merge with latest target branch (pull_request only)
       if: github.event_name == 'pull_request'
+      # When re-running a PR job, GitHub Actions reuses the merge commit
+      # created at the time of the original run, not a fresh merge with the
+      # latest target branch. Re-merging here validates the release build
+      # against the current target branch. A committer identity is required
+      # because a non-fast-forward merge creates a merge commit.
       run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
         git fetch origin ${{ github.event.pull_request.base.ref }}
         git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
-        # Refresh submodules in case the merge moved any gitlinks (e.g. cmake_modules/morse_cmake).
+        # Refresh submodules in case the merge moved any gitlinks
+        # (e.g. cmake_modules/morse_cmake).
         git submodule update --init --recursive
 
-    - name: Cache Ccache Directory (pull_request)
-      if: ${{ github.event_name == 'pull_request' }}
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.ccache
-        key: ccache-wheel-${{ runner.os }}-${{ github.event.pull_request.head.ref }}-${{ github.sha }}
-        restore-keys: |
-          ccache-wheel-${{ runner.os }}-${{ github.event.pull_request.head.ref }}-
-          ccache-wheel-${{ runner.os }}-${{ github.event.pull_request.base.ref }}-
-
-    - name: Cache Ccache Directory (push)
-      if: ${{ github.event_name == 'push' }}
-      uses: actions/cache@v4
+    - name: Cache Ccache Directory
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
       with:
         path: |
           ~/.ccache
         key: ccache-wheel-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
         restore-keys: |
           ccache-wheel-${{ runner.os }}-${{ github.ref_name }}-
+          ccache-wheel-${{ runner.os }}-
 
     - name: Set Ccache Directory
       run: |
-        echo "Start building---------------------------------"
         # HOST_CCACHE_DIR is consumed only by the docker bind-mount source
         # below; the in-container CCACHE_DIR is set in the Build Wheels
         # step's env: block (and forwarded via environment-pass).
         echo "HOST_CCACHE_DIR=${HOME}/.ccache" >> "$GITHUB_ENV"
 
     - name: Build Wheels
-      uses: pypa/cibuildwheel@v3.3.0
+      uses: pypa/cibuildwheel@63fd63b352a9a8bdcc24791c9dbee952ee9a8abc  # v3.3.0
       env:
         CMAKE_C_COMPILER_LAUNCHER: ccache
         CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -93,29 +90,29 @@ jobs:
         CIBW_CONTAINER_ENGINE: "docker; create_args: --volume ${{ env.HOST_CCACHE_DIR }}:/host_ccache"
         CIBW_TEST_COMMAND: "python {project}/tools/validate_ccache_stats.py"
 
-
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
       with:
         name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
         path: ./wheelhouse/*.whl
 
-  ReleaseTestPyPI:
-    name: ReleaseWheel-TestPyPI
+  ReleasePyPI:
+    name: ReleasePyPI
     needs: BuildWheel
-    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) }}
+    # BuildWheel runs on every trigger (PR and master push included) as a
+    # build-health check, but publishing to production PyPI happens only
+    # for `v*` tag pushes and manual dispatch.
+    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
       with:
         pattern: cibw-wheels-*
         path: dist
         merge-multiple: true
 
-    - name: Publish package distributions to TestPyPI (pull_request and tag push)
-      if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) }}
-      uses: pypa/gh-action-pypi-publish@release/v1
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
       with:
-        repository-url: https://test.pypi.org/legacy/
         packages-dir: dist

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,9 +63,21 @@ include(version.cmake)
 set(CYTNX_VERSION
   ${CYTNX_VERSION_MAJOR}.${CYTNX_VERSION_MINOR}.${CYTNX_VERSION_PATCH}
 )
+# `CYTNX_VERSION_FULL` carries an optional PEP 440-style suffix
+# (e.g. `.dev202605311220`) supplied via the `CYTNX_VERSION_TAG`
+# environment variable. The nightly release pipeline sets this from
+# tools/prepare_nightly_release.py so that the wheel filename
+# (cytnx_nightly-X.Y.Z.devN-*.whl) and the runtime `cytnx.__version__`
+# agree. `CYTNX_VERSION` itself stays strictly numeric because
+# `project(VERSION ...)` and `set_target_properties(VERSION ...)`
+# require MAJOR.MINOR.PATCH.
+set(CYTNX_VERSION_FULL "${CYTNX_VERSION}")
+if(DEFINED ENV{CYTNX_VERSION_TAG} AND NOT "$ENV{CYTNX_VERSION_TAG}" STREQUAL "")
+  string(APPEND CYTNX_VERSION_FULL "$ENV{CYTNX_VERSION_TAG}")
+endif()
 set(CYTNX_VARIANT_INFO "")
 
-message(STATUS " Version: ${CYTNX_VERSION}")
+message(STATUS " Version: ${CYTNX_VERSION_FULL}")
 
 # create a file that contain all the link flags:
 FILE(WRITE "${CMAKE_BINARY_DIR}/linkflags.tmp" "" "")
@@ -392,7 +404,7 @@ IF(BUILD_PYTHON)
     pybind/ncon_py.cpp
   )
   target_link_libraries(pycytnx PUBLIC cytnx)
-  target_compile_definitions(pycytnx PRIVATE CYTNX_VERSION="${CYTNX_VERSION}")
+  target_compile_definitions(pycytnx PRIVATE CYTNX_VERSION="${CYTNX_VERSION_FULL}")
 
   # On macOS, Python extensions should NOT link to libpython
   # Use -undefined dynamic_lookup to resolve symbols from the running interpreter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,8 @@ coverage = [
 # both Python and C++ coverage. Build-time deps (scikit-build-core,
 # pybind11) come from `[build-system].requires` automatically.
 dev = [
-    "pytest",
-    "pytest-cov",
-    "gcovr",
+    "cytnx[test]",
+    "cytnx[coverage]",
 ]
 docs = [
     "sphinx>=7.4.7",
@@ -55,6 +54,17 @@ docs = [
     "sphinxbootstrap4theme>=0.6.0",
     "furo>=2024.8.6",
 ]
+
+[dependency-groups]
+# Build / release helpers (e.g. tools/prepare_nightly_release.py,
+# which rewrites this file to stamp a nightly version). Declared as a
+# PEP 735 dependency-group rather than under
+# `[project.optional-dependencies]` because these tools are needed at
+# *build pipeline* time only, not at install or run time of cytnx
+# itself. `pip install --group release-tools` installs the listed
+# packages without invoking scikit-build-core to compile the project,
+# which `pip install .[release-tools]` would have forced.
+release-tools = ["tomlkit"]
 
 [project.urls]
 Documentation = "https://cytnx-dev.github.io/Cytnx/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ before-build = "python ./tools/cibuildwheel_before_build.py"
 [tool.cibuildwheel.linux]
 before-all = "bash ./tools/cibuildwheel_before_all.sh"
 environment = { CMAKE_INCLUDE_PATH = "/usr/include/openblas", CCACHE_DEBUG = "true", CCACHE_DEBUGLEVEL = "1", CCACHE_LOGFILE = "/tmp/cytnx-ccache.log" }
-environment-pass = ["CMAKE_C_COMPILER_LAUNCHER", "CMAKE_CXX_COMPILER_LAUNCHER", "CMAKE_CUDA_COMPILER_LAUNCHER", "CCACHE_COMPILERCHECK", "CCACHE_MAXSIZE", "CCACHE_DIR", "CCACHE_BASEDIR", "CCACHE_DEBUG", "CCACHE_DEBUGLEVEL", "CCACHE_LOGFILE"]
+environment-pass = ["CMAKE_C_COMPILER_LAUNCHER", "CMAKE_CXX_COMPILER_LAUNCHER", "CMAKE_CUDA_COMPILER_LAUNCHER", "CCACHE_COMPILERCHECK", "CCACHE_MAXSIZE", "CCACHE_DIR", "CCACHE_BASEDIR", "CCACHE_DEBUG", "CCACHE_DEBUGLEVEL", "CCACHE_LOGFILE", "CYTNX_VERSION_TAG"]
 
 [tool.cibuildwheel.macos]
 before-all = "bash ./tools/cibuildwheel_before_all_macos.sh"

--- a/tools/prepare_nightly_release.py
+++ b/tools/prepare_nightly_release.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Stamp pyproject.toml and emit the build version tag for a nightly release.
+
+The script
+
+  1. reads `MAJOR.MINOR.PATCH` from version.cmake using the same regex
+     that the `[tool.scikit-build.metadata.version]` block of
+     pyproject.toml uses, so there is only one source of truth for how
+     the version is parsed;
+  2. derives a PEP 440 dev version of the form
+     `MAJOR.MINOR.PATCH.devYYYYMMDDHHMM` (UTC stamp). When the
+     `CYTNX_VERSION_TAG` environment variable is already set and
+     non-empty, its value is used as the dev suffix verbatim instead
+     of generating a fresh one. This lets the surrounding CI job
+     compute the tag once and supply it to every matrix build so all
+     wheels for a workflow run carry the same version, even when the
+     matrix jobs cross a minute boundary;
+  3. rewrites pyproject.toml in place so cibuildwheel produces wheels
+     for the `cytnx` PyPI project with that static dev version
+     (`pip install --pre cytnx` will pick up the nightly; `pip install
+     cytnx` continues to install the latest stable, mirroring the
+     numpy / scipy convention); and
+  4. appends `CYTNX_VERSION_TAG=.devYYYYMMDDHHMM` to `$GITHUB_ENV` so
+     downstream steps that were not given the tag explicitly can
+     still forward it into CMake. The C++ compile definition
+     `CYTNX_VERSION` (which becomes `cytnx.__version__`) is built
+     from the numeric CMake version plus this tag, keeping
+     `cytnx.__version__` aligned with the wheel filename.
+
+This is intended to run inside a fresh CI checkout before cibuildwheel.
+It mutates the working tree and is not idempotent.
+
+Requires `tomlkit` (declared in pyproject.toml's `release-tools`
+dependency-group) so the rewrite preserves comments and formatting on
+round-trip.
+"""
+
+import datetime
+import os
+import pathlib
+import re
+import sys
+
+import tomlkit
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+VERSION_CMAKE = REPO_ROOT / "version.cmake"
+
+
+def load_version_regex(doc: tomlkit.TOMLDocument) -> re.Pattern[str]:
+    pattern = doc["tool"]["scikit-build"]["metadata"]["version"]["regex"]
+    return re.compile(str(pattern).strip())
+
+
+def read_base_version(version_re: re.Pattern[str]) -> str:
+    text = VERSION_CMAKE.read_text()
+    match = version_re.search(text)
+    if not match:
+        sys.exit(f"could not parse MAJOR/MINOR/PATCH from {VERSION_CMAKE}")
+    return f"{match['major']}.{match['minor']}.{match['patch']}"
+
+
+def build_dev_tag() -> str:
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d%H%M")
+    return f".dev{stamp}"
+
+
+def resolve_dev_tag() -> str:
+    # Prefer a caller-supplied tag so concurrent invocations agree on
+    # one version; fall back to a freshly-generated UTC stamp for
+    # standalone use.
+    return os.environ.get("CYTNX_VERSION_TAG") or build_dev_tag()
+
+
+def rewrite_pyproject(doc: tomlkit.TOMLDocument, version: str) -> None:
+    project = doc["project"]
+
+    dynamic = list(project.get("dynamic", []))
+    if "version" not in dynamic:
+        sys.exit('expected "version" in [project].dynamic in pyproject.toml')
+    dynamic.remove("version")
+    if dynamic:
+        project["dynamic"] = dynamic
+    else:
+        del project["dynamic"]
+    project["version"] = version
+
+    skb_metadata = doc["tool"]["scikit-build"]["metadata"]
+    if "version" not in skb_metadata:
+        sys.exit("expected [tool.scikit-build.metadata.version] in pyproject.toml")
+    del skb_metadata["version"]
+
+    PYPROJECT.write_text(tomlkit.dumps(doc))
+
+
+def emit_github_env(tag: str) -> None:
+    github_env = os.environ.get("GITHUB_ENV")
+    if not github_env:
+        # Outside Actions; print so the operator can pass it manually.
+        print(f"CYTNX_VERSION_TAG={tag}")
+        return
+    with open(github_env, "a", encoding="utf-8") as f:
+        f.write(f"CYTNX_VERSION_TAG={tag}\n")
+
+
+def main() -> None:
+    doc = tomlkit.parse(PYPROJECT.read_text())
+    version_re = load_version_regex(doc)
+    base = read_base_version(version_re)
+    tag = resolve_dev_tag()
+    version = f"{base}{tag}"
+
+    rewrite_pyproject(doc, version)
+    emit_github_env(tag)
+
+    print(f"stamped pyproject.toml: cytnx=={version}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Single `release_pypi.yml` workflow that builds wheels once with cibuildwheel and routes them by a resolved channel:

- **stable → PyPI** — on a `v*` tag push, publishes `cytnx X.Y.Z` to production PyPI via OIDC trusted publishing.
- **nightly → anaconda.org** — on a push to `master` (every merged PR), stamps a PEP 440 dev version (`MAJOR.MINOR.PATCH.devYYYYMMDDHHMM`, UTC) into pyproject.toml and uploads the wheels to the **`cytnx-nightly-wheels`** organisation channel on anaconda.org.
- **pull request → build only, no publish** — the PR is merged with its target branch and the **nightly** wheels are built (validating the nightly release path end to end), but nothing is uploaded.
- **workflow_dispatch** — a `channel` input (`auto` / `stable` / `nightly`); `auto` infers from `github.ref` (tag → stable, otherwise nightly).

A single `DetermineChannel` job emits two outputs — `channel` (stable/nightly) and `publish` (true/false) — consumed by the build steps and the two mutually-exclusive publish jobs.

The wheels keep the `cytnx` distribution name in both channels. Stable users do nothing new (`pip install cytnx`). Nightly users add the anaconda.org index:

```
pip install --pre \
  --extra-index-url https://pypi.anaconda.org/cytnx-nightly-wheels/simple \
  cytnx
```

`--pre` selects the `.devN` pre-release; `--extra-index-url` (not `--index-url`) lets cytnx's runtime deps (numpy, graphviz, beartype) keep resolving from PyPI.

## Why anaconda.org instead of PyPI for nightlies

The original design uploaded nightlies to PyPI as same-project `.devN` releases (numpy-style: `pip install cytnx` → stable, `pip install --pre cytnx` → nightly). We then applied for hosting on the shared **[scientific-python-nightly-wheels](https://anaconda.org/scientific-python-nightly-wheels) anaconda.org channel** (the channel numpy, scipy, scikit-learn, matplotlib, … use for their nightlies). **That application was rejected** (https://github.com/scientific-python/upload-nightly-action/issues/167), so we self-host the nightly index on our own anaconda.org organisation, **[`cytnx-nightly-wheels`](https://anaconda.org/cytnx-nightly-wheels)**.

This keeps the production PyPI project (`cytnx`) reserved for tagged stable releases only and isolates per-merge dev wheels on a dedicated index. The publish action (`scientific-python/upload-nightly-action`) is the same one the scientific-python ecosystem uses — only the target organisation differs.

## Why one workflow file (and why it builds on PRs)

The stable and nightly paths share the cibuildwheel matrix, ccache configuration, and the PR merge-with-target step; only the publish target differs. Folding both into one file means a change to the build matrix is made in one place, and a same-commit tag push + master merge no longer run two redundant builds.

Pull requests build the (nightly) release wheels but skip publishing, so a PR that breaks the release build — including the nightly version-stamping path — is caught before merge. `DetermineChannel` resolves PRs to `channel=nightly, publish=false`; the `publish == 'true'` clause on both publish jobs keeps PR runs from uploading.

## Commits

1. **`build: refactor optional-deps; add release-tools dependency-group`** — collapse `dev` extras to `cytnx[test] + cytnx[coverage]` (one source of truth per leaf group) and add a PEP 735 `[dependency-groups]` table with a `release-tools` group (`tomlkit`). A dependency-group, not an optional-dependency, so `pip install --group release-tools` installs the helper without going through scikit-build-core (which `pip install .[release-tools]` would, compiling cytnx on the host).
2. **`build: add CYTNX_VERSION_TAG env hook for dev-version suffixes`** — `CMakeLists.txt` gains `CYTNX_VERSION_FULL` = numeric `CYTNX_VERSION` + `$ENV{CYTNX_VERSION_TAG}` when set. Used only for the `CYTNX_VERSION` compile def (i.e. `cytnx.__version__`); numeric-only consumers (`project(VERSION ...)`, SOVERSION, libname) untouched. Also adds `CYTNX_VERSION_TAG` to the cibuildwheel Linux `environment-pass`. No-op when unset.
3. **`build: add nightly-release pyproject stamping helper`** — `tools/prepare_nightly_release.py` uses `tomlkit` to rewrite pyproject.toml (`dynamic = ["version"]` removed, static `version = "X.Y.Z.devYYYYMMDDHHMM"`, `[tool.scikit-build.metadata.version]` removed) and appends `CYTNX_VERSION_TAG` to `$GITHUB_ENV`. Reuses the regex from `[tool.scikit-build.metadata.version].regex`, so the regex lives in one place.
4. **`ci: switch release_pypi.yml from TestPyPI to production PyPI`** — publish destination TestPyPI → production PyPI. PR and master-push runs still build the full matrix as a build-health check but no longer upload anything (previously every PR/master push went to TestPyPI); publishing is gated to `v*` tags + dispatch. Job renamed `ReleaseTestPyPI` → `ReleasePyPI`. PR merge-with-target step retained (with an explicit committer identity for the merge commit). Login-shell `defaults` dropped; two ccache steps collapsed to one; third-party actions SHA-pinned.
5. **`ci: extend release_pypi.yml with nightly anaconda.org path`** — adds the `DetermineChannel` job (`channel` + `publish` outputs), the nightly stamping steps (gated on `channel == 'nightly'`), the `workflow_dispatch.channel` input, and a `PublishNightlyAnaconda` job uploading to anaconda.org via `scientific-python/upload-nightly-action` (SHA-pinned 0.6.4) with `ANACONDA_ORG_UPLOAD_TOKEN`. `ReleasePyPI`'s gate moves from the event-based expression to `channel == 'stable' && publish == 'true'`.

## Version stamping — why timestamp instead of incremental

A monotonic timestamp (`devYYYYMMDDHHMM`) needs no external state. An incremental `devN` would require querying the index for the last `.devN` or storing a counter — both race under parallel merges and break on repo moves. Minute resolution handles multiple merges per day; a same-minute collision is overwritten by `anaconda upload --force` on re-run.

## One-time setup required before merge

- **PyPI (`cytnx` project)** — add a trusted publisher: repository `Cytnx-dev/Cytnx`, workflow `release_pypi.yml`, job `ReleasePyPI`, no environment.
- **anaconda.org (`cytnx-nightly-wheels` org)** — create an API token with upload scope for the org, and store it as the **`ANACONDA_ORG_UPLOAD_TOKEN`** repository secret (Settings → Secrets and variables → Actions). The upload step reads it via `secrets.ANACONDA_ORG_UPLOAD_TOKEN`.

Until these are configured, the respective publish jobs will fail; this is intentional and safe. PR builds need neither secret (they don't publish).

## Test plan

- [x] PyPI trusted-publisher entry created on the `cytnx` project.
- [x] `ANACONDA_ORG_UPLOAD_TOKEN` repository secret created with upload scope for `cytnx-nightly-wheels`.