### PR TITLE
Fix Cytnx error formatting

### DIFF
--- a/include/cytnx_error.hpp
+++ b/include/cytnx_error.hpp
@@ -1,9 +1,11 @@
 #ifndef CYTNX_CYTNX_ERROR_H_
 #define CYTNX_CYTNX_ERROR_H_
 
+#include <algorithm>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <cctype>
 #include <cstring>
 
 #include <iostream>
@@ -78,6 +80,17 @@ namespace cytnx_error_detail {
 #endif
   }
 
+  static inline bool stack_trace_setting_enabled(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return !(value == "0" || value == "false" || value == "off" || value == "no");
+  }
+
+  static inline bool stack_trace_enabled() {
+    const char *setting = std::getenv("CYTNX_STACKTRACE");
+    return setting == nullptr || stack_trace_setting_enabled(std::string(setting));
+  }
+
 }  // namespace cytnx_error_detail
 
 #define cytnx_error(format, ...) \
@@ -100,7 +113,9 @@ static inline void error_msg(char const *const func, const char *const file, int
   const std::string output_str =
     cytnx_error_detail::format_report("error", func, file, line, message);
   std::cerr << output_str << std::endl;
-  cytnx_error_detail::print_stack_trace();
+  if (cytnx_error_detail::stack_trace_enabled()) {
+    cytnx_error_detail::print_stack_trace();
+  }
   throw std::logic_error(output_str);
 }
 #define cytnx_warning(format, ...) \

--- a/include/cytnx_error.hpp
+++ b/include/cytnx_error.hpp
@@ -1,13 +1,16 @@
 #ifndef CYTNX_CYTNX_ERROR_H_
 #define CYTNX_CYTNX_ERROR_H_
 
+#include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <stdarg.h>
 
 #include <iostream>
 #include <stdexcept>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #if defined(__has_include)
   #if __has_include(<execinfo.h>)
@@ -24,62 +27,99 @@
   #define __PRETTY_FUNCTION__ __FUNCTION__
 #endif
 
