### PR TITLE
[codex] fix Storage::Fromfile count handling

### DIFF
--- a/src/backend/Storage.cpp
+++ b/src/backend/Storage.cpp
@@ -217,7 +217,8 @@ namespace cytnx {
     } else {
       const cytnx_uint64 requested_count = static_cast<cytnx_uint64>(count);
       cytnx_error_msg(requested_count > total_elements,
-                      "[ERROR] count exceed the total # of elements %llu in file.\n",
+                      "[ERROR] count (%llu) exceeds the total # of elements (%llu) in file.\n",
+                      static_cast<unsigned long long>(requested_count),
                       static_cast<unsigned long long>(total_elements));
       Nelem = requested_count;
     }

--- a/src/backend/Storage.cpp
+++ b/src/backend/Storage.cpp
@@ -209,13 +209,17 @@ namespace cytnx {
     cytnx_error_msg(Nbytes % Type.typeSize(dtype),
                     "[ERROR] the total size of file is not an interval of assigned dtype.%s", "\n");
 
+    const cytnx_uint64 total_elements = Nbytes / Type.typeSize(dtype);
+
     // check count smaller than Nelem:
-    if (count < 0)
-      Nelem = Nbytes / Type.typeSize(dtype);
-    else {
-      cytnx_error_msg(count > Nelem, "[ERROR] count exceed the total # of elements %d in file.\n",
-                      Nelem);
-      Nelem = count;
+    if (count < 0) {
+      Nelem = total_elements;
+    } else {
+      const cytnx_uint64 requested_count = static_cast<cytnx_uint64>(count);
+      cytnx_error_msg(requested_count > total_elements,
+                      "[ERROR] count exceed the total # of elements %llu in file.\n",
+                      static_cast<unsigned long long>(total_elements));
+      Nelem = requested_count;
     }
 
     f.open(fname, std::ios::in | std::ios::binary);

--- a/tests/Storage_test.cpp
+++ b/tests/Storage_test.cpp
@@ -275,3 +275,33 @@ TEST_F(StorageTest, FromfileRejectsCountLargerThanFile) {
 
   EXPECT_THROW(Storage::Fromfile(path, Type.Double, 5), std::logic_error);
 }
+
+TEST_F(StorageTest, FromfileCountZeroReturnsEmptyStorage) {
+  const std::string path = ::testing::TempDir() + "cytnx_storage_fromfile_count_zero.bin";
+  std::remove(path.c_str());
+  const RemoveFileOnExit cleanup(path);
+
+  Storage source = Storage::from_vector(std::vector<cytnx_double>{1.0, 2.0, 3.0, 4.0});
+  source.Tofile(path);
+
+  Storage loaded = Storage::Fromfile(path, Type.Double, 0);
+  EXPECT_EQ(loaded.dtype(), Type.Double);
+  EXPECT_EQ(loaded.size(), 0);
+}
+
+TEST_F(StorageTest, FromfileCountEqualsTotalElementsReadsAll) {
+  const std::string path = ::testing::TempDir() + "cytnx_storage_fromfile_count_exact.bin";
+  std::remove(path.c_str());
+  const RemoveFileOnExit cleanup(path);
+
+  Storage source = Storage::from_vector(std::vector<cytnx_double>{1.0, 2.0, 3.0, 4.0});
+  source.Tofile(path);
+
+  // count == total elements: explicit count should match count < 0 behaviour
+  Storage loaded_explicit = Storage::Fromfile(path, Type.Double, 4);
+  Storage loaded_default = Storage::Fromfile(path, Type.Double, -1);
+  ASSERT_EQ(loaded_explicit.size(), 4);
+  ASSERT_EQ(loaded_default.size(), 4);
+  for (cytnx_uint64 i = 0; i < 4; i++)
+    EXPECT_DOUBLE_EQ(loaded_explicit.at<cytnx_double>(i), loaded_default.at<cytnx_double>(i));
+}

--- a/tests/Storage_test.cpp
+++ b/tests/Storage_test.cpp
@@ -1,5 +1,6 @@
 #include "Storage_test.h"
 
+#include <cstdio>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -230,4 +231,32 @@ TYPED_TEST(StoragePutValue, AppendWithReallocation) {
     EXPECT_GE(storage.capacity(), storage.size());
     EXPECT_EQ(storage.size(), 3);
   }
+}
+
+TEST_F(StorageTest, FromfileHonorsCount) {
+  const std::string path = ::testing::TempDir() + "cytnx_storage_fromfile_count.bin";
+  std::remove(path.c_str());
+
+  Storage source = Storage::from_vector(std::vector<cytnx_double>{1.0, 2.0, 3.0, 4.0});
+  source.Tofile(path);
+
+  Storage loaded = Storage::Fromfile(path, Type.Double, 2);
+  EXPECT_EQ(loaded.dtype(), Type.Double);
+  ASSERT_EQ(loaded.size(), 2);
+  EXPECT_DOUBLE_EQ(loaded.at<cytnx_double>(0), 1.0);
+  EXPECT_DOUBLE_EQ(loaded.at<cytnx_double>(1), 2.0);
+
+  std::remove(path.c_str());
+}
+
+TEST_F(StorageTest, FromfileRejectsCountLargerThanFile) {
+  const std::string path = ::testing::TempDir() + "cytnx_storage_fromfile_oversized_count.bin";
+  std::remove(path.c_str());
+
+  Storage source = Storage::from_vector(std::vector<cytnx_double>{1.0, 2.0, 3.0, 4.0});
+  source.Tofile(path);
+
+  EXPECT_THROW(Storage::Fromfile(path, Type.Double, 5), std::logic_error);
+
+  std::remove(path.c_str());
 }

