### PR TITLE
[codex] make TDVP pytest deterministic

### DIFF
--- a/example/TDVP/tdvp1_dense.py
+++ b/example/TDVP/tdvp1_dense.py
@@ -288,6 +288,29 @@ def prepare_rand_init_MPS(Nsites, chi, d):
     return A
 
 
+def prepare_x_init_MPS(Nsites, chi, d=2):
+    if d != 2:
+        raise ValueError("The |x> product state is only defined for d=2.")
+
+    A = [None for i in range(Nsites)]
+    amplitude = 1.0 / np.sqrt(2.0)
+    A[0] = cytnx.UniTensor.zeros([1, d, min(chi, d)]).set_rowrank_(2) \
+                                  .relabel_(["0","1","2"])
+    A[0][0,0,0] = amplitude
+    A[0][0,1,0] = amplitude
+
+    for k in range(1,Nsites):
+        dim1 = A[k-1].shape()[2]
+        dim2 = d
+        dim3 = min(min(chi, A[k-1].shape()[2] * d), d ** (Nsites - k - 1))
+        A[k] = cytnx.UniTensor.zeros([dim1, dim2, dim3]).set_rowrank(2)
+        A[k][0,0,0] = amplitude
+        A[k][0,1,0] = amplitude
+        lbl = [str(2*k),str(2*k+1),str(2*k+2)]
+        A[k].relabel_(lbl)
+    return A
+
+
 if __name__ == '__main__':
     #prepare random MPS
     Nsites = 7 # Number of sites

--- a/example/TDVP/tdvp1_dense.py
+++ b/example/TDVP/tdvp1_dense.py
@@ -294,19 +294,22 @@ def prepare_x_init_MPS(Nsites, chi, d=2):
 
     A = [None for i in range(Nsites)]
     amplitude = 1.0 / np.sqrt(2.0)
-    A[0] = cytnx.UniTensor.zeros([1, d, min(chi, d)]).set_rowrank_(2) \
-                                  .relabel_(["0","1","2"])
-    A[0][0,0,0] = amplitude
-    A[0][0,1,0] = amplitude
+    A[0] = (
+        cytnx.UniTensor.zeros([1, d, min(chi, d)])
+        .set_rowrank_(2)
+        .relabel_(["0", "1", "2"])
+    )
+    A[0][0, 0, 0] = amplitude
+    A[0][0, 1, 0] = amplitude
 
-    for k in range(1,Nsites):
-        dim1 = A[k-1].shape()[2]
+    for k in range(1, Nsites):
+        dim1 = A[k - 1].shape()[2]
         dim2 = d
-        dim3 = min(min(chi, A[k-1].shape()[2] * d), d ** (Nsites - k - 1))
-        A[k] = cytnx.UniTensor.zeros([dim1, dim2, dim3]).set_rowrank(2)
-        A[k][0,0,0] = amplitude
-        A[k][0,1,0] = amplitude
-        lbl = [str(2*k),str(2*k+1),str(2*k+2)]
+        dim3 = min(min(chi, A[k - 1].shape()[2] * d), d ** (Nsites - k - 1))
+        A[k] = cytnx.UniTensor.zeros([dim1, dim2, dim3]).set_rowrank_(2)
+        A[k][0, 0, 0] = amplitude
+        A[k][0, 1, 0] = amplitude
+        lbl = [str(2 * k), str(2 * k + 1), str(2 * k + 2)]
         A[k].relabel_(lbl)
     return A
 

--- a/pytests/example/TDVP/tdvp1_dense_test.py
+++ b/pytests/example/TDVP/tdvp1_dense_test.py
@@ -6,20 +6,20 @@ from tdvp1_dense import *
 from numpy import linalg as LA
 
 def test_tdvp1_dense():
-    #prepare random MPS
-    Nsites = 20 # Number of sites
-    chi = 16 # MPS bond dimension
+    # Prepare a deterministic product state with overlap on both local Sz eigenstates.
+    Nsites = 8 # Number of sites
+    chi = 2 # MPS bond dimension
     d = 2
-    MPS_rand = prepare_rand_init_MPS(Nsites, chi, d)
+    MPS_x = prepare_x_init_MPS(Nsites, chi, d)
 
     # simulate ground state by imaginary time evolution by tdvp
     J = 0.0
     Jz = 0.0
     hx = 0.0
     hz = -1.0
-    tau = -0.5j
-    time_step = 20
+    tau = -1.0j
+    time_step = 10
     # prepare up state
-    As, Es = tdvp1_XXZmodel_dense(J, Jz, hx, hz, MPS_rand, chi, tau, time_step)
+    As, Es = tdvp1_XXZmodel_dense(J, Jz, hx, hz, MPS_x, chi, tau, time_step)
     error = np.abs(Es[-1]-(-1.0*Nsites))
     assert error < 1e-6


### PR DESCRIPTION
## Summary

This replaces the TDVP pytest's random initial MPS with a deterministic `|x>` product-state initializer.

The previous test started from `prepare_rand_init_MPS`, which made a trivially local imaginary-time evolution test depend on random initial conditions. The new helper constructs a deterministic state with overlap on both local `Sz` eigenstates while keeping the same MPS bond layout shape as the random initializer, so the existing TDVP sweep code follows its normal path.

The pytest also uses a smaller system and bond dimension, which keeps the check focused and much faster while preserving the final ground-state energy assertion.

## Validation

- `python3 -m py_compile example/TDVP/tdvp1_dense.py pytests/example/TDVP/tdvp1_dense_test.py`
- `git diff --check`
- Built local Python extension with CMake in `/tmp/cytnx-tdvp-python-build` using explicit OpenBLAS + LAPACKE linkage.
- `PYTHONPATH=/tmp/cytnx-pydeps:/tmp/cytnx-tdvp-testpkg pytest pytests/example/TDVP/tdvp1_dense_test.py -q` from a temp test root: `1 passed in 0.37s`