### PR TITLE
Scale Lanczos_Exp beta breakdown tolerance

### DIFF
--- a/src/linalg/Lanczos_Exp.cpp
+++ b/src/linalg/Lanczos_Exp.cpp
@@ -4,9 +4,11 @@
 #include "Tensor.hpp"
 #include "LinOp.hpp"
 
+#include <algorithm>
 #include <cfloat>
-#include <vector>
 #include <cmath>
+#include <limits>
+#include <vector>
 #include "UniTensor.hpp"
 #include "utils/vec_print.hpp"
 #include <iomanip>
@@ -20,6 +22,8 @@ namespace cytnx {
     using namespace std;
 
     namespace {
+      constexpr double kBetaBreakdownRoundoff = 100.0;
+
       // <A|B>
       Scalar Dot_internal(const UniTensor &A, const UniTensor &B) {
         return Contract(A.Dagger(), B).item();
@@ -42,6 +46,47 @@ namespace cytnx {
         }
         return u;
       }
+
+      double dtype_epsilon_internal(const unsigned int dtype) {
+        if (dtype == Type.Float || dtype == Type.ComplexFloat) {
+          return std::numeric_limits<float>::epsilon();
+        }
+        return std::numeric_limits<double>::epsilon();
+      }
+
+      double float_cvgcrit_floor_internal() {
+        return kBetaBreakdownRoundoff * std::numeric_limits<float>::epsilon();
+      }
+
+      unsigned int krylov_matrix_dtype_internal(const unsigned int dtype) {
+        if (dtype == Type.Float) {
+          return Type.Double;
+        }
+        if (dtype == Type.ComplexFloat) {
+          return Type.ComplexDouble;
+        }
+        return dtype;
+      }
+
+      unsigned int lanczos_exp_output_dtype_internal(const unsigned int op_dtype,
+                                                     const unsigned int out_dtype) {
+        if (op_dtype == Type.Float) {
+          return Type.is_complex(out_dtype) ? Type.ComplexFloat : Type.Float;
+        }
+        if (op_dtype == Type.ComplexFloat) {
+          return Type.ComplexFloat;
+        }
+        return out_dtype;
+      }
+
+      void cast_dense_output_internal(UniTensor &out, const unsigned int dtype) {
+        if (out.dtype() == dtype) {
+          return;
+        }
+        out = out.astype(dtype);
+      }
+
+      double scalar_abs_internal(const Scalar &s) { return static_cast<double>(s.abs()); }
 
       Tensor resize_mat_internal(const Tensor &src, const cytnx_uint64 r, const cytnx_uint64 c) {
         const auto min_r = std::min(r, src.shape()[0]);
@@ -226,11 +271,12 @@ namespace cytnx {
       void Lanczos_Exp_Ut_internal(UniTensor &out, LinOp *Hop, const UniTensor &T, Scalar tau,
                                    const double &CvgCrit, const unsigned int &Maxiter,
                                    const bool &verbose) {
-        const double beta_tol = 1.0e-6;
+        const double eps = dtype_epsilon_internal(Hop->dtype());
         std::vector<UniTensor> vs;
         cytnx_uint32 vec_len = Hop->nx();
         cytnx_uint32 imp_maxiter = std::min(Maxiter, vec_len);
-        Tensor Hp = zeros({imp_maxiter, imp_maxiter}, Hop->dtype(), Hop->device());
+        Tensor Hp = zeros({imp_maxiter, imp_maxiter}, krylov_matrix_dtype_internal(Hop->dtype()),
+                          Hop->device());
 
         Tensor B_mat;
         // prepare initial tensor and normalize
@@ -243,6 +289,8 @@ namespace cytnx {
         auto alpha = Dot_internal(wp, v);
         Hp.at({0, 0}) = alpha;
         auto w = (wp - alpha * v).relabel_(v.labels());
+        double beta_prev = 0.0;
+        double beta_breakdown_scale = std::max(scalar_abs_internal(alpha), 1.0);
 
         // prepare U
         auto Vk_shape = v.shape();
@@ -259,7 +307,11 @@ namespace cytnx {
           }
           auto beta = std::sqrt(double(Dot_internal(w, w).real()));
           v_old = v.clone();
-          if (beta > beta_tol) {
+          auto local_scale = scalar_abs_internal(alpha) + std::abs(beta) + std::abs(beta_prev);
+          beta_breakdown_scale = std::max(beta_breakdown_scale, std::max(local_scale, 1.0));
+          auto beta_breakdown =
+            kBetaBreakdownRoundoff * eps * beta_breakdown_scale * std::sqrt(static_cast<double>(i));
+          if (beta > beta_breakdown) {
             v = (w / beta).relabel_(v.labels());
           } else {  // beta too small -> the norm of new vector too small. This vector cannot span
                     // the new dimension
@@ -276,6 +328,7 @@ namespace cytnx {
           alpha = Dot_internal(wp, v);
           Hp.at({(cytnx_uint64)i, (cytnx_uint64)i}) = alpha;
           w = (wp - alpha * v - beta * v_old).relabel_(v.labels());
+          beta_prev = beta;
 
           // Converge check
           Hp_sub = resize_mat_internal(Hp, i + 1, i + 1);
@@ -344,6 +397,8 @@ namespace cytnx {
         out = Contracts({T, VkDag_ut, B}, "", true);
         out = Contract(out, Vk_ut);
         out.set_rowrank_(v.rowrank());
+        cast_dense_output_internal(out,
+                                   lanczos_exp_output_dtype_internal(Hop->dtype(), out.dtype()));
       }
     }  // unnamed namespace
 
@@ -352,7 +407,8 @@ namespace cytnx {
                           const double &CvgCrit, const unsigned int &Maxiter, const bool &verbose) {
       // check device:
       cytnx_error_msg(Hop->device() != Device.cpu,
-                      "[ERROR][Lanczos_Exp] Lanczos_Exp still not sopprot cuda devices.%s", "\n");
+                      "[ERROR][Lanczos_Exp] Lanczos_Exp still does not support cuda devices.%s",
+                      "\n");
       // check type:
       cytnx_error_msg(!Type.is_float(Hop->dtype()),
                       "[ERROR][Lanczos_Exp] Lanczos_Exp can only accept operator with "
@@ -377,13 +433,14 @@ namespace cytnx {
       double _cvgcrit = CvgCrit;
 
       if (Hop->dtype() == Type.Float || Hop->dtype() == Type.ComplexFloat) {
-        if (_cvgcrit < 1.0e-7) {
-          _cvgcrit = 1.0e-7;
+        const double cvgcrit_floor = float_cvgcrit_floor_internal();
+        if (_cvgcrit < cvgcrit_floor) {
+          _cvgcrit = cvgcrit_floor;
           cytnx_warning_msg(
-            _cvgcrit < 1.0e-7,
-            "[WARNING][Lanczos_Exp] for float precision type, CvgCrit cannot exceed "
-            "it's own type precision limit 1e-7, and it's auto capped to 1.0e-7.%s",
-            "\n");
+            true,
+            "[WARNING][Lanczos_Exp] for float precision type, CvgCrit cannot be smaller "
+            "than %.8e, and is automatically raised to this value.%s",
+            cvgcrit_floor, "\n");
         }
       }
 

--- a/tests/linalg_test/Lanczos_Exp_test.cpp
+++ b/tests/linalg_test/Lanczos_Exp_test.cpp
@@ -1,6 +1,8 @@
 #include "gtest/gtest.h"
 
 #include <cmath>
+#include <complex>
+#include <limits>
 
 #include "test_tools.h"
 #include "cytnx.hpp"
@@ -52,6 +54,51 @@ namespace Lanczos_Exp_Ut_Test {
     UniTensor matvec(const UniTensor& A) override { return A * 3.0; }
   };
 
+  class SmallResidualOp : public LinOp {
+   public:
+    explicit SmallResidualOp(const double coupling, const unsigned int dtype = Type.Double)
+        : LinOp("mv", 3, dtype, Device.cpu), coupling_(coupling) {}
+
+    UniTensor matvec(const UniTensor& A) override {
+      auto out = UniTensor::zeros(A.shape(), A.labels(), A.dtype(), A.device());
+      out.set_rowrank_(A.rowrank());
+      out.at({0, 0}) = coupling_ * A.at({1, 0});
+      out.at({1, 0}) = coupling_ * A.at({0, 0});
+      return out;
+    }
+
+   private:
+    double coupling_;
+  };
+
+  double FloatLanczosExpTolerance() { return 100.0 * std::numeric_limits<float>::epsilon(); }
+
+  bool IsSinglePrecisionDType(const unsigned int dtype) {
+    return dtype == Type.Float || dtype == Type.ComplexFloat;
+  }
+
+  UniTensor SmallResidualInitialState(const unsigned int dtype) {
+    UniTensor Tin = UniTensor::zeros({3, 1}, {}, dtype, Device.cpu).set_rowrank_(1);
+    Tin.at({0, 0}) = 1.0;
+    return Tin;
+  }
+
+  UniTensor SmallResidualExpectedState(const double coupling, const double tau,
+                                       const unsigned int dtype) {
+    auto ans = UniTensor::zeros({3, 1}, {}, dtype, Device.cpu).set_rowrank_(1);
+    ans.at({0, 0}) = std::cosh(coupling * tau);
+    ans.at({1, 0}) = std::sinh(coupling * tau);
+    return ans;
+  }
+
+  UniTensor SmallResidualExpectedState(const double coupling, const cytnx_complex128 tau,
+                                       const unsigned int dtype) {
+    auto ans = UniTensor::zeros({3, 1}, {}, dtype, Device.cpu).set_rowrank_(1);
+    ans.at({0, 0}) = std::cosh(coupling * tau);
+    ans.at({1, 0}) = std::sinh(coupling * tau);
+    return ans;
+  }
+
   // describe:Real type test
   TEST(Lanczos_Exp_Ut, RealTypeTest) {
     int d = 2, D = 5;
@@ -62,7 +109,7 @@ namespace Lanczos_Exp_Ut_Test {
     auto x = linalg::Lanczos_Exp(&op, Tin, tau, crit);
     auto ans = GetAns(op.EffH, Tin, tau);
     auto err = static_cast<double>((x - ans).Norm().item().real());
-    EXPECT_TRUE(err <= crit);
+    EXPECT_LE(err, crit);
   }
 
   // describe:Complex type test
@@ -75,7 +122,7 @@ namespace Lanczos_Exp_Ut_Test {
     auto x = linalg::Lanczos_Exp(&op, Tin, tau, crit);
     auto ans = GetAns(op.EffH, Tin, tau);
     auto err = static_cast<double>((x - ans).Norm().item().real());
-    EXPECT_TRUE(err <= crit);
+    EXPECT_LE(err, crit);
   }
 
   // describe:Test non-Hermitian Op but the code will not crash
@@ -100,7 +147,7 @@ namespace Lanczos_Exp_Ut_Test {
     auto x = linalg::Lanczos_Exp(&op, Tin, tau, crit);
     auto ans = GetAns(op.EffH, Tin, tau);
     auto err = static_cast<double>((x - ans).Norm().item().real());
-    EXPECT_TRUE(err <= crit);
+    EXPECT_LE(err, crit);
   }
 
   TEST(Lanczos_Exp_Ut, OneDimensionalKrylovSpace) {
@@ -114,7 +161,86 @@ namespace Lanczos_Exp_Ut_Test {
     auto ans = Tin * std::exp(3.0 * tau);
     auto err = static_cast<double>((x - ans).Norm().item().real());
 
-    EXPECT_TRUE(err <= crit);
+    EXPECT_LE(err, crit);
+  }
+
+  TEST(Lanczos_Exp_Ut, SmallResidualIsNotBreakdown) {
+    const double coupling = 5.0e-7;
+    SmallResidualOp op(coupling);
+    auto Tin = SmallResidualInitialState(Type.Double);
+    const double crit = 1.0e-10;
+    const double tau = 1.0;
+    const unsigned int maxiter = 3;
+
+    auto x = linalg::Lanczos_Exp(&op, Tin, tau, crit, maxiter);
+    auto ans = SmallResidualExpectedState(coupling, tau, Type.Double);
+    auto err = static_cast<double>((x - ans).Norm().item().real());
+
+    EXPECT_LE(err, crit);
+  }
+
+  TEST(Lanczos_Exp_Ut, FloatSmallResidualBelowRoundoffFloor) {
+    const double coupling = 5.0e-6;
+    SmallResidualOp op(coupling, Type.Float);
+    auto Tin = SmallResidualInitialState(Type.Float);
+    const double tau = 1.0;
+    const unsigned int maxiter = 3;
+
+    auto x = linalg::Lanczos_Exp(&op, Tin, tau, 1.0e-10, maxiter);
+    auto ans = SmallResidualExpectedState(coupling, tau, x.dtype());
+    auto err = static_cast<double>((x - ans).Norm().item().real());
+
+    // ExpM currently returns a complex matrix even for this real case. Either
+    // real or complex output is acceptable here, but it must remain single precision.
+    EXPECT_TRUE(IsSinglePrecisionDType(x.dtype()));
+    EXPECT_LE(err, FloatLanczosExpTolerance());
+  }
+
+  TEST(Lanczos_Exp_Ut, FloatResidualAboveRoundoffFloorIsNotBreakdown) {
+    const double coupling = 5.0e-5;
+    SmallResidualOp op(coupling, Type.Float);
+    auto Tin = SmallResidualInitialState(Type.Float);
+    const double tau = 1.0;
+    const unsigned int maxiter = 3;
+
+    auto x = linalg::Lanczos_Exp(&op, Tin, tau, 1.0e-10, maxiter);
+    auto ans = SmallResidualExpectedState(coupling, tau, x.dtype());
+    auto err = static_cast<double>((x - ans).Norm().item().real());
+
+    // ExpM currently returns a complex matrix even for this real case. Either
+    // real or complex output is acceptable here, but it must remain single precision.
+    EXPECT_TRUE(IsSinglePrecisionDType(x.dtype()));
+    EXPECT_LE(err, FloatLanczosExpTolerance());
+  }
+
+  TEST(Lanczos_Exp_Ut, ComplexFloatResidualAboveRoundoffFloorIsNotBreakdown) {
+    const double coupling = 5.0e-5;
+    SmallResidualOp op(coupling, Type.ComplexFloat);
+    auto Tin = SmallResidualInitialState(Type.ComplexFloat);
+    const double tau = 1.0;
+    const unsigned int maxiter = 3;
+
+    auto x = linalg::Lanczos_Exp(&op, Tin, tau, 1.0e-10, maxiter);
+    auto ans = SmallResidualExpectedState(coupling, tau, Type.ComplexFloat);
+    auto err = static_cast<double>((x - ans).Norm().item().real());
+
+    EXPECT_EQ(x.dtype(), Type.ComplexFloat);
+    EXPECT_LE(err, FloatLanczosExpTolerance());
+  }
+
+  TEST(Lanczos_Exp_Ut, FloatComplexTauReturnsComplexFloat) {
+    const double coupling = 5.0e-5;
+    SmallResidualOp op(coupling, Type.Float);
+    auto Tin = SmallResidualInitialState(Type.Float);
+    const cytnx_complex128 tau(0.0, 1.0);
+    const unsigned int maxiter = 3;
+
+    auto x = linalg::Lanczos_Exp(&op, Tin, tau, 1.0e-10, maxiter);
+    auto ans = SmallResidualExpectedState(coupling, tau, Type.ComplexFloat);
+    auto err = static_cast<double>((x - ans).Norm().item().real());
+
+    EXPECT_EQ(x.dtype(), Type.ComplexFloat);
+    EXPECT_LE(err, FloatLanczosExpTolerance());
   }
 
   // describe:test incorrect data type


### PR DESCRIPTION
This replaces the fixed `beta_tol = 1.0e-6` cutoff in `Lanczos_Exp` with a scale-aware beta breakdown threshold.

The previous name and value made this look like a convergence tolerance, but beta is the Lanczos recurrence coefficient for the next Krylov vector. It should only detect numerical breakdown / an invariant Krylov subspace. Convergence of the exponential approximation remains controlled separately by `CvgCrit`.

The new threshold uses:

```text
100 * epsilon * running_recurrence_scale * sqrt(k)
```

where the recurrence scale is tracked from the Lanczos coefficients,

```text
|alpha_j| + |beta_j| + |beta_{j-1}|
```

with a floor of `1`. This keeps the threshold near roundoff while allowing for the operator scale observed during the recurrence and modest accumulation with Krylov dimension.

For `Float` and `ComplexFloat`, this also raises the minimum accepted `CvgCrit` to `100 * eps_float`. The previous `1e-7` floor is too close to single-precision machine epsilon to be a reliable requested accuracy for this path, and it conflicts with any roundoff-scale beta breakdown threshold.

The projected Krylov matrix is also promoted from float to double precision before evaluating the small dense exponential. This avoids a separate precision problem in `ExpM`: in the complex-float regression test, `ExpM` on the projected matrix reported a convergence coefficient around `1.3e-7` even though the omitted component in the final vector was still around `5e-5`. That made `Lanczos_Exp` stop early for the wrong reason.

This PR casts the final `Lanczos_Exp` result back to the public single-precision class after that internal promotion. For `Float` input, the result may be either `Float` or `ComplexFloat` depending on whether the lower-level exponential returns a real or complex matrix; for `ComplexFloat`, the result should be `ComplexFloat`. The important guarantee here is that an internal `Float -> Double` Krylov-matrix promotion does not leak out as `Double` or `ComplexDouble` state data.

This does not attempt to fix generic `ExpM`. That routine currently computes the matrix exponential through a general eigendecomposition and an explicit inverse of the eigenvector matrix, which is not a robust general-purpose matrix exponential algorithm. It also appears to return complex matrices even in cases where the input arithmetic is purely real. That is a serious problem for imaginary-time TEBD/TDVP-style workflows, because they can be dragged into complex arithmetic for no mathematical reason. The promoted projected matrix here is only a local mitigation for the small Krylov matrix used by `Lanczos_Exp`, and the output cast only prevents the internal precision promotion from escaping the function boundary.

The added regression tests cover:

- a double-precision residual of `5e-7`, which the old fixed `1e-6` cutoff incorrectly treated as breakdown;
- a float residual below the new roundoff-scale floor;
- float and complex-float residuals above the new floor, which must not be treated as breakdown;
- preservation of single-precision output storage after the internal projected Krylov matrix is promoted.

This is intended as a stacked follow-up to #889, so the PR branch targets `codex/investigate-tdvp-ci`. That branch itself targets `master`. The #889 fix removed the invalid random-vector continuation after beta breakdown; this PR makes the remaining breakdown test use a numerical-breakdown threshold instead of a convergence-sized cutoff.

After #889 is merged, this PR can be retargeted to `master` or rebased onto `master` without changing the intended code diff.

Tests:

```text
/tmp/cytnx-tdvp-build/tests/test_main --gtest_filter=Lanczos_Exp_Ut.*
/tmp/cytnx-tdvp-venv/bin/python -m pytest pytests/ -q
```

Co-authored-by: Codex <codex@openai.com>
