### PR TITLE
[codex] allow Fromfile count zero

### DIFF
--- a/include/Tensor.hpp
+++ b/include/Tensor.hpp
@@ -375,14 +375,14 @@ namespace cytnx {
      * @param dtype[in] the data type of the binary file. This can be any of the type defined in
      *   cytnx::Type.
      * @param count[in] the number of elements to be loaded from the binary file. If set to -1,
-     *  all elements in the binary file will be loaded.
+     *  all elements in the binary file will be loaded. If set to 0, this returns an empty Tensor
+     *  with the requested dtype.
      * @return Tensor
      * @pre
      *  1. The @p dtype cannot be Type.Void.
      *  2. The @p dtype must be the same as the data type of the binary file.
-     *  3. The @p Nelem cannot be 0.
-     *  4. The @p Nelem cannot be larger than the number of elements in the binary file.
-     *  5. The file name @p fname must be valid.
+     *  3. The @p count cannot be larger than the number of elements in the binary file.
+     *  4. The file name @p fname must be valid.
      * @see cytnx::Tensor::Tofile
      */
     static Tensor Fromfile(const std::string &fname, const unsigned int &dtype,

--- a/include/backend/Storage.hpp
+++ b/include/backend/Storage.hpp
@@ -575,14 +575,14 @@ namespace cytnx {
      *     to current Storage with specified dtype and number of elements.
      * @param[in] fname file name
      * @param[in] dtype the data type of the binary file. See cytnx::Type.
-     * @param[in] Nelem the number of elements you want to load from the binary file. If
-     *   \p Nelem is -1, then it will load all the elements in the binary file.
+     * @param[in] count the number of elements you want to load from the binary file. If
+     *   \p count is -1, then it will load all the elements in the binary file. If \p count is 0,
+     *   this returns an empty Storage with the requested dtype.
      * @pre
      *  1. The @p dtype cannot be Type.Void.
      *  2. The @p dtype must be the same as the data type of the binary file.
-     *  3. The @p Nelem cannot be 0.
-     *  4. The @p Nelem cannot be larger than the number of elements in the binary file.
-     *  5. The file name @p fname must be valid.
+     *  3. The @p count cannot be larger than the number of elements in the binary file.
+     *  4. The file name @p fname must be valid.
      *
      * @see Tofile(const std::string &fname) const
      */

--- a/pytests/io/test_tensor_fromfile.py
+++ b/pytests/io/test_tensor_fromfile.py
@@ -13,3 +13,15 @@ def test_tensor_fromfile_reads_raw_tofile_output(tmp_path):
     assert loaded.dtype() == cy.Type.Double
     assert list(loaded.shape()) == [5]
     np.testing.assert_allclose(loaded.numpy(), np.arange(5, dtype=np.float64))
+
+
+def test_tensor_fromfile_count_zero_returns_empty_tensor(tmp_path):
+    path = tmp_path / "tensor_raw.bin"
+    tensor = cy.arange(0, 5, 1, dtype=cy.Type.Double)
+
+    tensor.Tofile(str(path))
+    loaded = cy.Tensor.Fromfile(str(path), cy.Type.Double, 0)
+
+    assert loaded.dtype() == cy.Type.Double
+    assert list(loaded.shape()) == [0]
+    assert loaded.numpy().size == 0

--- a/src/backend/Storage.cpp
+++ b/src/backend/Storage.cpp
@@ -189,7 +189,6 @@ namespace cytnx {
   Storage Storage::Fromfile(const std::string &fname, const unsigned int &dtype,
                             const cytnx_int64 &count) {
     cytnx_error_msg(dtype == Type.Void, "[ERROR] Cannot have Void dtype.%s", "\n");
-    cytnx_error_msg(count == 0, "[ERROR] count cannot be zero!%s", "\n");
 
     Storage out;
     cytnx_uint64 Nbytes;
@@ -295,9 +294,9 @@ namespace cytnx {
   }
 
   void Storage::_Loadbinary(std::fstream &f, const unsigned int &dtype, const cytnx_uint64 &Nelem) {
-    // before enter this func, makesure
+    // Before entering this function, ensure:
     // 1. dtype is not void.
-    // 2. the Nelement is consistent and smaller than the file size, and should not be zero!
+    // 2. Nelem is consistent and no larger than the file size.
 
     // check:
     cytnx_error_msg(!f.is_open(), "[ERROR] invalid std::fstream!.%s", "\n");


### PR DESCRIPTION
Fixes the current master failure in `StorageTest.FromfileCountZeroReturnsEmptyStorage` after #885/#884 landed together.

`Storage::Fromfile` already validates the file path, dtype, file byte size, and requested count against the number of elements in the file. The only remaining blocker was a stale explicit `count == 0` rejection. Since zero-size typed storage is supported by `StorageImplementation::Init(0, ...)`, `count=0` can return an empty Storage/Tensor with the requested dtype without reading any payload bytes.

This change:
- removes the `count == 0` rejection from `Storage::Fromfile`;
- updates the Storage/Tensor Fromfile docs to state that `count=0` returns an empty object;
- adds Python coverage for `Tensor.Fromfile(..., count=0)` returning an empty tensor with the requested dtype.

Co-authored-by: Codex <codex@openai.com>