### PR TITLE
Restore type-checked Tensor pointer access in ARPACK wrappers

### DIFF
--- a/docs/source/guide/basic_obj/Tensor_3_access.rst
+++ b/docs/source/guide/basic_obj/Tensor_3_access.rst
@@ -121,4 +121,28 @@ In the following, let's see how it can be used to get/set the elements from/in a
 
     If your code makes frequent use of get/set elements, using the low-level API can reduce the overhead.
 
+Raw pointer access (C++ only)
+*****************************
+``Tensor::ptr_as<T>()`` and ``Tensor::gpu_ptr_as<T>()`` expose the raw storage
+address of a Tensor. They are intended for low-level library code and should be
+used with care.
+
+Use ``ptr_as<T>()`` when ``T`` is the logical Cytnx element type of the Tensor.
+This is the correct accessor for ordinary C++ code and for raw memory-copy
+interfaces such as ``memcpy`` or ``cudaMemcpy``. For complex tensors, the logical
+type is ``std::complex<double>`` or ``std::complex<float>``.
+
+Use ``gpu_ptr_as<T>()`` only when passing Tensor storage to CUDA APIs that require
+CUDA ABI element types. For complex tensors, this means ``cuDoubleComplex`` or
+``cuComplex``.
+
+Both accessors return the same underlying storage address. The difference is the
+dtype mapping they validate before returning it:
+
+* ``ptr_as<T>()`` checks ``T`` against the normal Cytnx type list.
+* ``gpu_ptr_as<T>()`` checks ``T`` against the CUDA type list.
+
+If a function only needs an address for a byte copy, keep the typed pointer from
+``ptr_as<T>()`` and pass it directly to the copy routine.
+
 .. toctree::