--- a/tests/Storage_test.cpp
+++ b/tests/Storage_test.cpp
@@ -1,12 +1,29 @@
 #include "Storage_test.h"
 
 #include <cstdio>
+#include <string>
 #include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "test_tools.h"
+
+namespace {
+
+  class RemoveFileOnExit {
+   public:
+    explicit RemoveFileOnExit(std::string path) : path_(std::move(path)) {}
+    ~RemoveFileOnExit() { std::remove(path_.c_str()); }
+
+    RemoveFileOnExit(const RemoveFileOnExit&) = delete;
+    RemoveFileOnExit& operator=(const RemoveFileOnExit&) = delete;
+
+   private:
+    std::string path_;
+  };
+
+}  // namespace
 
 TEST_F(StorageTest, dtype_str) {
   std::vector<cytnx_complex128> vcd = {cytnx_complex128(1, 2), cytnx_complex128(3, 4),
@@ -236,6 +253,7 @@ TYPED_TEST(StoragePutValue, AppendWithReallocation) {
 TEST_F(StorageTest, FromfileHonorsCount) {
   const std::string path = ::testing::TempDir() + "cytnx_storage_fromfile_count.bin";
   std::remove(path.c_str());
+  const RemoveFileOnExit cleanup(path);
 
   Storage source = Storage::from_vector(std::vector<cytnx_double>{1.0, 2.0, 3.0, 4.0});
   source.Tofile(path);
@@ -245,18 +263,15 @@ TEST_F(StorageTest, FromfileHonorsCount) {
   ASSERT_EQ(loaded.size(), 2);
   EXPECT_DOUBLE_EQ(loaded.at<cytnx_double>(0), 1.0);
   EXPECT_DOUBLE_EQ(loaded.at<cytnx_double>(1), 2.0);
-
-  std::remove(path.c_str());
 }
 
 TEST_F(StorageTest, FromfileRejectsCountLargerThanFile) {
   const std::string path = ::testing::TempDir() + "cytnx_storage_fromfile_oversized_count.bin";
   std::remove(path.c_str());
+  const RemoveFileOnExit cleanup(path);
 
   Storage source = Storage::from_vector(std::vector<cytnx_double>{1.0, 2.0, 3.0, 4.0});
   source.Tofile(path);
 
   EXPECT_THROW(Storage::Fromfile(path, Type.Double, 5), std::logic_error);
-
-  std::remove(path.c_str());
 }


### PR DESCRIPTION
Fixes #880.

`Storage::Fromfile` computed the file byte size but only initialized `Nelem` in the `count < 0` path. When callers passed an explicit positive `count`, the bounds check compared against an uninitialized `Nelem`, so valid counted reads could throw and oversized counts were undefined behavior.

This change computes the total element count before branching, compares explicit counts against that initialized value, and then uses the requested count for the raw load. It also updates the count-exceeded diagnostic to print the 64-bit element count with a matching format.

Regression coverage added:
- `StorageTest.FromfileHonorsCount` verifies an explicit count reads only the requested prefix of raw `Tofile` data.
- `StorageTest.FromfileRejectsCountLargerThanFile` verifies oversized counts throw deterministically.

Validation performed locally:
- Initialized required master-branch submodules for configure.
- Configured `/tmp/cytnx-storage-fromfile-count-build` with `RUN_TESTS=ON`, `BUILD_PYTHON=OFF`, `USE_HPTT=OFF`, `USE_MKL=OFF`, and explicit OpenBLAS + LAPACKE libraries.
- `cmake --build /tmp/cytnx-storage-fromfile-count-build --target test_main -j2`
- `/usr/bin/ctest --test-dir /tmp/cytnx-storage-fromfile-count-build -R "StorageTest\\.Fromfile" --output-on-failure`
- `/usr/bin/ctest --test-dir /tmp/cytnx-storage-fromfile-count-build -R "^StorageTest\\." --output-on-failure`
- `git diff --check`