### PR TITLE
style: clang-format the SVD-truncate discarded-singular-value helpers

### DIFF
--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -506,8 +506,7 @@ namespace cytnx {
           // every value in Sall is dropped.
           if (return_err) {
             Sall = algo::Sort(Sall);  // ascending; BuildBlockDiscardedSingularValues expects this
-            outCyT.push_back(
-              BuildBlockDiscardedSingularValues(Sall, Sall.shape()[0], return_err));
+            outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, Sall.shape()[0], return_err));
           }
         }
 

--- a/src/linalg/Svd_truncate.cpp
+++ b/src/linalg/Svd_truncate.cpp
@@ -454,8 +454,7 @@ namespace cytnx {
           // every value in Sall is dropped.
           if (return_err) {
             Sall = algo::Sort(Sall);  // ascending; BuildBlockDiscardedSingularValues expects this
-            outCyT.push_back(
-              BuildBlockDiscardedSingularValues(Sall, Sall.shape()[0], return_err));
+            outCyT.push_back(BuildBlockDiscardedSingularValues(Sall, Sall.shape()[0], return_err));
           }
         }
 

--- a/src/linalg/block_truncation_helpers.hpp
+++ b/src/linalg/block_truncation_helpers.hpp
@@ -14,8 +14,7 @@ namespace cytnx {
     // return_err: 1 → return largest dropped value; >1 → return all dropped values descending.
     //
     // When smidx == 0 (no truncation), returns a one-element zero tensor regardless of return_err.
-    inline UniTensor BuildBlockDiscardedSingularValues(const Tensor &Sall,
-                                                       const cytnx_uint64 smidx,
+    inline UniTensor BuildBlockDiscardedSingularValues(const Tensor &Sall, const cytnx_uint64 smidx,
                                                        const unsigned int return_err) {
       Tensor terr({1}, Sall.dtype());
       terr.storage().at(0) = 0;


### PR DESCRIPTION
## Summary

The `clang-format Check` CI scans the whole tree (`check-path: '.'`) with clang-format-14, and three files in the block SVD-truncate path currently fail the check on `master`:

- `src/linalg/Gesvd_truncate.cpp`
- `src/linalg/Svd_truncate.cpp`
- `src/linalg/block_truncation_helpers.hpp`

In each, the `BuildBlockDiscardedSingularValues(...)` call (or its declaration) was hand-wrapped onto two lines, but the single-line form fits within the project's column limit, so clang-format-14 wants it joined. This PR applies exactly that reflow — formatting only, no behavior change.

## Why a standalone PR

These files are unrelated to any in-flight feature work, but they break the formatting gate for every open PR. Fixing them on their own branch lets the fix land quickly and be cherry-picked into other branches that are currently red on this check.

## Verification

`clang-format-14 --style=file --dry-run --Werror` is clean on all three files after the change. (clang-format-14 is the version pinned by `.github/workflows/clang-format-check.yml`.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaG3EzXRt3emmZtkw7J1Tv)_