### PR TITLE
docs: troubleshoot CUDA device-LTO elfLink failure on apt nvidia-cuda-toolkit

### DIFF
--- a/docs/source/adv_install.rst
+++ b/docs/source/adv_install.rst
@@ -342,6 +342,60 @@ In the case that Cytnx is installed locally from binary build, not from anaconda
     CYTNX_ROOT is the path where Cytnx is installed from binary build.
 
 
+Build troubleshooting
+*************************************
+
+CUDA device link fails with ``elfLink linker library load error``
+-------------------------------------------------------------------------------------
+
+**Symptom.** A CUDA-enabled build (``-DUSE_CUDA=ON``) configures successfully,
+but the CUDA *device link* step aborts with::
+
+    nvlink fatal   : elfLink linker library load error
+
+On non-Apple builds Cytnx turns on interprocedural optimization
+(``CMAKE_INTERPROCEDURAL_OPTIMIZATION``) which, together with CUDA separable
+compilation, enables CUDA *device* link-time optimization (``nvcc -dlto``). The
+device link step then asks ``nvlink`` to load the NVVM library, and the error
+above means it could not.
+
+**Cause.** This is *not* caused by the empty ``libpthread.a`` / ``librt.a`` /
+``libdl.a`` stub archives that glibc 2.34+ ships -- those are tolerated by
+``nvlink``. It is a layout problem specific to the Debian/Ubuntu
+``nvidia-cuda-toolkit`` apt package. That package installs ``libnvvm.so`` into
+the multiarch directory ``/usr/lib/x86_64-linux-gnu/`` but does not place it
+under the toolkit's ``lib64`` directory, which is where ``nvcc`` tells
+``nvlink`` to look. ``nvcc`` passes ``-nvvmpath=/usr/lib/nvidia-cuda-toolkit``,
+so ``nvlink`` tries to open ``/usr/lib/nvidia-cuda-toolkit/lib64/libnvvm.so``
+and finds nothing. Regular (non-LTO) device linking does not load NVVM, which is
+why the failure appears only once device LTO is enabled.
+
+**Fix (recommended): use a complete CUDA toolkit.** Install CUDA from conda or
+NVIDIA's official installer instead of the distribution's
+``nvidia-cuda-toolkit`` package, and make sure its ``nvcc`` is first on
+``PATH``:
+
+.. code-block:: shell
+
+    $conda install -c nvidia cuda
+
+A toolkit laid out this way keeps ``libnvvm.so`` under ``nvvm/lib64`` where
+``nvlink`` expects it, so device LTO works with no further action. This is also
+the layout the CUDA build presets assume.
+
+**Workaround: keep the apt package and add the missing path.** If you must build
+against the distribution package, create the directory ``nvlink`` searches and
+symlink the packaged ``libnvvm.so`` into it:
+
+.. code-block:: shell
+
+    $sudo mkdir -p /usr/lib/nvidia-cuda-toolkit/lib64
+    $sudo ln -s /usr/lib/x86_64-linux-gnu/libnvvm.so /usr/lib/nvidia-cuda-toolkit/lib64/libnvvm.so
+
+Then re-run the build. On non-x86_64 hosts the multiarch directory differs;
+locate the real library first with ``find /usr -name 'libnvvm.so*'``.
+
+
 Check Cytnx version
 *************************************
 The current version of the library can be printed by:

--- a/docs/source/adv_install.rst
+++ b/docs/source/adv_install.rst
@@ -385,15 +385,20 @@ the layout the CUDA build presets assume.
 
 **Workaround: keep the apt package and add the missing path.** If you must build
 against the distribution package, create the directory ``nvlink`` searches and
-symlink the packaged ``libnvvm.so`` into it:
+symlink the packaged ``libnvvm`` library into it:
 
 .. code-block:: shell
 
