### PR TITLE
Exempt first cibuildwheel build from ccache-hit enforcement

### DIFF
--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -69,6 +69,13 @@ jobs:
         # below; the in-container CCACHE_DIR is set in the Build Wheels
         # step's env: block (and forwarded via environment-pass).
         echo "HOST_CCACHE_DIR=${HOME}/.ccache" >> "$GITHUB_ENV"
+        # Reset the "first wheel build" marker once per run (after the cache is
+        # restored, before cibuildwheel). tools/validate_ccache_stats.py allows
+        # zero cache hits only for the first python-version build of a run; this
+        # ensures a marker carried over inside the cached CCACHE_DIR can't mask a
+        # genuine cache-miss failure on later runs.
+        mkdir -p "${HOME}/.ccache"
+        rm -f "${HOME}/.ccache/.cytnx_first_wheel_build_done"
 
     - name: Build Wheels
       uses: pypa/cibuildwheel@v3.3.0

--- a/tools/validate_ccache_stats.py
+++ b/tools/validate_ccache_stats.py
@@ -82,5 +82,24 @@ finally:
 # Reset counters so the next Python-version build observes fresh, per-build stats.
 subprocess.check_call(['ccache', '--zero-stats'])
 
+# cibuildwheel runs this script once per Python-version build. The very first
+# build of a run compiles the C++ sources from a cold cache, so zero hits is
+# expected; later versions reuse those object files and must hit the cache.
+# A marker file inside CCACHE_DIR (shared across the per-version build
+# containers via the bind mount) lets us tell the first build apart. The CI
+# workflow removes this marker once per run before invoking cibuildwheel, so a
+# marker carried over inside the cached CCACHE_DIR never masks a real failure.
+ccache_dir = os.getenv('CCACHE_DIR')
+first_build_marker = pathlib.Path(ccache_dir) / '.cytnx_first_wheel_build_done' if ccache_dir else None
+is_first_build = first_build_marker is not None and not first_build_marker.exists()
+if first_build_marker is not None:
+    first_build_marker.parent.mkdir(parents=True, exist_ok=True)
+    first_build_marker.touch()
+
 if total <= 0:
-    raise SystemExit('No ccache hits detected for this python-version build.')
+    if is_first_build:
+        print('ccache_first_build_no_hits_ok')
+        print('No ccache hits detected, but this is the first python-version build '
+              'of the cibuildwheel run (cold cache); skipping hit enforcement.')
+    else:
+        raise SystemExit('No ccache hits detected for this python-version build.')


### PR DESCRIPTION
## Problem

`tools/validate_ccache_stats.py` runs as the `CIBW_TEST_COMMAND`, i.e. once **per Python-version build** in a cibuildwheel run, and zeroes the ccache counters at the end so each build observes fresh per-build stats. The first Python version compiles the C++ sources from a cold cache, so it legitimately reports zero cache hits — but the script unconditionally raises `SystemExit` whenever no hits are detected, failing that first build. Only the later Python versions can reuse the object files the first build produced.

## Change

- **`tools/validate_ccache_stats.py`**: Track the first build of a run with a marker file at `$CCACHE_DIR/.cytnx_first_wheel_build_done`. `CCACHE_DIR` is the only storage shared across the per-version build containers (via the bind mount), so it can carry this signal. When the marker is absent, the build is the first of the run: hit enforcement is skipped and the marker is created. When present, zero hits still fails as before.
- **`.github/workflows/release_pypi.yml`**: Remove the marker once per run, after the cache is restored and before cibuildwheel is invoked. This guarantees a marker that was persisted inside the cached `CCACHE_DIR` from a previous run cannot mask a genuine cache-miss failure on a later run.

## Behavior

| Build | Cache hits | Result |
|-------|-----------|--------|
| 1st Python version | 0 | pass (marker absent → cold cache expected) |
| later Python version | 0 | fail (marker present → real regression) |
| any Python version | > 0 | pass |

The per-run reset means the exemption applies to exactly one build per cibuildwheel invocation. macOS is covered too, since `CCACHE_DIR` there points at `$HOME/.ccache`.

Co-authored-by: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_012ixFdCzypBB8NzPQQxMv8Z)_