### PR TITLE
Fix Lanczos_Exp warning at full Krylov dimension

### DIFF
--- a/example/TDVP/tdvp1_dense.py
+++ b/example/TDVP/tdvp1_dense.py
@@ -11,7 +11,7 @@ def tdvp1_XXZmodel_dense(J, Jz, hx, hz, A, chi, dt, time_step):
     class OneSiteOp(cytnx.LinOp):
         def __init__(self, L, M, R):
             self.anet = cytnx.Network()
-            d = L.shape()[0]
+            d = M.shape()[2]
             D1 = L.shape()[2]
             D2 = R.shape()[2]
             cytnx.LinOp.__init__(self, "mv", D1*D2*d, L.dtype(), R.device())

--- a/src/linalg/Lanczos_Exp.cpp
+++ b/src/linalg/Lanczos_Exp.cpp
@@ -264,19 +264,9 @@ namespace cytnx {
           } else {  // beta too small -> the norm of new vector too small. This vector cannot span
                     // the new dimension
             if (verbose) {
-              std::cout << "beta too small, pick another vector." << i << std::endl;
+              std::cout << "beta too small. Break." << i << std::endl;
             }
-            // pick a new vector perpendicular to all vector in Vs
-            v = Gram_Schmidt_internal(Vs).relabel_(v.labels());
-            auto v_norm = Dot_internal(v, v);
-            // if the picked vector also too small, break and construct expH
-            if (abs(v_norm) <= beta_tol) {
-              if (verbose) {
-                std::cout << "All vector form the space. Break." << i << std::endl;
-              }
-              break;
-            }
-            v = v / v_norm;
+            break;
           }
           Vk.append(v.get_block_().contiguous());
           Vs.push_back(v);

