### PR TITLE
Remove namespace std

### DIFF
--- a/include/Type.hpp
+++ b/include/Type.hpp
@@ -46,7 +46,7 @@ namespace cytnx {
   typedef int64_t cytnx_int64;
   typedef int32_t cytnx_int32;
   typedef int16_t cytnx_int16;
-  typedef size_t cytnx_size_t;
+  typedef std::size_t cytnx_size_t;
   typedef std::complex<float> cytnx_complex64;
   typedef std::complex<double> cytnx_complex128;
   typedef bool cytnx_bool;
@@ -113,22 +113,22 @@ namespace cytnx {
 
   template <typename T, typename... Types>
   struct variant_index<T, std::variant<Types...>> {
-    static constexpr size_t value = std::variant_size_v<std::variant<Types...>>;
+    static constexpr std::size_t value = std::variant_size_v<std::variant<Types...>>;
   };
 
   template <typename T, typename... Types>
   struct variant_index<T, std::variant<T, Types...>> {
-    static constexpr size_t value = 0;
+    static constexpr std::size_t value = 0;
   };
 
   template <typename T, typename U, typename... Types>
   struct variant_index<T, std::variant<U, Types...>> {
-    static constexpr size_t value = 1 + variant_index<T, std::variant<Types...>>::value;
+    static constexpr std::size_t value = 1 + variant_index<T, std::variant<Types...>>::value;
   };
 
   // helper template variable
   template <typename T, typename Variant>
-  static constexpr size_t variant_index_v = variant_index<T, Variant>::value;
+  static constexpr std::size_t variant_index_v = variant_index<T, Variant>::value;
 
   namespace internal {
     // type_size returns the sizeof(T) for the supported types. This is the same as

--- a/include/UniTensor.hpp
+++ b/include/UniTensor.hpp
@@ -29,7 +29,6 @@ namespace cytnx {
     extern std::random_device __static_random_device;
   }
 
-  using namespace cytnx;
   /// @cond
   class UniTensorType_class {
    public:

--- a/include/cytnx_error.hpp
+++ b/include/cytnx_error.hpp
@@ -46,10 +46,10 @@ static inline void error_msg(char const *const func, const char *const file, int
 #if CYTNX_HAS_EXECINFO
     std::cerr << "Stack trace:" << std::endl;
     void *array[10];
-    size_t size;
+    std::size_t size;
     size = backtrace(array, 10);
     char **strings = backtrace_symbols(array, size);
-    for (size_t i = 0; i < size; i++) {
+    for (std::size_t i = 0; i < size; i++) {
       std::cerr << strings[i] << std::endl;
     }
     free(strings);

--- a/pybind/storage_py.cpp
+++ b/pybind/storage_py.cpp
@@ -35,7 +35,7 @@ void storage_binding(py::module &m) {
            }
 
            // calculate stride:
-           size_t type_size = Type.typeSize(tmpIN.dtype());
+           std::size_t type_size = Type.typeSize(tmpIN.dtype());
            std::vector<ssize_t> stride(1, type_size);
            std::vector<ssize_t> shape(1, tmpIN.size());
 

--- a/src/BlockFermionicUniTensor.cpp
+++ b/src/BlockFermionicUniTensor.cpp
@@ -10,7 +10,6 @@
 #include <map>
 #include <boost/unordered_map.hpp>
 #include <stack>
-using namespace std;
 
 #ifdef BACKEND_TORCH
 #else
@@ -18,7 +17,7 @@ using namespace std;
 namespace cytnx {
   typedef Accessor ac;
   void BlockFermionicUniTensor::Init(const std::vector<Bond> &bonds,
-                                     const std::vector<string> &in_labels,
+                                     const std::vector<std::string> &in_labels,
                                      const cytnx_int64 &rowrank, const unsigned int &dtype,
                                      const int &device, const bool &is_diag, const bool &no_alloc,
                                      const std::string &name) {
@@ -31,7 +30,7 @@ namespace cytnx {
 
     // check Symmetry for all bonds
     cytnx_uint32 N_symmetry = bonds[0].Nsym();
-    vector<Symmetry> tmpSyms = bonds[0].syms();
+    std::vector<Symmetry> tmpSyms = bonds[0].syms();
 
     cytnx_uint32 N_ket = 0;
     for (cytnx_uint64 i = 0; i < bonds.size(); i++) {
@@ -89,14 +88,14 @@ namespace cytnx {
 
     // check labels:
     if (in_labels.size() == 0) {
-      for (cytnx_int64 i = 0; i < bonds.size(); i++) this->_labels.push_back(to_string(i));
+      for (cytnx_int64 i = 0; i < bonds.size(); i++) this->_labels.push_back(std::to_string(i));
 
     } else {
       // check bonds & labels dim
       cytnx_error_msg(bonds.size() != in_labels.size(), "%s",
                       "[ERROR] labels must have same length as # of bonds.");
 
-      std::vector<string> tmp = vec_unique(in_labels);
+      std::vector<std::string> tmp = vec_unique(in_labels);
       cytnx_error_msg(tmp.size() != in_labels.size(),
                       "[ERROR] labels cannot contain duplicated elements.%s", "\n");
       this->_labels = in_labels;
@@ -129,10 +128,6 @@ namespace cytnx {
     // copy bonds, otherwise it will share objects:
     this->_bonds = vec_clone(bonds);
     this->_is_braket_form = this->_update_braket();
-
-    // vector<cytnx_uint64> blocklens;
-    // vector<vector<cytnx_uint64>> blocksizes;
-    // cytnx_uint64 totblocksize = 0;
 
     if (this->_is_diag) {
       for (int b = 0; b < this->_bonds[0].qnums().size(); b++) {
@@ -230,29 +225,29 @@ namespace cytnx {
     for (int i = 0; i < Total_line; i++) {
       // Lside:
       if (i < Nin) {
-        Lside[i] += "[" + to_string(qn_indices[i]) + "] ";
+        Lside[i] += "[" + std::to_string(qn_indices[i]) + "] ";
         for (int s = 0; s < bonds[0].Nsym(); s++) {
           Lside[i] += bonds[0]._impl->_syms[s].stype_str() + "(" +
-                      to_string(bonds[i]._impl->_qnums[qn_indices[i]][s]) + ")";
+                      std::to_string(bonds[i]._impl->_qnums[qn_indices[i]][s]) + ")";
         }
         if (Lmax < Lside[i].size()) Lmax = Lside[i].size();
 
-        MidL[i] += to_string(block.shape()[i]);
+        MidL[i] += std::to_string(block.shape()[i]);
         if (mL < MidL[i].size()) mL = MidL[i].size();
       }
 
       // Rside:
       if (i < Nout) {
-        Rside[i] += "[" + to_string(qn_indices[Nin + i]) + "] ";
+        Rside[i] += "[" + std::to_string(qn_indices[Nin + i]) + "] ";
         for (int s = 0; s < bonds[0].Nsym(); s++) {
           Rside[i] += bonds[0]._impl->_syms[s].stype_str() + "(" +
-                      to_string(bonds[Nin + i]._impl->_qnums[qn_indices[Nin + i]][s]) + ")";
+                      std::to_string(bonds[Nin + i]._impl->_qnums[qn_indices[Nin + i]][s]) + ")";
         }
         // check if is_diag = true:
         if (block.shape().size() == 1 && bonds.size() == 2)
-          MidR[i] += to_string(block.shape()[i]);
+          MidR[i] += std::to_string(block.shape()[i]);
         else
-          MidR[i] += to_string(block.shape()[Nin + i]);
+          MidR[i] += std::to_string(block.shape()[Nin + i]);
         if (mR < MidR[i].size()) mR = MidR[i].size();
       }
     }
@@ -260,13 +255,13 @@ namespace cytnx {
     // filling space:
     for (int i = 0; i < Total_line; i++) {
       if (Lside[i].size() < Lmax) {
-        Lside[i] += string(" ") * (Lmax - Lside[i].size());
+        Lside[i] += std::string(" ") * (Lmax - Lside[i].size());
       }
       if (MidL[i].size() < mL) {
-        MidL[i] += string(" ") * (mL - MidL[i].size());
+        MidL[i] += std::string(" ") * (mL - MidL[i].size());
       }
       if (MidR[i].size() < mR) {
-        MidR[i] += string(" ") * (mR - MidR[i].size());
+        MidR[i] += std::string(" ") * (mR - MidR[i].size());
       }
     }
 
@@ -274,8 +269,8 @@ namespace cytnx {
     //  3spacing, Lmax , 5 for arrow
     std::string empty_line =
       (std::string(" ") * (3 + Lmax + 5)) + "| " + std::string(" ") * (mL + 5 + mR) + " |";
-    os << (std::string(" ") * (3 + Lmax + 5)) << std::string("-") * (4 + mL + mR + 5) << endl;
-    os << empty_line << endl;
+    os << (std::string(" ") * (3 + Lmax + 5)) << std::string("-") * (4 + mL + mR + 5) << std::endl;
+    os << empty_line << std::endl;
 
     std::string bks;
     for (int i = 0; i < Total_line; i++) {
@@ -299,11 +294,11 @@ namespace cytnx {
         bks = "";
       }
 
-      os << bks << Rside[i] << endl;
-      os << empty_line << endl;
+      os << bks << Rside[i] << std::endl;
+      os << empty_line << std::endl;
     }
 
-    os << (std::string(" ") * (3 + Lmax + 5)) << std::string("-") * (4 + mL + mR + 5) << endl;
+    os << (std::string(" ") * (3 + Lmax + 5)) << std::string("-") * (4 + mL + mR + 5) << std::endl;
   }
 
   void BlockFermionicUniTensor::print_block(const cytnx_int64 &idx, const bool &full_info) const {
@@ -319,27 +314,6 @@ namespace cytnx {
     if (this->_is_diag) os << " *is_diag: True\n";
     os << "BLOCK [#" << idx << "]\n";
     os << "fermionic sign = " << (this->_signflip[idx] ? -1 : +1) << "\n";
-    /*
-    os << "  |-Qn indices for each axis:\n   {\t";
-    for(int s=0;s<this->_inner_to_outer_idx[idx].size();s++){
-        os << this->_inner_to_outer_idx[idx][s] << "\t";
-    }
-    os << "}" << endl;
-    os << "\t";
-    for(int s=0;s<this->_bonds.size();s++){
-        os << ((this->_bonds[s].type()>0)?"OUT":"IN") << "\t";
-    }
-    os << endl;
-    os << "  |-Qn for each axis:\n";
-    for(int s=0;s<this->_bonds[0].Nsym();s++){
-        os << " " <<this->_bonds[0]._impl->_syms[s].stype_str() << ":\t";
-        for(int l=0;l<this->_blocks[idx].shape().size();l++){
-            os << std::showpos <<
-    this->_bonds[l]._impl->_qnums[this->_inner_to_outer_idx[idx][l]][s] << "\t";
-        }
-        os << std::noshowpos << endl;
-    }
-    */
     os << " |- []   : Qn index \n";
     os << " |- Sym(): Qnum of correspond symmetry\n";
     this->beauty_print_block(os, this->_rowrank, this->_labels.size() - this->_rowrank,
@@ -348,9 +322,10 @@ namespace cytnx {
     if (full_info)
       os << this->_blocks[idx];
     else {
-      os << "  |-dtype:\t" << Type.getname(this->_blocks[idx].dtype()) << endl;
-      os << "  |-device:\t" << Device.getname(this->_blocks[idx].device()) << endl;
-      os << "  |-contiguous:\t" << (this->_blocks[idx].is_contiguous() ? "True" : "False") << endl;
+      os << "  |-dtype:\t" << Type.getname(this->_blocks[idx].dtype()) << std::endl;
+      os << "  |-device:\t" << Device.getname(this->_blocks[idx].device()) << std::endl;
+      os << "  |-contiguous:\t" << (this->_blocks[idx].is_contiguous() ? "True" : "False")
+         << std::endl;
       os << "  |-shape:\t";
       vec_print_simple(os, this->_blocks[idx].shape());
     }
@@ -386,7 +361,7 @@ namespace cytnx {
     os << "Symmetries: ";
     for(int s=0;s<this->_bonds[0].Nsym();s++)
         os << this->_bonds[0]._impl->_syms[s].stype_str() << " ";
-    os << endl;
+    os << std::endl;
     */
 
     // print each blocks with its qnum!
@@ -394,27 +369,6 @@ namespace cytnx {
       this->print_block(b, full_info);
     }
 
-    /*
-      auto tmp_qnums = in.get_blocks_qnums();
-      std::vector<Tensor> tmp = in.get_blocks_(true);
-      sprintf(buffer, "BLOCKS:: %s", "\n");
-      os << std::string(buffer);
-      os << "=============\n";
-
-      if (!in.is_contiguous()) {
-        cytnx_warning_msg(
-          true,
-          "[WARNING][Symmetric] cout/print UniTensor on a non-contiguous UniTensor. the blocks "
-          "appears here could be different than the current shape of UniTensor.%s",
-          "\n");
-      }
-      for (cytnx_uint64 i = 0; i < tmp.size(); i++) {
-        os << "Qnum:" << tmp_qnums[i] << std::endl;
-        os << tmp[i] << std::endl;
-        os << "=============\n";
-      }
-      os << "-------- end of print ---------\n";
-    */
     free(buffer);
   }
 
@@ -467,17 +421,17 @@ namespace cytnx {
     for (cytnx_uint64 i = 0; i < vl; i++) {
       if (i < Nin) {
         if (Space_Llabel_max < this->_labels[i].size()) Space_Llabel_max = this->_labels[i].size();
-        if (Space_Ldim_max < to_string(this->_bonds[i].dim()).size())
-          Space_Ldim_max = to_string(this->_bonds[i].dim()).size();
+        if (Space_Ldim_max < std::to_string(this->_bonds[i].dim()).size())
+          Space_Ldim_max = std::to_string(this->_bonds[i].dim()).size();
       }
       if (i < Nout) {
-        if (Space_Rdim_max < to_string(this->_bonds[Nin + i].dim()).size())
-          Space_Rdim_max = to_string(this->_bonds[Nin + i].dim()).size();
+        if (Space_Rdim_max < std::to_string(this->_bonds[Nin + i].dim()).size())
+          Space_Rdim_max = std::to_string(this->_bonds[Nin + i].dim()).size();
       }
     }
-    string LallSpace = (string(" ") * (Space_Llabel_max + 3 + 1));
-    string MallSpace = string(" ") * (1 + Space_Ldim_max + 5 + Space_Rdim_max + 1);
-    string M_dashes = string("-") * (1 + Space_Ldim_max + 5 + Space_Rdim_max + 1);
+    std::string LallSpace = (std::string(" ") * (Space_Llabel_max + 3 + 1));
+    std::string MallSpace = std::string(" ") * (1 + Space_Ldim_max + 5 + Space_Rdim_max + 1);
+    std::string M_dashes = std::string("-") * (1 + Space_Ldim_max + 5 + Space_Rdim_max + 1);
 
     std::string tmpss;
     sprintf(buffer, "%s row %s col %s", LallSpace.c_str(), MallSpace.c_str(), "\n");
@@ -497,8 +451,8 @@ namespace cytnx {
         memset(llbl, 0, sizeof(char) * BUFFsize);
         tmpss = this->_labels[i] + std::string(" ") * (Space_Llabel_max - this->_labels[i].size());
         sprintf(l, "%s %s", tmpss.c_str(), bks.c_str());
-        tmpss = to_string(this->_bonds[i].dim()) +
-                std::string(" ") * (Space_Ldim_max - to_string(this->_bonds[i].dim()).size());
+        tmpss = std::to_string(this->_bonds[i].dim()) +
+                std::string(" ") * (Space_Ldim_max - std::to_string(this->_bonds[i].dim()).size());
         sprintf(llbl, "%s", tmpss.c_str());
       } else {
         memset(l, 0, sizeof(char) * BUFFsize);
@@ -518,8 +472,9 @@ namespace cytnx {
 
         sprintf(r, "%s %s", bks.c_str(), this->_labels[Nin + i].c_str());
 
-        tmpss = to_string(this->_bonds[Nin + i].dim()) +
-                std::string(" ") * (Space_Rdim_max - to_string(this->_bonds[Nin + i].dim()).size());
+        tmpss =
+          std::to_string(this->_bonds[Nin + i].dim()) +
+          std::string(" ") * (Space_Rdim_max - std::to_string(this->_bonds[Nin + i].dim()).size());
         sprintf(rlbl, "%s", tmpss.c_str());
 
       } else {
@@ -662,7 +617,7 @@ namespace cytnx {
 
     std::vector<cytnx_int64> mapper_i64;
     // cytnx_error_msg(true,"[Developing!]%s","\n");
-    std::vector<string>::iterator it;
+    std::vector<std::string>::iterator it;
     for (cytnx_int64 i = 0; i < mapper.size(); i++) {
       it = std::find(out_raw->_labels.begin(), out_raw->_labels.end(), mapper[i]);
       cytnx_error_msg(
@@ -792,7 +747,7 @@ namespace cytnx {
 
     std::vector<cytnx_int64> mapper_i64;
     // cytnx_error_msg(true,"[Developing!]%s","\n");
-    std::vector<string>::iterator it;
+    std::vector<std::string>::iterator it;
     for (cytnx_int64 i = 0; i < mapper.size(); i++) {
       it = std::find(out_raw->_labels.begin(), out_raw->_labels.end(), mapper[i]);
       cytnx_error_msg(it == out_raw->_labels.end(),
@@ -1189,7 +1144,7 @@ namespace cytnx {
 
   boost::intrusive_ptr<UniTensor_base> BlockFermionicUniTensor::relabel(
     //[21 Aug 2024] This is a copy from BlockUniTensor; creates a BlockFermionicUniTensor
-    const std::vector<string> &new_labels) {
+    const std::vector<std::string> &new_labels) {
     BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->set_labels(new_labels);
@@ -1209,7 +1164,7 @@ namespace cytnx {
 
   boost::intrusive_ptr<UniTensor_base> BlockFermionicUniTensor::relabels(
     //[21 Aug 2024] This is a copy from BlockUniTensor; creates a BlockFermionicUniTensor
-    const std::vector<string> &new_labels) {
+    const std::vector<std::string> &new_labels) {
     BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->set_labels(new_labels);
@@ -1227,8 +1182,8 @@ namespace cytnx {
     return out;
   }
 
-  boost::intrusive_ptr<UniTensor_base> BlockFermionicUniTensor::relabel(const cytnx_int64 &inx,
-                                                                        const string &new_label) {
+  boost::intrusive_ptr<UniTensor_base> BlockFermionicUniTensor::relabel(
+    const cytnx_int64 &inx, const std::string &new_label) {
     //[21 Aug 2024] This is a copy from BlockUniTensor; creates a BlockFermionicUniTensor
     BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
@@ -1237,8 +1192,8 @@ namespace cytnx {
     return out;
   }
 
-  boost::intrusive_ptr<UniTensor_base> BlockFermionicUniTensor::relabel(const string &inx,
-                                                                        const string &new_label) {
+  boost::intrusive_ptr<UniTensor_base> BlockFermionicUniTensor::relabel(
+    const std::string &inx, const std::string &new_label) {
     //[21 Aug 2024] This is a copy from BlockUniTensor; creates a BlockFermionicUniTensor
     BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
@@ -1254,7 +1209,7 @@ namespace cytnx {
     }
     BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
     tmp->_blocks.resize(this->_blocks.size());
-    for (std::size_t i = 0; i < tmp->_blocks.size(); i++)
+    for (size_t i = 0; i < tmp->_blocks.size(); i++)
       tmp->_blocks[i] = cytnx::linalg::Diag(this->_blocks[i]);
     tmp->_is_diag = false;
     boost::intrusive_ptr<UniTensor_base> out(tmp);
@@ -1288,7 +1243,7 @@ namespace cytnx {
       "\n");
 
     // get common labels:
-    std::vector<string> comm_labels;
+    std::vector<std::string> comm_labels;
     std::vector<cytnx_uint64> comm_idx1, comm_idx2;
     vec_intersect_(comm_labels, this->labels(), rhs->labels(), comm_idx1, comm_idx2);
 
@@ -1297,7 +1252,7 @@ namespace cytnx {
       BlockFermionicUniTensor *tmp = new BlockFermionicUniTensor();
       BlockFermionicUniTensor *Rtn = (BlockFermionicUniTensor *)rhs.get();
       const unsigned int common_dtype = Type.type_promote(this->dtype(), rhs->dtype());
-      std::vector<string> out_labels;
+      std::vector<std::string> out_labels;
       std::vector<Bond> out_bonds;
       cytnx_int64 out_rowrank;
 
@@ -1473,7 +1428,7 @@ namespace cytnx {
         BlockFermionicUniTensor *tmp = new BlockFermionicUniTensor();
         BlockFermionicUniTensor *Rtn = (BlockFermionicUniTensor *)rhs.get();
         const unsigned int common_dtype = Type.type_promote(this->dtype(), rhs->dtype());
-        std::vector<string> out_labels;
+        std::vector<std::string> out_labels;
         std::vector<Bond> out_bonds;
         cytnx_int64 out_rowrank;
 
@@ -1684,9 +1639,9 @@ namespace cytnx {
               this->_blocks[a].reshape_({-1, comm_dim});
               // Collect block pairs for this left block then call Gemm_Batch once.
               // Fermionic sign flips are encoded in alpha (+1 or -1 per group).
-              vector<Tensor> batch_a, batch_b, batch_c;
-              vector<Scalar> batch_alpha, batch_beta;
-              vector<cytnx_int64> batch_targ_b;
+              std::vector<Tensor> batch_a, batch_b, batch_c;
+              std::vector<Scalar> batch_alpha, batch_beta;
+              std::vector<cytnx_int64> batch_targ_b;
 
               // loop over all right blocks that can contract with this->_blocks[a]
               for (cytnx_uint64 binx = 0; binx < itoiR_idx.size(); binx++) {
@@ -1725,7 +1680,7 @@ namespace cytnx {
                 batch_targ_b.push_back(targ_b);
               }
               if (!batch_a.empty()) {
-                vector<cytnx_int64> group_sizes(batch_a.size(), 1);
+                std::vector<cytnx_int64> group_sizes(batch_a.size(), 1);
                 linalg::Gemm_Batch(batch_alpha, batch_a, batch_b, batch_beta, batch_c, group_sizes);
                 for (size_t i = 0; i < batch_c.size(); i++)
                   tmp->_blocks[batch_targ_b[i]] = batch_c[i];

--- a/src/BlockFermionicUniTensor.cpp
+++ b/src/BlockFermionicUniTensor.cpp
@@ -1209,7 +1209,7 @@ namespace cytnx {
     }
     BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
     tmp->_blocks.resize(this->_blocks.size());
-    for (size_t i = 0; i < tmp->_blocks.size(); i++)
+    for (std::size_t i = 0; i < tmp->_blocks.size(); i++)
       tmp->_blocks[i] = cytnx::linalg::Diag(this->_blocks[i]);
     tmp->_is_diag = false;
     boost::intrusive_ptr<UniTensor_base> out(tmp);
@@ -1682,7 +1682,7 @@ namespace cytnx {
               if (!batch_a.empty()) {
                 std::vector<cytnx_int64> group_sizes(batch_a.size(), 1);
                 linalg::Gemm_Batch(batch_alpha, batch_a, batch_b, batch_beta, batch_c, group_sizes);
-                for (size_t i = 0; i < batch_c.size(); i++)
+                for (std::size_t i = 0; i < batch_c.size(); i++)
                   tmp->_blocks[batch_targ_b[i]] = batch_c[i];
               }
               // restore the shape&permutation of this->_blocks[a]

--- a/src/BlockUniTensor.cpp
+++ b/src/BlockUniTensor.cpp
@@ -10,17 +10,16 @@
 #include <map>
 #include <boost/unordered_map.hpp>
 #include <stack>
-using namespace std;
 
 #ifdef BACKEND_TORCH
 #else
 
 namespace cytnx {
   typedef Accessor ac;
-  void BlockUniTensor::Init(const std::vector<Bond> &bonds, const std::vector<string> &in_labels,
-                            const cytnx_int64 &rowrank, const unsigned int &dtype,
-                            const int &device, const bool &is_diag, const bool &no_alloc,
-                            const std::string &name) {
+  void BlockUniTensor::Init(const std::vector<Bond> &bonds,
+                            const std::vector<std::string> &in_labels, const cytnx_int64 &rowrank,
+                            const unsigned int &dtype, const int &device, const bool &is_diag,
+                            const bool &no_alloc, const std::string &name) {
     this->_name = name;
     // the entering is already check all the bonds have symmetry.
     //  need to check:
@@ -29,7 +28,7 @@ namespace cytnx {
 
     // check Symmetry for all bonds
     cytnx_uint32 N_symmetry = bonds[0].Nsym();
-    vector<Symmetry> tmpSyms = bonds[0].syms();
+    std::vector<Symmetry> tmpSyms = bonds[0].syms();
 
     cytnx_uint32 N_ket = 0;
     for (cytnx_uint64 i = 0; i < bonds.size(); i++) {
@@ -82,14 +81,14 @@ namespace cytnx {
 
     // check labels:
     if (in_labels.size() == 0) {
-      for (cytnx_int64 i = 0; i < bonds.size(); i++) this->_labels.push_back(to_string(i));
+      for (cytnx_int64 i = 0; i < bonds.size(); i++) this->_labels.push_back(std::to_string(i));
 
     } else {
       // check bonds & labels dim
       cytnx_error_msg(bonds.size() != in_labels.size(), "%s",
                       "[ERROR] labels must have same length as # of bonds.");
 
-      std::vector<string> tmp = vec_unique(in_labels);
+      std::vector<std::string> tmp = vec_unique(in_labels);
       cytnx_error_msg(tmp.size() != in_labels.size(),
                       "[ERROR] labels cannot contain duplicated elements.%s", "\n");
       this->_labels = in_labels;
@@ -118,10 +117,6 @@ namespace cytnx {
     // copy bonds, otherwise it will share objects:
     this->_bonds = vec_clone(bonds);
     this->_is_braket_form = this->_update_braket();
-
-    // vector<cytnx_uint64> blocklens;
-    // vector<vector<cytnx_uint64>> blocksizes;
-    // cytnx_uint64 totblocksize = 0;
 
     if (this->_is_diag) {
       for (int b = 0; b < this->_bonds[0].qnums().size(); b++) {
@@ -212,29 +207,29 @@ namespace cytnx {
     for (int i = 0; i < Total_line; i++) {
       // Lside:
       if (i < Nin) {
-        Lside[i] += "[" + to_string(qn_indices[i]) + "] ";
+        Lside[i] += "[" + std::to_string(qn_indices[i]) + "] ";
         for (int s = 0; s < bonds[0].Nsym(); s++) {
           Lside[i] += bonds[0]._impl->_syms[s].stype_str() + "(" +
-                      to_string(bonds[i]._impl->_qnums[qn_indices[i]][s]) + ")";
+                      std::to_string(bonds[i]._impl->_qnums[qn_indices[i]][s]) + ")";
         }
         if (Lmax < Lside[i].size()) Lmax = Lside[i].size();
 
-        MidL[i] += to_string(block.shape()[i]);
+        MidL[i] += std::to_string(block.shape()[i]);
         if (mL < MidL[i].size()) mL = MidL[i].size();
       }
 
       // Rside:
       if (i < Nout) {
-        Rside[i] += "[" + to_string(qn_indices[Nin + i]) + "] ";
+        Rside[i] += "[" + std::to_string(qn_indices[Nin + i]) + "] ";
         for (int s = 0; s < bonds[0].Nsym(); s++) {
           Rside[i] += bonds[0]._impl->_syms[s].stype_str() + "(" +
-                      to_string(bonds[Nin + i]._impl->_qnums[qn_indices[Nin + i]][s]) + ")";
+                      std::to_string(bonds[Nin + i]._impl->_qnums[qn_indices[Nin + i]][s]) + ")";
         }
         // check if is_diag = true:
         if (block.shape().size() == 1 && bonds.size() == 2)
-          MidR[i] += to_string(block.shape()[i]);
+          MidR[i] += std::to_string(block.shape()[i]);
         else
-          MidR[i] += to_string(block.shape()[Nin + i]);
+          MidR[i] += std::to_string(block.shape()[Nin + i]);
         if (mR < MidR[i].size()) mR = MidR[i].size();
       }
     }
@@ -242,13 +237,13 @@ namespace cytnx {
     // filling space:
     for (int i = 0; i < Total_line; i++) {
       if (Lside[i].size() < Lmax) {
-        Lside[i] += string(" ") * (Lmax - Lside[i].size());
+        Lside[i] += std::string(" ") * (Lmax - Lside[i].size());
       }
       if (MidL[i].size() < mL) {
-        MidL[i] += string(" ") * (mL - MidL[i].size());
+        MidL[i] += std::string(" ") * (mL - MidL[i].size());
       }
       if (MidR[i].size() < mR) {
-        MidR[i] += string(" ") * (mR - MidR[i].size());
+        MidR[i] += std::string(" ") * (mR - MidR[i].size());
       }
     }
 
@@ -256,8 +251,8 @@ namespace cytnx {
     //  3spacing, Lmax , 5 for arrow
     std::string empty_line =
       (std::string(" ") * (3 + Lmax + 5)) + "| " + std::string(" ") * (mL + 5 + mR) + " |";
-    os << (std::string(" ") * (3 + Lmax + 5)) << std::string("-") * (4 + mL + mR + 5) << endl;
-    os << empty_line << endl;
+    os << (std::string(" ") * (3 + Lmax + 5)) << std::string("-") * (4 + mL + mR + 5) << std::endl;
+    os << empty_line << std::endl;
 
     std::string bks;
     for (int i = 0; i < Total_line; i++) {
@@ -281,11 +276,11 @@ namespace cytnx {
         bks = "";
       }
 
-      os << bks << Rside[i] << endl;
-      os << empty_line << endl;
+      os << bks << Rside[i] << std::endl;
+      os << empty_line << std::endl;
     }
 
-    os << (std::string(" ") * (3 + Lmax + 5)) << std::string("-") * (4 + mL + mR + 5) << endl;
+    os << (std::string(" ") * (3 + Lmax + 5)) << std::string("-") * (4 + mL + mR + 5) << std::endl;
   }
   void BlockUniTensor::print_block(const cytnx_int64 &idx, const bool &full_info) const {
     cytnx_error_msg(
@@ -303,12 +298,12 @@ namespace cytnx {
     for(int s=0;s<this->_inner_to_outer_idx[idx].size();s++){
         os << this->_inner_to_outer_idx[idx][s] << "\t";
     }
-    os << "}" << endl;
+    os << "}" << std::endl;
     os << "\t";
     for(int s=0;s<this->_bonds.size();s++){
         os << ((this->_bonds[s].type()>0)?"OUT":"IN") << "\t";
     }
-    os << endl;
+    os << std::endl;
     os << "  |-Qn for each axis:\n";
     for(int s=0;s<this->_bonds[0].Nsym();s++){
         os << " " <<this->_bonds[0]._impl->_syms[s].stype_str() << ":\t";
@@ -316,7 +311,7 @@ namespace cytnx {
             os << std::showpos <<
     this->_bonds[l]._impl->_qnums[this->_inner_to_outer_idx[idx][l]][s] << "\t";
         }
-        os << std::noshowpos << endl;
+        os << std::noshowpos << std::endl;
     }
     */
     os << " |- []   : Qn index \n";
@@ -327,9 +322,10 @@ namespace cytnx {
     if (full_info)
       os << this->_blocks[idx];
     else {
-      os << "  |-dtype:\t" << Type.getname(this->_blocks[idx].dtype()) << endl;
-      os << "  |-device:\t" << Device.getname(this->_blocks[idx].device()) << endl;
-      os << "  |-contiguous:\t" << (this->_blocks[idx].is_contiguous() ? "True" : "False") << endl;
+      os << "  |-dtype:\t" << Type.getname(this->_blocks[idx].dtype()) << std::endl;
+      os << "  |-device:\t" << Device.getname(this->_blocks[idx].device()) << std::endl;
+      os << "  |-contiguous:\t" << (this->_blocks[idx].is_contiguous() ? "True" : "False")
+         << std::endl;
       os << "  |-shape:\t";
       vec_print_simple(os, this->_blocks[idx].shape());
     }
@@ -356,7 +352,7 @@ namespace cytnx {
     os << "Symmetries: ";
     for(int s=0;s<this->_bonds[0].Nsym();s++)
         os << this->_bonds[0]._impl->_syms[s].stype_str() << " ";
-    os << endl;
+    os << std::endl;
     */
 
     // print each blocks with its qnum!
@@ -364,27 +360,6 @@ namespace cytnx {
       this->print_block(b, full_info);
     }
 
-    /*
-      auto tmp_qnums = in.get_blocks_qnums();
-      std::vector<Tensor> tmp = in.get_blocks_(true);
-      sprintf(buffer, "BLOCKS:: %s", "\n");
-      os << std::string(buffer);
-      os << "=============\n";
-
-      if (!in.is_contiguous()) {
-        cytnx_warning_msg(
-          true,
-          "[WARNING][Symmetric] cout/print UniTensor on a non-contiguous UniTensor. the blocks "
-          "appears here could be different than the current shape of UniTensor.%s",
-          "\n");
-      }
-      for (cytnx_uint64 i = 0; i < tmp.size(); i++) {
-        os << "Qnum:" << tmp_qnums[i] << std::endl;
-        os << tmp[i] << std::endl;
-        os << "=============\n";
-      }
-      os << "-------- end of print ---------\n";
-    */
     free(buffer);
   }
 
@@ -429,17 +404,17 @@ namespace cytnx {
     for (cytnx_uint64 i = 0; i < vl; i++) {
       if (i < Nin) {
         if (Space_Llabel_max < this->_labels[i].size()) Space_Llabel_max = this->_labels[i].size();
-        if (Space_Ldim_max < to_string(this->_bonds[i].dim()).size())
-          Space_Ldim_max = to_string(this->_bonds[i].dim()).size();
+        if (Space_Ldim_max < std::to_string(this->_bonds[i].dim()).size())
+          Space_Ldim_max = std::to_string(this->_bonds[i].dim()).size();
       }
       if (i < Nout) {
-        if (Space_Rdim_max < to_string(this->_bonds[Nin + i].dim()).size())
-          Space_Rdim_max = to_string(this->_bonds[Nin + i].dim()).size();
+        if (Space_Rdim_max < std::to_string(this->_bonds[Nin + i].dim()).size())
+          Space_Rdim_max = std::to_string(this->_bonds[Nin + i].dim()).size();
       }
     }
-    string LallSpace = (string(" ") * (Space_Llabel_max + 3 + 1));
-    string MallSpace = string(" ") * (1 + Space_Ldim_max + 5 + Space_Rdim_max + 1);
-    string M_dashes = string("-") * (1 + Space_Ldim_max + 5 + Space_Rdim_max + 1);
+    std::string LallSpace = (std::string(" ") * (Space_Llabel_max + 3 + 1));
+    std::string MallSpace = std::string(" ") * (1 + Space_Ldim_max + 5 + Space_Rdim_max + 1);
+    std::string M_dashes = std::string("-") * (1 + Space_Ldim_max + 5 + Space_Rdim_max + 1);
 
     std::string tmpss;
     sprintf(buffer, "%s row %s col %s", LallSpace.c_str(), MallSpace.c_str(), "\n");
@@ -459,8 +434,8 @@ namespace cytnx {
         memset(llbl, 0, sizeof(char) * BUFFsize);
         tmpss = this->_labels[i] + std::string(" ") * (Space_Llabel_max - this->_labels[i].size());
         sprintf(l, "%s %s", tmpss.c_str(), bks.c_str());
-        tmpss = to_string(this->_bonds[i].dim()) +
-                std::string(" ") * (Space_Ldim_max - to_string(this->_bonds[i].dim()).size());
+        tmpss = std::to_string(this->_bonds[i].dim()) +
+                std::string(" ") * (Space_Ldim_max - std::to_string(this->_bonds[i].dim()).size());
         sprintf(llbl, "%s", tmpss.c_str());
       } else {
         memset(l, 0, sizeof(char) * BUFFsize);
@@ -480,8 +455,9 @@ namespace cytnx {
 
         sprintf(r, "%s %s", bks.c_str(), this->_labels[Nin + i].c_str());
 
-        tmpss = to_string(this->_bonds[Nin + i].dim()) +
-                std::string(" ") * (Space_Rdim_max - to_string(this->_bonds[Nin + i].dim()).size());
+        tmpss =
+          std::to_string(this->_bonds[Nin + i].dim()) +
+          std::string(" ") * (Space_Rdim_max - std::to_string(this->_bonds[Nin + i].dim()).size());
         sprintf(rlbl, "%s", tmpss.c_str());
 
       } else {
@@ -591,7 +567,7 @@ namespace cytnx {
 
     std::vector<cytnx_int64> mapper_i64;
     // cytnx_error_msg(true,"[Developing!]%s","\n");
-    std::vector<string>::iterator it;
+    std::vector<std::string>::iterator it;
     for (cytnx_int64 i = 0; i < mapper.size(); i++) {
       it = std::find(out_raw->_labels.begin(), out_raw->_labels.end(), mapper[i]);
       cytnx_error_msg(
@@ -659,7 +635,7 @@ namespace cytnx {
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockUniTensor::relabel(
-    const std::vector<string> &new_labels) {
+    const std::vector<std::string> &new_labels) {
     BlockUniTensor *tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->set_labels(new_labels);
@@ -677,7 +653,7 @@ namespace cytnx {
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockUniTensor::relabels(
-    const std::vector<string> &new_labels) {
+    const std::vector<std::string> &new_labels) {
     BlockUniTensor *tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->set_labels(new_labels);
@@ -695,7 +671,7 @@ namespace cytnx {
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockUniTensor::relabel(const cytnx_int64 &inx,
-                                                               const string &new_label) {
+                                                               const std::string &new_label) {
     BlockUniTensor *tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->set_label(inx, new_label);
@@ -703,8 +679,8 @@ namespace cytnx {
     return out;
   }
 
-  boost::intrusive_ptr<UniTensor_base> BlockUniTensor::relabel(const string &inx,
-                                                               const string &new_label) {
+  boost::intrusive_ptr<UniTensor_base> BlockUniTensor::relabel(const std::string &inx,
+                                                               const std::string &new_label) {
     BlockUniTensor *tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->set_label(inx, new_label);
@@ -719,7 +695,7 @@ namespace cytnx {
     }
     BlockUniTensor *tmp = this->clone_meta(true, true);
     tmp->_blocks.resize(this->_blocks.size());
-    for (std::size_t i = 0; i < tmp->_blocks.size(); i++)
+    for (size_t i = 0; i < tmp->_blocks.size(); i++)
       tmp->_blocks[i] = cytnx::linalg::Diag(this->_blocks[i]);
     tmp->_is_diag = false;
     boost::intrusive_ptr<UniTensor_base> out(tmp);
@@ -749,7 +725,7 @@ namespace cytnx {
       "\n");
 
     // get common labels:
-    std::vector<string> comm_labels;
+    std::vector<std::string> comm_labels;
     std::vector<cytnx_uint64> comm_idx1, comm_idx2;
     vec_intersect_(comm_labels, this->labels(), rhs->labels(), comm_idx1, comm_idx2);
 
@@ -758,7 +734,7 @@ namespace cytnx {
       BlockUniTensor *tmp = new BlockUniTensor();
       BlockUniTensor *Rtn = (BlockUniTensor *)rhs.get();
       const unsigned int common_dtype = Type.type_promote(this->dtype(), rhs->dtype());
-      std::vector<string> out_labels;
+      std::vector<std::string> out_labels;
       std::vector<Bond> out_bonds;
       cytnx_int64 out_rowrank;
 
@@ -911,7 +887,7 @@ namespace cytnx {
         BlockUniTensor *tmp = new BlockUniTensor();
         BlockUniTensor *Rtn = (BlockUniTensor *)rhs.get();
         const unsigned int common_dtype = Type.type_promote(this->dtype(), rhs->dtype());
-        std::vector<string> out_labels;
+        std::vector<std::string> out_labels;
         std::vector<Bond> out_bonds;
         cytnx_int64 out_rowrank;
 
@@ -1103,9 +1079,9 @@ namespace cytnx {
               oldshapeL = this->_blocks[a].shape();
               this->_blocks[a].reshape_({-1, comm_dim});
               // Collect block pairs for this left block then call Gemm_Batch once.
-              vector<Tensor> batch_a, batch_b, batch_c;
-              vector<Scalar> batch_alpha, batch_beta;
-              vector<cytnx_int64> batch_targ_b;
+              std::vector<Tensor> batch_a, batch_b, batch_c;
+              std::vector<Scalar> batch_alpha, batch_beta;
+              std::vector<cytnx_int64> batch_targ_b;
 
               // loop over all right blocks that can contract with this->_blocks[a]
               for (cytnx_uint64 binx = 0; binx < itoiR_idx.size(); binx++) {
@@ -1142,7 +1118,7 @@ namespace cytnx {
                 batch_targ_b.push_back(targ_b);
               }
               if (!batch_a.empty()) {
-                vector<cytnx_int64> group_sizes(batch_a.size(), 1);
+                std::vector<cytnx_int64> group_sizes(batch_a.size(), 1);
                 linalg::Gemm_Batch(batch_alpha, batch_a, batch_b, batch_beta, batch_c, group_sizes);
                 for (size_t i = 0; i < batch_c.size(); i++)
                   tmp->_blocks[batch_targ_b[i]] = batch_c[i];

--- a/src/BlockUniTensor.cpp
+++ b/src/BlockUniTensor.cpp
@@ -695,7 +695,7 @@ namespace cytnx {
     }
     BlockUniTensor *tmp = this->clone_meta(true, true);
     tmp->_blocks.resize(this->_blocks.size());
-    for (size_t i = 0; i < tmp->_blocks.size(); i++)
+    for (std::size_t i = 0; i < tmp->_blocks.size(); i++)
       tmp->_blocks[i] = cytnx::linalg::Diag(this->_blocks[i]);
     tmp->_is_diag = false;
     boost::intrusive_ptr<UniTensor_base> out(tmp);
@@ -1120,7 +1120,7 @@ namespace cytnx {
               if (!batch_a.empty()) {
                 std::vector<cytnx_int64> group_sizes(batch_a.size(), 1);
                 linalg::Gemm_Batch(batch_alpha, batch_a, batch_b, batch_beta, batch_c, group_sizes);
-                for (size_t i = 0; i < batch_c.size(); i++)
+                for (std::size_t i = 0; i < batch_c.size(); i++)
                   tmp->_blocks[batch_targ_b[i]] = batch_c[i];
               }
               // restore the shape&permutation of this->_blocks[a]

--- a/src/DenseUniTensor.cpp
+++ b/src/DenseUniTensor.cpp
@@ -8,8 +8,6 @@
 #include <vector>
 typedef cytnx::Accessor ac;
 
-using namespace std;
-
 #ifdef BACKEND_TORCH
 #else
 
@@ -436,8 +434,8 @@ namespace cytnx {
     if (full_info)
       os << this->_block << std::endl;
     else {
-      os << "dtype: " << Type.getname(this->_block.dtype()) << endl;
-      os << "device: " << Device.getname(this->_block.device()) << endl;
+      os << "dtype: " << Type.getname(this->_block.dtype()) << std::endl;
+      os << "device: " << Device.getname(this->_block.device()) << std::endl;
       os << "shape: ";
       vec_print_simple(os, this->_block.shape());
     }
@@ -484,17 +482,17 @@ namespace cytnx {
     for (cytnx_uint64 i = 0; i < vl; i++) {
       if (i < Nin) {
         if (Space_Llabel_max < this->_labels[i].size()) Space_Llabel_max = this->_labels[i].size();
-        if (Space_Ldim_max < to_string(this->_bonds[i].dim()).size())
-          Space_Ldim_max = to_string(this->_bonds[i].dim()).size();
+        if (Space_Ldim_max < std::to_string(this->_bonds[i].dim()).size())
+          Space_Ldim_max = std::to_string(this->_bonds[i].dim()).size();
       }
       if (i < Nout) {
-        if (Space_Rdim_max < to_string(this->_bonds[Nin + i].dim()).size())
-          Space_Rdim_max = to_string(this->_bonds[Nin + i].dim()).size();
+        if (Space_Rdim_max < std::to_string(this->_bonds[Nin + i].dim()).size())
+          Space_Rdim_max = std::to_string(this->_bonds[Nin + i].dim()).size();
       }
     }
-    string LallSpace = (string(" ") * (Space_Llabel_max + 3 + 1));
-    string MallSpace = string(" ") * (1 + Space_Ldim_max + 5 + Space_Rdim_max + 1);
-    string M_dashes = string("-") * (1 + Space_Ldim_max + 5 + Space_Rdim_max + 1);
+    std::string LallSpace = (std::string(" ") * (Space_Llabel_max + 3 + 1));
+    std::string MallSpace = std::string(" ") * (1 + Space_Ldim_max + 5 + Space_Rdim_max + 1);
+    std::string M_dashes = std::string("-") * (1 + Space_Ldim_max + 5 + Space_Rdim_max + 1);
     std::string tmpss;
 
     if (this->is_tag()) {
@@ -519,8 +517,9 @@ namespace cytnx {
           tmpss =
             this->_labels[i] + std::string(" ") * (Space_Llabel_max - this->_labels[i].size());
           sprintf(l, "%s %s", tmpss.c_str(), bks.c_str());
-          tmpss = to_string(this->_bonds[i].dim()) +
-                  std::string(" ") * (Space_Ldim_max - to_string(this->_bonds[i].dim()).size());
+          tmpss =
+            std::to_string(this->_bonds[i].dim()) +
+            std::string(" ") * (Space_Ldim_max - std::to_string(this->_bonds[i].dim()).size());
           sprintf(llbl, "%s", tmpss.c_str());
         } else {
           memset(l, 0, sizeof(char) * BUFFsize);
@@ -540,9 +539,9 @@ namespace cytnx {
 
           sprintf(r, "%s %s", bks.c_str(), this->_labels[Nin + i].c_str());
 
-          tmpss =
-            to_string(this->_bonds[Nin + i].dim()) +
-            std::string(" ") * (Space_Rdim_max - to_string(this->_bonds[Nin + i].dim()).size());
+          tmpss = std::to_string(this->_bonds[Nin + i].dim()) +
+                  std::string(" ") *
+                    (Space_Rdim_max - std::to_string(this->_bonds[Nin + i].dim()).size());
           sprintf(rlbl, "%s", tmpss.c_str());
 
         } else {
@@ -581,8 +580,9 @@ namespace cytnx {
           tmpss =
             this->_labels[i] + std::string(" ") * (Space_Llabel_max - this->_labels[i].size());
           sprintf(l, "%s %s", tmpss.c_str(), bks.c_str());
-          tmpss = to_string(this->_bonds[i].dim()) +
-                  std::string(" ") * (Space_Ldim_max - to_string(this->_bonds[i].dim()).size());
+          tmpss =
+            std::to_string(this->_bonds[i].dim()) +
+            std::string(" ") * (Space_Ldim_max - std::to_string(this->_bonds[i].dim()).size());
           sprintf(llbl, "%s", tmpss.c_str());
 
         } else {
@@ -601,9 +601,9 @@ namespace cytnx {
 
           sprintf(r, "%s %s", bks.c_str(), this->_labels[Nin + i].c_str());
 
-          tmpss =
-            to_string(this->_bonds[Nin + i].dim()) +
-            std::string(" ") * (Space_Rdim_max - to_string(this->_bonds[Nin + i].dim()).size());
+          tmpss = std::to_string(this->_bonds[Nin + i].dim()) +
+                  std::string(" ") *
+                    (Space_Rdim_max - std::to_string(this->_bonds[Nin + i].dim()).size());
           sprintf(rlbl, "%s", tmpss.c_str());
 
         } else {
@@ -1070,16 +1070,11 @@ namespace cytnx {
           tmpR = rhs->get_block_().contiguous();
       }
       std::vector<cytnx_int64> old_shape_L(tmpL.shape().begin(), tmpL.shape().end());
-      // vector<cytnx_int64> old_shape_R(tmpR.shape().begin(),tmpR.shape().end());
       std::vector<cytnx_int64> shape_L =
         vec_concatenate(old_shape_L, std::vector<cytnx_int64>(tmpR.shape().size(), 1));
-      // vector<cytnx_int64> shape_R =
-      // vec_concatenate(vector<cytnx_int64>(old_shape_L.size(),1),old_shape_R);
       tmpL.reshape_(shape_L);
-      // tmpR.reshape_(shape_R);
       tmp->_block = linalg::Kron(tmpL, tmpR, false, true);
       tmpL.reshape_(old_shape_L);
-      // tmpR.reshape_(old_shapeR);
       tmp->_is_diag = false;
 
       //}

--- a/src/Gncon.cpp
+++ b/src/Gncon.cpp
@@ -1,19 +1,17 @@
 #include "Gncon.hpp"
 
-using namespace std;
-
 #ifdef BACKEND_TORCH
 #else
 
 namespace cytnx {
   std::string GnconType_class::getname(const int& nwrktype_id) {
     if (nwrktype_id == this->Regular) {
-      return string("Regular");
+      return std::string("Regular");
     } else if (nwrktype_id == this->Fermion) {
-      return string("Fermion");
+      return std::string("Fermion");
     } else {
       cytnx_error_msg(true, "%s", "[ERROR] invalid nwrktype_id");
-      return string("");
+      return std::string("");
     }
     // extend more in here!!
   }

--- a/src/Gncon_base.cpp
+++ b/src/Gncon_base.cpp
@@ -3,8 +3,6 @@
 
 #include "linalg.hpp"
 
-using namespace std;
-
 #ifdef BACKEND_TORCH
 #else
 
@@ -29,7 +27,7 @@ namespace cytnx {
   void Gncon_base::PutUniTensor(const cytnx_uint64 &idx, const UniTensor &utensor) {
     cytnx_error_msg(true, "[ERROR][Gncon][PutUniTensor] call from uninitialize Gncon.%s", "\n");
   }
-  void Gncon_base::PutUniTensors(const std::vector<string> &names,
+  void Gncon_base::PutUniTensors(const std::vector<std::string> &names,
                                  const std::vector<UniTensor> &utensors) {
     cytnx_error_msg(true, "[ERROR][Gncon][PutUniTensors] call from uninitialize Gncon.%s", "\n");
   }
@@ -49,9 +47,9 @@ namespace cytnx {
     return nullptr;
   }
   void Gncon_base::PrintNet(std::ostream &os) {
-    os << "        [Empty Gncon]" << endl;
+    os << "        [Empty Gncon]" << std::endl;
     os << "--- Please Load Gncon file ---\n";
-    os << endl;
+    os << std::endl;
   }
 
 }  // namespace cytnx

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -3,20 +3,18 @@
 
 #include "linalg.hpp"
 
-using namespace std;
-
 #ifdef BACKEND_TORCH
 #else
 
 namespace cytnx {
   std::string NetworkType_class::getname(const int& nwrktype_id) {
     if (nwrktype_id == this->Regular) {
-      return string("Regular");
+      return std::string("Regular");
     } else if (nwrktype_id == this->Fermion) {
-      return string("Fermion");
+      return std::string("Fermion");
     } else {
       cytnx_error_msg(true, "%s", "[ERROR] invalid nwrktype_id");
-      return string("");
+      return std::string("");
     }
     // extend more in here!!
   }

--- a/src/Network_base.cpp
+++ b/src/Network_base.cpp
@@ -3,8 +3,6 @@
 
 #include "linalg.hpp"
 
-using namespace std;
-
 #ifdef BACKEND_TORCH
 #else
 
@@ -38,11 +36,11 @@ namespace cytnx {
   void Network_base::RmUniTensor(const cytnx_uint64 &idx) {
     cytnx_error_msg(true, "[ERROR][Network][RmUniTensor] call from uninitialized network.%s", "\n");
   }
-  void Network_base::RmUniTensors(const std::vector<string> &names) {
+  void Network_base::RmUniTensors(const std::vector<std::string> &names) {
     cytnx_error_msg(true, "[ERROR][Network][RmUniTensors] call from uninitialized network.%s",
                     "\n");
   }
-  void Network_base::PutUniTensors(const std::vector<string> &names,
+  void Network_base::PutUniTensors(const std::vector<std::string> &names,
                                    const std::vector<UniTensor> &utensors) {
     cytnx_error_msg(true, "[ERROR][Network][PutUniTensors] call from uninitialized network.%s",
                     "\n");
@@ -82,9 +80,9 @@ namespace cytnx {
     return nullptr;
   }
   void Network_base::PrintNet(std::ostream &os) {
-    os << "        [Empty Network]" << endl;
+    os << "        [Empty Network]" << std::endl;
     os << "--- Please Load Network file ---\n";
-    os << endl;
+    os << std::endl;
   }
 
 };  // namespace cytnx

--- a/src/RegularGncon.cpp
+++ b/src/RegularGncon.cpp
@@ -6,18 +6,18 @@
 #include <algorithm>
 #include <iostream>
 
-using namespace std;
-
 #ifdef BACKEND_TORCH
 #else
 
 namespace cytnx {
   // these three are internal functions:
 
-  void _parse_task_line_(string line, vector<vector<pair<string, string>>> &table,
-                         vector<std::string> &names, map<string, cytnx_uint64> &name2pos, int i) {
-    vector<string> tmpvs, tmpvs_;
-    tmpvs = str_split(line, false, "-");  // note that checking empty string!
+  void _parse_task_line_(std::string line,
+                         std::vector<std::vector<std::pair<std::string, std::string>>> &table,
+                         std::vector<std::string> &names,
+                         std::map<std::string, cytnx_uint64> &name2pos, int i) {
+    std::vector<std::string> tmpvs, tmpvs_;
+    tmpvs = str_split(line, false, "-");  // note that checking empty std::string!
 
     cytnx_error_msg(tmpvs.size() != 2, "[ERROR][Gncon] invalid line in Gncon file at line: %d. \n",
                     i);
@@ -27,10 +27,10 @@ namespace cytnx {
 
       // A valid line should contain ':'
       cytnx_error_msg(
-        tmpvs[j].find_first_of(":") == string::npos,
+        tmpvs[j].find_first_of(":") == std::string::npos,
         "[ERROR][Gncon][Fromfile] invalid Gncon description at line: %d. should contain \':\'", i);
-      vector<string> task;
-      tmpvs_ = str_split(tmpvs[j], false, ":");  // note that checking empty string!
+      std::vector<std::string> task;
+      tmpvs_ = str_split(tmpvs[j], false, ":");  // note that checking empty std::string!
 
       cytnx_error_msg(tmpvs_.size() != 2,
                       "[ERROR][Gncon] invalid line in Gncon file at line: %d. \n", i);
@@ -45,22 +45,21 @@ namespace cytnx {
       // check if name not exist:
       if (name2pos.find(tmpvs_[0]) == name2pos.end()) {
         names.push_back(tmpvs_[0]);
-        table.push_back(vector<pair<string, string>>());
-        // rep_labels.push_back(vector<pair<string, string>>());
+        table.push_back(std::vector<std::pair<std::string, std::string>>());
         name2pos[tmpvs_[0]] = names.size() - 1;  // register
       }
-      pair<string, string> ptmp(tmpvs_[1], "/" + to_string(i));
+      std::pair<std::string, std::string> ptmp(tmpvs_[1], "/" + std::to_string(i));
       // table[i] =  i-th tensor's leg names to be contracted, and its target labels.
       table[name2pos[tmpvs_[0]]].push_back(ptmp);
     }
   }
 
-  void _parse_ORDER_line_(vector<string> &tokens, const string &line,
+  void _parse_ORDER_line_(std::vector<std::string> &tokens, const std::string &line,
                           const cytnx_uint64 &line_num) {
-    cytnx_error_msg((line.find_first_of("\t;\n:") != string::npos),
+    cytnx_error_msg((line.find_first_of("\t;\n:") != std::string::npos),
                     "[ERROR][Gncon][Fromfile] line:%d invalid ORDER line format.%s", line_num,
                     "\n");
-    cytnx_error_msg((line.find_first_of("(),") == string::npos),
+    cytnx_error_msg((line.find_first_of("(),") == std::string::npos),
                     "[ERROR][Gncon][Fromfile] line:%d invalid ORDER line format.%s", line_num,
                     " tensors should be seperate by delimiter \',\' (comma), and/or wrapped with "
                     "\'(\' and \')\'");
@@ -76,65 +75,65 @@ namespace cytnx {
     cytnx_error_msg(tokens.size() == 0, "[ERROR][Gncon][Fromfile] line:%d invalid ORDER line.%s",
                     line_num, "\n");
   }
-  void _parse_TOUT_line_(vector<cytnx_int64> &lbls, cytnx_uint64 &TOUT_iBondNum,
-                         vector<vector<pair<string, string>>> &table,
-                         map<string, cytnx_uint64> name2pos, const string &line,
+  void _parse_TOUT_line_(std::vector<cytnx_int64> &lbls, cytnx_uint64 &TOUT_iBondNum,
+                         std::vector<std::vector<std::pair<std::string, std::string>>> &table,
+                         std::map<std::string, cytnx_uint64> name2pos, const std::string &line,
                          const cytnx_uint64 &line_num) {
     // A:a->b,c->d ; B:b,c
 
-    vector<string> tmp = str_split(line, false, ";");
+    std::vector<std::string> tmp = str_split(line, false, ";");
     for (int i = 0; i < tmp.size(); i++) {
       tmp[i] = str_strip(tmp[i]);  // remove spaces
-      vector<string> tmp_ = str_split(tmp[i], false, "/");
-      string name = str_strip(tmp_[0]);
-      string content = str_strip(tmp_[1]);
-      vector<string> reps = str_split(content, false, ",");
+      std::vector<std::string> tmp_ = str_split(tmp[i], false, "/");
+      std::string name = str_strip(tmp_[0]);
+      std::string content = str_strip(tmp_[1]);
+      std::vector<std::string> reps = str_split(content, false, ",");
       int tidx = name2pos[name];
       for (int j = 0; j < reps.size(); j++) {
         reps[j] = str_strip(reps[j]);  // remove spaces
-        vector<string> ls = str_split(reps[j], false, ">");
+        std::vector<std::string> ls = str_split(reps[j], false, ">");
         ls[0] = str_strip(ls[0]);  // remove spaces
         ls[1] = str_strip(ls[1]);  // remove spaces
-        pair<string, string> tmp(ls[0], ls[1]);
+        std::pair<std::string, std::string> tmp(ls[0], ls[1]);
         table[tidx].push_back(tmp);
       }
     }
 
     // // handle col-space lbl
-    // vector<string> ket_lbls = str_split(tmp[0], false, ",");
+    // std::vector<std::string> ket_lbls = str_split(tmp[0], false, ",");
     // if (ket_lbls.size() == 1)
     //   if (ket_lbls[0].length() == 0) ket_lbls.clear();
     // for (cytnx_uint64 i = 0; i < ket_lbls.size(); i++) {
-    //   string tmp = str_strip(ket_lbls[i]);
+    //   std::string tmp = str_strip(ket_lbls[i]);
     //   cytnx_error_msg(tmp.length() == 0,
     //                   "[ERROR][Gncon][Fromfile] line:%d Invalid labels for TOUT line.%s",
     //                   line_num, "\n");
-    //   cytnx_error_msg((tmp.find_first_not_of("0123456789-") != string::npos),
+    //   cytnx_error_msg((tmp.find_first_not_of("0123456789-") != std::string::npos),
     //                   "[ERROR][Gncon][Fromfile] line:%d %s\n", line_num,
     //                   "Invalid TOUT line. label contain non integer.");
-    //   lbls.push_back(stoi(tmp, nullptr));
+    //   lbls.push_back(std::stoi(tmp, nullptr));
     // }
     // TOUT_iBondNum = lbls.size();
 
     // // handle row-space lbl
-    // vector<string> bra_lbls = str_split(tmp[1], false, ",");
+    // std::vector<std::string> bra_lbls = str_split(tmp[1], false, ",");
     // if (bra_lbls.size() == 1)
     //   if (bra_lbls[0].length() == 0) bra_lbls.clear();
     // for (cytnx_uint64 i = 0; i < bra_lbls.size(); i++) {
-    //   string tmp = str_strip(bra_lbls[i]);
+    //   std::string tmp = str_strip(bra_lbls[i]);
     //   cytnx_error_msg(tmp.length() == 0,
     //                   "[ERROR][Gncon][Fromfile] line:%d Invalid labels for TOUT line.%s",
     //                   line_num, "\n");
-    //   cytnx_error_msg((tmp.find_first_not_of("0123456789-") != string::npos),
+    //   cytnx_error_msg((tmp.find_first_not_of("0123456789-") != std::string::npos),
     //                   "[ERROR][Gncon][Fromfile] line:%d %s\n", line_num,
     //                   "Invalid TOUT line. label contain non integer.");
-    //   lbls.push_back(stoi(tmp, nullptr));
+    //   lbls.push_back(std::stoi(tmp, nullptr));
     // }
   }
 
   /// This is debug function
-  void print_gn(std::vector<vector<pair<string, string>>> &table, vector<string> &names,
-                map<string, cytnx_uint64> &name2pos) {
+  void print_gn(std::vector<std::vector<std::pair<std::string, std::string>>> &table,
+                std::vector<std::string> &names, std::map<std::string, cytnx_uint64> &name2pos) {
     std::cout << "### table  ###" << std::endl;
     for (int i = 0; i < table.size(); i++) {
       for (int j = 0; j < table[i].size(); j++) {
@@ -148,10 +147,11 @@ namespace cytnx {
     }
   }
 
-  void _extract_TNs_from_ORDER_(vector<string> &TN_names, const vector<string> &tokens) {
+  void _extract_TNs_from_ORDER_(std::vector<std::string> &TN_names,
+                                const std::vector<std::string> &tokens) {
     TN_names.clear();
     for (cytnx_uint64 i = 0; i < tokens.size(); i++) {
-      string tok = str_strip(tokens[i]);  // remove space.
+      std::string tok = str_strip(tokens[i]);  // remove space.
       if (tok.length() == 0) continue;
       if ((tok != "(") && (tok != ")") && (tok != ",")) {
         TN_names.push_back(tok);
@@ -201,7 +201,7 @@ namespace cytnx {
     //     if (utensors[i].name().length()) {
     //       name = utensors[i].name() + "_usr";
     //     } else {
-    //       name = "uname_T" + to_string(i);
+    //       name = "uname_T" + std::to_string(i);
     //     }
     //     this->names.push_back(name);
     //   }
@@ -215,7 +215,7 @@ namespace cytnx {
     //   }
 
     //   this->name2pos[name] = names.size() - 1;  // register
-    //   this->label_arr.push_back(vector<cytnx_int64>());
+    //   this->label_arr.push_back(std::vector<cytnx_int64>());
     //   cytnx_uint64 tmp_iBN;
     //   // this is an internal function that is defined in this cpp file.
     //   this->label_arr.back() = utensors[i].labels();
@@ -231,7 +231,7 @@ namespace cytnx {
     // // checking if all TN are set in ORDER.
     // //  only alias assigned will activate order
     // if (isORDER_exist) {
-    //   std::vector<string> TN_names;  // this should be integer!
+    //   std::vector<std::string> TN_names;  // this should be integer!
     //   _extract_TNs_from_ORDER_(TN_names, this->ORDER_tokens);
     //   cytnx_error_msg(TN_names.size() != utensors.size(),
     //                   "[ERROR][Gncon][Contract--planning] order assigned but the [%d] tensors "
@@ -246,17 +246,18 @@ namespace cytnx {
     //     TN_names.erase(it);
     //   }
     //   if (TN_names.size() != 0) {
-    //     cout << "[ERROR] Following TNs appeared in ORDER line, but is not defined." << endl;
-    //     for (int i = 0; i < TN_names.size(); i++) {
-    //       cout << "        " << TN_names[i] << endl;
-    //     }
+    // std::cout << "[ERROR] Following TNs appeared in ORDER line, but is not defined." <<
+    //   std::endl;
+    // for (int i = 0; i < TN_names.size(); i++) {
+    //   std::cout << "        " << TN_names[i] << std::endl;
+    // }
     //     cytnx_error_msg(true, "%s", "\n");
     //   }
 
     // }  // check all RN.
 
     // // checking label matching:
-    // map<cytnx_int64, cytnx_int64> lblcnt;
+    // std::map<cytnx_int64, cytnx_int64> lblcnt;
     // for (int i = 0; i < this->names.size(); i++) {
     //   for (int j = 0; j < this->label_arr[i].size(); j++) {
     //     if (lblcnt.find(this->label_arr[i][j]) == lblcnt.end())
@@ -265,8 +266,9 @@ namespace cytnx {
     //       lblcnt[this->label_arr[i][j]] += 1;
     //   }
     // }
-    // vector<cytnx_int64> expected_TOUT;
-    // for (map<cytnx_int64, cytnx_int64>::iterator it = lblcnt.begin(); it != lblcnt.end(); ++it) {
+    // std::vector<cytnx_int64> expected_TOUT;
+    // for (std::map<cytnx_int64, cytnx_int64>::iterator it = lblcnt.begin(); it != lblcnt.end();
+    // ++it) {
     //   if (it->second == 1) expected_TOUT.push_back(it->first);
     // }
     // bool err = false;
@@ -274,20 +276,20 @@ namespace cytnx {
     //   std::cout << expected_TOUT.size() << std::endl;
     //   err = true;
     // }
-    // vector<cytnx_int64> itrsct = vec_intersect(expected_TOUT, this->TOUT_labels);
+    // std::vector<cytnx_int64> itrsct = vec_intersect(expected_TOUT, this->TOUT_labels);
     // if (itrsct.size() != expected_TOUT.size()) {
     //   err = true;
     // }
 
     // if (err) {
-    //   cout << "[ERROR][Gncon][Contract--planning] The TOUT contains labels that does not match "
-    //           "with the delcartion from TNs.\n";
-    //   cout << "  > The reduced labels [rank:" << expected_TOUT.size() << "] should be:";
-    //   for (int i = 0; i < expected_TOUT.size(); i++) cout << expected_TOUT[i] << " ";
-    //   cout << endl;
-    //   cout << "  > The TOUT [rank" << TOUT_labels.size() << "] specified is:";
-    //   for (int i = 0; i < TOUT_labels.size(); i++) cout << TOUT_labels[i] << " ";
-    //   cout << endl;
+    //   std::cout << "[ERROR][Gncon][Contract--planning] The TOUT contains labels that does not "
+    //   << "match with the delcartion from TNs.\n";
+    //   std::cout << "  > The reduced labels [rank:" << expected_TOUT.size() << "] should be:";
+    //   for (int i = 0; i < expected_TOUT.size(); i++) std::cout << expected_TOUT[i] << " ";
+    //   std::cout << std::endl;
+    //   std::cout << "  > The TOUT [rank" << TOUT_labels.size() << "] specified is:";
+    //   for (int i = 0; i < TOUT_labels.size(); i++) std::cout << TOUT_labels[i] << " ";
+    //   std::cout << std::endl;
     //   cytnx_error_msg(true, "%s", "\n");
     // }
 
@@ -311,13 +313,13 @@ namespace cytnx {
 
     this->clear();
 
-    string line;
-    vector<string> tmpvs;
+    std::string line;
+    std::vector<std::string> tmpvs;
 
     bool isORDER_exist = false;
 
     for (int i = 0; i < contents.size(); i++) {
-      vector<string> task;
+      std::vector<std::string> task;
       line = contents[i];
       line = str_strip(line, "\n");  // remove leading and ending /n
       line = str_strip(line);  // remove leading and ending spaces and tab
@@ -326,13 +328,13 @@ namespace cytnx {
 
       // remove any comment at eol :
       line = str_split(line, true, "#")[0];  // remove comment on end.
-      if (line.find_first_of("-") == string::npos) {
+      if (line.find_first_of("-") == std::string::npos) {
         // Not a contraction line, should be either ORDER or TOUT
 
-        tmpvs = str_split(line, false, ":");  // note that checking empty string!
-        string command = str_strip(tmpvs[0]);
-        string content = str_strip(tmpvs[1]);
-        // cytnx_error_msg(command.find_first_of(" ;,") != string::npos,
+        tmpvs = str_split(line, false, ":");  // note that checking empty std::string!
+        std::string command = str_strip(tmpvs[0]);
+        std::string content = str_strip(tmpvs[1]);
+        // cytnx_error_msg(command.find_first_of(" ;,") != std::string::npos,
         //                 "[ERROR] invalid Tensor name at line %d\n", i);
 
         if (command == "ORDER") {
@@ -357,7 +359,7 @@ namespace cytnx {
       } else {
         // Is a cotraction task line!
         _parse_task_line_(line, this->table, this->names, this->name2pos, i);
-      }  // end line.find_first_of("-") == string::npos
+      }  // end line.find_first_of("-") == std::string::npos
 
     }  // end for i loop
 
@@ -375,7 +377,7 @@ namespace cytnx {
 
     // checking if all TN are set in ORDER.
     if (isORDER_exist) {
-      std::vector<string> TN_names;
+      std::vector<std::string> TN_names;
       _extract_TNs_from_ORDER_(TN_names, this->ORDER_tokens);
       for (int i = 0; i < this->names.size(); i++) {
         auto it = std::find(TN_names.begin(), TN_names.end(), this->names[i]);
@@ -385,9 +387,10 @@ namespace cytnx {
         TN_names.erase(it);
       }
       if (TN_names.size() != 0) {
-        cerr << "[ERROR] Following TNs appeared in ORDER line, but is not defined." << endl;
+        std::cerr << "[ERROR] Following TNs appeared in ORDER line, but is not defined."
+                  << std::endl;
         for (int i = 0; i < TN_names.size(); i++) {
-          cerr << "        " << TN_names[i] << endl;
+          std::cerr << "        " << TN_names[i] << std::endl;
         }
         cytnx_error_msg(true, "%s", "\n");
       }
@@ -409,15 +412,15 @@ namespace cytnx {
     }
     filename = fname;
 
-    string line;
+    std::string line;
     cytnx_uint64 lnum = 0;
 
-    vector<string> contents;
+    std::vector<std::string> contents;
 
     // read each line:
     while (lnum < MAXLINES) {
       lnum++;
-      getline(infile, line);
+      std::getline(infile, line);
       contents.push_back(line);
       if (infile.eof()) break;
 
@@ -434,7 +437,7 @@ namespace cytnx {
     this->FromString(contents);
   }
 
-  void RegularGncon::PutUniTensors(const std::vector<string> &names,
+  void RegularGncon::PutUniTensors(const std::vector<std::string> &names,
                                    const std::vector<UniTensor> &utensors) {
     cytnx_error_msg(names.size() != utensors.size(),
                     "[ERROR][RegularGncon][PutUniTensors] total number of names does not match "
@@ -468,7 +471,7 @@ namespace cytnx {
 
     // update label_arr: update
     for (int i = 0; i < this->table[idx].size(); i++) {
-      pair<string, string> tmp = this->table[idx][i];
+      std::pair<std::string, std::string> tmp = this->table[idx][i];
       int utidx = utensor.get_index(tmp.first);
       this->label_arr[idx][utidx] = tmp.second;
       // this->is_contracted[idx][utidx] = 1;
@@ -480,8 +483,8 @@ namespace cytnx {
                     "[ERROR][RegularGncon][Savefile] Cannot save empty Gncon to Gncon file!%s",
                     "\n");
 
-    fstream fo;
-    fo.open(fname + ".net", ios::out | ios::trunc);
+    std::fstream fo;
+    fo.open(fname + ".net", std::ios::out | std::ios::trunc);
     if (!fo.is_open()) {
       cytnx_error_msg(true, "[ERROR][RegularGncon][Savefile] Cannot open/create file:%s\n",
                       fname.c_str());
@@ -524,7 +527,7 @@ namespace cytnx {
       for (int i = 0; i < ORDER_tokens.size(); i++) {
         fo << ORDER_tokens[i];
       }
-      fo << endl;
+      fo << std::endl;
     }
 
     fo.close();
@@ -545,10 +548,10 @@ namespace cytnx {
   }
 
   void RegularGncon::PrintNet(std::ostream &os) {
-    string status;
-    os << "==== Gncon ====" << endl;
+    std::string status;
+    os << "==== Gncon ====" << std::endl;
     if (this->tensors.size() == 0) {
-      os << "      Empty      " << endl;
+      os << "      Empty      " << std::endl;
     } else {
       for (cytnx_uint64 i = 0; i < this->tensors.size(); i++) {
         if (this->tensors[i].uten_type() != UTenType.Void)
@@ -568,7 +571,7 @@ namespace cytnx {
           os << this->label_arr[i][j] << " ";
           // printf("%d ",this->label_arr[i][j]);
         }
-        os << endl;
+        os << std::endl;
       }
 
       os << "TOUT : ";
@@ -582,17 +585,17 @@ namespace cytnx {
         os << this->TOUT_labels[j] << " ";
         // printf("%d ",this->TOUT_labels[j]);
       }
-      os << endl;
+      os << std::endl;
       os << "ORDER : ";
       for (cytnx_int64 i = 0; i < this->ORDER_tokens.size(); i++) {
         os << this->ORDER_tokens[i];
       }
-      os << endl;
-      os << "=================" << endl;
+      os << std::endl;
+      os << "=================" << std::endl;
     }
   }
 
-  string RegularGncon::getOptimalOrder() {
+  std::string RegularGncon::getOptimalOrder() {
     // Creat a SearchTree to search for optim contraction order.
     SearchTree Stree;
     Stree.base_nodes.clear();
@@ -606,7 +609,8 @@ namespace cytnx {
     return Stree.get_root().back()[0]->accu_str;
   }
 
-  UniTensor RegularGncon::Launch(const bool &optimal, const string &contract_order /*default ""*/) {
+  UniTensor RegularGncon::Launch(const bool &optimal,
+                                 const std::string &contract_order /*default ""*/) {
     // 1. check tensors are all set, and put all unitensor on node for contraction:
     cytnx_error_msg(this->tensors.size() == 0,
                     "[ERROR][Launch][RegularGncon] Cannot launch an un-initialize Gncon.%s", "\n");
@@ -642,7 +646,7 @@ namespace cytnx {
 
     } else {
       if (optimal == true) {
-        string Optim_ORDERline = this->getOptimalOrder();
+        std::string Optim_ORDERline = this->getOptimalOrder();
         this->ORDER_tokens.clear();
         _parse_ORDER_line_(ORDER_tokens, Optim_ORDERline, 999999);
         CtTree.build_contraction_tree_by_tokens(this->name2pos, ORDER_tokens);
@@ -656,7 +660,7 @@ namespace cytnx {
     }
 
     // 2. contract using postorder traversal:
-    stack<std::shared_ptr<Node>> stk;
+    std::stack<std::shared_ptr<Node>> stk;
     std::shared_ptr<Node> root = this->CtTree.nodes_container.back();
     int ly = 0;
     bool ict;

--- a/src/RegularGncon.cpp
+++ b/src/RegularGncon.cpp
@@ -537,7 +537,7 @@ namespace cytnx {
     cytnx_uint64 idx;
     try {
       idx = this->name2pos.at(name);
-    } catch (std::out_of_range) {
+    } catch (const std::out_of_range &) {
       cytnx_error_msg(true,
                       "[ERROR][RegularGncon][PutUniTensor] Cannot find the tensor name: [%s] in "
                       "current Gncon.\n",

--- a/src/RegularGncon.cpp
+++ b/src/RegularGncon.cpp
@@ -65,8 +65,8 @@ namespace cytnx {
                     "\'(\' and \')\'");
 
     // check mismatch:
-    size_t lbrac_n = std::count(line.begin(), line.end(), '(');
-    size_t rbrac_n = std::count(line.begin(), line.end(), ')');
+    std::size_t lbrac_n = std::count(line.begin(), line.end(), '(');
+    std::size_t rbrac_n = std::count(line.begin(), line.end(), ')');
     cytnx_error_msg(lbrac_n != rbrac_n, "[ERROR][Gncon][Fromfile] parentheses mismatch.%s", "\n");
 
     // slice the line into pieces by parentheses and comma
@@ -301,7 +301,7 @@ namespace cytnx {
     this->CtTree.base_nodes.clear();
 
     // Create nodes using make_shared
-    for (size_t i = 0; i < this->names.size(); i++) {
+    for (std::size_t i = 0; i < this->names.size(); i++) {
       auto node = std::make_shared<Node>();
       node->name = this->names[i];
       this->CtTree.base_nodes.push_back(node);

--- a/src/RegularNetwork.cpp
+++ b/src/RegularNetwork.cpp
@@ -7,7 +7,6 @@
 #include "Generator.hpp"
 #include "Network.hpp"
 #include "search_tree.hpp"
-using namespace std;
 
 #ifdef BACKEND_TORCH
 #else
@@ -16,43 +15,45 @@ using namespace std;
 namespace cytnx {
 
   namespace {
-    vector<string> ParseOrderLineInternal(const string &line, const cytnx_uint64 &line_num) {
-      cytnx_error_msg((line.find_first_of("\t;\n:") != string::npos),
+    std::vector<std::string> ParseOrderLineInternal(const std::string &line,
+                                                    const cytnx_uint64 &line_num) {
+      cytnx_error_msg((line.find_first_of("\t;\n:") != std::string::npos),
                       "[ERROR][Network][Fromfile] line:%d invalid ORDER line format.%s", line_num,
                       "\n");
-      cytnx_error_msg((line.find_first_of("(),") == string::npos),
+      cytnx_error_msg((line.find_first_of("(),") == std::string::npos),
                       "[ERROR][Network][Fromfile] line:%d invalid ORDER line format.%s", line_num,
                       " tensors should be seperate by delimiter \',\' (comma), and/or wrapped with "
                       "\'(\' and \')\'");
 
       // check mismatch:
-      size_t lbrac_n = count(line.begin(), line.end(), '(');
-      size_t rbrac_n = count(line.begin(), line.end(), ')');
+      size_t lbrac_n = std::count(line.begin(), line.end(), '(');
+      size_t rbrac_n = std::count(line.begin(), line.end(), ')');
       cytnx_error_msg(lbrac_n != rbrac_n, "[ERROR][Network][Fromfile] parentheses mismatch.%s",
                       "\n");
 
       // slice the line into pieces by parentheses and comma
-      vector<string> tokens = str_findall(line, "(),");
+      std::vector<std::string> tokens = str_findall(line, "(),");
 
       cytnx_error_msg(tokens.size() == 0,
                       "[ERROR][Network][Fromfile] line:%d invalid ORDER line.%s", line_num, "\n");
       return tokens;
     }
 
-    vector<string> ParseToutLineInternal(cytnx_uint64 &TOUT_iBondNum, const string &line,
-                                         const cytnx_uint64 &line_num) {
-      vector<string> labels;
+    std::vector<std::string> ParseToutLineInternal(cytnx_uint64 &TOUT_iBondNum,
+                                                   const std::string &line,
+                                                   const cytnx_uint64 &line_num) {
+      std::vector<std::string> labels;
 
-      vector<string> tmp = str_split(line, false, ";");
+      std::vector<std::string> tmp = str_split(line, false, ";");
       // cytnx_error_msg(tmp.size() != 2, "[ERROR][Network][Fromfile] line:%d %s\n", line_num,
       //                 "Invalid TOUT line");
       if (tmp.size() == 1) {
         // no ; provided
-        vector<string> tout_lbls = str_split(line, false, ",");
+        std::vector<std::string> tout_lbls = str_split(line, false, ",");
         cytnx_uint64 default_rowrank = tout_lbls.size() / 2;
         // handle col-space label
         for (cytnx_uint64 i = 0; i < default_rowrank; i++) {
-          string tmp_ = str_strip(tout_lbls[i]);
+          std::string tmp_ = str_strip(tout_lbls[i]);
           cytnx_error_msg(tmp_.length() == 0,
                           "[ERROR][Network][Fromfile] line:%d Invalid labels for TOUT line.%s",
                           line_num, "\n");
@@ -61,7 +62,7 @@ namespace cytnx {
         TOUT_iBondNum = labels.size();
         // handle row-space label
         for (cytnx_uint64 i = default_rowrank; i < tout_lbls.size(); i++) {
-          string tmp_ = str_strip(tout_lbls[i]);
+          std::string tmp_ = str_strip(tout_lbls[i]);
           cytnx_error_msg(tmp_.length() == 0,
                           "[ERROR][Network][Fromfile] line:%d Invalid labels for TOUT line.%s",
                           line_num, "\n");
@@ -70,11 +71,11 @@ namespace cytnx {
       } else if (tmp.size() == 2) {
         // one ;
         // handle col-space label
-        vector<string> ket_labels = str_split(tmp[0], false, ",");
+        std::vector<std::string> ket_labels = str_split(tmp[0], false, ",");
         if (ket_labels.size() == 1)
           if (ket_labels[0].length() == 0) ket_labels.clear();
         for (cytnx_uint64 i = 0; i < ket_labels.size(); i++) {
-          string tmp = str_strip(ket_labels[i]);
+          std::string tmp = str_strip(ket_labels[i]);
           cytnx_error_msg(tmp.length() == 0,
                           "[ERROR][Network][Fromfile] line:%d Invalid labels for TOUT line.%s",
                           line_num, "\n");
@@ -82,11 +83,11 @@ namespace cytnx {
         }
         TOUT_iBondNum = labels.size();
         // handle row-space label
-        vector<string> bra_labels = str_split(tmp[1], false, ",");
+        std::vector<std::string> bra_labels = str_split(tmp[1], false, ",");
         if (bra_labels.size() == 1)
           if (bra_labels[0].length() == 0) bra_labels.clear();
         for (cytnx_uint64 i = 0; i < bra_labels.size(); i++) {
-          string tmp = str_strip(bra_labels[i]);
+          std::string tmp = str_strip(bra_labels[i]);
           cytnx_error_msg(tmp.length() == 0,
                           "[ERROR][Network][Fromfile] line:%d Invalid labels for TOUT line.%s",
                           line_num, "\n");
@@ -99,18 +100,19 @@ namespace cytnx {
       return labels;
     }
 
-    vector<string> ParseTnLineInternal(const string &line, const cytnx_uint64 &line_num) {
-      vector<string> labels;
+    std::vector<std::string> ParseTnLineInternal(const std::string &line,
+                                                 const cytnx_uint64 &line_num) {
+      std::vector<std::string> labels;
 
-      vector<string> alllabels = str_split(line, false, ",");
+      std::vector<std::string> alllabels = str_split(line, false, ",");
       if (alllabels.size() == 1)
         if (alllabels[0].length() == 0) alllabels.clear();
       for (cytnx_uint64 i = 0; i < alllabels.size(); i++) {
-        string tmp = str_strip(alllabels[i]);
+        std::string tmp = str_strip(alllabels[i]);
         cytnx_error_msg(tmp.length() == 0,
                         "[ERROR][Network][Fromfile] line:%d Invalid labels for TN line.%s",
                         line_num, "\n");
-        // cytnx_error_msg((tmp.find_first_not_of("0123456789-") != string::npos),
+        // cytnx_error_msg((tmp.find_first_not_of("0123456789-") != std::string::npos),
         //                 "[ERROR][Network][Fromfile] line:%d %s\n", line_num,
         //                 "Invalid TN line. label contain non integer.");
         labels.push_back(tmp);
@@ -121,10 +123,10 @@ namespace cytnx {
       return labels;
     }
 
-    vector<string> ExtractTnsFromOrderInternal(const vector<string> &tokens) {
-      vector<string> TN_names;
+    std::vector<std::string> ExtractTnsFromOrderInternal(const std::vector<std::string> &tokens) {
+      std::vector<std::string> TN_names;
       for (cytnx_uint64 i = 0; i < tokens.size(); i++) {
-        string tok = str_strip(tokens[i]);  // remove space.
+        std::string tok = str_strip(tokens[i]);  // remove space.
         if (tok.length() == 0) continue;
         if ((tok != "(") && (tok != ")") && (tok != ",")) {
           TN_names.push_back(tok);
@@ -133,9 +135,9 @@ namespace cytnx {
       return TN_names;
     }
 
-    string EinsumpathToStringInternal(vector<pair<cytnx_int64, cytnx_int64>> path,
-                                      vector<string> tns) {
-      string res;
+    std::string EinsumpathToStringInternal(std::vector<std::pair<cytnx_int64, cytnx_int64>> path,
+                                           std::vector<std::string> tns) {
+      std::string res;
       for (int i = 0; i < path.size(); i++) {
         int id1 = path[i].first;
         int id2 = path[i].second;
@@ -155,10 +157,10 @@ namespace cytnx {
       return res;
     }
 
-    vector<pair<cytnx_int64, cytnx_int64>> CtTreeToEinsumpathInternal(ContractionTree CtTree,
-                                                                      vector<string> tns) {
-      vector<pair<cytnx_int64, cytnx_int64>> path;
-      stack<std::shared_ptr<Node>> stk;
+    std::vector<std::pair<cytnx_int64, cytnx_int64>> CtTreeToEinsumpathInternal(
+      ContractionTree CtTree, std::vector<std::string> tns) {
+      std::vector<std::pair<cytnx_int64, cytnx_int64>> path;
+      std::stack<std::shared_ptr<Node>> stk;
       std::shared_ptr<Node> root = CtTree.nodes_container.back();
       bool ict;
       do {
@@ -180,9 +182,9 @@ namespace cytnx {
         }
         if (ict) {
           if ((root->right != nullptr) && (root->left != nullptr)) {
-            auto it = find(tns.begin(), tns.end(), root->left->name);
+            auto it = std::find(tns.begin(), tns.end(), root->left->name);
             int id1 = it - tns.begin();
-            it = find(tns.begin(), tns.end(), root->right->name);
+            it = std::find(tns.begin(), tns.end(), root->right->name);
             int id2 = it - tns.begin();
             tns.erase(tns.begin() + id1);
             if (id1 > id2)
@@ -199,7 +201,7 @@ namespace cytnx {
       return path;
     }
 
-    void CheckInternal(vector<UniTensor> &tns, vector<string> &tn_names) {
+    void CheckInternal(std::vector<UniTensor> &tns, std::vector<std::string> &tn_names) {
       // check tensors are all set, and put all unitensor on node for contraction:
       cytnx_error_msg(
         tns.size() == 0,
@@ -233,8 +235,9 @@ namespace cytnx {
     }
   }  // namespace
 
-  void RegularNetwork::Contract_plan(const vector<UniTensor> &utensors, const string &Tout,
-                                     const vector<string> &alias, const string &contract_order) {
+  void RegularNetwork::Contract_plan(const std::vector<UniTensor> &utensors,
+                                     const std::string &Tout, const std::vector<std::string> &alias,
+                                     const std::string &contract_order) {
     cytnx_error_msg(utensors.size() < 2,
                     "[ERROR][Network] invalid network. Should have at least 2 tensors defined.%s",
                     "\n");
@@ -264,7 +267,7 @@ namespace cytnx {
     }
 
     // assign input tensors into slots:
-    string name;
+    std::string name;
     for (unsigned int i = 0; i < utensors.size(); i++) {
       if (alias.size()) {
         this->names.push_back(alias[i]);
@@ -273,7 +276,7 @@ namespace cytnx {
         if (utensors[i].name().length()) {
           name = utensors[i].name() + "_usr";
         } else {
-          name = "uname_T" + to_string(i);
+          name = "uname_T" + std::to_string(i);
         }
         this->names.push_back(name);
       }
@@ -287,7 +290,7 @@ namespace cytnx {
       }
 
       this->name2pos[name] = names.size() - 1;  // register
-      this->label_arr.push_back(vector<string>());
+      this->label_arr.push_back(std::vector<std::string>());
       cytnx_uint64 tmp_iBN;
       // this is an internal function that is defined in this cpp file.
       this->label_arr.back() = utensors[i].labels();
@@ -300,24 +303,25 @@ namespace cytnx {
     // checking if all TN are set in ORDER.
     //  only alias assigned will activate order
     if (isORDER_exist) {
-      vector<string> TN_names;  // this should be integer!
+      std::vector<std::string> TN_names;  // this should be integer!
       TN_names = ExtractTnsFromOrderInternal(this->ORDER_tokens);
       cytnx_error_msg(TN_names.size() != utensors.size(),
                       "[ERROR][Network][Contract--planning] order assigned but the [%d] tensors "
                       "appears in ORDER does not match the # input tensors [%d]\n",
                       TN_names.size(), utensors.size());
       for (int i = 0; i < this->names.size(); i++) {
-        auto it = find(TN_names.begin(), TN_names.end(), this->names[i]);
+        auto it = std::find(TN_names.begin(), TN_names.end(), this->names[i]);
         cytnx_error_msg(
-          it == end(TN_names),
+          it == std::end(TN_names),
           "[ERROR][Network][Contract--planning] TN: <%s> defined but is not used in ORDER line\n",
           this->names[i].c_str());
         TN_names.erase(it);
       }
       if (TN_names.size() != 0) {
-        cerr << "[ERROR] Following TNs appeared in ORDER line, but is not defined." << endl;
+        std::cerr << "[ERROR] Following TNs appeared in ORDER line, but is not defined."
+                  << std::endl;
         for (int i = 0; i < TN_names.size(); i++) {
-          cerr << "        " << TN_names[i] << endl;
+          std::cerr << "        " << TN_names[i] << std::endl;
         }
         cytnx_error_msg(true, "%s", "\n");
       }
@@ -325,7 +329,7 @@ namespace cytnx {
     }  // check all RN.
 
     // checking label matching:
-    map<string, cytnx_int64> labelcnt;
+    std::map<std::string, cytnx_int64> labelcnt;
     for (int i = 0; i < this->names.size(); i++) {
       for (int j = 0; j < this->label_arr[i].size(); j++) {
         if (labelcnt.find(this->label_arr[i][j]) == labelcnt.end())
@@ -334,29 +338,31 @@ namespace cytnx {
           labelcnt[this->label_arr[i][j]] += 1;
       }
     }
-    vector<string> expected_TOUT;
-    for (map<string, cytnx_int64>::iterator it = labelcnt.begin(); it != labelcnt.end(); ++it) {
+    std::vector<std::string> expected_TOUT;
+    for (std::map<std::string, cytnx_int64>::iterator it = labelcnt.begin(); it != labelcnt.end();
+         ++it) {
       if (it->second == 1) expected_TOUT.push_back(it->first);
     }
     bool err = false;
     if (expected_TOUT.size() != TOUT_labels.size()) {
-      cout << expected_TOUT.size() << endl;
+      std::cout << expected_TOUT.size() << std::endl;
       err = true;
     }
-    vector<string> itrsct = vec_intersect(expected_TOUT, this->TOUT_labels);
+    std::vector<std::string> itrsct = vec_intersect(expected_TOUT, this->TOUT_labels);
     if (itrsct.size() != expected_TOUT.size()) {
       err = true;
     }
 
     if (err) {
-      cerr << "[ERROR][Network][Contract--planning] The TOUT contains labels that does not match "
-              "with the delcartion from TNs.\n";
-      cerr << "  > The reduced labels [rank:" << expected_TOUT.size() << "] should be:";
-      for (int i = 0; i < expected_TOUT.size(); i++) cerr << expected_TOUT[i] << " ";
-      cerr << endl;
-      cerr << "  > The TOUT [rank" << TOUT_labels.size() << "] specified is:";
-      for (int i = 0; i < TOUT_labels.size(); i++) cerr << TOUT_labels[i] << " ";
-      cerr << endl;
+      std::cerr
+        << "[ERROR][Network][Contract--planning] The TOUT contains labels that does not match "
+           "with the delcartion from TNs.\n";
+      std::cerr << "  > The reduced labels [rank:" << expected_TOUT.size() << "] should be:";
+      for (int i = 0; i < expected_TOUT.size(); i++) std::cerr << expected_TOUT[i] << " ";
+      std::cerr << std::endl;
+      std::cerr << "  > The TOUT [rank" << TOUT_labels.size() << "] specified is:";
+      for (int i = 0; i < TOUT_labels.size(); i++) std::cerr << TOUT_labels[i] << " ";
+      std::cerr << std::endl;
       cytnx_error_msg(true, "%s", "\n");
     }
 
@@ -364,11 +370,11 @@ namespace cytnx {
     for (int i = 0; i < utensors.size(); i++) this->tensors[i] = utensors[i];
   }
 
-  void RegularNetwork::FromString(const vector<string> &contents) {
+  void RegularNetwork::FromString(const std::vector<std::string> &contents) {
     this->clear();
 
-    string line;
-    vector<string> tmpvs;
+    std::string line;
+    std::vector<std::string> tmpvs;
     bool isORDER_exist = false;
 
     for (int i = 0; i < contents.size(); i++) {
@@ -383,21 +389,21 @@ namespace cytnx {
 
       // A valid line should contain ':':
       cytnx_error_msg(
-        line.find_first_of(":") == string::npos,
+        line.find_first_of(":") == std::string::npos,
         "[ERROR][Network][Fromfile] invalid network description at line: %d. should contain \':\'",
         i);
 
-      tmpvs = str_split(line, false, ":");  // note that checking empty string!
+      tmpvs = str_split(line, false, ":");  // note that checking empty std::string!
       cytnx_error_msg(tmpvs.size() != 2,
                       "[ERROR][Network] invalid line in network file at line: %d. \n", i);
 
-      string name = str_strip(tmpvs[0]);
-      string content = str_strip(tmpvs[1]);
+      std::string name = str_strip(tmpvs[0]);
+      std::string content = str_strip(tmpvs[1]);
 
       // check if name contain invalid keyword or not assigned.
       cytnx_error_msg(name.length() == 0,
                       "[ERROR][Network][Fromfile] invalid tensor name at line: %d\n", i);
-      cytnx_error_msg(name.find_first_of(" ;,") != string::npos,
+      cytnx_error_msg(name.find_first_of(" ;,") != std::string::npos,
                       "[ERROR] invalid Tensor name at line %d\n", i);
 
       // dispatch
@@ -425,7 +431,7 @@ namespace cytnx {
                           "have duplicated tensor name in a network.",
                           name.c_str());
         }
-        cytnx_error_msg(name.find_first_of("\t;\n: ") != string::npos,
+        cytnx_error_msg(name.find_first_of("\t;\n: ") != std::string::npos,
                         "[ERROR][Network][Fromfile] invalid tensor name. cannot contain [' '] or "
                         "[';'] or [':'] or ['\\t'] .%s",
                         "\n");
@@ -437,7 +443,7 @@ namespace cytnx {
                         i);
 
         this->name2pos[name] = names.size() - 1;  // register
-        this->label_arr.push_back(vector<string>());
+        this->label_arr.push_back(std::vector<std::string>());
         // this is an internal function that is defined in this cpp file.
         this->label_arr.back() = ParseTnLineInternal(content, i);
         this->iBondNums.push_back(this->label_arr.back().size());
@@ -466,27 +472,28 @@ namespace cytnx {
 
     // checking if all TN are set in ORDER.
     if (isORDER_exist) {
-      vector<string> TN_names;
+      std::vector<std::string> TN_names;
       TN_names = ExtractTnsFromOrderInternal(this->ORDER_tokens);
       for (int i = 0; i < this->names.size(); i++) {
-        auto it = find(TN_names.begin(), TN_names.end(), this->names[i]);
+        auto it = std::find(TN_names.begin(), TN_names.end(), this->names[i]);
         cytnx_error_msg(
-          it == end(TN_names),
+          it == std::end(TN_names),
           "[ERROR][Network][Fromfile] TN: <%s> defined but is not used in ORDER line\n",
           this->names[i].c_str());
         TN_names.erase(it);
       }
       if (TN_names.size() != 0) {
-        cerr << "[ERROR] Following TNs appeared in ORDER line, but is not defined." << endl;
+        std::cerr << "[ERROR] Following TNs appeared in ORDER line, but is not defined."
+                  << std::endl;
         for (int i = 0; i < TN_names.size(); i++) {
-          cerr << "        " << TN_names[i] << endl;
+          std::cerr << "        " << TN_names[i] << std::endl;
         }
         cytnx_error_msg(true, "%s", "\n");
       }
     }  // check all RN.
 
     // checking label matching:
-    map<string, cytnx_int64> labelcnt;
+    std::map<std::string, cytnx_int64> labelcnt;
     for (int i = 0; i < this->names.size(); i++) {
       for (int j = 0; j < this->label_arr[i].size(); j++) {
         if (labelcnt.find(this->label_arr[i][j]) == labelcnt.end())
@@ -495,39 +502,41 @@ namespace cytnx {
           labelcnt[this->label_arr[i][j]] += 1;
       }
     }
-    vector<string> expected_TOUT;
-    for (map<string, cytnx_int64>::iterator it = labelcnt.begin(); it != labelcnt.end(); ++it) {
+    std::vector<std::string> expected_TOUT;
+    for (std::map<std::string, cytnx_int64>::iterator it = labelcnt.begin(); it != labelcnt.end();
+         ++it) {
       if (it->second == 1) expected_TOUT.push_back(it->first);
     }
     bool err = false;
     if (expected_TOUT.size() != TOUT_labels.size()) {
       err = true;
     }
-    vector<string> itrsct = vec_intersect(expected_TOUT, this->TOUT_labels);
+    std::vector<std::string> itrsct = vec_intersect(expected_TOUT, this->TOUT_labels);
     if (itrsct.size() != expected_TOUT.size()) {
       err = true;
     }
 
     if (err) {
-      cerr << "[ERROR][Network][Fromfile] The TOUT contains labels that does not match with the "
-              "delcartion from TNs.\n";
-      cerr << "  > The reduced labels [rank:" << expected_TOUT.size() << "] should be:";
-      for (int i = 0; i < expected_TOUT.size(); i++) cerr << expected_TOUT[i] << " ";
-      cerr << endl;
-      cerr << "  > The TOUT [rank" << TOUT_labels.size() << "] specified is:";
-      for (int i = 0; i < TOUT_labels.size(); i++) cerr << TOUT_labels[i] << " ";
-      cerr << endl;
+      std::cerr
+        << "[ERROR][Network][Fromfile] The TOUT contains labels that does not match with the "
+           "delcartion from TNs.\n";
+      std::cerr << "  > The reduced labels [rank:" << expected_TOUT.size() << "] should be:";
+      for (int i = 0; i < expected_TOUT.size(); i++) std::cerr << expected_TOUT[i] << " ";
+      std::cerr << std::endl;
+      std::cerr << "  > The TOUT [rank" << TOUT_labels.size() << "] specified is:";
+      for (int i = 0; i < TOUT_labels.size(); i++) std::cerr << TOUT_labels[i] << " ";
+      std::cerr << std::endl;
       cytnx_error_msg(true, "%s", "\n");
     }
 
     // maintain TOUT leg position
-    TOUT_pos = vector<pair<int, int>>();
+    TOUT_pos = std::vector<std::pair<int, int>>();
     for (int i = 0; i < TOUT_labels.size(); i++) {
       for (int j = 0; j < label_arr.size(); j++) {
-        vector<string>::iterator it;
-        it = find(this->label_arr[j].begin(), this->label_arr[j].end(), TOUT_labels[i]);
+        std::vector<std::string>::iterator it;
+        it = std::find(this->label_arr[j].begin(), this->label_arr[j].end(), TOUT_labels[i]);
         if (it != this->label_arr[j].end()) {
-          TOUT_pos.push_back(make_pair(j, distance(label_arr[j].begin(), it)));
+          TOUT_pos.push_back(std::make_pair(j, distance(label_arr[j].begin(), it)));
           break;
         }
       }
@@ -556,7 +565,7 @@ namespace cytnx {
     #endif
   #endif
 
-    vector<string> names;
+    std::vector<std::string> names;
     for (int i = 0; i < this->names.size(); i++) {
       names.push_back(this->names[i]);
       CtTree.base_nodes[i]->name = this->names[i];
@@ -569,29 +578,29 @@ namespace cytnx {
     this->einsum_path = CtTreeToEinsumpathInternal(CtTree, names);
   }  // end of FromString
 
-  void RegularNetwork::Fromfile(const string &fname) {
+  void RegularNetwork::Fromfile(const std::string &fname) {
     const cytnx_uint64 MAXLINES = 1024;
 
     // empty all
     // this->clear();
 
     // open file
-    ifstream infile;
+    std::ifstream infile;
     infile.open(fname.c_str());
     if (!(infile.is_open())) {
       cytnx_error_msg(true, "[Network] Error in opening file \'", fname.c_str(), "\'.\n");
     }
     filename = fname;
 
-    string line;
+    std::string line;
     cytnx_uint64 lnum = 0;
 
-    vector<string> contents;
+    std::vector<std::string> contents;
 
     // read each line:
     while (lnum < MAXLINES) {
       lnum++;
-      getline(infile, line);
+      std::getline(infile, line);
       contents.push_back(line);
       if (infile.eof()) break;
 
@@ -608,8 +617,8 @@ namespace cytnx {
     this->FromString(contents);
   }
 
-  void RegularNetwork::PutUniTensors(const vector<string> &names,
-                                     const vector<UniTensor> &utensors) {
+  void RegularNetwork::PutUniTensors(const std::vector<std::string> &names,
+                                     const std::vector<UniTensor> &utensors) {
     cytnx_error_msg(names.size() != utensors.size(),
                     "[ERROR][RegularNetwork][PutUniTensors] total number of names does not match "
                     "number of input UniTensors.%s",
@@ -638,11 +647,11 @@ namespace cytnx {
 
     this->tensors[idx] = UniTensor();
   }
-  void RegularNetwork::RmUniTensor(const string &name) {
+  void RegularNetwork::RmUniTensor(const std::string &name) {
     cytnx_uint64 idx;
     try {
       idx = this->name2pos.at(name);
-    } catch (out_of_range) {
+    } catch (std::out_of_range) {
       cytnx_error_msg(true,
                       "[ERROR][RegularNetwork][RmUniTensor] Cannot find the tensor name: [%s] in "
                       "current network.\n",
@@ -651,19 +660,19 @@ namespace cytnx {
 
     this->RmUniTensor(idx);
   }
-  void RegularNetwork::RmUniTensors(const vector<string> &names) {
+  void RegularNetwork::RmUniTensors(const std::vector<std::string> &names) {
     for (int i = 0; i < names.size(); i++) {
       this->RmUniTensor(names[i]);
     }
   }
 
-  void RegularNetwork::Savefile(const string &fname) {
+  void RegularNetwork::Savefile(const std::string &fname) {
     cytnx_error_msg(
       this->label_arr.size() == 0,
       "[ERROR][RegularNetwork][Savefile] Cannot save empty network to network file!%s", "\n");
 
-    fstream fo;
-    fo.open(fname + ".net", ios::out | ios::trunc);
+    std::fstream fo;
+    fo.open(fname + ".net", std::ios::out | std::ios::trunc);
     if (!fo.is_open()) {
       cytnx_error_msg(true, "[ERROR][RegularNetwork][Savefile] Cannot open/create file:%s\n",
                       fname.c_str());
@@ -705,17 +714,17 @@ namespace cytnx {
       for (int i = 0; i < ORDER_tokens.size(); i++) {
         fo << ORDER_tokens[i];
       }
-      fo << endl;
+      fo << std::endl;
     }
 
     fo.close();
   }
 
-  void RegularNetwork::PutUniTensor(const string &name, const UniTensor &utensor) {
+  void RegularNetwork::PutUniTensor(const std::string &name, const UniTensor &utensor) {
     cytnx_uint64 idx;
     try {
       idx = this->name2pos.at(name);
-    } catch (out_of_range) {
+    } catch (std::out_of_range) {
       cytnx_error_msg(true,
                       "[ERROR][RegularNetwork][PutUniTensor] Cannot find the tensor name: [%s] in "
                       "current network.\n",
@@ -725,11 +734,11 @@ namespace cytnx {
     this->PutUniTensor(idx, utensor);
   }
 
-  void RegularNetwork::PrintNet(ostream &os) {
-    string status;
-    os << "==== Network ====" << endl;
+  void RegularNetwork::PrintNet(std::ostream &os) {
+    std::string status;
+    os << "==== Network ====" << std::endl;
     if (this->tensors.size() == 0) {
-      os << "      Empty      " << endl;
+      os << "      Empty      " << std::endl;
     } else {
       for (cytnx_uint64 i = 0; i < this->tensors.size(); i++) {
         if (this->tensors[i].uten_type() != UTenType.Void)
@@ -749,7 +758,7 @@ namespace cytnx {
           os << this->label_arr[i][j] << " ";
           // printf("%d ",this->label_arr[i][j]);
         }
-        os << endl;
+        os << std::endl;
       }
 
       os << "TOUT : ";
@@ -763,17 +772,17 @@ namespace cytnx {
         os << this->TOUT_labels[j] << " ";
         // printf("%d ",this->TOUT_labels[j]);
       }
-      os << endl;
+      os << std::endl;
       os << "ORDER : ";
       for (cytnx_int64 i = 0; i < this->ORDER_tokens.size(); i++) {
         os << this->ORDER_tokens[i];
       }
-      os << endl;
-      os << "=================" << endl;
+      os << std::endl;
+      os << "=================" << std::endl;
     }
   }
 
-  string RegularNetwork::getOrder() {
+  std::string RegularNetwork::getOrder() {
     if (this->order_line != "") {
       return this->order_line;
     } else {
@@ -781,33 +790,35 @@ namespace cytnx {
     }
   }
 
-  void RegularNetwork::setOrder(const bool &optimal, const string &contract_order /*default ""*/) {
+  void RegularNetwork::setOrder(const bool &optimal,
+                                const std::string &contract_order /*default ""*/) {
     cytnx_warning_msg(optimal && (contract_order != ""),
                       "[WARNING][setOrder][RegularNetwork] Setting Optimal = true while specifying "
                       "the order, will find the optimal order instead."
                       "to use the desired order please set Optimal = false.%s",
                       "\n");
-    cytnx_warning_msg((!optimal) && (contract_order == ""),
-                      "[WARNING][setOrder][RegularNetwork] Setting Optimal = false while not "
-                      "specifying the order string, will use default contraciton order instrad.%s",
-                      "\n");
+    cytnx_warning_msg(
+      (!optimal) && (contract_order == ""),
+      "[WARNING][setOrder][RegularNetwork] Setting Optimal = false while not "
+      "specifying the order std::string, will use default contraciton order instrad.%s",
+      "\n");
     this->ORDER_tokens.clear();
     if (optimal) {
       CheckInternal(this->tensors, this->names);
 
       if (this->tensors[0].device() == Device.cpu) {
-        string Optim_ORDERline = this->getOptimalOrder();
+        std::string Optim_ORDERline = this->getOptimalOrder();
         this->order_line = Optim_ORDERline;
         ORDER_tokens = ParseOrderLineInternal(Optim_ORDERline, 999999);
       } else {
   #ifdef UNI_GPU
     #ifdef UNI_CUQUANTUM
         if (this->tensors[0].uten_type() != UTenType.Dense) {
-          string Optim_ORDERline = this->getOptimalOrder();
+          std::string Optim_ORDERline = this->getOptimalOrder();
           this->order_line = Optim_ORDERline;
           ORDER_tokens = ParseOrderLineInternal(Optim_ORDERline, 999999);
         } else {
-          vector<cytnx_uint64> out_shape;
+          std::vector<cytnx_uint64> out_shape;
           for (int i = 0; i < this->TOUT_labels.size(); i++) {
             out_shape.push_back(this->tensors[TOUT_pos[i].first].shape()[TOUT_pos[i].second]);
           }
@@ -824,10 +835,10 @@ namespace cytnx {
           this->optimizerInfo = cutn.findOptimalOrder();
 
           // Get contraction path
-          vector<pair<cytnx_int64, cytnx_int64>> path = cutn.getContractionPath();
+          std::vector<std::pair<cytnx_int64, cytnx_int64>> path = cutn.getContractionPath();
           cutn.freeHandle();
 
-          vector<string> names;
+          std::vector<std::string> names;
           for (int i = 0; i < this->names.size(); i++) {
             names.push_back(this->names[i]);
           }
@@ -838,7 +849,7 @@ namespace cytnx {
         // cytnx_error_msg(true, "[ERROR][setOrder][RegularNetwork] fatal error,%s",
         //                 "try to call the gpu section for finding optimal contraction order
         //                 without " "CUQUANTUM support.\n");
-        string Optim_ORDERline = this->getOptimalOrder();
+        std::string Optim_ORDERline = this->getOptimalOrder();
         this->order_line = Optim_ORDERline;
         ORDER_tokens = ParseOrderLineInternal(Optim_ORDERline, 999999);
     #endif
@@ -861,7 +872,7 @@ namespace cytnx {
     }
   }
 
-  string RegularNetwork::getOptimalOrder() {
+  std::string RegularNetwork::getOptimalOrder() {
     // Creat a SearchTree to search for optim contraction order.
     SearchTree Stree;
     Stree.base_nodes.resize(this->tensors.size());
@@ -881,7 +892,7 @@ namespace cytnx {
 
   #if defined(UNI_GPU) && defined(UNI_CUQUANTUM)  // gpu workflow with cuquantum
     if (tn_device != Device.cpu && this->tensors[0].uten_type() == UTenType.Dense) {
-      vector<cytnx_uint64> out_shape;
+      std::vector<cytnx_uint64> out_shape;
       out_shape.reserve(this->TOUT_labels.size());
       for (int i = 0; i < this->TOUT_labels.size(); i++) {
         out_shape.push_back(this->tensors[TOUT_pos[i].first].shape()[TOUT_pos[i].second]);
@@ -932,7 +943,7 @@ namespace cytnx {
     }
 
     // 2. contract using postorder traversal:
-    stack<std::shared_ptr<Node>> stk;
+    std::stack<std::shared_ptr<Node>> stk;
     std::shared_ptr<Node> root = this->CtTree.nodes_container.back();
     root->set_root_ptrs();  // Add this line
     bool ict;
@@ -982,9 +993,10 @@ namespace cytnx {
     return out;
   }
 
-  void RegularNetwork::construct(const vector<string> &alias, const vector<vector<string>> &labels,
-                                 const vector<string> &outlabel, const cytnx_int64 &outrk,
-                                 const string &order, const bool optim) {
+  void RegularNetwork::construct(const std::vector<std::string> &alias,
+                                 const std::vector<std::vector<std::string>> &labels,
+                                 const std::vector<std::string> &outlabel, const cytnx_int64 &outrk,
+                                 const std::string &order, const bool optim) {
     this->clear();
     for (int i = 0; i < alias.size(); i++) {
       this->names.push_back(alias[i]);
@@ -1001,20 +1013,21 @@ namespace cytnx {
       this->order_line = order;
       // checking if all TN are set in ORDER.
       this->ORDER_tokens = ParseOrderLineInternal(order, 0);
-      vector<string> TN_names;
+      std::vector<std::string> TN_names;
       TN_names = ExtractTnsFromOrderInternal(this->ORDER_tokens);
       for (int i = 0; i < this->names.size(); i++) {
-        auto it = find(TN_names.begin(), TN_names.end(), this->names[i]);
+        auto it = std::find(TN_names.begin(), TN_names.end(), this->names[i]);
         cytnx_error_msg(
-          it == end(TN_names),
+          it == std::end(TN_names),
           "[ERROR][Network][Fromfile] TN: <%s> defined but is not used in ORDER line\n",
           this->names[i].c_str());
         TN_names.erase(it);
       }
       if (TN_names.size() != 0) {
-        cerr << "[ERROR] Following TNs appeared in ORDER line, but is not defined." << endl;
+        std::cerr << "[ERROR] Following TNs appeared in ORDER line, but is not defined."
+                  << std::endl;
         for (int i = 0; i < TN_names.size(); i++) {
-          cerr << "        " << TN_names[i] << endl;
+          std::cerr << "        " << TN_names[i] << std::endl;
         }
         cytnx_error_msg(true, "%s", "\n");
       }
@@ -1036,7 +1049,7 @@ namespace cytnx {
     }
 
     // checking label matching:
-    map<string, cytnx_int64> labelcnt;
+    std::map<std::string, cytnx_int64> labelcnt;
     for (int i = 0; i < this->names.size(); i++) {
       for (int j = 0; j < this->label_arr[i].size(); j++) {
         if (labelcnt.find(this->label_arr[i][j]) == labelcnt.end())
@@ -1045,9 +1058,10 @@ namespace cytnx {
           labelcnt[this->label_arr[i][j]] += 1;
       }
     }
-    vector<string> expected_TOUT;
+    std::vector<std::string> expected_TOUT;
 
-    for (map<string, cytnx_int64>::iterator it = labelcnt.begin(); it != labelcnt.end(); ++it) {
+    for (std::map<std::string, cytnx_int64>::iterator it = labelcnt.begin(); it != labelcnt.end();
+         ++it) {
       if (it->second == 1) expected_TOUT.push_back(it->first);
     }
     if (this->TOUT_labels.size() == 0) {
@@ -1057,31 +1071,32 @@ namespace cytnx {
       if (expected_TOUT.size() != TOUT_labels.size()) {
         err = true;
       }
-      vector<string> itrsct = vec_intersect(expected_TOUT, this->TOUT_labels);
+      std::vector<std::string> itrsct = vec_intersect(expected_TOUT, this->TOUT_labels);
       if (itrsct.size() != expected_TOUT.size()) {
         err = true;
       }
       if (err) {
-        cerr << "[ERROR][Network][Fromfile] The TOUT contains labels that does not match with the "
-                "delcartion from TNs.\n";
-        cerr << "  > The reduced labels [rank:" << expected_TOUT.size() << "] should be:";
-        for (int i = 0; i < expected_TOUT.size(); i++) cerr << expected_TOUT[i] << " ";
-        cerr << endl;
-        cerr << "  > The TOUT [rank" << TOUT_labels.size() << "] specified is:";
-        for (int i = 0; i < TOUT_labels.size(); i++) cerr << TOUT_labels[i] << " ";
-        cerr << endl;
+        std::cerr
+          << "[ERROR][Network][Fromfile] The TOUT contains labels that does not match with the "
+             "delcartion from TNs.\n";
+        std::cerr << "  > The reduced labels [rank:" << expected_TOUT.size() << "] should be:";
+        for (int i = 0; i < expected_TOUT.size(); i++) std::cerr << expected_TOUT[i] << " ";
+        std::cerr << std::endl;
+        std::cerr << "  > The TOUT [rank" << TOUT_labels.size() << "] specified is:";
+        for (int i = 0; i < TOUT_labels.size(); i++) std::cerr << TOUT_labels[i] << " ";
+        std::cerr << std::endl;
         cytnx_error_msg(true, "%s", "\n");
       }
     }
 
     // maintain TOUT leg position
-    TOUT_pos = vector<pair<int, int>>();
+    TOUT_pos = std::vector<std::pair<int, int>>();
     for (int i = 0; i < TOUT_labels.size(); i++) {
       for (int j = 0; j < label_arr.size(); j++) {
-        vector<string>::iterator it;
-        it = find(this->label_arr[j].begin(), this->label_arr[j].end(), TOUT_labels[i]);
+        std::vector<std::string>::iterator it;
+        it = std::find(this->label_arr[j].begin(), this->label_arr[j].end(), TOUT_labels[i]);
         if (it != this->label_arr[j].end()) {
-          TOUT_pos.push_back(make_pair(j, distance(label_arr[j].begin(), it)));
+          TOUT_pos.push_back(std::make_pair(j, distance(label_arr[j].begin(), it)));
           break;
         }
       }
@@ -1110,7 +1125,7 @@ namespace cytnx {
     #endif
   #endif
 
-    vector<string> names;
+    std::vector<std::string> names;
     for (int i = 0; i < this->names.size(); i++) {
       names.push_back(this->names[i]);
       CtTree.base_nodes[i]->name = this->names[i];

--- a/src/RegularNetwork.cpp
+++ b/src/RegularNetwork.cpp
@@ -651,7 +651,7 @@ namespace cytnx {
     cytnx_uint64 idx;
     try {
       idx = this->name2pos.at(name);
-    } catch (std::out_of_range) {
+    } catch (const std::out_of_range &) {
       cytnx_error_msg(true,
                       "[ERROR][RegularNetwork][RmUniTensor] Cannot find the tensor name: [%s] in "
                       "current network.\n",
@@ -724,7 +724,7 @@ namespace cytnx {
     cytnx_uint64 idx;
     try {
       idx = this->name2pos.at(name);
-    } catch (std::out_of_range) {
+    } catch (const std::out_of_range &) {
       cytnx_error_msg(true,
                       "[ERROR][RegularNetwork][PutUniTensor] Cannot find the tensor name: [%s] in "
                       "current network.\n",

--- a/src/RegularNetwork.cpp
+++ b/src/RegularNetwork.cpp
@@ -26,8 +26,8 @@ namespace cytnx {
                       "\'(\' and \')\'");
 
       // check mismatch:
-      size_t lbrac_n = std::count(line.begin(), line.end(), '(');
-      size_t rbrac_n = std::count(line.begin(), line.end(), ')');
+      std::size_t lbrac_n = std::count(line.begin(), line.end(), '(');
+      std::size_t rbrac_n = std::count(line.begin(), line.end(), ')');
       cytnx_error_msg(lbrac_n != rbrac_n, "[ERROR][Network][Fromfile] parentheses mismatch.%s",
                       "\n");
 
@@ -464,7 +464,7 @@ namespace cytnx {
     this->CtTree.base_nodes.clear();
 
     // Create base nodes properly
-    for (size_t i = 0; i < this->names.size(); i++) {
+    for (std::size_t i = 0; i < this->names.size(); i++) {
       auto node = std::make_shared<Node>();
       node->name = this->names[i];
       this->CtTree.base_nodes.push_back(node);
@@ -547,15 +547,15 @@ namespace cytnx {
     this->int_modes = std::vector<std::vector<cytnx_int64>>(this->label_arr.size());
     this->int_out_mode = std::vector<cytnx_int64>(this->TOUT_labels.size());
     cytnx_int64 label_int = 0;
-    for (size_t i = 0; i < this->label_arr.size(); i++) {
+    for (std::size_t i = 0; i < this->label_arr.size(); i++) {
       this->int_modes[i] = std::vector<cytnx_int64>(this->label_arr[i].size());
-      for (size_t j = 0; j < this->label_arr[i].size(); j++) {
+      for (std::size_t j = 0; j < this->label_arr[i].size(); j++) {
         labelmap.insert(std::pair<std::string, cytnx_int64>(this->label_arr[i][j], label_int));
         this->int_modes[i][j] = labelmap[this->label_arr[i][j]];
         label_int += 1;
       }
     }
-    for (size_t i = 0; i < TOUT_labels.size(); i++) {
+    for (std::size_t i = 0; i < TOUT_labels.size(); i++) {
       this->int_out_mode[i] = labelmap[this->TOUT_labels[i]];
     }
 
@@ -1042,7 +1042,7 @@ namespace cytnx {
     this->CtTree.base_nodes.clear();
 
     // Create nodes using make_shared
-    for (size_t i = 0; i < this->names.size(); i++) {
+    for (std::size_t i = 0; i < this->names.size(); i++) {
       auto node = std::make_shared<Node>();
       node->name = this->names[i];
       this->CtTree.base_nodes.push_back(node);
@@ -1107,15 +1107,15 @@ namespace cytnx {
     this->int_modes = std::vector<std::vector<cytnx_int64>>(this->label_arr.size());
     this->int_out_mode = std::vector<cytnx_int64>(this->TOUT_labels.size());
     cytnx_int64 label_int = 0;
-    for (size_t i = 0; i < this->label_arr.size(); i++) {
+    for (std::size_t i = 0; i < this->label_arr.size(); i++) {
       this->int_modes[i] = std::vector<cytnx_int64>(this->label_arr[i].size());
-      for (size_t j = 0; j < this->label_arr[i].size(); j++) {
+      for (std::size_t j = 0; j < this->label_arr[i].size(); j++) {
         labelmap.insert(std::pair<std::string, cytnx_int64>(this->label_arr[i][j], label_int));
         this->int_modes[i][j] = labelmap[this->label_arr[i][j]];
         label_int += 1;
       }
     }
-    for (size_t i = 0; i < TOUT_labels.size(); i++) {
+    for (std::size_t i = 0; i < TOUT_labels.size(); i++) {
       this->int_out_mode[i] = labelmap[this->TOUT_labels[i]];
     }
 

--- a/src/Symmetry.cpp
+++ b/src/Symmetry.cpp
@@ -6,8 +6,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
-
 namespace cytnx {
 
   namespace {
@@ -103,12 +101,12 @@ namespace cytnx {
   void cytnx::U1Symmetry::reverse_rule_(cytnx_int64 &out, const cytnx_int64 &in) { out = in * -1; }
 
   void cytnx::U1Symmetry::print_info() const {
-    cout << "--------------------\n";
-    cout << "[Symmetry]" << endl;
-    cout << "type : Abelian, U1" << endl;
-    cout << "combine rule : Q1 + Q2" << endl;
-    cout << "reverse rule : Q*(-1) " << endl;
-    cout << "--------------------\n";
+    std::cout << "--------------------\n";
+    std::cout << "[Symmetry]" << std::endl;
+    std::cout << "type : Abelian, U1" << std::endl;
+    std::cout << "combine rule : Q1 + Q2" << std::endl;
+    std::cout << "reverse rule : Q*(-1) " << std::endl;
+    std::cout << "--------------------\n";
   }
 
   ///========================
@@ -153,12 +151,12 @@ namespace cytnx {
   }
 
   void cytnx::ZnSymmetry::print_info() const {
-    cout << "--------------------\n";
-    cout << "[Symmetry]" << endl;
-    cout << "type : Abelian, Z(" << this->n << ")" << endl;
-    cout << "combine rule : (Q1 + Q2)\%" << this->n << endl;
-    cout << "reverse rule : Q*(-1) " << endl;
-    cout << "--------------------\n";
+    std::cout << "--------------------\n";
+    std::cout << "[Symmetry]" << std::endl;
+    std::cout << "type : Abelian, Z(" << this->n << ")" << std::endl;
+    std::cout << "combine rule : (Q1 + Q2)\%" << this->n << std::endl;
+    std::cout << "reverse rule : Q*(-1) " << std::endl;
+    std::cout << "--------------------\n";
   }
 
   ///========================
@@ -196,7 +194,7 @@ namespace cytnx {
   }
 
   fermionParity cytnx::FermionParitySymmetry::get_fermion_parity(const cytnx_int64 &in_qnum) const {
-    // vector<fermionParity> out(this->n);
+    // std::vector<fermionParity> out(this->n);
     if (in_qnum == 0)
       return EVEN;
     else if (in_qnum == 1)
@@ -207,12 +205,12 @@ namespace cytnx {
   }
 
   void cytnx::FermionParitySymmetry::print_info() const {
-    cout << "--------------------\n";
-    cout << "[Symmetry]" << endl;
-    cout << "type : fermionic, FermionParity" << endl;
-    cout << "combine rule : (Q1 + Q2)\2" << endl;
-    cout << "reverse rule : Q*(-1) " << endl;
-    cout << "--------------------\n";
+    std::cout << "--------------------\n";
+    std::cout << "[Symmetry]" << std::endl;
+    std::cout << "type : fermionic, FermionParity" << std::endl;
+    std::cout << "combine rule : (Q1 + Q2)\2" << std::endl;
+    std::cout << "reverse rule : Q*(-1) " << std::endl;
+    std::cout << "--------------------\n";
   }
 
   ///=========================
@@ -241,7 +239,7 @@ namespace cytnx {
   }
 
   fermionParity cytnx::FermionNumberSymmetry::get_fermion_parity(const cytnx_int64 &in_qnum) const {
-    // vector<fermionParity> out(this->n);
+    // std::vector<fermionParity> out(this->n);
     if (in_qnum % 2 == 0)
       return EVEN;
     else
@@ -249,28 +247,28 @@ namespace cytnx {
   }
 
   void cytnx::FermionNumberSymmetry::print_info() const {
-    cout << "--------------------\n";
-    cout << "[Symmetry]" << endl;
-    cout << "type : fermionic, FermionNumber" << endl;
-    cout << "combine rule : Q1 + Q2" << endl;
-    cout << "reverse rule : Q*(-1) " << endl;
-    cout << "--------------------\n";
+    std::cout << "--------------------\n";
+    std::cout << "[Symmetry]" << std::endl;
+    std::cout << "type : fermionic, FermionNumber" << std::endl;
+    std::cout << "combine rule : Q1 + Q2" << std::endl;
+    std::cout << "reverse rule : Q*(-1) " << std::endl;
+    std::cout << "--------------------\n";
   }
 
   //==================================================
 
   void cytnx::Symmetry::Save(const std::string &fname) const {
-    fstream f;
+    std::fstream f;
     if (std::filesystem::path(fname).has_extension()) {
       // filename extension is given
-      f.open(fname, ios::out | ios::trunc | ios::binary);
+      f.open(fname, std::ios::out | std::ios::trunc | std::ios::binary);
     } else {
       // add filename extension
       cytnx_warning_msg(true,
                         "Missing file extension in fname '%s'. I am adding the extension '.cysym'. "
                         "This is deprecated, please provide the file extension in the future.\n",
                         fname.c_str());
-      f.open((fname + ".cysym"), ios::out | ios::trunc | ios::binary);
+      f.open((fname + ".cysym"), std::ios::out | std::ios::trunc | std::ios::binary);
     }
     if (!f.is_open()) {
       cytnx_error_msg(true, "[ERROR] invalid file path for save.%s", "\n");
@@ -278,12 +276,12 @@ namespace cytnx {
     this->_Save(f);
     f.close();
   }
-  void cytnx::Symmetry::Save(const char *fname) const { this->Save(string(fname)); }
+  void cytnx::Symmetry::Save(const char *fname) const { this->Save(std::string(fname)); }
 
   cytnx::Symmetry cytnx::Symmetry::Load(const std::string &fname) {
     Symmetry out;
-    fstream f;
-    f.open(fname, ios::in | ios::binary);
+    std::fstream f;
+    f.open(fname, std::ios::in | std::ios::binary);
     if (!f.is_open()) {
       cytnx_error_msg(true, "[ERROR] Cannot open file '%s'.\n", fname.c_str());
     }
@@ -292,19 +290,19 @@ namespace cytnx {
     return out;
   }
   cytnx::Symmetry cytnx::Symmetry::Load(const char *fname) {
-    return cytnx::Symmetry::Load(string(fname));
+    return cytnx::Symmetry::Load(std::string(fname));
   }
 
   //==================
-  void cytnx::Symmetry::_Save(fstream &f) const {
-    cytnx_error_msg(!f.is_open(), "[ERROR][Symmetry] invalid fstream%s", "\n");
+  void cytnx::Symmetry::_Save(std::fstream &f) const {
+    cytnx_error_msg(!f.is_open(), "[ERROR][Symmetry] invalid std::fstream%s", "\n");
     unsigned int IDDs = 777;
     f.write((char *)&IDDs, sizeof(unsigned int));
     f.write((char *)&this->_impl->stype_id, sizeof(int));
     f.write((char *)&this->_impl->n, sizeof(int));
   }
-  void cytnx::Symmetry::_Load(fstream &f) {
-    cytnx_error_msg(!f.is_open(), "[ERROR][Symmetry] invalid fstream%s", "\n");
+  void cytnx::Symmetry::_Load(std::fstream &f) {
+    cytnx_error_msg(!f.is_open(), "[ERROR][Symmetry] invalid std::fstream%s", "\n");
     unsigned int tmpIDDs;
     f.read((char *)&tmpIDDs, sizeof(unsigned int));
     cytnx_error_msg(tmpIDDs != 777, "[ERROR] the object is not a cytnx symmetry!%s", "\n");
@@ -315,7 +313,7 @@ namespace cytnx {
     this->Init(stype_in, n_in);
   }
 
-  ostream &operator<<(ostream &os, const Symmetry &in) {
+  std::ostream &operator<<(std::ostream &os, const Symmetry &in) {
     in.print_info();
     return os;
   }

--- a/src/UniTensor.cpp
+++ b/src/UniTensor.cpp
@@ -73,7 +73,7 @@ namespace cytnx {
     cytnx_uint64 rank = this->_impl->_labels.size();
     f.write((char *)&rank, sizeof(cytnx_uint64));
     for (cytnx_uint64 i = 0; i < rank; i++) {
-      size_t tmp = this->_impl->_labels[i].size();
+      std::size_t tmp = this->_impl->_labels[i].size();
       f.write((char *)&tmp, sizeof(this->_impl->_labels[i].size()));
     }
     for (cytnx_uint64 i = 0; i < rank; i++) {
@@ -136,8 +136,8 @@ namespace cytnx {
     this->_impl->_labels.resize(rank);
     this->_impl->_bonds.resize(rank);
     for (cytnx_uint64 i = 0; i < rank; i++) {
-      size_t tmp;
-      f.read((char *)&tmp, sizeof(size_t));
+      std::size_t tmp;
+      f.read((char *)&tmp, sizeof(std::size_t));
       this->_impl->_labels[i].resize(tmp);
     }
     for (cytnx_uint64 i = 0; i < rank; i++) {

--- a/src/backend/Storage.cpp
+++ b/src/backend/Storage.cpp
@@ -3,8 +3,6 @@
 #include <filesystem>
 #include <iostream>
 
-using namespace std;
-
 namespace cytnx {
 
   Storage_init_interface __SII;
@@ -83,17 +81,17 @@ namespace cytnx {
   bool Storage::operator!=(const Storage &rhs) { return !(*this == rhs); }
 
   void Storage::Save(const std::string &fname) const {
-    fstream f;
+    std::fstream f;
     if (std::filesystem::path(fname).has_extension()) {
       // filename extension is given
-      f.open(fname, ios::out | ios::trunc | ios::binary);
+      f.open(fname, std::ios::out | std::ios::trunc | std::ios::binary);
     } else {
       // add filename extension
       cytnx_warning_msg(true,
                         "Missing file extension in fname '%s'. I am adding the extension '.cyst'. "
                         "This is deprecated, please provide the file extension in the future.\n",
                         fname.c_str());
-      f.open((fname + ".cyst"), ios::out | ios::trunc | ios::binary);
+      f.open((fname + ".cyst"), std::ios::out | std::ios::trunc | std::ios::binary);
     }
     if (!f.is_open()) {
       cytnx_error_msg(true, "[ERROR] invalid file path for save.%s", "\n");
@@ -101,10 +99,10 @@ namespace cytnx {
     this->_Save(f);
     f.close();
   }
-  void Storage::Save(const char *fname) const { this->Save(string(fname)); }
+  void Storage::Save(const char *fname) const { this->Save(std::string(fname)); }
   void Storage::Tofile(const std::string &fname) const {
-    fstream f;
-    f.open(fname, ios::out | ios::trunc | ios::binary);
+    std::fstream f;
+    f.open(fname, std::ios::out | std::ios::trunc | std::ios::binary);
     if (!f.is_open()) {
       cytnx_error_msg(true, "[ERROR] invalid file path for save.%s", "\n");
     }
@@ -112,26 +110,26 @@ namespace cytnx {
     f.close();
   }
   void Storage::Tofile(const char *fname) const {
-    fstream f;
-    string ffname = string(fname);
-    f.open(ffname, ios::out | ios::trunc | ios::binary);
+    std::fstream f;
+    std::string ffname = std::string(fname);
+    f.open(ffname, std::ios::out | std::ios::trunc | std::ios::binary);
     if (!f.is_open()) {
       cytnx_error_msg(true, "[ERROR] invalid file path for save.%s", "\n");
     }
     this->_Savebinary(f);
     f.close();
   }
-  void Storage::Tofile(fstream &f) const {
+  void Storage::Tofile(std::fstream &f) const {
     if (!f.is_open()) {
       cytnx_error_msg(true, "[ERROR] invalid file path for save.%s", "\n");
     }
     this->_Savebinary(f);
   }
 
-  void Storage::_Save(fstream &f) const {
+  void Storage::_Save(std::fstream &f) const {
     // header
     // check:
-    cytnx_error_msg(!f.is_open(), "[ERROR] invalid fstream!.%s", "\n");
+    cytnx_error_msg(!f.is_open(), "[ERROR] invalid std::fstream!.%s", "\n");
 
     unsigned int IDDs = 999;
     f.write((char *)&IDDs, sizeof(unsigned int));
@@ -160,10 +158,10 @@ namespace cytnx {
 #endif
     }
   }
-  void Storage::_Savebinary(fstream &f) const {
+  void Storage::_Savebinary(std::fstream &f) const {
     // header
     // check:
-    cytnx_error_msg(!f.is_open(), "[ERROR] invalid fstream!.%s", "\n");
+    cytnx_error_msg(!f.is_open(), "[ERROR] invalid std::fstream!.%s", "\n");
 
     // data:
     if (this->device() == Device.cpu) {
@@ -186,7 +184,7 @@ namespace cytnx {
 
   Storage Storage::Fromfile(const char *fname, const unsigned int &dtype,
                             const cytnx_int64 &count) {
-    return Storage::Fromfile(string(fname), dtype, count);
+    return Storage::Fromfile(std::string(fname), dtype, count);
   }
   Storage Storage::Fromfile(const std::string &fname, const unsigned int &dtype,
                             const cytnx_int64 &count) {
@@ -198,15 +196,15 @@ namespace cytnx {
     cytnx_uint64 Nelem;
 
     // check size:
-    ifstream jf;
-    jf.open(fname, ios::ate | ios::binary);
+    std::ifstream jf;
+    jf.open(fname, std::ios::ate | std::ios::binary);
     if (!jf.is_open()) {
       cytnx_error_msg(true, "[ERROR] Cannot open file '%s'.\n", fname.c_str());
     }
     Nbytes = jf.tellg();
     jf.close();
 
-    fstream f;
+    std::fstream f;
     // check if type match?
     cytnx_error_msg(Nbytes % Type.typeSize(dtype),
                     "[ERROR] the total size of file is not an interval of assigned dtype.%s", "\n");
@@ -220,7 +218,7 @@ namespace cytnx {
       Nelem = count;
     }
 
-    f.open(fname, ios::in | ios::binary);
+    f.open(fname, std::ios::in | std::ios::binary);
     if (!f.is_open()) {
       cytnx_error_msg(true, "[ERROR] Cannot open file '%s'.\n", fname.c_str());
     }
@@ -230,8 +228,8 @@ namespace cytnx {
   }
   Storage Storage::Load(const std::string &fname) {
     Storage out;
-    fstream f;
-    f.open(fname, ios::in | ios::binary);
+    std::fstream f;
+    f.open(fname, std::ios::in | std::ios::binary);
     if (!f.is_open()) {
       cytnx_error_msg(true, "[ERROR] Cannot open file '%s'.\n", fname.c_str());
     }
@@ -239,15 +237,15 @@ namespace cytnx {
     f.close();
     return out;
   }
-  Storage Storage::Load(const char *fname) { return Storage::Load(string(fname)); }
-  void Storage::_Load(fstream &f) {
+  Storage Storage::Load(const char *fname) { return Storage::Load(std::string(fname)); }
+  void Storage::_Load(std::fstream &f) {
     // header
     unsigned long long sz;
     unsigned int dt;
     int dv;
 
     // check:
-    cytnx_error_msg(!f.is_open(), "[ERROR] invalid fstream!.%s", "\n");
+    cytnx_error_msg(!f.is_open(), "[ERROR] invalid std::fstream!.%s", "\n");
 
     // checking IDD
     unsigned int tmpIDDs;
@@ -291,13 +289,13 @@ namespace cytnx {
     }
   }
 
-  void Storage::_Loadbinary(fstream &f, const unsigned int &dtype, const cytnx_uint64 &Nelem) {
+  void Storage::_Loadbinary(std::fstream &f, const unsigned int &dtype, const cytnx_uint64 &Nelem) {
     // before enter this func, makesure
     // 1. dtype is not void.
     // 2. the Nelement is consistent and smaller than the file size, and should not be zero!
 
     // check:
-    cytnx_error_msg(!f.is_open(), "[ERROR] invalid fstream!.%s", "\n");
+    cytnx_error_msg(!f.is_open(), "[ERROR] invalid std::fstream!.%s", "\n");
 
     this->_impl = __SII.USIInit[dtype]();
     this->_impl->Init(Nelem, Device.cpu);

--- a/src/backend/StorageImplementation.cpp
+++ b/src/backend/StorageImplementation.cpp
@@ -28,7 +28,6 @@
   #include "cuda_runtime_api.h"
 #endif
 
-using namespace std;
 namespace cytnx {
   template <typename DType>
   void PrintValueAndSpace(std::ostream &os, const DType &value) {
@@ -449,7 +448,7 @@ namespace cytnx {
   template <typename DType>
   void StorageImplementation<DType>::print_elems() {
     DType *elem_ptr_ = reinterpret_cast<DType *>(this->start_);
-    cout << "[ ";
+    std::cout << "[ ";
     for (unsigned long long cnt = 0; cnt < this->size_; cnt++) {
       PrintValueAndSpace(std::cout, elem_ptr_[cnt]);
     }
@@ -784,9 +783,9 @@ namespace cytnx {
     } else {
       ++this->size_;
     }
-    if constexpr (is_same_v<DType, cytnx_complex128>) {
+    if constexpr (std::is_same_v<DType, cytnx_complex128>) {
       this->at<DType>(this->size_ - 1) = complex128(value);
-    } else if constexpr (is_same_v<DType, cytnx_complex64>) {
+    } else if constexpr (std::is_same_v<DType, cytnx_complex64>) {
       this->at<DType>(this->size_ - 1) = complex64(value);
     } else {
       this->at<DType>(this->size_ - 1) = static_cast<DType>(value);
@@ -807,9 +806,9 @@ namespace cytnx {
 
   template <typename DType>
   void StorageImplementation<DType>::SetItem(cytnx_uint64 index, const Scalar &value) {
-    if constexpr (is_same_v<DType, cytnx_complex128>) {
+    if constexpr (std::is_same_v<DType, cytnx_complex128>) {
       this->at<DType>(index) = complex128(value);
-    } else if constexpr (is_same_v<DType, cytnx_complex64>) {
+    } else if constexpr (std::is_same_v<DType, cytnx_complex64>) {
       this->at<DType>(index) = complex64(value);
     } else {
       this->at<DType>(index) = static_cast<DType>(value);

--- a/src/backend/Storage_base.cpp
+++ b/src/backend/Storage_base.cpp
@@ -2,8 +2,6 @@
 #include "utils_internal_interface.hpp"
 #include "utils/vec_print.hpp"
 
-using namespace std;
-
 namespace cytnx {
 
   // Storage Init interface.
@@ -127,8 +125,8 @@ namespace cytnx {
     return out;
   }
 
-  string Storage_base::dtype_str() const { return Type.getname(this->dtype()); }
-  string Storage_base::device_str() const { return Device.getname(this->device()); }
+  std::string Storage_base::dtype_str() const { return Type.getname(this->dtype()); }
+  std::string Storage_base::device_str() const { return Device.getname(this->device()); }
   void Storage_base::_Init_byptr(void *rawptr, const unsigned long long &len_in, const int &device,
                                  const bool &iscap, const unsigned long long &cap_in) {
     cytnx_error_msg(true, "%s", "[ERROR] call _Init_byptr in base");
@@ -164,9 +162,9 @@ namespace cytnx {
   }
 
   void Storage_base::print_info() {
-    cout << "dtype : " << this->dtype_str() << endl;
-    cout << "device: " << Device.getname(this->device()) << endl;
-    cout << "size  : " << this->size() << endl;
+    std::cout << "dtype : " << this->dtype_str() << std::endl;
+    std::cout << "device: " << Device.getname(this->device()) << std::endl;
+    std::cout << "size  : " << this->size() << std::endl;
   }
   void Storage_base::print_elems() {
     cytnx_error_msg(true, "%s", "[ERROR] call print_elems directly on Void Storage.");
@@ -518,7 +516,7 @@ namespace cytnx {
   std::complex<double> *Storage_base::data<std::complex<double>>() const {
     cytnx_error_msg(
       this->dtype() != Type.ComplexDouble,
-      "[ERROR] type mismatch. try to get < complex<double> > type from raw data of type %s",
+      "[ERROR] type mismatch. try to get < std::complex<double> > type from raw data of type %s",
       Type.getname(this->dtype()).c_str());
 #ifdef UNI_GPU
     cudaDeviceSynchronize();
@@ -530,7 +528,7 @@ namespace cytnx {
   std::complex<float> *Storage_base::data<std::complex<float>>() const {
     cytnx_error_msg(
       this->dtype() != Type.ComplexFloat,
-      "[ERROR] type mismatch. try to get < complex<float> > type from raw data of type %s",
+      "[ERROR] type mismatch. try to get < std::complex<float> > type from raw data of type %s",
       Type.getname(this->dtype()).c_str());
 #ifdef UNI_GPU
     cudaDeviceSynchronize();
@@ -623,9 +621,10 @@ namespace cytnx {
       this->dtype() != Type.ComplexDouble,
       "[ERROR] type mismatch. try to get <cuDoubleComplex> type from raw data of type %s",
       Type.getname(this->dtype()).c_str());
-    cytnx_error_msg(this->device() == Device.cpu, "%s",
-                    "[ERROR] the Storage is on CPU(Host) but try to get with CUDA complex type "
-                    "cuDoubleComplex. use type <cytnx_complex128> or < complex<double> > instead.");
+    cytnx_error_msg(
+      this->device() == Device.cpu, "%s",
+      "[ERROR] the Storage is on CPU(Host) but try to get with CUDA complex type "
+      "cuDoubleComplex. use type <cytnx_complex128> or < std::complex<double> > instead.");
     cudaDeviceSynchronize();
     return static_cast<cuDoubleComplex *>(this->data());
   }
@@ -635,9 +634,10 @@ namespace cytnx {
       this->dtype() != Type.ComplexFloat,
       "[ERROR] type mismatch. try to get <cuFloatComplex> type from raw data of type %s",
       Type.getname(this->dtype()).c_str());
-    cytnx_error_msg(this->device() == Device.cpu, "%s",
-                    "[ERROR] the Storage is on CPU(Host) but try to get with CUDA complex type "
-                    "cuFloatComplex. use type <cytnx_complex64> or < complex<float> > instead.");
+    cytnx_error_msg(
+      this->device() == Device.cpu, "%s",
+      "[ERROR] the Storage is on CPU(Host) but try to get with CUDA complex type "
+      "cuFloatComplex. use type <cytnx_complex64> or < std::complex<float> > instead.");
     cudaDeviceSynchronize();
     return static_cast<cuFloatComplex *>(this->data());
   }
@@ -682,7 +682,7 @@ namespace cytnx {
     if (cytnx::User_debug)
       cytnx_error_msg(
         this->dtype() != Type.ComplexFloat,
-        "[ERROR] type mismatch. try to get < complex<float> > type from raw data of type %s",
+        "[ERROR] type mismatch. try to get < std::complex<float> > type from raw data of type %s",
         Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
       cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
@@ -690,7 +690,7 @@ namespace cytnx {
 #ifdef UNI_GPU
     cudaDeviceSynchronize();
 #endif
-    return static_cast<complex<float> *>(this->data())[idx];
+    return static_cast<std::complex<float> *>(this->data())[idx];
   }
 
   template <>
@@ -698,7 +698,7 @@ namespace cytnx {
     if (cytnx::User_debug)
       cytnx_error_msg(
         this->dtype() != Type.ComplexDouble,
-        "[ERROR] type mismatch. try to get < complex<double> > type from raw data of type %s",
+        "[ERROR] type mismatch. try to get < std::complex<double> > type from raw data of type %s",
         Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
       cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
@@ -706,7 +706,7 @@ namespace cytnx {
 #ifdef UNI_GPU
     cudaDeviceSynchronize();
 #endif
-    return static_cast<complex<double> *>(this->data())[idx];
+    return static_cast<std::complex<double> *>(this->data())[idx];
   }
 
   template <>
@@ -847,27 +847,27 @@ namespace cytnx {
   std::complex<float> &Storage_base::back<std::complex<float>>() const {
     cytnx_error_msg(
       this->dtype() != Type.ComplexFloat,
-      "[ERROR] type mismatch. try to get < complex<float> > type from raw data of type %s",
+      "[ERROR] type mismatch. try to get < std::complex<float> > type from raw data of type %s",
       Type.getname(this->dtype()).c_str());
     cytnx_error_msg(this->size() == 0, "[ERROR] Cannot call back on empty stoarge.%s", "\n");
 #ifdef UNI_GPU
     cudaDeviceSynchronize();
 #endif
 
-    return static_cast<complex<float> *>(this->data())[this->size() - 1];
+    return static_cast<std::complex<float> *>(this->data())[this->size() - 1];
   }
 
   template <>
   std::complex<double> &Storage_base::back<std::complex<double>>() const {
     cytnx_error_msg(
       this->dtype() != Type.ComplexDouble,
-      "[ERROR] type mismatch. try to get < complex<double> > type from raw data of type %s",
+      "[ERROR] type mismatch. try to get < std::complex<double> > type from raw data of type %s",
       Type.getname(this->dtype()).c_str());
     cytnx_error_msg(this->size() == 0, "[ERROR] Cannot call back on empty stoarge.%s", "\n");
 #ifdef UNI_GPU
     cudaDeviceSynchronize();
 #endif
-    return static_cast<complex<double> *>(this->data())[this->size() - 1];
+    return static_cast<std::complex<double> *>(this->data())[this->size() - 1];
   }
 
   template <>

--- a/src/backend/linalg_internal_gpu/cuGemm_Batch_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuGemm_Batch_internal.cu
@@ -16,8 +16,8 @@ namespace cytnx {
                                   const blas_int *group_size) {
       std::vector<cytnx_complex128> alphas(alpha_array.size());
       std::vector<cytnx_complex128> betas(beta_array.size());
-      for (size_t i = 0; i < alpha_array.size(); i++) alphas[i] = complex128(alpha_array[i]);
-      for (size_t i = 0; i < beta_array.size(); i++) betas[i] = complex128(beta_array[i]);
+      for (std::size_t i = 0; i < alpha_array.size(); i++) alphas[i] = complex128(alpha_array[i]);
+      for (std::size_t i = 0; i < beta_array.size(); i++) betas[i] = complex128(beta_array[i]);
 
       cytnx_uint64 idx = 0;
       for (cytnx_uint64 i = 0; i < group_count; i++) {
@@ -73,8 +73,8 @@ namespace cytnx {
                                   const blas_int *group_size) {
       std::vector<cytnx_complex64> alphas(alpha_array.size());
       std::vector<cytnx_complex64> betas(beta_array.size());
-      for (size_t i = 0; i < alpha_array.size(); i++) alphas[i] = complex64(alpha_array[i]);
-      for (size_t i = 0; i < beta_array.size(); i++) betas[i] = complex64(beta_array[i]);
+      for (std::size_t i = 0; i < alpha_array.size(); i++) alphas[i] = complex64(alpha_array[i]);
+      for (std::size_t i = 0; i < beta_array.size(); i++) betas[i] = complex64(beta_array[i]);
 
       cytnx_uint64 idx = 0;
       for (cytnx_uint64 i = 0; i < group_count; i++) {
@@ -130,8 +130,8 @@ namespace cytnx {
                                  const blas_int *group_size) {
       std::vector<cytnx_double> alphas(alpha_array.size());
       std::vector<cytnx_double> betas(beta_array.size());
-      for (size_t i = 0; i < alpha_array.size(); i++) alphas[i] = double(alpha_array[i]);
-      for (size_t i = 0; i < beta_array.size(); i++) betas[i] = double(beta_array[i]);
+      for (std::size_t i = 0; i < alpha_array.size(); i++) alphas[i] = double(alpha_array[i]);
+      for (std::size_t i = 0; i < beta_array.size(); i++) betas[i] = double(beta_array[i]);
 
       cytnx_uint64 idx = 0;
       for (cytnx_uint64 i = 0; i < group_count; i++) {
@@ -186,8 +186,8 @@ namespace cytnx {
                                  const blas_int *group_size) {
       std::vector<cytnx_float> alphas(alpha_array.size());
       std::vector<cytnx_float> betas(beta_array.size());
-      for (size_t i = 0; i < alpha_array.size(); i++) alphas[i] = float(alpha_array[i]);
-      for (size_t i = 0; i < beta_array.size(); i++) betas[i] = float(beta_array[i]);
+      for (std::size_t i = 0; i < alpha_array.size(); i++) alphas[i] = float(alpha_array[i]);
+      for (std::size_t i = 0; i < beta_array.size(); i++) betas[i] = float(beta_array[i]);
 
       cytnx_uint64 idx = 0;
       for (cytnx_uint64 i = 0; i < group_count; i++) {

--- a/src/backend/linalg_internal_gpu/cuQuantumGeSvd_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuQuantumGeSvd_internal.cu
@@ -280,7 +280,7 @@ namespace cytnx {
     void cuQuantumGeSvd_internal_cd(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                     const double &err, const unsigned int &return_err, Tensor &U,
                                     Tensor &S, Tensor &vT, Tensor &terr) {
-      const size_t cuTensornetVersion = cutensornetGetVersion();
+      const std::size_t cuTensornetVersion = cutensornetGetVersion();
       // printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
       cudaDeviceProp prop;
       int deviceId = Tin.device();
@@ -523,7 +523,7 @@ namespace cytnx {
     void cuQuantumGeSvd_internal_cf(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                     const double &err, const unsigned int &return_err, Tensor &U,
                                     Tensor &S, Tensor &vT, Tensor &terr) {
-      const size_t cuTensornetVersion = cutensornetGetVersion();
+      const std::size_t cuTensornetVersion = cutensornetGetVersion();
       // printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
 
       cudaDeviceProp prop;
@@ -767,7 +767,7 @@ namespace cytnx {
     void cuQuantumGeSvd_internal_d(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                    const double &err, const unsigned int &return_err, Tensor &U,
                                    Tensor &S, Tensor &vT, Tensor &terr) {
-      const size_t cuTensornetVersion = cutensornetGetVersion();
+      const std::size_t cuTensornetVersion = cutensornetGetVersion();
       // printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
 
       cudaDeviceProp prop;
@@ -1011,7 +1011,7 @@ namespace cytnx {
     void cuQuantumGeSvd_internal_f(const Tensor &Tin, const cytnx_uint64 &keepdim,
                                    const double &err, const unsigned int &return_err, Tensor &U,
                                    Tensor &S, Tensor &vT, Tensor &terr) {
-      const size_t cuTensornetVersion = cutensornetGetVersion();
+      const std::size_t cuTensornetVersion = cutensornetGetVersion();
       // printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
 
       cudaDeviceProp prop;

--- a/src/backend/linalg_internal_gpu/cuQuantumQr_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuQuantumQr_internal.cu
@@ -81,7 +81,7 @@ namespace cytnx {
                                  boost::intrusive_ptr<Storage_base> &D,
                                  boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
                                  const cytnx_int64 &N, const bool &is_d) {
-      // const size_t cuTensornetVersion = cutensornetGetVersion();
+      // const std::size_t cuTensornetVersion = cutensornetGetVersion();
       // printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
 
       /**********************************************
@@ -219,7 +219,7 @@ namespace cytnx {
                                  boost::intrusive_ptr<Storage_base> &D,
                                  boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
                                  const cytnx_int64 &N, const bool &is_d) {
-      // const size_t cuTensornetVersion = cutensornetGetVersion();
+      // const std::size_t cuTensornetVersion = cutensornetGetVersion();
       // printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
 
       /**********************************************
@@ -356,7 +356,7 @@ namespace cytnx {
                                 boost::intrusive_ptr<Storage_base> &D,
                                 boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
                                 const cytnx_int64 &N, const bool &is_d) {
-      // const size_t cuTensornetVersion = cutensornetGetVersion();
+      // const std::size_t cuTensornetVersion = cutensornetGetVersion();
       // printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
 
       /**********************************************
@@ -493,7 +493,7 @@ namespace cytnx {
                                 boost::intrusive_ptr<Storage_base> &D,
                                 boost::intrusive_ptr<Storage_base> &tau, const cytnx_int64 &M,
                                 const cytnx_int64 &N, const bool &is_d) {
-      // const size_t cuTensornetVersion = cutensornetGetVersion();
+      // const std::size_t cuTensornetVersion = cutensornetGetVersion();
       // printf("cuTensorNet-vers:%ld\n", cuTensornetVersion);
 
       /**********************************************

--- a/src/backend/linalg_internal_gpu/cuSvd_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuSvd_internal.cu
@@ -50,9 +50,9 @@ namespace cytnx {
           checkCudaErrors(cudaMalloc(&vTMem, max * max * sizeof(data_type)));
       }
 
-      size_t d_lwork = 0; /* size of workspace */
+      std::size_t d_lwork = 0; /* size of workspace */
       void *d_work = nullptr; /* device workspace for getrf */
-      size_t h_lwork = 0; /* size of workspace */
+      std::size_t h_lwork = 0; /* size of workspace */
       void *h_work = nullptr; /* host workspace for getrf */
       cytnx_double h_err_sigma;
       // query working space :
@@ -161,9 +161,9 @@ namespace cytnx {
           checkCudaErrors(cudaMalloc(&vTMem, max * max * sizeof(data_type)));
       }
 
-      size_t d_lwork = 0; /* size of workspace */
+      std::size_t d_lwork = 0; /* size of workspace */
       void *d_work = nullptr; /* device workspace for getrf */
-      size_t h_lwork = 0; /* size of workspace */
+      std::size_t h_lwork = 0; /* size of workspace */
       void *h_work = nullptr; /* host workspace for getrf */
       cytnx_double h_err_sigma;
       // query working space :
@@ -271,9 +271,9 @@ namespace cytnx {
           checkCudaErrors(cudaMalloc(&vTMem, max * max * sizeof(data_type)));
       }
 
-      size_t d_lwork = 0; /* size of workspace */
+      std::size_t d_lwork = 0; /* size of workspace */
       void *d_work = nullptr; /* device workspace for getrf */
-      size_t h_lwork = 0; /* size of workspace */
+      std::size_t h_lwork = 0; /* size of workspace */
       void *h_work = nullptr; /* host workspace for getrf */
       cytnx_double h_err_sigma;
       // query working space :
@@ -380,9 +380,9 @@ namespace cytnx {
           checkCudaErrors(cudaMalloc(&vTMem, max * max * sizeof(data_type)));
       }
 
-      size_t d_lwork = 0; /* size of workspace */
+      std::size_t d_lwork = 0; /* size of workspace */
       void *d_work = nullptr; /* device workspace for getrf */
-      size_t h_lwork = 0; /* size of workspace */
+      std::size_t h_lwork = 0; /* size of workspace */
       void *h_work = nullptr; /* host workspace for getrf */
       cytnx_double h_err_sigma;
       // query working space :

--- a/src/contraction_tree.cpp
+++ b/src/contraction_tree.cpp
@@ -104,7 +104,7 @@ namespace cytnx {
         cytnx_uint64 idx;
         try {
           idx = name2pos.at(tok);
-        } catch (std::out_of_range) {
+        } catch (const std::out_of_range &) {
           cytnx_error_msg(true,
                           "[ERROR][ContractionTree][build_contraction_order_by_token] tokens "
                           "contain invalid TN name: %s ,which is not previously defined. \n",

--- a/src/contraction_tree.cpp
+++ b/src/contraction_tree.cpp
@@ -50,7 +50,7 @@ namespace cytnx {
     std::shared_ptr<Node> left, right;
     stack<char> operators;
     char topc;
-    size_t pos = 0;
+    std::size_t pos = 0;
     std::string tok;
 
     // evaluate each token, and construct the Contraction Tree.

--- a/src/linalg/Gemm_Batch.cpp
+++ b/src/linalg/Gemm_Batch.cpp
@@ -39,9 +39,9 @@ namespace cytnx {
                       "[Gemm_Batch] error, b_tensors.size() != total tensor count%s", "\n");
       cytnx_error_msg(c_tensors.size() != total_matrices,
                       "[Gemm_Batch] error, c_tensors.size() != total tensor count%s", "\n");
-      cytnx_error_msg(alpha_array.size() != static_cast<size_t>(group_count),
+      cytnx_error_msg(alpha_array.size() != static_cast<std::size_t>(group_count),
                       "[Gemm_Batch] error, alpha_array.size() != group_count%s", "\n");
-      cytnx_error_msg(beta_array.size() != static_cast<size_t>(group_count),
+      cytnx_error_msg(beta_array.size() != static_cast<std::size_t>(group_count),
                       "[Gemm_Batch] error, beta_array.size() != group_count%s", "\n");
 
       if (total_matrices == 0) return;

--- a/src/search_tree.cpp
+++ b/src/search_tree.cpp
@@ -62,12 +62,12 @@ namespace cytnx {
 
   namespace OptimalTreeSolver {
     // Helper function to find connected components using DFS
-    void dfs(size_t node, const std::vector<IndexSet>& adjacencyMatrix, IndexSet& visited,
-             std::vector<size_t>& component) {
+    void dfs(std::size_t node, const std::vector<IndexSet>& adjacencyMatrix, IndexSet& visited,
+             std::vector<std::size_t>& component) {
       visited.set(node);
       component.push_back(node);
 
-      for (size_t i = 0; i < adjacencyMatrix.size(); ++i) {
+      for (std::size_t i = 0; i < adjacencyMatrix.size(); ++i) {
         if (adjacencyMatrix[node].test(i) && !visited.test(i)) {
           dfs(i, adjacencyMatrix, visited, component);
         }
@@ -75,14 +75,14 @@ namespace cytnx {
     }
 
     // Find connected components in the tensor network
-    std::vector<std::vector<size_t>> findConnectedComponents(
+    std::vector<std::vector<std::size_t>> findConnectedComponents(
       const std::vector<IndexSet>& adjacencyMatrix) {
-      std::vector<std::vector<size_t>> components;
+      std::vector<std::vector<std::size_t>> components;
       IndexSet visited;
 
-      for (size_t i = 0; i < adjacencyMatrix.size(); ++i) {
+      for (std::size_t i = 0; i < adjacencyMatrix.size(); ++i) {
         if (!visited.test(i)) {
-          std::vector<size_t> component;
+          std::vector<std::size_t> component;
           dfs(i, adjacencyMatrix, visited, component);
           components.push_back(component);
         }
@@ -100,20 +100,20 @@ namespace cytnx {
       // Initialize nodes with copies of input tensors
       std::vector<std::unique_ptr<PseudoUniTensor>> nodes;
       nodes.reserve(tensors.size());
-      for (size_t i = 0; i < tensors.size(); ++i) {
+      for (std::size_t i = 0; i < tensors.size(); ++i) {
         auto node = std::make_unique<PseudoUniTensor>(i);
         *node = tensors[i];
         node->ID = 1ULL << i;
         nodes.push_back(std::move(node));
       }
 
-      const size_t n = nodes.size();
+      const std::size_t n = nodes.size();
       // Build adjacency matrix with proper size
       std::vector<IndexSet> adjacencyMatrix(n);
 
       // Fill adjacency matrix
-      for (size_t i = 0; i < n; ++i) {
-        for (size_t j = i + 1; j < n; ++j) {
+      for (std::size_t i = 0; i < n; ++i) {
+        for (std::size_t j = i + 1; j < n; ++j) {
           // Find common labels
           vector<string> common_lbl;
           vector<cytnx_uint64> comm_idx1, comm_idx2;
@@ -137,17 +137,17 @@ namespace cytnx {
       for (const auto& component : components) {
         // Extract nodes for this component
         std::vector<std::unique_ptr<PseudoUniTensor>> component_nodes;
-        std::vector<size_t> remaining_indices = component;
+        std::vector<std::size_t> remaining_indices = component;
 
         while (remaining_indices.size() > 1) {
           // Find best contraction pair within component
-          size_t best_i = 0, best_j = 1;
+          std::size_t best_i = 0, best_j = 1;
           cytnx_float min_cost = std::numeric_limits<cytnx_float>::max();
 
-          for (size_t ii = 0; ii < remaining_indices.size(); ++ii) {
-            size_t i = remaining_indices.at(ii);
-            for (size_t jj = ii + 1; jj < remaining_indices.size(); ++jj) {
-              size_t j = remaining_indices.at(jj);
+          for (std::size_t ii = 0; ii < remaining_indices.size(); ++ii) {
+            std::size_t i = remaining_indices.at(ii);
+            for (std::size_t jj = ii + 1; jj < remaining_indices.size(); ++jj) {
+              std::size_t j = remaining_indices.at(jj);
               if (adjacencyMatrix[i].test(j)) {
                 cytnx_float cost = get_cost(*nodes[i], *nodes[j]);
                 if (cost < min_cost) {
@@ -175,7 +175,7 @@ namespace cytnx {
           remaining_indices.erase(remaining_indices.begin() + best_i);
 
           // Store result in original nodes vector
-          size_t new_idx = nodes.size();
+          std::size_t new_idx = nodes.size();
           nodes.push_back(std::move(result_ptr));
           remaining_indices.push_back(new_idx);
         }

--- a/src/utils/cutensornet.cu
+++ b/src/utils/cutensornet.cu
@@ -99,7 +99,7 @@ namespace cytnx {
   //   modesR.clear();
   //   tns.clear();
   //   modesIn.clear();
-  //   // // for (size_t i = 0; i < tmp_modes.size(); i++) {
+  //   // // for (std::size_t i = 0; i < tmp_modes.size(); i++) {
   //   //   tmp_modes[i].clear();
   //   //   tmp_extents[i].clear();
   //   // }
@@ -124,16 +124,16 @@ namespace cytnx {
     modesR = std::vector<int32_t>(labels.size());
     rawDataIn_d = std::vector<void *>(labels.size());
 
-    for (size_t i = 0; i < labels.size(); i++) {
+    for (std::size_t i = 0; i < labels.size(); i++) {
       tmp_modes[i] = std::vector<int32_t>(labels[i].size());
       tmp_extents[i] = std::vector<int64_t>(labels[i].size());
-      for (size_t j = 0; j < labels[i].size(); j++) {
+      for (std::size_t j = 0; j < labels[i].size(); j++) {
         tmp_modes[i][j] = (labels[i][labels[i].size() - 1 - j]);
       }
       modesIn[i] = tmp_modes[i].data();
       numModesIn[i] = labels[i].size();
     }
-    for (size_t i = 0; i < res_label.size(); i++) {
+    for (std::size_t i = 0; i < res_label.size(); i++) {
       modesR[i] = res_label[res_label.size() - 1 - i];
     }
     numInputs = labels.size();
@@ -143,7 +143,8 @@ namespace cytnx {
   void cutensornet::set_output_extents(std::vector<cytnx_uint64> &outshape) {
     extentR = std::vector<int64_t>(outshape.size());
     // reversed tranversal the labels and extents because cuTensor is column-major by default
-    for (size_t i = 0; i < outshape.size(); i++) extentR[i] = outshape[outshape.size() - 1 - i];
+    for (std::size_t i = 0; i < outshape.size(); i++)
+      extentR[i] = outshape[outshape.size() - 1 - i];
   }
 
   void cutensornet::setOutputMem(UniTensor &res) {
@@ -170,8 +171,8 @@ namespace cytnx {
 
   void cutensornet::set_extents(std::vector<UniTensor> &uts) {
     // reversed tranversal the labels and extents because cuTensor is column-major by default
-    for (size_t idx = 0; idx < numInputs; idx++) {
-      for (size_t j = 0; j < numModesIn[idx]; j++) {
+    for (std::size_t idx = 0; idx < numInputs; idx++) {
+      for (std::size_t j = 0; j < numModesIn[idx]; j++) {
         tmp_extents[idx][j] = uts[idx].shape()[numModesIn[idx] - 1 - j];
       }
       extentsIn[idx] = tmp_extents[idx].data();

--- a/src/utils/cutensornet.hpp
+++ b/src/utils/cutensornet.hpp
@@ -23,7 +23,7 @@ namespace cytnx {
     // std::vector<cudaDataType_t> type_mapper;
 
     // cuTensorNet version
-    size_t cuTensornetVersion;
+    std::size_t cuTensornetVersion;
 
     // GPU device
     int numDevices{0};
@@ -45,7 +45,7 @@ namespace cytnx {
     cutensornetNetworkDescriptor_t descNet;
 
     // mem info
-    size_t freeMem, totalMem;
+    std::size_t freeMem, totalMem;
     uint64_t workspaceLimit;
 
     // optimizer config

--- a/src/utils/str_utils.cpp
+++ b/src/utils/str_utils.cpp
@@ -6,8 +6,8 @@ namespace cytnx {
 
   vector<string> str_split(const string &in, const bool remove_null, const string &delimiter) {
     vector<string> out;
-    size_t last = 0;
-    size_t next = 0;
+    std::size_t last = 0;
+    std::size_t next = 0;
     string tmps;
     while ((next = in.find(delimiter, last)) != string::npos) {
       tmps = in.substr(last, next - last);
@@ -51,7 +51,7 @@ namespace cytnx {
     vector<string> out;
     if (in.empty()) return out;
 
-    size_t pos = 0, endpos;
+    std::size_t pos = 0, endpos;
     string tmp, op;
     if ((endpos = in.find_first_of(tokens, pos)) == string::npos) {
       out.push_back(in);


### PR DESCRIPTION
This pull request removes the global "using namespace std;" directive and replaces unqualified standard library types and functions with explicitly qualified `std::` counterparts.

Also removes a `using cytnx` inside `namespace cytnx`.