--- a/include/Tensor.hpp
+++ b/include/Tensor.hpp
@@ -512,17 +512,18 @@ namespace cytnx {
     // convert this->_impl->_storage._impl->Mem to a typed variant of pointers, excluding void*
     pointer_types ptr() const;
 
-    // convert this->_impl->_strorage->Mem to the given pointer type.
-    // Throws an exception if T does not match this->dtype
+    // Convert storage to the logical Cytnx element pointer type.
+    //
+    // Use ptr_as<T>() for host code and raw memory copies, including cudaMemcpy. For complex
+    // tensors, T is std::complex<...>. Use gpu_ptr_as<T>() only for CUDA APIs that require CUDA
+    // ABI element types such as cuDoubleComplex or cuComplex.
     template <typename T>
-    T *ptr_as(bool check_type = true) const {
-      if (check_type) {
-        cytnx_error_msg(this->dtype() != Type_class::cy_typeid_v<std::remove_cv_t<T>>,
-                        "[ERROR] Attempt to convert dtype %d (%s) to pointer of type %s",
-                        this->dtype(), Type_class::getname(this->dtype()).c_str(),
-                        Type_class::getname(Type_class::cy_typeid_v<std::remove_cv_t<T>>).c_str());
-      }
-      return reinterpret_cast<T *>(this->_impl->_storage._impl->data());
+    T *ptr_as() const {
+      cytnx_error_msg(this->dtype() != Type_class::cy_typeid_v<std::remove_cv_t<T>>,
+                      "[ERROR] Attempt to convert dtype %d (%s) to pointer of type %s",
+                      this->dtype(), Type_class::getname(this->dtype()).c_str(),
+                      Type_class::getname(Type_class::cy_typeid_v<std::remove_cv_t<T>>).c_str());
+      return static_cast<T *>(this->_impl->_storage._impl->data());
     }
 
   #ifdef UNI_GPU
@@ -534,18 +535,18 @@ namespace cytnx {
     // convert this->_impl->_storage->Mem to a typed variant of pointers, excluding void*
     gpu_pointer_types gpu_ptr() const;
 
-    // convert this->_impl->_strorage->Mem to the given pointer type.
-    // Throws an exception if T does not match this->dtype
+    // Convert storage to the CUDA ABI element pointer type.
+    //
+    // This is for CUDA/cuBLAS/cuSOLVER/kernel interfaces. Generic host code and cudaMemcpy byte
+    // copies should use ptr_as<T>() so the logical Cytnx dtype mapping is checked.
     template <typename T>
-    T *gpu_ptr_as(bool check_type = true) const {
-      if (check_type) {
-        cytnx_error_msg(
-          this->dtype() != Type_class::cy_typeid_gpu_v<std::remove_cv_t<T>>,
-          "[ERROR] Attempt to convert dtype %d (%s) to GPU pointer of type %s", this->dtype(),
-          Type_class::getname(this->dtype()).c_str(),
-          Type_class::getname(Type_class::cy_typeid_gpu_v<std::remove_cv_t<T>>).c_str());
-      }
-      return reinterpret_cast<T *>(this->_impl->_storage._impl->data());
+    T *gpu_ptr_as() const {
+      cytnx_error_msg(
+        this->dtype() != Type_class::cy_typeid_gpu_v<std::remove_cv_t<T>>,
+        "[ERROR] Attempt to convert dtype %d (%s) to GPU pointer of type %s", this->dtype(),
+        Type_class::getname(this->dtype()).c_str(),
+        Type_class::getname(Type_class::cy_typeid_gpu_v<std::remove_cv_t<T>>).c_str());
+      return static_cast<T *>(this->_impl->_storage._impl->data());
     }
   #endif
 

--- a/src/linalg/Arnoldi.cpp
+++ b/src/linalg/Arnoldi.cpp
@@ -21,31 +21,12 @@ namespace cytnx {
     static T* get_obj_data_ptr(const T_ten& buffer, const cytnx_int32 bk_idx = 0) {
       if constexpr (std::is_same_v<T_ten, UniTensor>) {
         if (buffer.uten_type() == UTenType.Block || buffer.uten_type() == UTenType.BlockFermionic) {
-          if (buffer.device() == Device.cpu) {
-            return buffer.get_blocks_()[bk_idx].template ptr_as<T>();
-          } else {  // on cuda
-  #ifdef UNI_GPU
-            return reinterpret_cast<T*>(
-              buffer.get_blocks_()[bk_idx].template gpu_ptr_as<void>(false));
-  #endif
-          }
+          return buffer.get_blocks_()[bk_idx].template ptr_as<T>();
         } else if (buffer.uten_type() == UTenType.Dense) {
-          if (buffer.device() == Device.cpu) {
-            return buffer.get_block_().template ptr_as<T>();
-          } else {  // on cuda
-  #ifdef UNI_GPU
-            return reinterpret_cast<T*>(buffer.get_block_().template gpu_ptr_as<void>(false));
-  #endif
-          }
+          return buffer.get_block_().template ptr_as<T>();
         }
       } else if constexpr (std::is_same_v<T_ten, Tensor>) {
-        if (buffer.device() == Device.cpu) {
-          return buffer.template ptr_as<T>();
-        } else {  // cuda
-  #ifdef UNI_GPU
-          return reinterpret_cast<T*>(buffer.template gpu_ptr_as<void>(false));
-  #endif
-        }
+        return buffer.template ptr_as<T>();
       }
     }
 
@@ -357,17 +338,16 @@ namespace cytnx {
       }
 
       if (is_V) {
-        T* z_data_ptr = reinterpret_cast<T*>(z);
         if constexpr (std::is_same_v<T_ten, UniTensor>) {
           for (cytnx_int32 ik = 0; ik < k; ++ik) {
-            T* z_k_ptr = z_data_ptr + sorted_idx[ik] * dim;
+            T* z_k_ptr = z + sorted_idx[ik] * dim;
             pass_data_UT<T, T_ten>(out[ik + 1], z_k_ptr, true);
           }
         } else if constexpr (std::is_same_v<T_ten, Tensor>) {
           T* tens_data = get_obj_data_ptr<T, T_ten>(out[1]);
           for (cytnx_int32 ik = 0; ik < k; ++ik) {
             T* tmp_data = tens_data + ik * dim;
-            T* z_k_ptr = z_data_ptr + sorted_idx[ik] * dim;
+            T* z_k_ptr = z + sorted_idx[ik] * dim;
             if (Hop->device() == Device.cpu) {
               memcpy(tmp_data, z_k_ptr, dim * sizeof(T));
             } else {
@@ -547,7 +527,6 @@ namespace cytnx {
       }
       if (is_V) {
         const T img_tol = std::numeric_limits<T>::epsilon() * 100;
-        T* z_data_ptr = reinterpret_cast<T*>(z);
         auto z_ptr_shifts = std::vector<cytnx_int64>(nconv, 0);
         cytnx_int64 tmp = 0;
         z_ptr_shifts.at(0) = tmp;

--- a/src/linalg/Lanczos.cpp
+++ b/src/linalg/Lanczos.cpp
@@ -24,31 +24,12 @@ namespace cytnx {
     static T *get_obj_data_ptr(const T_ten &buffer, const cytnx_int32 bk_idx = 0) {
       if constexpr (std::is_same_v<T_ten, UniTensor>) {
         if (buffer.uten_type() == UTenType.Block || buffer.uten_type() == UTenType.BlockFermionic) {
-          if (buffer.device() == Device.cpu) {
-            return buffer.get_blocks_()[bk_idx].template ptr_as<T>();
-          } else {  // on cuda
-  #ifdef UNI_GPU
-            return reinterpret_cast<T *>(
-              buffer.get_blocks_()[bk_idx].template gpu_ptr_as<void>(false));
-  #endif
-          }
+          return buffer.get_blocks_()[bk_idx].template ptr_as<T>();
         } else if (buffer.uten_type() == UTenType.Dense) {
-          if (buffer.device() == Device.cpu) {
-            return buffer.get_block_().template ptr_as<T>();
-          } else {  // on cuda
-  #ifdef UNI_GPU
-            return reinterpret_cast<T *>(buffer.get_block_().template gpu_ptr_as<void>(false));
-  #endif
-          }
+          return buffer.get_block_().template ptr_as<T>();
         }
       } else if constexpr (std::is_same_v<T_ten, Tensor>) {
-        if (buffer.device() == Device.cpu) {
-          return buffer.template ptr_as<T>();
-        } else {  // cuda
-  #ifdef UNI_GPU
-          return reinterpret_cast<T *>(buffer.template gpu_ptr_as<void>(false));
-  #endif
-        }
+        return buffer.template ptr_as<T>();
       }
     }
 
@@ -396,17 +377,16 @@ namespace cytnx {
       }
 
       if (is_V) {
-        T *z_data_ptr = reinterpret_cast<T *>(z);
         if constexpr (std::is_same_v<T_ten, UniTensor>) {
           for (cytnx_int32 ik = 0; ik < k; ++ik) {
-            T *z_k_ptr = z_data_ptr + sorted_idx[ik] * dim;
+            T *z_k_ptr = z + sorted_idx[ik] * dim;
             pass_data_UT<T, T_ten>(out[ik + 1], z_k_ptr, true);
           }
         } else if constexpr (std::is_same_v<T_ten, Tensor>) {
           T *tens_data = get_obj_data_ptr<T, T_ten>(out[1]);
           for (cytnx_int32 ik = 0; ik < k; ++ik) {
             T *tmp_data = tens_data + ik * dim;
-            T *z_k_ptr = z_data_ptr + sorted_idx[ik] * dim;
+            T *z_k_ptr = z + sorted_idx[ik] * dim;
             if (Hop->device() == Device.cpu) {
               memcpy(tmp_data, z_k_ptr, dim * sizeof(T));
             } else {


### PR DESCRIPTION
This removes an unsafe bypass to the Tensor pointer-access type-safety mechanism. The accessor API had grown a `check_type=false` flag, turning a type-checked wrapper into an unchecked cast helper. That defeats the point of having `ptr_as<T>()` and `gpu_ptr_as<T>()` in the first place.

The ARPACK Arnoldi/Lanczos GPU data path used that bypass together with a`reinterpret_cast<T*>`, so the dtype checks in the typed Tensor pointer accessors were no longer enforced there, then the surrounding code cast it to the same `T*` that `ptr_as<T>()` would have checked and returned.

This is exactly the kind of low-level shortcut that makes runtime dtype systems fragile: the code still compiles, but the type mapping that is supposed to distinguish Cytnx logical element types from CUDA ABI element types is no longerbeing enforced.

This PR restores the intended contract:

* `Tensor::ptr_as<T>()` always checks `T` against the normal Cytnx logical type list, and returns the storage address with a normal `static_cast` from `void*`.
* `Tensor::gpu_ptr_as<T>()` always checks `T` against the CUDA type list, and is reserved for CUDA APIs that expect CUDA ABI element types such as `cuComplex` or `cuDoubleComplex`.
* The ARPACK wrappers now use `ptr_as<T>()` for their raw data-copy path. That is the correct accessor here: the code is copying bytes to/from ARPACK host buffers with `memcpy()` or `cudaMemcpy()`, not passing the pointer to a CUDA complex API that expects `cuComplex` or `cuDoubleComplex`.
* The intended use of `ptr_as<T>()` and `gpu_ptr_as<T>()` is documented in `docs/source/guide/basic_obj/Tensor_3_access.rst`, and the comments beside the accessor definitions in `include/Tensor.hpp` better describe the same distinction.

With that change, the CPU and GPU branches in the ARPACK helper were identical, so the redundant `#ifdef UNI_GPU` pointer-retrieval branches were removed. A few redundant `reinterpret_cast<T*>(z)` casts were also removed where `z` was already declared as `T*`.

This PR deliberately does not attempt to audit every `reinterpret_cast` in the codebase. There are several other uses that appear erroneous or at least highly questionable, but they are outside the scope of this targeted fix. The important point here is to remove the public pointer-access bypass and the ARPACK use of it, because that combination made it easy to silently defeat the dtype checks at a central Tensor API boundary. I also note that the ARPACK wrapper helper code to get the object pointer is considerably simplified in the process.

Also not touched in this PR, names such as `_Arnoldi`, that use a spelling reserved by the C++ standard for implementations.

Verification:

* `git diff --check`
* CPU: `/tmp/cytnx-lanczos-exp-test-build/tests/test_main --gtest_filter='Arnoldi*:*Lanczos*'`
  passed, 75 tests.
* GPU: `/tmp/cytnx-gpu-arpack-build/tests/gpu/gpu_test_main --gtest_filter='Arnoldi*.gpu*:*Arnoldi*:Lanczos*.gpu*:*Lanczos*'`
  passed, 29 tests, on a dual-GV100 machine.

Co-authored-by: Codex <codex@openai.com>