--- a/src/linalg/Lanczos_Exp.cpp
+++ b/src/linalg/Lanczos_Exp.cpp
@@ -301,7 +301,7 @@ namespace cytnx {
         UniTensor v_old;
         Tensor Hp_sub;
 
-        for (int i = 1; i < imp_maxiter; ++i) {
+        for (cytnx_uint32 i = 1; i < imp_maxiter; ++i) {
           if (verbose) {
             std::cout << "Lanczos iteration:" << i << std::endl;
           }
@@ -336,13 +336,16 @@ namespace cytnx {
           B_mat = linalg::ExpM(Hp_sub * tau);
           // Set the error as the element of bottom left of the exp(H_sub*tau)
           auto error = abs(B_mat.at({(cytnx_uint64)i, 0}));
-          if (error < CvgCrit || i == imp_maxiter - 1) {
-            if (i == imp_maxiter - 1 && error > CvgCrit) {
+          if (error < CvgCrit) {
+            break;
+          }
+          if (i == imp_maxiter - 1) {
+            if (Maxiter < vec_len) {
               cytnx_warning_msg(
                 true,
-                "[WARNING][Lanczos_Exp] Fail to converge at eigv [%d], try increasing "
-                "maxiter?\n Note:: ignore if this is intended.%s",
-                imp_maxiter, "\n");
+                "[WARNING][Lanczos_Exp] Did not converge after Maxiter [%u] iterations; try "
+                "increasing maxiter.",
+                imp_maxiter);
             }
             break;
           }

--- a/src/linalg/Lanczos_Exp.cpp
+++ b/src/linalg/Lanczos_Exp.cpp
@@ -264,7 +264,7 @@ namespace cytnx {
           } else {  // beta too small -> the norm of new vector too small. This vector cannot span
                     // the new dimension
             if (verbose) {
-              std::cout << "beta too small. Break." << i << std::endl;
+              std::cout << "beta too small. Break at iteration " << i << std::endl;
             }
             break;
           }

--- a/src/linalg/Lanczos_Exp.cpp
+++ b/src/linalg/Lanczos_Exp.cpp
@@ -4,9 +4,11 @@
 #include "Tensor.hpp"
 #include "LinOp.hpp"
 
+#include <algorithm>
 #include <cfloat>
-#include <vector>
 #include <cmath>
+#include <limits>
+#include <vector>
 #include "UniTensor.hpp"
 #include "utils/vec_print.hpp"
 #include <iomanip>
@@ -20,6 +22,8 @@ namespace cytnx {
     using namespace std;
 
     namespace {
+      constexpr double kBetaBreakdownRoundoff = 100.0;
+
       // <A|B>
       Scalar Dot_internal(const UniTensor &A, const UniTensor &B) {
         return Contract(A.Dagger(), B).item();
@@ -42,6 +46,47 @@ namespace cytnx {
         }
         return u;
       }
+
+      double dtype_epsilon_internal(const unsigned int dtype) {
+        if (dtype == Type.Float || dtype == Type.ComplexFloat) {
+          return std::numeric_limits<float>::epsilon();
+        }
+        return std::numeric_limits<double>::epsilon();
+      }
+
+      double float_cvgcrit_floor_internal() {
+        return kBetaBreakdownRoundoff * std::numeric_limits<float>::epsilon();
+      }
+
+      unsigned int krylov_matrix_dtype_internal(const unsigned int dtype) {
+        if (dtype == Type.Float) {
+          return Type.Double;
+        }
+        if (dtype == Type.ComplexFloat) {
+          return Type.ComplexDouble;
+        }
+        return dtype;
+      }
+
+      unsigned int lanczos_exp_output_dtype_internal(const unsigned int op_dtype,
+                                                     const unsigned int out_dtype) {
+        if (op_dtype == Type.Float) {
+          return Type.is_complex(out_dtype) ? Type.ComplexFloat : Type.Float;
+        }
+        if (op_dtype == Type.ComplexFloat) {
+          return Type.ComplexFloat;
+        }
+        return out_dtype;
+      }
+
+      void cast_dense_output_internal(UniTensor &out, const unsigned int dtype) {
+        if (out.dtype() == dtype) {
+          return;
+        }
+        out = out.astype(dtype);
+      }
+
+      double scalar_abs_internal(const Scalar &s) { return static_cast<double>(s.abs()); }
 
       Tensor resize_mat_internal(const Tensor &src, const cytnx_uint64 r, const cytnx_uint64 c) {
         const auto min_r = std::min(r, src.shape()[0]);
@@ -226,11 +271,12 @@ namespace cytnx {
       void Lanczos_Exp_Ut_internal(UniTensor &out, LinOp *Hop, const UniTensor &T, Scalar tau,
                                    const double &CvgCrit, const unsigned int &Maxiter,
                                    const bool &verbose) {
-        const double beta_tol = 1.0e-6;
+        const double eps = dtype_epsilon_internal(Hop->dtype());
         std::vector<UniTensor> vs;
         cytnx_uint32 vec_len = Hop->nx();
         cytnx_uint32 imp_maxiter = std::min(Maxiter, vec_len);
-        Tensor Hp = zeros({imp_maxiter, imp_maxiter}, Hop->dtype(), Hop->device());
+        Tensor Hp = zeros({imp_maxiter, imp_maxiter}, krylov_matrix_dtype_internal(Hop->dtype()),
+                          Hop->device());
 
         Tensor B_mat;
         // prepare initial tensor and normalize
@@ -243,6 +289,8 @@ namespace cytnx {
         auto alpha = Dot_internal(wp, v);
         Hp.at({0, 0}) = alpha;
         auto w = (wp - alpha * v).relabel_(v.labels());
+        double beta_prev = 0.0;
+        double beta_breakdown_scale = std::max(scalar_abs_internal(alpha), 1.0);
 
         // prepare U
         auto Vk_shape = v.shape();
@@ -259,7 +307,11 @@ namespace cytnx {
           }
           auto beta = std::sqrt(double(Dot_internal(w, w).real()));
           v_old = v.clone();
-          if (beta > beta_tol) {
+          auto local_scale = scalar_abs_internal(alpha) + std::abs(beta) + std::abs(beta_prev);
+          beta_breakdown_scale = std::max(beta_breakdown_scale, std::max(local_scale, 1.0));
+          auto beta_breakdown =
+            kBetaBreakdownRoundoff * eps * beta_breakdown_scale * std::sqrt(static_cast<double>(i));
+          if (beta > beta_breakdown) {
             v = (w / beta).relabel_(v.labels());
           } else {  // beta too small -> the norm of new vector too small. This vector cannot span
                     // the new dimension
@@ -276,6 +328,7 @@ namespace cytnx {
           alpha = Dot_internal(wp, v);
           Hp.at({(cytnx_uint64)i, (cytnx_uint64)i}) = alpha;
           w = (wp - alpha * v - beta * v_old).relabel_(v.labels());
+          beta_prev = beta;
 
           // Converge check
           Hp_sub = resize_mat_internal(Hp, i + 1, i + 1);
@@ -344,6 +397,8 @@ namespace cytnx {
         out = Contracts({T, VkDag_ut, B}, "", true);
         out = Contract(out, Vk_ut);
         out.set_rowrank_(v.rowrank());
+        cast_dense_output_internal(out,
+                                   lanczos_exp_output_dtype_internal(Hop->dtype(), out.dtype()));
       }
     }  // unnamed namespace
 
@@ -352,7 +407,8 @@ namespace cytnx {
                           const double &CvgCrit, const unsigned int &Maxiter, const bool &verbose) {
       // check device:
       cytnx_error_msg(Hop->device() != Device.cpu,
-                      "[ERROR][Lanczos_Exp] Lanczos_Exp still not sopprot cuda devices.%s", "\n");
+                      "[ERROR][Lanczos_Exp] Lanczos_Exp still does not support cuda devices.%s",
+                      "\n");
       // check type:
       cytnx_error_msg(!Type.is_float(Hop->dtype()),
                       "[ERROR][Lanczos_Exp] Lanczos_Exp can only accept operator with "
@@ -377,13 +433,14 @@ namespace cytnx {
       double _cvgcrit = CvgCrit;
 
       if (Hop->dtype() == Type.Float || Hop->dtype() == Type.ComplexFloat) {
-        if (_cvgcrit < 1.0e-7) {
-          _cvgcrit = 1.0e-7;
+        const double cvgcrit_floor = float_cvgcrit_floor_internal();
+        if (_cvgcrit < cvgcrit_floor) {
+          _cvgcrit = cvgcrit_floor;
           cytnx_warning_msg(
-            _cvgcrit < 1.0e-7,
-            "[WARNING][Lanczos_Exp] for float precision type, CvgCrit cannot exceed "
-            "it's own type precision limit 1e-7, and it's auto capped to 1.0e-7.%s",
-            "\n");
+            true,
+            "[WARNING][Lanczos_Exp] for float precision type, CvgCrit cannot be smaller "
+            "than %.8e, and is automatically raised to this value.%s",
+            cvgcrit_floor, "\n");
         }
       }
 

--- a/tests/linalg_test/Lanczos_Exp_test.cpp
+++ b/tests/linalg_test/Lanczos_Exp_test.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <complex>
 #include <limits>
+#include <string>
 
 #include "test_tools.h"
 #include "cytnx.hpp"
@@ -23,7 +24,7 @@ namespace Lanczos_Exp_Ut_Test {
    public:
     OneSiteOp(const int d, const int D, const unsigned int dtype = Type.Double,
               const int& device = Device.cpu)
-        : LinOp("mv", D * D, dtype, device) {
+        : LinOp("mv", D * d * D, dtype, device) {
       EffH = CreateOneSiteEffHam(d, D, dtype, device);
     }
     UniTensor EffH;
@@ -71,6 +72,19 @@ namespace Lanczos_Exp_Ut_Test {
     double coupling_;
   };
 
+  class TwoDimMixingOp : public LinOp {
+   public:
+    TwoDimMixingOp() : LinOp("mv", 2, Type.Double, Device.cpu) {}
+
+    UniTensor matvec(const UniTensor& A) override {
+      auto out = UniTensor::zeros(A.shape(), A.labels(), A.dtype(), A.device());
+      out.set_rowrank_(A.rowrank());
+      out.at({0, 0}) = A.at({1, 0});
+      out.at({1, 0}) = A.at({0, 0});
+      return out;
+    }
+  };
+
   double FloatLanczosExpTolerance() { return 100.0 * std::numeric_limits<float>::epsilon(); }
 
   bool IsSinglePrecisionDType(const unsigned int dtype) {
@@ -96,6 +110,19 @@ namespace Lanczos_Exp_Ut_Test {
     auto ans = UniTensor::zeros({3, 1}, {}, dtype, Device.cpu).set_rowrank_(1);
     ans.at({0, 0}) = std::cosh(coupling * tau);
     ans.at({1, 0}) = std::sinh(coupling * tau);
+    return ans;
+  }
+
+  UniTensor TwoDimInitialState() {
+    auto Tin = UniTensor::zeros({2, 1}, {}, Type.Double, Device.cpu).set_rowrank_(1);
+    Tin.at({0, 0}) = 1.0;
+    return Tin;
+  }
+
+  UniTensor TwoDimExpectedState(const double tau) {
+    auto ans = UniTensor::zeros({2, 1}, {}, Type.Double, Device.cpu).set_rowrank_(1);
+    ans.at({0, 0}) = std::cosh(tau);
+    ans.at({1, 0}) = std::sinh(tau);
     return ans;
   }
 
@@ -161,6 +188,23 @@ namespace Lanczos_Exp_Ut_Test {
     auto ans = Tin * std::exp(3.0 * tau);
     auto err = static_cast<double>((x - ans).Norm().item().real());
 
+    EXPECT_LE(err, crit);
+  }
+
+  TEST(Lanczos_Exp_Ut, FullKrylovSpaceDoesNotWarnAtDimensionLimit) {
+    TwoDimMixingOp op;
+    auto Tin = TwoDimInitialState();
+    const double crit = 1.0e-12;
+    const double tau = 1.0;
+    const unsigned int maxiter = 2;
+
+    testing::internal::CaptureStderr();
+    auto x = linalg::Lanczos_Exp(&op, Tin, tau, crit, maxiter);
+    const std::string stderr_output = testing::internal::GetCapturedStderr();
+    auto ans = TwoDimExpectedState(tau);
+    auto err = static_cast<double>((x - ans).Norm().item().real());
+
+    EXPECT_EQ(stderr_output.find("[WARNING][Lanczos_Exp]"), std::string::npos) << stderr_output;
     EXPECT_LE(err, crit);
   }
 

--- a/tests/linalg_test/Lanczos_Exp_test.cpp
+++ b/tests/linalg_test/Lanczos_Exp_test.cpp
@@ -1,6 +1,8 @@
 #include "gtest/gtest.h"
 
 #include <cmath>
+#include <complex>
+#include <limits>
 
 #include "test_tools.h"
 #include "cytnx.hpp"
@@ -52,6 +54,51 @@ namespace Lanczos_Exp_Ut_Test {
     UniTensor matvec(const UniTensor& A) override { return A * 3.0; }
   };
 
+  class SmallResidualOp : public LinOp {
+   public:
+    explicit SmallResidualOp(const double coupling, const unsigned int dtype = Type.Double)
+        : LinOp("mv", 3, dtype, Device.cpu), coupling_(coupling) {}
+
+    UniTensor matvec(const UniTensor& A) override {
+      auto out = UniTensor::zeros(A.shape(), A.labels(), A.dtype(), A.device());
+      out.set_rowrank_(A.rowrank());
+      out.at({0, 0}) = coupling_ * A.at({1, 0});
+      out.at({1, 0}) = coupling_ * A.at({0, 0});
+      return out;
+    }
+
+   private:
+    double coupling_;
+  };
+
+  double FloatLanczosExpTolerance() { return 100.0 * std::numeric_limits<float>::epsilon(); }
+
+  bool IsSinglePrecisionDType(const unsigned int dtype) {
+    return dtype == Type.Float || dtype == Type.ComplexFloat;
+  }
+
+  UniTensor SmallResidualInitialState(const unsigned int dtype) {
+    UniTensor Tin = UniTensor::zeros({3, 1}, {}, dtype, Device.cpu).set_rowrank_(1);
+    Tin.at({0, 0}) = 1.0;
+    return Tin;
+  }
+
+  UniTensor SmallResidualExpectedState(const double coupling, const double tau,
+                                       const unsigned int dtype) {
+    auto ans = UniTensor::zeros({3, 1}, {}, dtype, Device.cpu).set_rowrank_(1);
+    ans.at({0, 0}) = std::cosh(coupling * tau);
+    ans.at({1, 0}) = std::sinh(coupling * tau);
+    return ans;
+  }
+
+  UniTensor SmallResidualExpectedState(const double coupling, const cytnx_complex128 tau,
+                                       const unsigned int dtype) {
+    auto ans = UniTensor::zeros({3, 1}, {}, dtype, Device.cpu).set_rowrank_(1);
+    ans.at({0, 0}) = std::cosh(coupling * tau);
+    ans.at({1, 0}) = std::sinh(coupling * tau);
+    return ans;
+  }
+
   // describe:Real type test
   TEST(Lanczos_Exp_Ut, RealTypeTest) {
     int d = 2, D = 5;
@@ -62,7 +109,7 @@ namespace Lanczos_Exp_Ut_Test {
     auto x = linalg::Lanczos_Exp(&op, Tin, tau, crit);
     auto ans = GetAns(op.EffH, Tin, tau);
     auto err = static_cast<double>((x - ans).Norm().item().real());
-    EXPECT_TRUE(err <= crit);
+    EXPECT_LE(err, crit);
   }
 
   // describe:Complex type test
@@ -75,7 +122,7 @@ namespace Lanczos_Exp_Ut_Test {
     auto x = linalg::Lanczos_Exp(&op, Tin, tau, crit);
     auto ans = GetAns(op.EffH, Tin, tau);
     auto err = static_cast<double>((x - ans).Norm().item().real());
-    EXPECT_TRUE(err <= crit);
+    EXPECT_LE(err, crit);
   }
 
   // describe:Test non-Hermitian Op but the code will not crash
@@ -100,7 +147,7 @@ namespace Lanczos_Exp_Ut_Test {
     auto x = linalg::Lanczos_Exp(&op, Tin, tau, crit);
     auto ans = GetAns(op.EffH, Tin, tau);
     auto err = static_cast<double>((x - ans).Norm().item().real());
-    EXPECT_TRUE(err <= crit);
+    EXPECT_LE(err, crit);
   }
 
   TEST(Lanczos_Exp_Ut, OneDimensionalKrylovSpace) {
@@ -114,7 +161,86 @@ namespace Lanczos_Exp_Ut_Test {
     auto ans = Tin * std::exp(3.0 * tau);
     auto err = static_cast<double>((x - ans).Norm().item().real());
 
-    EXPECT_TRUE(err <= crit);
+    EXPECT_LE(err, crit);
+  }
+
+  TEST(Lanczos_Exp_Ut, SmallResidualIsNotBreakdown) {
+    const double coupling = 5.0e-7;
+    SmallResidualOp op(coupling);
+    auto Tin = SmallResidualInitialState(Type.Double);
+    const double crit = 1.0e-10;
+    const double tau = 1.0;
+    const unsigned int maxiter = 3;
+
+    auto x = linalg::Lanczos_Exp(&op, Tin, tau, crit, maxiter);
+    auto ans = SmallResidualExpectedState(coupling, tau, Type.Double);
+    auto err = static_cast<double>((x - ans).Norm().item().real());
+
+    EXPECT_LE(err, crit);
+  }
+
+  TEST(Lanczos_Exp_Ut, FloatSmallResidualBelowRoundoffFloor) {
+    const double coupling = 5.0e-6;
+    SmallResidualOp op(coupling, Type.Float);
+    auto Tin = SmallResidualInitialState(Type.Float);
+    const double tau = 1.0;
+    const unsigned int maxiter = 3;
+
+    auto x = linalg::Lanczos_Exp(&op, Tin, tau, 1.0e-10, maxiter);
+    auto ans = SmallResidualExpectedState(coupling, tau, x.dtype());
+    auto err = static_cast<double>((x - ans).Norm().item().real());
+
+    // ExpM currently returns a complex matrix even for this real case. Either
+    // real or complex output is acceptable here, but it must remain single precision.
+    EXPECT_TRUE(IsSinglePrecisionDType(x.dtype()));
+    EXPECT_LE(err, FloatLanczosExpTolerance());
+  }
+
+  TEST(Lanczos_Exp_Ut, FloatResidualAboveRoundoffFloorIsNotBreakdown) {
+    const double coupling = 5.0e-5;
+    SmallResidualOp op(coupling, Type.Float);
+    auto Tin = SmallResidualInitialState(Type.Float);
+    const double tau = 1.0;
+    const unsigned int maxiter = 3;
+
+    auto x = linalg::Lanczos_Exp(&op, Tin, tau, 1.0e-10, maxiter);
+    auto ans = SmallResidualExpectedState(coupling, tau, x.dtype());
+    auto err = static_cast<double>((x - ans).Norm().item().real());
+
+    // ExpM currently returns a complex matrix even for this real case. Either
+    // real or complex output is acceptable here, but it must remain single precision.
+    EXPECT_TRUE(IsSinglePrecisionDType(x.dtype()));
+    EXPECT_LE(err, FloatLanczosExpTolerance());
+  }
+
+  TEST(Lanczos_Exp_Ut, ComplexFloatResidualAboveRoundoffFloorIsNotBreakdown) {
+    const double coupling = 5.0e-5;
+    SmallResidualOp op(coupling, Type.ComplexFloat);
+    auto Tin = SmallResidualInitialState(Type.ComplexFloat);
+    const double tau = 1.0;
+    const unsigned int maxiter = 3;
+
+    auto x = linalg::Lanczos_Exp(&op, Tin, tau, 1.0e-10, maxiter);
+    auto ans = SmallResidualExpectedState(coupling, tau, Type.ComplexFloat);
+    auto err = static_cast<double>((x - ans).Norm().item().real());
+
+    EXPECT_EQ(x.dtype(), Type.ComplexFloat);
+    EXPECT_LE(err, FloatLanczosExpTolerance());
+  }
+
+  TEST(Lanczos_Exp_Ut, FloatComplexTauReturnsComplexFloat) {
+    const double coupling = 5.0e-5;
+    SmallResidualOp op(coupling, Type.Float);
+    auto Tin = SmallResidualInitialState(Type.Float);
+    const cytnx_complex128 tau(0.0, 1.0);
+    const unsigned int maxiter = 3;
+
+    auto x = linalg::Lanczos_Exp(&op, Tin, tau, 1.0e-10, maxiter);
+    auto ans = SmallResidualExpectedState(coupling, tau, Type.ComplexFloat);
+    auto err = static_cast<double>((x - ans).Norm().item().real());
+
+    EXPECT_EQ(x.dtype(), Type.ComplexFloat);
+    EXPECT_LE(err, FloatLanczosExpTolerance());
   }
 
   // describe:test incorrect data type


### PR DESCRIPTION
Base: #890 / `codex/lanczos-exp-beta-breakdown`

This is a stacked follow-up to #890. It fixes a warning path that became visible once the parent stack stopped `Lanczos_Exp` from trying to construct one more Krylov vector than the finite vector-space dimension allows.

This is a regression in observable behavior, but only because the previous off-by-one behavior could mask the case of exhausting the finite space. The old loop would attempt to continue beyond `Hop->nx()`, and that would sometimes cause the `beta=0` "happy breakdown" successful convergence trigger (and also sometimes cause erroneous results). Once the Krylov basis is correctly limited to `Hop->nx()` vectors, the code reaches the end of the iteration loop and the Krylov space is complete so the exponential is numerically exact.

At that point, the projected-exponential coefficient used as a convergence estimator is no longer a reason to warn. It is only a nonconvergence warning when the iterations are stopped because the caller's `Maxiter` is smaller than `Hop->nx()`. If the final vector is reached because `imp_maxiter == Hop->nx()`, the Krylov basis spans the full finite vector space, so the calculation has exhausted the available space and should stop without a nonconvergence warning, regardless of the last projected-exponential coefficient.

This PR changes the convergence loop to:

- break immediately when the projected-exponential estimator passes;
- otherwise break at the final allocated Krylov vector;
- emit the nonconvergence warning only when that final vector was reached because `Maxiter < Hop->nx()`.

It also cleans up the warning text.

The regression test uses a two-dimensional mixing operator where the full Krylov space is reached and the last projected-exponential coefficient is nonzero. This is the case the old off-by-one loop did not test cleanly: the exact finite-space result should be returned without a `Lanczos_Exp` warning.

Verification:

```text
cmake --build /tmp/cytnx-tdvp-build --target test_main -j 8
/tmp/cytnx-tdvp-build/tests/test_main --gtest_filter=Lanczos_Exp_Ut.*
```

The focused `Lanczos_Exp_Ut.*` suite passes locally.

I also rebuilt `pycytnx` and reran the deterministic TDVP probe with `chi = 1`; it converges to energy `-8.000000000000009+0j` with error `8.88e-15` and no `Lanczos_Exp` warning.

Co-authored-by: Codex <codex@openai.com>