-#define cytnx_error_msg(is_true, format, ...)                                               \
-  {                                                                                         \
-    if (is_true)                                                                            \
-      error_msg(__PRETTY_FUNCTION__, __FILE__, __LINE__, (is_true), (format), __VA_ARGS__); \
+namespace cytnx_error_detail {
+
+  static inline std::string format_message(char const *format, va_list args) {
+    if (format == nullptr) {
+      return {};
+    }
+
+    va_list count_args;
+    va_copy(count_args, args);
+    const int count = std::vsnprintf(nullptr, 0, format, count_args);
+    va_end(count_args);
+    if (count < 0) {
+      return std::string("[formatting failed] ") + format;
+    }
+
+    std::vector<char> buffer(static_cast<std::size_t>(count) + 1);
+    const int written = std::vsnprintf(buffer.data(), buffer.size(), format, args);
+    if (written < 0) {
+      return std::string("[formatting failed] ") + format;
+    }
+    return std::string(buffer.data(), static_cast<std::size_t>(written));
   }
-static inline void error_msg(char const *const func, const char *const file, int const line,
-                             bool is_true, char const *format, ...) {
-  // try {
-  if (is_true) {
-    va_list args;
-    char output_str[1024];
-    char msg[512];
-    va_start(args, format);
-    vsprintf(msg, format, args);
-    sprintf(output_str, "\n# Cytnx error occur at %s\n# error: %s\n# file : %s (%d)", func, msg,
-            file, line);
-    va_end(args);
-    // std::cerr << output_str << std::endl;
-    std::cerr << output_str << std::endl;
+
+  static inline std::string format_report(char const *kind, char const *func, char const *file,
+                                          int line, const std::string &message) {
+    std::ostringstream out;
+    out << "\n# Cytnx " << kind << " occur at " << func << "\n# " << kind << ": " << message
+        << "\n# file : " << file << " (" << line << ")";
+    return out.str();
+  }
+
+  static inline void print_stack_trace() {
 #if CYTNX_HAS_EXECINFO
     std::cerr << "Stack trace:" << std::endl;
     void *array[10];
-    std::size_t size;
-    size = backtrace(array, 10);
+    const std::size_t size = backtrace(array, 10);
     char **strings = backtrace_symbols(array, size);
-    for (std::size_t i = 0; i < size; i++) {
-      std::cerr << strings[i] << std::endl;
+    if (strings != nullptr) {
+      for (std::size_t i = 0; i < size; i++) {
+        std::cerr << strings[i] << std::endl;
+      }
+      free(strings);
     }
-    free(strings);
 #else
     std::cerr << "Stack trace is unavailable on this platform/compiler." << std::endl;
 #endif
-    throw std::logic_error(output_str);
   }
-  // } catch (const char *output_msg) {
-  //   std::cerr << output_msg << std::endl;
-  // }
-}
-#define cytnx_warning_msg(is_true, format, ...)                                               \
+
+}  // namespace cytnx_error_detail
+
+#define cytnx_error(format, ...) \
+  { error_msg(__PRETTY_FUNCTION__, __FILE__, __LINE__, (format)__VA_OPT__(, ) __VA_ARGS__); }
+#define cytnx_error_if(is_true, format, ...)                                                  \
   {                                                                                           \
-    if (is_true)                                                                              \
-      warning_msg(__PRETTY_FUNCTION__, __FILE__, __LINE__, (is_true), (format), __VA_ARGS__); \
+    if (is_true) {                                                                            \
+      error_msg(__PRETTY_FUNCTION__, __FILE__, __LINE__, (format)__VA_OPT__(, ) __VA_ARGS__); \
+    }                                                                                         \
   }
+#define cytnx_error_msg(is_true, format, ...) \
+  cytnx_error_if(is_true, format __VA_OPT__(, ) __VA_ARGS__)
+static inline void error_msg(char const *const func, const char *const file, int const line,
+                             char const *format, ...) {
+  va_list args;
+  va_start(args, format);
+  const std::string message = cytnx_error_detail::format_message(format, args);
+  va_end(args);
+
+  const std::string output_str =
+    cytnx_error_detail::format_report("error", func, file, line, message);
+  std::cerr << output_str << std::endl;
+  cytnx_error_detail::print_stack_trace();
+  throw std::logic_error(output_str);
+}
+#define cytnx_warning(format, ...) \
+  { warning_msg(__PRETTY_FUNCTION__, __FILE__, __LINE__, (format)__VA_OPT__(, ) __VA_ARGS__); }
+#define cytnx_warning_if(is_true, format, ...)                                                  \
+  {                                                                                             \
+    if (is_true) {                                                                              \
+      warning_msg(__PRETTY_FUNCTION__, __FILE__, __LINE__, (format)__VA_OPT__(, ) __VA_ARGS__); \
+    }                                                                                           \
+  }
+#define cytnx_warning_msg(is_true, format, ...) \
+  cytnx_warning_if(is_true, format __VA_OPT__(, ) __VA_ARGS__)
 static inline void warning_msg(char const *const func, const char *const file, int const line,
-                               bool is_true, char const *format, ...) {
-  if (is_true) {
-    va_list args;
-    char output_str[1024];
-    char msg[512];
-    va_start(args, format);
-    vsprintf(msg, format, args);
-    sprintf(output_str, "\n# Cytnx warning occur at %s\n# warning: %s\n# file : %s (%d)", func, msg,
-            file, line);
-    va_end(args);
-    std::cerr << output_str << std::endl;
-  }
+                               char const *format, ...) {
+  va_list args;
+  va_start(args, format);
+  const std::string message = cytnx_error_detail::format_message(format, args);
+  va_end(args);
+
+  const std::string output_str =
+    cytnx_error_detail::format_report("warning", func, file, line, message);
+  std::cerr << output_str << std::endl;
 }
 
 #if defined(UNI_GPU)

--- a/include/cytnx_error.hpp
+++ b/include/cytnx_error.hpp
@@ -43,7 +43,10 @@ namespace cytnx_error_detail {
     }
 
     std::vector<char> buffer(static_cast<std::size_t>(count) + 1);
-    const int written = std::vsnprintf(buffer.data(), buffer.size(), format, args);
+    va_list write_args;
+    va_copy(write_args, args);
+    const int written = std::vsnprintf(buffer.data(), buffer.size(), format, write_args);
+    va_end(write_args);
     if (written < 0) {
       return std::string("[formatting failed] ") + format;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(
   BlockFermionicUniTensor_test.cpp
   DenseUniTensor_test.cpp
   Accessor_test.cpp
+  cytnx_error_test.cpp
   Tensor_test.cpp
   Storage_test.cpp
   search_tree_test.cpp

--- a/tests/cytnx_error_test.cpp
+++ b/tests/cytnx_error_test.cpp
@@ -2,10 +2,37 @@
 
 #include "cytnx_error.hpp"
 
+#include <cstdlib>
+#include <optional>
 #include <stdexcept>
 #include <string>
 
 namespace {
+
+  class ScopedStackTraceEnv {
+   public:
+    explicit ScopedStackTraceEnv(const char *value) {
+      const char *old_value = std::getenv("CYTNX_STACKTRACE");
+      if (old_value != nullptr) {
+        old_value_ = old_value;
+      }
+      setenv("CYTNX_STACKTRACE", value, 1);
+    }
+
+    ~ScopedStackTraceEnv() {
+      if (old_value_.has_value()) {
+        setenv("CYTNX_STACKTRACE", old_value_->c_str(), 1);
+      } else {
+        unsetenv("CYTNX_STACKTRACE");
+      }
+    }
+
+    ScopedStackTraceEnv(const ScopedStackTraceEnv &) = delete;
+    ScopedStackTraceEnv &operator=(const ScopedStackTraceEnv &) = delete;
+
+   private:
+    std::optional<std::string> old_value_;
+  };
 
   TEST(CytnxErrorTest, ErrorMessageSupportsLongFormattedText) {
     const std::string payload(2000, 'x');
@@ -63,6 +90,30 @@ namespace {
     const std::string stderr_output = testing::internal::GetCapturedStderr();
 
     EXPECT_TRUE(stderr_output.empty());
+  }
+
+  TEST(CytnxErrorTest, StackTraceEnvironmentParserIsCaseInsensitive) {
+    EXPECT_FALSE(cytnx_error_detail::stack_trace_setting_enabled("Off"));
+    EXPECT_FALSE(cytnx_error_detail::stack_trace_setting_enabled("FALSE"));
+    EXPECT_FALSE(cytnx_error_detail::stack_trace_setting_enabled("No"));
+    EXPECT_TRUE(cytnx_error_detail::stack_trace_setting_enabled("1"));
+    EXPECT_TRUE(cytnx_error_detail::stack_trace_setting_enabled("on"));
+  }
+
+  TEST(CytnxErrorTest, StackTraceCanBeDisabledByEnvironment) {
+    ScopedStackTraceEnv stack_trace("Off");
+
+    testing::internal::CaptureStderr();
+    try {
+      cytnx_error("stack trace disabled");
+      FAIL() << "Expected cytnx_error to throw.";
+    } catch (const std::logic_error &err) {
+      const std::string stderr_output = testing::internal::GetCapturedStderr();
+      const std::string message = err.what();
+      EXPECT_NE(message.find("stack trace disabled"), std::string::npos);
+      EXPECT_NE(stderr_output.find("stack trace disabled"), std::string::npos);
+      EXPECT_EQ(stderr_output.find("Stack trace"), std::string::npos);
+    }
   }
 
 }  // namespace

--- a/tests/cytnx_error_test.cpp
+++ b/tests/cytnx_error_test.cpp
@@ -1,0 +1,68 @@
+#include <gtest/gtest.h>
+
+#include "cytnx_error.hpp"
+
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+  TEST(CytnxErrorTest, ErrorMessageSupportsLongFormattedText) {
+    const std::string payload(2000, 'x');
+
+    testing::internal::CaptureStderr();
+    try {
+      cytnx_error("long message: %s", payload.c_str());
+      FAIL() << "Expected cytnx_error to throw.";
+    } catch (const std::logic_error &err) {
+      const std::string stderr_output = testing::internal::GetCapturedStderr();
+      const std::string message = err.what();
+      EXPECT_NE(message.find("# Cytnx error occur at"), std::string::npos);
+      EXPECT_NE(message.find("long message: " + payload), std::string::npos);
+      EXPECT_NE(stderr_output.find("long message: " + payload), std::string::npos);
+    }
+  }
+
+  TEST(CytnxErrorTest, ErrorMessageDoesNotNeedDummyVarargs) {
+    testing::internal::CaptureStderr();
+    try {
+      cytnx_error_if(true, "plain message without dummy varargs");
+      FAIL() << "Expected cytnx_error_if to throw.";
+    } catch (const std::logic_error &err) {
+      testing::internal::GetCapturedStderr();
+      const std::string message = err.what();
+      EXPECT_NE(message.find("plain message without dummy varargs"), std::string::npos);
+    }
+  }
+
+  TEST(CytnxErrorTest, WarningMessageSupportsLongFormattedText) {
+    const std::string payload(2000, 'w');
+
+    testing::internal::CaptureStderr();
+    cytnx_warning("long warning: %s", payload.c_str());
+    const std::string stderr_output = testing::internal::GetCapturedStderr();
+
+    EXPECT_NE(stderr_output.find("# Cytnx warning occur at"), std::string::npos);
+    EXPECT_NE(stderr_output.find("long warning: " + payload), std::string::npos);
+  }
+
+  TEST(CytnxErrorTest, WarningMessageDoesNotNeedDummyVarargs) {
+    testing::internal::CaptureStderr();
+    cytnx_warning_if(true, "plain warning without dummy varargs");
+    const std::string stderr_output = testing::internal::GetCapturedStderr();
+
+    EXPECT_NE(stderr_output.find("plain warning without dummy varargs"), std::string::npos);
+  }
+
+  TEST(CytnxErrorTest, ConditionalAliasesDoNothingWhenFalse) {
+    testing::internal::CaptureStderr();
+    cytnx_error_if(false, "suppressed error");
+    cytnx_warning_if(false, "suppressed warning");
+    cytnx_error_msg(false, "suppressed legacy error");
+    cytnx_warning_msg(false, "suppressed legacy warning");
+    const std::string stderr_output = testing::internal::GetCapturedStderr();
+
+    EXPECT_TRUE(stderr_output.empty());
+  }
+
+}  // namespace

--- a/tests/cytnx_error_test.cpp
+++ b/tests/cytnx_error_test.cpp
@@ -2,37 +2,10 @@
 
 #include "cytnx_error.hpp"
 
-#include <cstdlib>
-#include <optional>
 #include <stdexcept>
 #include <string>
 
 namespace {
-
-  class ScopedStackTraceEnv {
-   public:
-    explicit ScopedStackTraceEnv(const char *value) {
-      const char *old_value = std::getenv("CYTNX_STACKTRACE");
-      if (old_value != nullptr) {
-        old_value_ = old_value;
-      }
-      setenv("CYTNX_STACKTRACE", value, 1);
-    }
-
-    ~ScopedStackTraceEnv() {
-      if (old_value_.has_value()) {
-        setenv("CYTNX_STACKTRACE", old_value_->c_str(), 1);
-      } else {
-        unsetenv("CYTNX_STACKTRACE");
-      }
-    }
-
-    ScopedStackTraceEnv(const ScopedStackTraceEnv &) = delete;
-    ScopedStackTraceEnv &operator=(const ScopedStackTraceEnv &) = delete;
-
-   private:
-    std::optional<std::string> old_value_;
-  };
 
   TEST(CytnxErrorTest, ErrorMessageSupportsLongFormattedText) {
     const std::string payload(2000, 'x');
@@ -98,22 +71,6 @@ namespace {
     EXPECT_FALSE(cytnx_error_detail::stack_trace_setting_enabled("No"));
     EXPECT_TRUE(cytnx_error_detail::stack_trace_setting_enabled("1"));
     EXPECT_TRUE(cytnx_error_detail::stack_trace_setting_enabled("on"));
-  }
-
-  TEST(CytnxErrorTest, StackTraceCanBeDisabledByEnvironment) {
-    ScopedStackTraceEnv stack_trace("Off");
-
-    testing::internal::CaptureStderr();
-    try {
-      cytnx_error("stack trace disabled");
-      FAIL() << "Expected cytnx_error to throw.";
-    } catch (const std::logic_error &err) {
-      const std::string stderr_output = testing::internal::GetCapturedStderr();
-      const std::string message = err.what();
-      EXPECT_NE(message.find("stack trace disabled"), std::string::npos);
-      EXPECT_NE(stderr_output.find("stack trace disabled"), std::string::npos);
-      EXPECT_EQ(stderr_output.find("Stack trace"), std::string::npos);
-    }
   }
 
 }  // namespace


### PR DESCRIPTION
## Summary

At long last...

This PR is the first step to cleaning up the error reporting in cytnx.  

It does not yet change any of the uses of `cytnx_error_msg()` or `cytnx_warning_msg()`, this first PR simply cleans up the implementation and adds clearer macro names:

- `cytnx_error(...)` for unconditional errors
- `cytnx_error_if(condition, ...)` for conditional errors
- `cytnx_warning(...)` for unconditional warnings
- `cytnx_warning_if(condition, ...)` for conditional warnings

The existing `cytnx_error_msg()` and `cytnx_warning_msg()` names remain available as compatibility aliases for the conditional forms.

The implementation has been cleaned up to use dynamically sized buffers, avoiding the overflow problems of the old code that would format into 512-byte or 1024-byte stack buffers and overflow the buffer on a larger message.

It also fixes the old problem that `cytnx_error_msg(cond, msg)` was not valid, it was always required to add at least one more _varargs_ parameter, hence the large number of appearances of code similar to
```c++
cytnx_error_msg(true, "An error happened.%s", "\n");
```

This can be replaced with
```c++
cytnx_error("An error happened.");
```

Note that it is not, and has never been, necessary to add a newline `"\n"` at the end of cytnx error messages.

The confusing naming of `cytnx_error_msg()` is perhaps the reason why there are many instances of code such as
```c++
if (n != 1) cytnx_error_msg(true, "%s", "[ERROR] U1Symmetry should set n = 1");
```

After this PR, this can be replaced with
```c++
cytnx_error_if(n != 1, "[ERROR] U1Symmetry should set n = 1");
```
Or, if the developer prefers,
```c++
if (n != 1) cytnx_error("[ERROR] U1Symmetry should set n = 1");
```

The updated version also adds a capability to set the environment variable `CYTNX_STACKTRACE=0` (or `no`/`off`/`false`) to disable printing stacktraces on error.  This is purely to reduce the amount of terminal output when running tests of the error handling system ;-)

## Future directions

If this PR is accepted, the next steps are reasonably straightforward:
1. Use AI to scan the entire codebase and replace `cytnx_error_msg()` and `cytnx_warning_msg()` calls with the appropriate conditional or unconditional new spelling, and clean up the syntax.
2. After the syntax is cleaned up, it should be simple to replace the `printf`-based formatter with `std::format()` formatting, which is type-safe and avoids future problems such as the existing: (src/backend/Storage_base.cpp:657)
```c++
cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
```
`idx` and `size()` are not `int`; this is undefined behavior. A future `std::format()` version would transform this into
```c++
cytnx_error("[ERROR] index [{}] out of bound [{}]", idx, this->size());
```
and it will be detected at compile time if the number of parameters does not match the number of substitutions.

## Notes

The compatibility macros intentionally keep the old block-style expansion rather than using the usual `do { ... } while (false)` idiom, because existing code contains call sites that omit the trailing semicolon before an `else`. This can also be fixed as part of the future cleanup.

## Tests

- `cmake --build build-mdspan --target test_main -j 8`
- `./build-mdspan/tests/test_main --gtest_filter=CytnxErrorTest.*`
