### PR TITLE
Fix Lanczos_Exp one-dimensional Krylov spaces

### DIFF
--- a/src/linalg/Lanczos_Exp.cpp
+++ b/src/linalg/Lanczos_Exp.cpp
@@ -229,7 +229,7 @@ namespace cytnx {
         const double beta_tol = 1.0e-6;
         std::vector<UniTensor> vs;
         cytnx_uint32 vec_len = Hop->nx();
-        cytnx_uint32 imp_maxiter = std::min(Maxiter, vec_len + 1);
+        cytnx_uint32 imp_maxiter = std::min(Maxiter, vec_len);
         Tensor Hp = zeros({imp_maxiter, imp_maxiter}, Hop->dtype(), Hop->device());
 
         Tensor B_mat;
@@ -303,6 +303,10 @@ namespace cytnx {
             }
             break;
           }
+        }
+        if (B_mat.dtype() == Type.Void) {
+          Hp_sub = resize_mat_internal(Hp, Vs.size(), Vs.size());
+          B_mat = linalg::ExpM(Hp_sub * tau);
         }
 
         // Let V_k be the n × (k + 1) matrix whose columns are v[0],...,v[k] respectively.

--- a/tests/linalg_test/Lanczos_Exp_test.cpp
+++ b/tests/linalg_test/Lanczos_Exp_test.cpp
@@ -1,5 +1,7 @@
 #include "gtest/gtest.h"
 
+#include <cmath>
+
 #include "test_tools.h"
 #include "cytnx.hpp"
 
@@ -42,6 +44,12 @@ namespace Lanczos_Exp_Ut_Test {
       tmp.relabel_(A.labels());
       return tmp;
     }
+  };
+
+  class OneDimScaleOp : public LinOp {
+   public:
+    OneDimScaleOp() : LinOp("mv", 1, Type.Double, Device.cpu) {}
+    UniTensor matvec(const UniTensor& A) override { return A * 3.0; }
   };
 
   // describe:Real type test
@@ -92,6 +100,20 @@ namespace Lanczos_Exp_Ut_Test {
     auto x = linalg::Lanczos_Exp(&op, Tin, tau, crit);
     auto ans = GetAns(op.EffH, Tin, tau);
     auto err = static_cast<double>((x - ans).Norm().item().real());
+    EXPECT_TRUE(err <= crit);
+  }
+
+  TEST(Lanczos_Exp_Ut, OneDimensionalKrylovSpace) {
+    OneDimScaleOp op;
+    UniTensor Tin = UniTensor::zeros({1, 1}, {}, Type.Double, Device.cpu).set_rowrank_(1);
+    Tin.at({0, 0}) = 2.0;
+    const double crit = 1.0e-12;
+    const double tau = 0.2;
+
+    auto x = linalg::Lanczos_Exp(&op, Tin, tau, crit);
+    auto ans = Tin * std::exp(3.0 * tau);
+    auto err = static_cast<double>((x - ans).Norm().item().real());
+
     EXPECT_TRUE(err <= crit);
   }
 


### PR DESCRIPTION
## Summary

When working on #886, the TDVP test that uses imaginary time evolution to find an 'all spins down' groundstate, I noticed that TDVP fails on an input state that is a chi=1 product state.  This was resolved in #886 by making the initial state chi=2, matching the bond dimensions of the previous randomly generated state.

The failure in TDVP is a bug in a `Lanczos_Exp` edge case where the implementation sets the number of iterations to `min(MaxIter, vec_len + 1)`.  This is erroneous, because if vec_len < MaxIter, it asks to compute a Krylov basis of size `vec_len + 1`, which cannot possibly be linearly independent. What allows the algorithm to work at all is the check on the magnitude of `beta`, since when this becomes zero the Lanczos iterations have found the full invariant subspace. But this check is not necessarily reliable. A much better fix is to cap the Krylov basis size at `vec_len`, not `vec_len+1`.

There is also a bug in `Lanczos_Exp` when invoked with a 1-dimensional vector. In that case the first lanczos vector already spans the full effective space. The current implementation detects that no additional vector can be generated, exits the iteration loop, and then later attempts to construct a `UniTensor` from an uninitialized `B_mat`. The fix to the iteration count above means that on a 1-dimensional vector it doesn't enter the loop at all, for the same outcome.

The fix is intentionally narrow:

1. cap the actual Krylov basis size at the operator dimension, and 
2. after the Lanczos loop, if `B_mat` has not yet been initialized, construct it from the current valid projected Hamiltonian.

## Details

The existing code computes `B_mat = ExpM(Hp_sub * tau)` inside the iteration loop as part of the convergence check. This means `B_mat` is both:

1. an intermediate convergence diagnostic, and
2. the final projected exponential used after the loop.

If the loop does not run, or if it exits before reaching that convergence-check block, `B_mat` remains uninitialized.

The current code also sets the implicit maximum iteration count to `min(Maxiter, vec_len + 1)`. For an operator acting on an `N`-dimensional space, there can be at most `N` independent Krylov vectors, so this PR caps the actual basis size at `vec_len`.

This PR adds a fallback after the loop:

```cpp
if (B_mat.dtype() == Type.Void) {
  Hp_sub = resize_mat_internal(Hp, Vs.size(), Vs.size());
  B_mat = linalg::ExpM(Hp_sub * tau);
}
```

## Notes

While investigating this, I also noticed a broader issue in the surrounding implementation:

- The `beta < beta_tol` path attempts to recover by drawing a random vector and Gram-Schmidt orthogonalizing it against the existing Krylov vectors. That path is nondeterministic and I don't think it serves any useful purpose. Lanczos-based eigensolvers often have a recovery from breakdown of orthogonality because it is possible that the wanted eigenvector is orthogonal (or nearly so) to the input vector. But for the Lanczos exponential, the exponential is taken on the input vector itself, so once an invariant subspace is found there is no point adding new orthogonal vectors, since they will have zero overlap with the final vector. It also looks like there is a bug in that code path since it normalizes the added vector by dividing by `dot(v,v)` rather than `sqrt(dot(v,v))`. So the fact that the added vectors will have numerically zero overlap with the output vector is probably saving `Lanczos_Exp` from catastrophe. This PR deliberately does not refactor that path, but keeps the fix to the minimum to get `Lanczos_Exp` working on length-1 vectors and avoiding the possibility of constructing a Krylov basis larger than the vector length.

- During local TDVP experiments, the one-dimensional product-state got past the original `Lanczos_Exp` failure but later exposed a separate `Svd_truncate`/`zgesvd` failure. I am not going to continue going down this rabbit hole.

## Tests

Added a direct regression test for a one-dimensional Krylov space:

- `Lanczos_Exp_Ut.OneDimensionalKrylovSpace`

Verified locally with:

```bash
/tmp/cytnx-lanczos-exp-test-build/tests/test_main --gtest_filter=Lanczos_Exp_Ut.*
```