+    $libnvvm_src=$(ls -1 /usr/lib/x86_64-linux-gnu/libnvvm.so* | sort -V | tail -1)
     $sudo mkdir -p /usr/lib/nvidia-cuda-toolkit/lib64
-    $sudo ln -s /usr/lib/x86_64-linux-gnu/libnvvm.so /usr/lib/nvidia-cuda-toolkit/lib64/libnvvm.so
+    $sudo ln -s "$libnvvm_src" /usr/lib/nvidia-cuda-toolkit/lib64/libnvvm.so
 
+The ``ls … | sort -V | tail -1`` picks the highest-version file present
+(``libnvvm.so.4``, ``libnvvm.so.4.0.0``, or an unversioned ``libnvvm.so``),
+so the command works regardless of whether the development symlink was installed.
 Then re-run the build. On non-x86_64 hosts the multiarch directory differs;
-locate the real library first with ``find /usr -name 'libnvvm.so*'``.
+locate the real library first with ``find /usr -name 'libnvvm.so*'`` and adjust
+``libnvvm_src`` accordingly.
 
 
 Check Cytnx version

--- a/docs/source/adv_install.rst
+++ b/docs/source/adv_install.rst
@@ -400,6 +400,17 @@ Then re-run the build. On non-x86_64 hosts the multiarch directory differs;
 locate the real library first with ``find /usr -name 'libnvvm.so*'`` and adjust
 ``libnvvm_src`` accordingly.
 
+**Alternative: disable device LTO.** If changing the toolkit layout is not
+practical, configure with ``-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF`` to skip
+device LTO entirely:
+
+.. code-block:: shell
+
+    $cmake --preset openblas-cuda -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF
+
+The build will complete without link-time optimizations, which trades a small
+runtime performance cost for compatibility with the unmodified apt package.
+
 
 Check Cytnx version
 *************************************


### PR DESCRIPTION
## Summary

Adds a **Build troubleshooting** section to `docs/source/adv_install.rst` documenting the CUDA device-LTO failure:

```
nvlink fatal : elfLink linker library load error
```

This surfaced while preparing a CUDA build on Ubuntu and was initially misattributed to glibc 2.34+ empty stub archives. The doc records the real cause and the fix so others don't chase the same dead end.

## What the section explains

- **Symptom** — a `-DUSE_CUDA=ON` build configures fine but the device-link step aborts with the `elfLink` error. It only appears because Cytnx enables `CMAKE_INTERPROCEDURAL_OPTIMIZATION` on non-Apple builds, which (with CUDA separable compilation) turns on CUDA device LTO (`nvcc -dlto`).
- **Cause** — the Debian/Ubuntu `nvidia-cuda-toolkit` apt package ships `libnvvm.so` in `/usr/lib/x86_64-linux-gnu/` but not under the toolkit's `lib64/`, where `nvcc` points nvlink via `-nvvmpath=/usr/lib/nvidia-cuda-toolkit`. nvlink then can't open `/usr/lib/nvidia-cuda-toolkit/lib64/libnvvm.so`. The empty glibc stub archives are explicitly called out as **not** the cause (nvlink tolerates them).
- **Fix (recommended)** — install a complete CUDA toolkit via conda (`conda install -c nvidia cuda`) or NVIDIA's installer, which keep `libnvvm.so` under `nvvm/lib64`.
- **Workaround** — symlink the packaged `libnvvm.so` into the path nvlink searches.

## Evidence

All verified on glibc 2.39: device LTO links cleanly on conda CUDA 12.0–12.9 (even with empty stubs on the line) and on a standard install; it fails only on the apt-packaged 12.0, with or without stubs. `strace` confirmed the single failing `openat` is `/usr/lib/nvidia-cuda-toolkit/lib64/libnvvm.so`, and adding that one symlink makes the link succeed.

## Notes

- Docs-only change; no code touched.
- Born out of the same investigation as #875 (the CMake portability + device-LTO PR), but kept separate since it's documentation.
- Branched from latest `master`.