### PR TITLE
Add typed mdspan Tensor views

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ ENDIF ()
 add_library(cytnx STATIC)
 set_property(TARGET cytnx PROPERTY C_VISIBILITY_PRESET hidden)
 set_property(TARGET cytnx PROPERTY VISIBILITY_INLINES_HIDDEN ON)
+target_compile_features(cytnx PUBLIC cxx_std_20)
 
 target_include_directories(cytnx
   PRIVATE

--- a/include/Tensor.hpp
+++ b/include/Tensor.hpp
@@ -9,6 +9,8 @@
 #include <fstream>
 #include "utils/dynamic_arg_resolver.hpp"
 #include "Accessor.hpp"
+#include "mdspan.hpp"
+#include <array>
 #include <utility>
 #include <vector>
 #include <initializer_list>
@@ -524,6 +526,74 @@ namespace cytnx {
                       this->dtype(), Type_class::getname(this->dtype()).c_str(),
                       Type_class::getname(Type_class::cy_typeid_v<std::remove_cv_t<T>>).c_str());
       return static_cast<T *>(this->_impl->_storage._impl->data());
+    }
+
+    /**
+     * @brief Return a non-owning typed mdspan view of the Tensor storage.
+     *
+     * The returned view preserves the Tensor's current logical layout, including non-contiguous
+     * permutations, using a `stdex::layout_stride` mapping. The Tensor storage must outlive the
+     * returned mdspan. The template type and rank must match the Tensor dtype and rank.
+     */
+    template <typename T, std::size_t Rank>
+    auto as_mdspan() const {
+      using element_type = std::remove_cv_t<T>;
+      using extents_type = stdex::dextents<std::size_t, Rank>;
+      using mapping_type = typename stdex::layout_stride::template mapping<extents_type>;
+
+      cytnx_error_msg(this->dtype() != Type_class::cy_typeid_v<element_type>,
+                      "[ERROR] Attempt to convert dtype %d (%s) to mdspan of type %s",
+                      this->dtype(), Type_class::getname(this->dtype()).c_str(),
+                      Type_class::getname(Type_class::cy_typeid_v<element_type>).c_str());
+      cytnx_error_msg(
+        this->rank() != Rank, "[ERROR] Attempt to view rank-%llu Tensor as rank-%llu mdspan.%s",
+        static_cast<unsigned long long>(this->rank()), static_cast<unsigned long long>(Rank), "\n");
+
+      std::array<std::size_t, Rank> extents{};
+      std::array<std::size_t, Rank> strides{};
+      for (std::size_t i = 0; i < Rank; ++i) {
+        extents[i] = static_cast<std::size_t>(this->_impl->_shape[i]);
+      }
+      std::size_t step = 1;
+      for (std::size_t i = Rank; i-- > 0;) {
+        const std::size_t axis = static_cast<std::size_t>(this->_impl->_invmapper[i]);
+        cytnx_error_msg(axis >= Rank, "[ERROR] Invalid Tensor mapper metadata.%s", "\n");
+        strides[axis] = step;
+        step *= extents[axis];
+      }
+
+      return stdex::mdspan<T, extents_type, stdex::layout_stride>(
+        this->ptr_as<T>(), mapping_type(extents_type(extents), strides));
+    }
+
+    /**
+     * @brief Return a non-owning typed layout-right mdspan view of this Tensor.
+     *
+     * This is a mutating function: it first calls `contiguous_()`, so a non-contiguous Tensor may
+     * receive new contiguous storage. The returned view then uses `stdex::layout_right`, matching
+     * Cytnx's default row-major contiguous Tensor layout. The Tensor storage must outlive the
+     * returned mdspan. The template type and rank must match the Tensor dtype and rank.
+     */
+    template <typename T, std::size_t Rank>
+    auto as_right_mdspan() {
+      using element_type = std::remove_cv_t<T>;
+      using extents_type = stdex::dextents<std::size_t, Rank>;
+
+      cytnx_error_msg(this->dtype() != Type_class::cy_typeid_v<element_type>,
+                      "[ERROR] Attempt to convert dtype %d (%s) to mdspan of type %s",
+                      this->dtype(), Type_class::getname(this->dtype()).c_str(),
+                      Type_class::getname(Type_class::cy_typeid_v<element_type>).c_str());
+      cytnx_error_msg(
+        this->rank() != Rank, "[ERROR] Attempt to view rank-%llu Tensor as rank-%llu mdspan.%s",
+        static_cast<unsigned long long>(this->rank()), static_cast<unsigned long long>(Rank), "\n");
+      this->contiguous_();
+
+      std::array<std::size_t, Rank> extents{};
+      for (std::size_t i = 0; i < Rank; ++i) {
+        extents[i] = static_cast<std::size_t>(this->_impl->_shape[i]);
+      }
+      return stdex::mdspan<T, extents_type, stdex::layout_right>(this->ptr_as<T>(),
+                                                                 extents_type(extents));
     }
 
   #ifdef UNI_GPU

--- a/include/Tensor.hpp
+++ b/include/Tensor.hpp
@@ -16,12 +16,9 @@
 #include <initializer_list>
 #include <string>
 
-#ifdef BACKEND_TORCH
-#else
-
-  #include "backend/Scalar.hpp"
-  #include "backend/Storage.hpp"
-  #include "backend/Tensor_impl.hpp"
+#include "backend/Scalar.hpp"
+#include "backend/Storage.hpp"
+#include "backend/Tensor_impl.hpp"
 
 namespace cytnx {
 
@@ -596,7 +593,7 @@ namespace cytnx {
                                                                  extents_type(extents));
     }
 
-  #ifdef UNI_GPU
+#ifdef UNI_GPU
     // std::variant of pointers to Type_list_gpu, without void ....
     using gpu_pointer_types =
       make_variant_from_transform_t<typename internal::exclude_first<Type_list_gpu>::type,
@@ -618,7 +615,7 @@ namespace cytnx {
         Type_class::getname(Type_class::cy_typeid_gpu_v<std::remove_cv_t<T>>).c_str());
       return static_cast<T *>(this->_impl->_storage._impl->data());
     }
-  #endif
+#endif
 
     /**
     @brief Convert a Storage to Tensor
@@ -1802,7 +1799,5 @@ namespace cytnx {
   ///@endcond
   //{ os << Tensor(in);};
 }  // namespace cytnx
-
-#endif  // BACKEND_TORCH
 
 #endif  // CYTNX_TENSOR_H_

--- a/include/TensorT.hpp
+++ b/include/TensorT.hpp
@@ -73,11 +73,15 @@ namespace cytnx {
     TensorT(owner_type owner, view_type view, Access access = Access{})
         : owner_(std::move(owner)), view_(view), access_(access) {}
     explicit TensorT(const std::array<std::size_t, Rank> &extents, Access access = Access{})
-      requires std::same_as<Access, host_access>
-        : TensorT(allocate(extents), access) {}
+        : TensorT(allocate(extents), access) {
+      static_assert(std::same_as<Access, host_access>,
+                    "Direct TensorT allocation currently supports host_access only");
+    }
     explicit TensorT(std::initializer_list<std::size_t> extents, Access access = Access{})
-      requires std::same_as<Access, host_access>
-        : TensorT(extents_from_list(extents), access) {}
+        : TensorT(extents_from_list(extents), access) {
+      static_assert(std::same_as<Access, host_access>,
+                    "Direct TensorT allocation currently supports host_access only");
+    }
 
     std::size_t extent(std::size_t axis) const noexcept { return view_.extent(axis); }
     std::size_t stride(std::size_t axis) const noexcept { return view_.stride(axis); }

--- a/include/TensorT.hpp
+++ b/include/TensorT.hpp
@@ -13,8 +13,11 @@
 
 #include "boost/smart_ptr/intrusive_ptr.hpp"
 
+#include <algorithm>
 #include <array>
+#include <concepts>
 #include <cstddef>
+#include <initializer_list>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -61,6 +64,7 @@ namespace cytnx {
     using layout_type = Layout;
     using extents_type = stdex::dextents<std::size_t, Rank>;
     using view_type = stdex::mdspan<T, extents_type, Layout>;
+    using mapping_type = typename view_type::mapping_type;
     using owner_type = data_owner<T>;
 
     static constexpr std::size_t rank() noexcept { return Rank; }
@@ -68,6 +72,12 @@ namespace cytnx {
     TensorT() = default;
     TensorT(owner_type owner, view_type view, Access access = Access{})
         : owner_(std::move(owner)), view_(view), access_(access) {}
+    explicit TensorT(const std::array<std::size_t, Rank> &extents, Access access = Access{})
+      requires std::same_as<Access, host_access>
+        : TensorT(allocate(extents), access) {}
+    explicit TensorT(std::initializer_list<std::size_t> extents, Access access = Access{})
+      requires std::same_as<Access, host_access>
+        : TensorT(extents_from_list(extents), access) {}
 
     std::size_t extent(std::size_t axis) const noexcept { return view_.extent(axis); }
     std::size_t stride(std::size_t axis) const noexcept { return view_.stride(axis); }
@@ -89,6 +99,51 @@ namespace cytnx {
     }
 
    private:
+    struct allocated_view {
+      owner_type owner;
+      view_type view;
+    };
+
+    explicit TensorT(allocated_view allocated, Access access)
+        : owner_(std::move(allocated.owner)), view_(allocated.view), access_(access) {}
+
+    static std::array<std::size_t, Rank> extents_from_list(
+      std::initializer_list<std::size_t> extents) {
+      cytnx_error_msg(extents.size() != Rank,
+                      "[ERROR] TensorT rank-%llu allocation received %llu extents.%s",
+                      static_cast<unsigned long long>(Rank),
+                      static_cast<unsigned long long>(extents.size()), "\n");
+      std::array<std::size_t, Rank> out{};
+      std::copy(extents.begin(), extents.end(), out.begin());
+      return out;
+    }
+
+    static mapping_type make_contiguous_mapping(const std::array<std::size_t, Rank> &extents) {
+      const extents_type md_extents(extents);
+      if constexpr (std::same_as<Layout, stdex::layout_right>) {
+        return mapping_type(md_extents);
+      } else if constexpr (std::same_as<Layout, stdex::layout_stride>) {
+        std::array<std::size_t, Rank> strides{};
+        std::size_t step = 1;
+        for (std::size_t i = Rank; i-- > 0;) {
+          strides[i] = step;
+          step *= extents[i];
+        }
+        return mapping_type(md_extents, strides);
+      } else {
+        static_assert(
+          std::same_as<Layout, stdex::layout_right> || std::same_as<Layout, stdex::layout_stride>,
+          "Unsupported TensorT layout for direct allocation");
+      }
+    }
+
+    static allocated_view allocate(const std::array<std::size_t, Rank> &extents) {
+      const mapping_type mapping = make_contiguous_mapping(extents);
+      auto owner = owner_type(
+        std::shared_ptr<T>(new T[mapping.required_span_size()](), std::default_delete<T[]>()));
+      return allocated_view{owner, view_type(owner.get(), mapping)};
+    }
+
     owner_type owner_;
     view_type view_;
     [[no_unique_address]] Access access_{};

--- a/include/TensorT.hpp
+++ b/include/TensorT.hpp
@@ -19,9 +19,17 @@
 #include <type_traits>
 #include <utility>
 #include <variant>
+#include <vector>
 
 namespace cytnx {
 
+  /**
+   * @brief Shared typed owner for the data pointer used by TensorT.
+   *
+   * This is currently backed by a `std::shared_ptr<T>`. For views created from legacy `Tensor`, the
+   * shared pointer aliases the Tensor storage and uses a deleter that keeps the legacy storage
+   * reference count alive.
+   */
   template <class T>
   class data_owner {
    public:
@@ -38,6 +46,13 @@ namespace cytnx {
     std::shared_ptr<T> data_;
   };
 
+  /**
+   * @brief Typed, ranked Tensor view with shared ownership of its data pointer.
+   *
+   * `TensorT` is intended as an internal kernel-facing representation. The element type, rank,
+   * access policy, and layout are part of the C++ type, while `owner()` keeps the pointed-to data
+   * alive independently of any legacy `Tensor` object used to create the view.
+   */
   template <class T, std::size_t Rank, class Access, class Layout = stdex::layout_stride>
   class TensorT {
    public:
@@ -98,6 +113,13 @@ namespace cytnx {
 
   namespace tensor_t_detail {
 
+    /**
+     * @brief Deleter used when a TensorT view aliases legacy Cytnx Storage.
+     *
+     * The deleter does not delete the raw pointer directly. It captures the legacy intrusive
+     * storage handle so the allocation stays alive for the lifetime of the typed shared pointer.
+     * `std::get_deleter` can recover this object for no-copy conversion back to legacy `Tensor`.
+     */
     template <typename T>
     class legacy_storage_deleter {
      public:
@@ -156,6 +178,55 @@ namespace cytnx {
       return data_owner<T>(std::shared_ptr<T>(data, legacy_storage_deleter<T>(std::move(storage))));
     }
 
+    template <typename T>
+    boost::intrusive_ptr<Storage_base> legacy_storage_from_owner(const data_owner<T> &owner) {
+      auto *deleter = std::get_deleter<legacy_storage_deleter<T>>(owner.shared_ptr());
+      cytnx_error_msg(deleter == nullptr,
+                      "[ERROR] Cannot create a Tensor view from TensorT without legacy storage.%s",
+                      "\n");
+      return deleter->storage();
+    }
+
+    /**
+     * @brief Return the logical axes ordered by physical contiguous memory order.
+     *
+     * This only accepts stride patterns that are exactly a contiguous row-major layout up to a
+     * permutation of axes. General strided or offset views are not representable by current Cytnx
+     * Tensor mapper metadata and are rejected.
+     */
+    template <class TensorView>
+    std::vector<cytnx_uint64> memory_order_from_strides(const TensorView &view) {
+      constexpr std::size_t rank = TensorView::rank();
+      cytnx_error_msg(rank == 0, "[ERROR] Cannot convert rank-0 TensorT to Tensor.%s", "\n");
+
+      std::array<bool, rank> used{};
+      std::vector<cytnx_uint64> inner_to_outer;
+      inner_to_outer.reserve(rank);
+
+      std::size_t expected_stride = 1;
+      for (std::size_t step = 0; step < rank; ++step) {
+        bool found = false;
+        for (std::size_t axis = 0; axis < rank; ++axis) {
+          if (!used[axis] && view.stride(axis) == expected_stride) {
+            used[axis] = true;
+            inner_to_outer.push_back(static_cast<cytnx_uint64>(axis));
+            expected_stride *= view.extent(axis);
+            found = true;
+            break;
+          }
+        }
+        cytnx_error_msg(!found, "[ERROR] TensorT strides are not a contiguous permutation.%s",
+                        "\n");
+      }
+
+      std::vector<cytnx_uint64> memory_order;
+      memory_order.reserve(rank);
+      for (std::size_t i = inner_to_outer.size(); i-- > 0;) {
+        memory_order.push_back(inner_to_outer[i]);
+      }
+      return memory_order;
+    }
+
   }  // namespace tensor_t_detail
 
   /**
@@ -197,6 +268,38 @@ namespace cytnx {
     auto owner = tensor_t_detail::owner_from_tensor<T>(tensor);
     view_type view(owner.get(), extents_type(extents));
     return TensorT<T, Rank, Access, stdex::layout_right>(std::move(owner), view, access);
+  }
+
+  /**
+   * @brief Create a legacy Tensor sharing the storage owned by a TensorT view.
+   *
+   * This bridge is only available for TensorT objects backed by legacy Cytnx storage. The mdspan
+   * layout must be exactly representable by Cytnx's current contiguous-or-permuted-contiguous
+   * Tensor metadata; otherwise this function throws.
+   */
+  template <typename T, std::size_t Rank, class Access, class Layout>
+  Tensor to_tensor(const TensorT<T, Rank, Access, Layout> &view) {
+    auto storage = tensor_t_detail::legacy_storage_from_owner(view.owner());
+    cytnx_error_msg(storage->device() != view.device(),
+                    "[ERROR] TensorT access device does not match legacy storage device.%s", "\n");
+
+    const auto memory_order = tensor_t_detail::memory_order_from_strides(view);
+
+    std::vector<cytnx_int64> memory_shape;
+    memory_shape.reserve(Rank);
+    for (const auto axis : memory_order) {
+      memory_shape.push_back(static_cast<cytnx_int64>(view.extent(axis)));
+    }
+
+    std::vector<cytnx_uint64> perm(Rank);
+    for (std::size_t physical_axis = 0; physical_axis < Rank; ++physical_axis) {
+      perm[memory_order[physical_axis]] = static_cast<cytnx_uint64>(physical_axis);
+    }
+
+    Tensor out = Tensor::from_storage(Storage(storage));
+    out = out.reshape(memory_shape);
+    out = out.permute(perm);
+    return out;
   }
 
 }  // namespace cytnx

--- a/include/TensorT.hpp
+++ b/include/TensorT.hpp
@@ -72,6 +72,11 @@ namespace cytnx {
     TensorT() = default;
     TensorT(owner_type owner, view_type view, Access access = Access{})
         : owner_(std::move(owner)), view_(view), access_(access) {}
+    explicit TensorT(const T &value, Access access = Access{}) requires(Rank == 0)
+        : TensorT(allocate_scalar(value), access) {
+      static_assert(std::same_as<Access, host_access>,
+                    "Direct TensorT allocation currently supports host_access only");
+    }
     explicit TensorT(const std::array<std::size_t, Rank> &extents, Access access = Access{})
         : TensorT(allocate(extents), access) {
       static_assert(std::same_as<Access, host_access>,
@@ -86,6 +91,9 @@ namespace cytnx {
     std::size_t extent(std::size_t axis) const noexcept { return view_.extent(axis); }
     std::size_t stride(std::size_t axis) const noexcept { return view_.stride(axis); }
     std::size_t required_span_size() const noexcept { return view_.required_span_size(); }
+    std::size_t size() const noexcept requires(Rank == 1) { return extent(0); }
+    std::size_t rows() const noexcept requires(Rank == 2) { return extent(0); }
+    std::size_t cols() const noexcept requires(Rank == 2) { return extent(1); }
 
     T *data() const noexcept { return view_.data_handle(); }
     T *data_handle() const noexcept { return view_.data_handle(); }
@@ -96,6 +104,7 @@ namespace cytnx {
 
     static constexpr unsigned int dtype() { return Type_class::cy_typeid_v<std::remove_cv_t<T>>; }
     int device() const { return tensor_t_detail::access_device(access_); }
+    T &value() const noexcept requires(Rank == 0) { return view_(); }
 
     template <class... Indices>
     T &operator()(Indices... indices) const noexcept {
@@ -146,6 +155,13 @@ namespace cytnx {
       auto owner = owner_type(
         std::shared_ptr<T>(new T[mapping.required_span_size()](), std::default_delete<T[]>()));
       return allocated_view{owner, view_type(owner.get(), mapping)};
+    }
+
+    static allocated_view allocate_scalar(const T &value) {
+      std::array<std::size_t, Rank> extents{};
+      allocated_view allocated = allocate(extents);
+      allocated.view() = value;
+      return allocated;
     }
 
     owner_type owner_;

--- a/include/TensorT.hpp
+++ b/include/TensorT.hpp
@@ -1,0 +1,188 @@
+#ifndef CYTNX_TENSORT_HPP_
+#define CYTNX_TENSORT_HPP_
+
+#include "Tensor.hpp"
+#include "TensorT_cpu.hpp"
+#include "Type.hpp"
+#include "cytnx_error.hpp"
+#include "mdspan.hpp"
+
+#ifdef UNI_GPU
+  #include "TensorT_gpu.hpp"
+#endif
+
+#include "boost/smart_ptr/intrusive_ptr.hpp"
+
+#include <array>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+namespace cytnx {
+
+  class storage_owner {
+   public:
+    storage_owner() = default;
+    explicit storage_owner(boost::intrusive_ptr<Storage_base> storage)
+        : storage_(std::move(storage)) {}
+
+    Storage_base *get() const noexcept { return storage_.get(); }
+    Storage_base &operator*() const noexcept { return *storage_; }
+    Storage_base *operator->() const noexcept { return storage_.get(); }
+    explicit operator bool() const noexcept { return static_cast<bool>(storage_); }
+
+    unsigned int dtype() const { return storage_->dtype(); }
+    int device() const { return storage_->device(); }
+    unsigned long long size() const { return storage_->size(); }
+
+   private:
+    boost::intrusive_ptr<Storage_base> storage_;
+  };
+
+  template <class T, std::size_t Rank, class Access, class Layout = stdex::layout_stride>
+  class TensorT {
+   public:
+    using element_type = T;
+    using access_type = Access;
+    using layout_type = Layout;
+    using extents_type = stdex::dextents<std::size_t, Rank>;
+    using view_type = stdex::mdspan<T, extents_type, Layout>;
+    using storage_type = storage_owner;
+
+    static constexpr std::size_t rank() noexcept { return Rank; }
+
+    TensorT() = default;
+    TensorT(storage_type storage, view_type view, Access access = Access{})
+        : storage_(std::move(storage)), view_(view), access_(access) {}
+
+    std::size_t extent(std::size_t axis) const noexcept { return view_.extent(axis); }
+    std::size_t stride(std::size_t axis) const noexcept { return view_.stride(axis); }
+    std::size_t required_span_size() const noexcept { return view_.required_span_size(); }
+
+    T *data() const noexcept { return view_.data_handle(); }
+    T *data_handle() const noexcept { return view_.data_handle(); }
+
+    const view_type &view() const noexcept { return view_; }
+    const storage_type &storage() const noexcept { return storage_; }
+    const Access &access() const noexcept { return access_; }
+
+    unsigned int dtype() const { return storage_.dtype(); }
+    int device() const { return storage_.device(); }
+
+    template <class... Indices>
+    T &operator()(Indices... indices) const noexcept {
+      return view_(indices...);
+    }
+
+   private:
+    storage_type storage_;
+    view_type view_;
+    [[no_unique_address]] Access access_{};
+  };
+
+  template <class T, std::size_t Rank, class Layout = stdex::layout_stride>
+  using HostTensorT = TensorT<T, Rank, host_access, Layout>;
+
+  template <class T, class Access, class Layout = stdex::layout_stride>
+  using VectorT = TensorT<T, 1, Access, Layout>;
+
+  template <class T, class Access, class Layout = stdex::layout_stride>
+  using MatrixT = TensorT<T, 2, Access, Layout>;
+
+  template <class T, std::size_t Rank, class Layout = stdex::layout_stride>
+  using TensorDeviceT = std::variant<HostTensorT<T, Rank, Layout>
+#ifdef UNI_GPU
+                                     ,
+                                     TensorT<T, Rank, cuda_access, Layout>
+#endif
+                                     >;
+
+  namespace tensor_t_detail {
+
+    template <typename T, std::size_t Rank>
+    void check_tensor_type_and_rank(const Tensor &tensor) {
+      using element_type = std::remove_cv_t<T>;
+      cytnx_error_msg(tensor.dtype() != Type_class::cy_typeid_v<element_type>,
+                      "[ERROR] Attempt to convert dtype %d (%s) to TensorT of type %s",
+                      tensor.dtype(), Type_class::getname(tensor.dtype()).c_str(),
+                      Type_class::getname(Type_class::cy_typeid_v<element_type>).c_str());
+      cytnx_error_msg(tensor.rank() != Rank,
+                      "[ERROR] Attempt to view rank-%llu Tensor as rank-%llu TensorT.%s",
+                      static_cast<unsigned long long>(tensor.rank()),
+                      static_cast<unsigned long long>(Rank), "\n");
+    }
+
+    template <std::size_t Rank>
+    std::array<std::size_t, Rank> extents_from_tensor(const Tensor &tensor) {
+      std::array<std::size_t, Rank> extents{};
+      for (std::size_t i = 0; i < Rank; ++i) {
+        extents[i] = static_cast<std::size_t>(tensor._impl->shape()[i]);
+      }
+      return extents;
+    }
+
+    template <std::size_t Rank>
+    std::array<std::size_t, Rank> strides_from_tensor(
+      const Tensor &tensor, const std::array<std::size_t, Rank> &extents) {
+      std::array<std::size_t, Rank> strides{};
+      std::size_t step = 1;
+      for (std::size_t i = Rank; i-- > 0;) {
+        const std::size_t axis = static_cast<std::size_t>(tensor._impl->invmapper()[i]);
+        cytnx_error_msg(axis >= Rank, "[ERROR] Invalid Tensor mapper metadata.%s", "\n");
+        strides[axis] = step;
+        step *= extents[axis];
+      }
+      return strides;
+    }
+
+    inline storage_owner storage_from_tensor(const Tensor &tensor) {
+      return storage_owner(tensor._impl->storage()._impl);
+    }
+
+  }  // namespace tensor_t_detail
+
+  /**
+   * @brief Create a storage-owning typed TensorT view preserving the Tensor's current layout.
+   *
+   * The returned TensorT keeps the Tensor storage alive independently of the legacy Tensor object.
+   * The requested element type, rank, and backend access policy must match the Tensor metadata.
+   */
+  template <typename T, std::size_t Rank, class Access = host_access>
+  TensorT<T, Rank, Access, stdex::layout_stride> make_tensor_t(Tensor &tensor) {
+    using extents_type = stdex::dextents<std::size_t, Rank>;
+    using mapping_type = typename stdex::layout_stride::template mapping<extents_type>;
+    using view_type = stdex::mdspan<T, extents_type, stdex::layout_stride>;
+
+    tensor_t_detail::check_tensor_type_and_rank<T, Rank>(tensor);
+    auto access = tensor_t_detail::make_access<Access>(tensor.device());
+    const auto extents = tensor_t_detail::extents_from_tensor<Rank>(tensor);
+    const auto strides = tensor_t_detail::strides_from_tensor<Rank>(tensor, extents);
+    auto storage = tensor_t_detail::storage_from_tensor(tensor);
+    view_type view(tensor.ptr_as<T>(), mapping_type(extents_type(extents), strides));
+    return TensorT<T, Rank, Access, stdex::layout_stride>(std::move(storage), view, access);
+  }
+
+  /**
+   * @brief Create a storage-owning typed layout-right TensorT view.
+   *
+   * This is a mutating function: it first calls `contiguous_()` on the legacy Tensor, so a
+   * non-contiguous Tensor may receive new contiguous storage.
+   */
+  template <typename T, std::size_t Rank, class Access = host_access>
+  TensorT<T, Rank, Access, stdex::layout_right> make_right_tensor_t(Tensor &tensor) {
+    using extents_type = stdex::dextents<std::size_t, Rank>;
+    using view_type = stdex::mdspan<T, extents_type, stdex::layout_right>;
+
+    tensor_t_detail::check_tensor_type_and_rank<T, Rank>(tensor);
+    auto access = tensor_t_detail::make_access<Access>(tensor.device());
+    tensor.contiguous_();
+    const auto extents = tensor_t_detail::extents_from_tensor<Rank>(tensor);
+    auto storage = tensor_t_detail::storage_from_tensor(tensor);
+    view_type view(tensor.ptr_as<T>(), extents_type(extents));
+    return TensorT<T, Rank, Access, stdex::layout_right>(std::move(storage), view, access);
+  }
+
+}  // namespace cytnx
+
+#endif  // CYTNX_TENSORT_HPP_

--- a/include/TensorT.hpp
+++ b/include/TensorT.hpp
@@ -15,29 +15,27 @@
 
 #include <array>
 #include <cstddef>
+#include <memory>
 #include <type_traits>
 #include <utility>
 #include <variant>
 
 namespace cytnx {
 
-  class storage_owner {
+  template <class T>
+  class data_owner {
    public:
-    storage_owner() = default;
-    explicit storage_owner(boost::intrusive_ptr<Storage_base> storage)
-        : storage_(std::move(storage)) {}
+    data_owner() = default;
+    explicit data_owner(std::shared_ptr<T> data) : data_(std::move(data)) {}
 
-    Storage_base *get() const noexcept { return storage_.get(); }
-    Storage_base &operator*() const noexcept { return *storage_; }
-    Storage_base *operator->() const noexcept { return storage_.get(); }
-    explicit operator bool() const noexcept { return static_cast<bool>(storage_); }
+    T *get() const noexcept { return data_.get(); }
+    T *operator->() const noexcept { return data_.get(); }
+    explicit operator bool() const noexcept { return static_cast<bool>(data_); }
 
-    unsigned int dtype() const { return storage_->dtype(); }
-    int device() const { return storage_->device(); }
-    unsigned long long size() const { return storage_->size(); }
+    const std::shared_ptr<T> &shared_ptr() const noexcept { return data_; }
 
    private:
-    boost::intrusive_ptr<Storage_base> storage_;
+    std::shared_ptr<T> data_;
   };
 
   template <class T, std::size_t Rank, class Access, class Layout = stdex::layout_stride>
@@ -48,13 +46,13 @@ namespace cytnx {
     using layout_type = Layout;
     using extents_type = stdex::dextents<std::size_t, Rank>;
     using view_type = stdex::mdspan<T, extents_type, Layout>;
-    using storage_type = storage_owner;
+    using owner_type = data_owner<T>;
 
     static constexpr std::size_t rank() noexcept { return Rank; }
 
     TensorT() = default;
-    TensorT(storage_type storage, view_type view, Access access = Access{})
-        : storage_(std::move(storage)), view_(view), access_(access) {}
+    TensorT(owner_type owner, view_type view, Access access = Access{})
+        : owner_(std::move(owner)), view_(view), access_(access) {}
 
     std::size_t extent(std::size_t axis) const noexcept { return view_.extent(axis); }
     std::size_t stride(std::size_t axis) const noexcept { return view_.stride(axis); }
@@ -64,11 +62,11 @@ namespace cytnx {
     T *data_handle() const noexcept { return view_.data_handle(); }
 
     const view_type &view() const noexcept { return view_; }
-    const storage_type &storage() const noexcept { return storage_; }
+    const owner_type &owner() const noexcept { return owner_; }
     const Access &access() const noexcept { return access_; }
 
-    unsigned int dtype() const { return storage_.dtype(); }
-    int device() const { return storage_.device(); }
+    static constexpr unsigned int dtype() { return Type_class::cy_typeid_v<std::remove_cv_t<T>>; }
+    int device() const { return tensor_t_detail::access_device(access_); }
 
     template <class... Indices>
     T &operator()(Indices... indices) const noexcept {
@@ -76,7 +74,7 @@ namespace cytnx {
     }
 
    private:
-    storage_type storage_;
+    owner_type owner_;
     view_type view_;
     [[no_unique_address]] Access access_{};
   };
@@ -99,6 +97,21 @@ namespace cytnx {
                                      >;
 
   namespace tensor_t_detail {
+
+    template <typename T>
+    class legacy_storage_deleter {
+     public:
+      legacy_storage_deleter() = default;
+      explicit legacy_storage_deleter(boost::intrusive_ptr<Storage_base> storage)
+          : storage_(std::move(storage)) {}
+
+      void operator()(T *) noexcept { storage_.reset(); }
+
+      const boost::intrusive_ptr<Storage_base> &storage() const noexcept { return storage_; }
+
+     private:
+      boost::intrusive_ptr<Storage_base> storage_;
+    };
 
     template <typename T, std::size_t Rank>
     void check_tensor_type_and_rank(const Tensor &tensor) {
@@ -136,8 +149,11 @@ namespace cytnx {
       return strides;
     }
 
-    inline storage_owner storage_from_tensor(const Tensor &tensor) {
-      return storage_owner(tensor._impl->storage()._impl);
+    template <typename T>
+    data_owner<T> owner_from_tensor(Tensor &tensor) {
+      auto storage = tensor._impl->storage()._impl;
+      T *data = tensor.ptr_as<T>();
+      return data_owner<T>(std::shared_ptr<T>(data, legacy_storage_deleter<T>(std::move(storage))));
     }
 
   }  // namespace tensor_t_detail
@@ -158,9 +174,9 @@ namespace cytnx {
     auto access = tensor_t_detail::make_access<Access>(tensor.device());
     const auto extents = tensor_t_detail::extents_from_tensor<Rank>(tensor);
     const auto strides = tensor_t_detail::strides_from_tensor<Rank>(tensor, extents);
-    auto storage = tensor_t_detail::storage_from_tensor(tensor);
-    view_type view(tensor.ptr_as<T>(), mapping_type(extents_type(extents), strides));
-    return TensorT<T, Rank, Access, stdex::layout_stride>(std::move(storage), view, access);
+    auto owner = tensor_t_detail::owner_from_tensor<T>(tensor);
+    view_type view(owner.get(), mapping_type(extents_type(extents), strides));
+    return TensorT<T, Rank, Access, stdex::layout_stride>(std::move(owner), view, access);
   }
 
   /**
@@ -178,9 +194,9 @@ namespace cytnx {
     auto access = tensor_t_detail::make_access<Access>(tensor.device());
     tensor.contiguous_();
     const auto extents = tensor_t_detail::extents_from_tensor<Rank>(tensor);
-    auto storage = tensor_t_detail::storage_from_tensor(tensor);
-    view_type view(tensor.ptr_as<T>(), extents_type(extents));
-    return TensorT<T, Rank, Access, stdex::layout_right>(std::move(storage), view, access);
+    auto owner = tensor_t_detail::owner_from_tensor<T>(tensor);
+    view_type view(owner.get(), extents_type(extents));
+    return TensorT<T, Rank, Access, stdex::layout_right>(std::move(owner), view, access);
   }
 
 }  // namespace cytnx

--- a/include/TensorT.hpp
+++ b/include/TensorT.hpp
@@ -97,6 +97,11 @@ namespace cytnx {
   template <class T, std::size_t Rank, class Layout = stdex::layout_stride>
   using HostTensorT = TensorT<T, Rank, host_access, Layout>;
 
+#ifdef UNI_GPU
+  template <class T, std::size_t Rank, class Layout = stdex::layout_stride>
+  using CudaTensorT = TensorT<T, Rank, cuda_access, Layout>;
+#endif
+
   template <class T, class Access, class Layout = stdex::layout_stride>
   using VectorT = TensorT<T, 1, Access, Layout>;
 
@@ -107,7 +112,7 @@ namespace cytnx {
   using TensorDeviceT = std::variant<HostTensorT<T, Rank, Layout>
 #ifdef UNI_GPU
                                      ,
-                                     TensorT<T, Rank, cuda_access, Layout>
+                                     CudaTensorT<T, Rank, Layout>
 #endif
                                      >;
 

--- a/include/TensorT.hpp
+++ b/include/TensorT.hpp
@@ -1,5 +1,5 @@
-#ifndef CYTNX_TENSORT_HPP_
-#define CYTNX_TENSORT_HPP_
+#ifndef CYTNX_TENSORT_H_
+#define CYTNX_TENSORT_H_
 
 #include "Tensor.hpp"
 #include "TensorT_cpu.hpp"
@@ -390,4 +390,4 @@ namespace cytnx {
 
 }  // namespace cytnx
 
-#endif  // CYTNX_TENSORT_HPP_
+#endif  // CYTNX_TENSORT_H_

--- a/include/TensorT.hpp
+++ b/include/TensorT.hpp
@@ -359,27 +359,33 @@ namespace cytnx {
    */
   template <typename T, std::size_t Rank, class Access, class Layout>
   Tensor to_tensor(const TensorT<T, Rank, Access, Layout> &view) {
-    auto storage = tensor_t_detail::legacy_storage_from_owner(view.owner());
-    cytnx_error_msg(storage->device() != view.device(),
-                    "[ERROR] TensorT access device does not match legacy storage device.%s", "\n");
+    if constexpr (Rank == 0) {
+      cytnx_error_msg(true, "[ERROR] Cannot convert rank-0 TensorT to legacy Tensor.%s", "\n");
+      return Tensor();
+    } else {
+      auto storage = tensor_t_detail::legacy_storage_from_owner(view.owner());
+      cytnx_error_msg(storage->device() != view.device(),
+                      "[ERROR] TensorT access device does not match legacy storage device.%s",
+                      "\n");
 
-    const auto memory_order = tensor_t_detail::memory_order_from_strides(view);
+      const auto memory_order = tensor_t_detail::memory_order_from_strides(view);
 
-    std::vector<cytnx_int64> memory_shape;
-    memory_shape.reserve(Rank);
-    for (const auto axis : memory_order) {
-      memory_shape.push_back(static_cast<cytnx_int64>(view.extent(axis)));
+      std::vector<cytnx_int64> memory_shape;
+      memory_shape.reserve(Rank);
+      for (const auto axis : memory_order) {
+        memory_shape.push_back(static_cast<cytnx_int64>(view.extent(axis)));
+      }
+
+      std::vector<cytnx_uint64> perm(Rank);
+      for (std::size_t physical_axis = 0; physical_axis < Rank; ++physical_axis) {
+        perm[memory_order[physical_axis]] = static_cast<cytnx_uint64>(physical_axis);
+      }
+
+      Tensor out = Tensor::from_storage(Storage(storage));
+      out = out.reshape(memory_shape);
+      out = out.permute(perm);
+      return out;
     }
-
-    std::vector<cytnx_uint64> perm(Rank);
-    for (std::size_t physical_axis = 0; physical_axis < Rank; ++physical_axis) {
-      perm[memory_order[physical_axis]] = static_cast<cytnx_uint64>(physical_axis);
-    }
-
-    Tensor out = Tensor::from_storage(Storage(storage));
-    out = out.reshape(memory_shape);
-    out = out.permute(perm);
-    return out;
   }
 
 }  // namespace cytnx

--- a/include/TensorT_cpu.hpp
+++ b/include/TensorT_cpu.hpp
@@ -1,5 +1,5 @@
-#ifndef CYTNX_TENSORT_CPU_HPP_
-#define CYTNX_TENSORT_CPU_HPP_
+#ifndef CYTNX_TENSORT_CPU_H_
+#define CYTNX_TENSORT_CPU_H_
 
 #include "Device.hpp"
 #include "cytnx_error.hpp"
@@ -33,4 +33,4 @@ namespace cytnx {
 
 }  // namespace cytnx
 
-#endif  // CYTNX_TENSORT_CPU_HPP_
+#endif  // CYTNX_TENSORT_CPU_H_

--- a/include/TensorT_cpu.hpp
+++ b/include/TensorT_cpu.hpp
@@ -27,6 +27,8 @@ namespace cytnx {
 
     inline int access_device(host_access) { return Device.cpu; }
 
+    inline bool access_accepts_device(host_access, int device) { return device == Device.cpu; }
+
   }  // namespace tensor_t_detail
 
 }  // namespace cytnx

--- a/include/TensorT_cpu.hpp
+++ b/include/TensorT_cpu.hpp
@@ -25,6 +25,8 @@ namespace cytnx {
       return {};
     }
 
+    inline int access_device(host_access) { return Device.cpu; }
+
   }  // namespace tensor_t_detail
 
 }  // namespace cytnx

--- a/include/TensorT_cpu.hpp
+++ b/include/TensorT_cpu.hpp
@@ -1,0 +1,32 @@
+#ifndef CYTNX_TENSORT_CPU_HPP_
+#define CYTNX_TENSORT_CPU_HPP_
+
+#include "Device.hpp"
+#include "cytnx_error.hpp"
+
+namespace cytnx {
+
+  struct host_space {};
+
+  struct host_access {
+    using space = host_space;
+  };
+
+  namespace tensor_t_detail {
+
+    template <class Access>
+    Access make_access(int device);
+
+    template <>
+    inline host_access make_access<host_access>(int device) {
+      cytnx_error_msg(device != Device.cpu,
+                      "[ERROR] Attempt to create a host TensorT from Tensor on device %d.%s",
+                      device, "\n");
+      return {};
+    }
+
+  }  // namespace tensor_t_detail
+
+}  // namespace cytnx
+
+#endif  // CYTNX_TENSORT_CPU_HPP_

--- a/include/TensorT_gpu.hpp
+++ b/include/TensorT_gpu.hpp
@@ -27,6 +27,8 @@ namespace cytnx {
       return cuda_access{device};
     }
 
+    inline int access_device(cuda_access access) { return access.device; }
+
   }  // namespace tensor_t_detail
 
 }  // namespace cytnx

--- a/include/TensorT_gpu.hpp
+++ b/include/TensorT_gpu.hpp
@@ -1,0 +1,34 @@
+#ifndef CYTNX_TENSORT_GPU_HPP_
+#define CYTNX_TENSORT_GPU_HPP_
+
+#ifndef UNI_GPU
+  #error "TensorT_gpu.hpp requires UNI_GPU"
+#endif
+
+#include "Device.hpp"
+#include "TensorT_cpu.hpp"
+#include "cytnx_error.hpp"
+
+namespace cytnx {
+
+  struct cuda_space {};
+
+  struct cuda_access {
+    using space = cuda_space;
+    int device = Device.cuda;
+  };
+
+  namespace tensor_t_detail {
+
+    template <>
+    inline cuda_access make_access<cuda_access>(int device) {
+      cytnx_error_msg(device < Device.cuda,
+                      "[ERROR] Attempt to create a CUDA TensorT from CPU Tensor.%s", "\n");
+      return cuda_access{device};
+    }
+
+  }  // namespace tensor_t_detail
+
+}  // namespace cytnx
+
+#endif  // CYTNX_TENSORT_GPU_HPP_

--- a/include/TensorT_gpu.hpp
+++ b/include/TensorT_gpu.hpp
@@ -1,5 +1,5 @@
-#ifndef CYTNX_TENSORT_GPU_HPP_
-#define CYTNX_TENSORT_GPU_HPP_
+#ifndef CYTNX_TENSORT_GPU_H_
+#define CYTNX_TENSORT_GPU_H_
 
 #ifndef UNI_GPU
   #error "TensorT_gpu.hpp requires UNI_GPU"
@@ -35,4 +35,4 @@ namespace cytnx {
 
 }  // namespace cytnx
 
-#endif  // CYTNX_TENSORT_GPU_HPP_
+#endif  // CYTNX_TENSORT_GPU_H_

--- a/include/TensorT_gpu.hpp
+++ b/include/TensorT_gpu.hpp
@@ -29,6 +29,8 @@ namespace cytnx {
 
     inline int access_device(cuda_access access) { return access.device; }
 
+    inline bool access_accepts_device(cuda_access, int device) { return device >= Device.cuda; }
+
   }  // namespace tensor_t_detail
 
 }  // namespace cytnx

--- a/include/TensorT_traits.hpp
+++ b/include/TensorT_traits.hpp
@@ -1,0 +1,170 @@
+#ifndef CYTNX_TENSORT_TRAITS_HPP_
+#define CYTNX_TENSORT_TRAITS_HPP_
+
+#include "TensorT.hpp"
+#include "Type.hpp"
+
+#include <concepts>
+#include <tuple>
+#include <type_traits>
+#include <variant>
+
+namespace cytnx {
+
+  /// Element type concept for the supported real floating-point TensorT scalar types.
+  template <class T>
+  concept RealScalar = std::same_as<std::remove_cv_t<T>, cytnx_float> ||
+                       std::same_as<std::remove_cv_t<T>, cytnx_double>;
+
+  /// Element type concept for the supported complex floating-point TensorT scalar types.
+  template <class T>
+  concept ComplexScalar = std::same_as<std::remove_cv_t<T>, cytnx_complex64> ||
+                          std::same_as<std::remove_cv_t<T>, cytnx_complex128>;
+
+  /// Element type concept for supported real or complex floating-point TensorT scalar types.
+  template <class T>
+  concept NumericScalar = RealScalar<T> || ComplexScalar<T>;
+
+  /// Type list used to build real TensorT dispatch variants.
+  using RealScalars = std::tuple<cytnx_float, cytnx_double>;
+
+  /// Type list used to build complex TensorT dispatch variants.
+  using ComplexScalars = std::tuple<cytnx_complex64, cytnx_complex128>;
+
+  /// Type list used to build real-or-complex TensorT dispatch variants.
+  using NumericScalars = std::tuple<cytnx_float, cytnx_double, cytnx_complex64, cytnx_complex128>;
+
+#ifdef UNI_GPU
+  using TensorAccesses = std::tuple<host_access, cuda_access>;
+#else
+  using TensorAccesses = std::tuple<host_access>;
+#endif
+
+  namespace tensor_t_detail {
+
+    template <std::size_t Rank, class Layout, class Scalar, class Accesses>
+    struct tensor_variant_for_scalar;
+
+    template <std::size_t Rank, class Layout, class Scalar, class... Accesses>
+    struct tensor_variant_for_scalar<Rank, Layout, Scalar, std::tuple<Accesses...>> {
+      using type = std::variant<TensorT<Scalar, Rank, Accesses, Layout>...>;
+    };
+
+    template <class... Variants>
+    struct variant_cat;
+
+    template <class... Types>
+    struct variant_cat<std::variant<Types...>> {
+      using type = std::variant<Types...>;
+    };
+
+    template <class... Left, class... Right, class... Rest>
+    struct variant_cat<std::variant<Left...>, std::variant<Right...>, Rest...> {
+      using type = typename variant_cat<std::variant<Left..., Right...>, Rest...>::type;
+    };
+
+    template <std::size_t Rank, class Layout, class Scalars, class Accesses>
+    struct tensor_variant_from_lists;
+
+    template <std::size_t Rank, class Layout, class... Scalars, class... Accesses>
+    struct tensor_variant_from_lists<Rank, Layout, std::tuple<Scalars...>,
+                                     std::tuple<Accesses...>> {
+      using type = typename variant_cat<typename tensor_variant_for_scalar<
+        Rank, Layout, Scalars, std::tuple<Accesses...>>::type...>::type;
+    };
+
+  }  // namespace tensor_t_detail
+
+  template <std::size_t Rank, class Layout, class Scalars, class Accesses = TensorAccesses>
+  using TensorVariantT =
+    typename tensor_t_detail::tensor_variant_from_lists<Rank, Layout, Scalars, Accesses>::type;
+
+  /// Variant over real scalar types and enabled access backends.
+  template <std::size_t Rank, class Layout = stdex::layout_right>
+  using RealTensor = TensorVariantT<Rank, Layout, RealScalars>;
+
+  /// Variant over complex scalar types and enabled access backends.
+  template <std::size_t Rank, class Layout = stdex::layout_right>
+  using ComplexTensor = TensorVariantT<Rank, Layout, ComplexScalars>;
+
+  /// Variant over real-or-complex scalar types and enabled access backends.
+  template <std::size_t Rank, class Layout = stdex::layout_right>
+  using NumericTensor = TensorVariantT<Rank, Layout, NumericScalars>;
+
+  namespace tensor_t_detail {
+
+    template <class T>
+    struct tensor_t_alternative;
+
+    template <class T, std::size_t Rank, class Access, class Layout>
+    struct tensor_t_alternative<TensorT<T, Rank, Access, Layout>> {
+      using element_type = T;
+      using access_type = Access;
+      using layout_type = Layout;
+      static constexpr std::size_t rank = Rank;
+    };
+
+    template <class Alternative>
+    bool tensor_matches_alternative(const Tensor &tensor) {
+      using traits = tensor_t_alternative<Alternative>;
+      using element_type = typename traits::element_type;
+      using access_type = typename traits::access_type;
+      return tensor.rank() == traits::rank &&
+             tensor.dtype() == Type_class::cy_typeid_v<std::remove_cv_t<element_type>> &&
+             access_accepts_device(access_type{}, tensor.device());
+    }
+
+    template <class Alternative, class Variant>
+    bool try_make_tensor_alternative(const Tensor &input, Variant &out) {
+      if (!tensor_matches_alternative<Alternative>(input)) return false;
+
+      using traits = tensor_t_alternative<Alternative>;
+      using element_type = typename traits::element_type;
+      using access_type = typename traits::access_type;
+      using layout_type = typename traits::layout_type;
+
+      if constexpr (std::same_as<layout_type, stdex::layout_right>) {
+        Tensor tensor = input.contiguous();
+        out = make_right_tensor_t<element_type, traits::rank, access_type>(tensor);
+      } else if constexpr (std::same_as<layout_type, stdex::layout_stride>) {
+        Tensor tensor = input;
+        out = make_tensor_t<element_type, traits::rank, access_type>(tensor);
+      } else {
+        static_assert(std::same_as<layout_type, stdex::layout_right> ||
+                        std::same_as<layout_type, stdex::layout_stride>,
+                      "Unsupported TensorT layout for make_tensor");
+      }
+      return true;
+    }
+
+    template <class Variant, std::size_t... Indices>
+    Variant make_tensor_impl(const Tensor &tensor, std::index_sequence<Indices...>) {
+      Variant out;
+      const bool matched =
+        (try_make_tensor_alternative<std::variant_alternative_t<Indices, Variant>>(tensor, out) ||
+         ...);
+      cytnx_error_msg(!matched,
+                      "[ERROR] Tensor dtype/device/rank is not represented by this TensorT "
+                      "variant.%s",
+                      "\n");
+      return out;
+    }
+
+  }  // namespace tensor_t_detail
+
+  /**
+   * @brief Create a typed TensorT variant from a legacy Tensor.
+   *
+   * `Variant` must be a `std::variant` whose alternatives are `TensorT` specializations. The
+   * factory selects the alternative matching the Tensor rank, dtype, device backend, and requested
+   * layout. Layout-right alternatives are made contiguous without mutating the input Tensor.
+   */
+  template <class Variant>
+  Variant make_tensor(const Tensor &tensor) {
+    return tensor_t_detail::make_tensor_impl<Variant>(
+      tensor, std::make_index_sequence<std::variant_size_v<Variant>>{});
+  }
+
+}  // namespace cytnx
+
+#endif  // CYTNX_TENSORT_TRAITS_HPP_

--- a/include/TensorT_traits.hpp
+++ b/include/TensorT_traits.hpp
@@ -13,13 +13,15 @@ namespace cytnx {
 
   /// Element type concept for the supported real floating-point TensorT scalar types.
   template <class T>
-  concept RealScalar = std::same_as<std::remove_cv_t<T>, cytnx_float> ||
-                       std::same_as<std::remove_cv_t<T>, cytnx_double>;
+  concept RealScalar =
+    std::same_as<std::remove_cv_t<T>, cytnx_float> ||
+    std::same_as<std::remove_cv_t<T>, cytnx_double>;
 
   /// Element type concept for the supported complex floating-point TensorT scalar types.
   template <class T>
-  concept ComplexScalar = std::same_as<std::remove_cv_t<T>, cytnx_complex64> ||
-                          std::same_as<std::remove_cv_t<T>, cytnx_complex128>;
+  concept ComplexScalar =
+    std::same_as<std::remove_cv_t<T>, cytnx_complex64> ||
+    std::same_as<std::remove_cv_t<T>, cytnx_complex128>;
 
   /// Element type concept for supported real or complex floating-point TensorT scalar types.
   template <class T>

--- a/include/TensorT_traits.hpp
+++ b/include/TensorT_traits.hpp
@@ -1,5 +1,5 @@
-#ifndef CYTNX_TENSORT_TRAITS_HPP_
-#define CYTNX_TENSORT_TRAITS_HPP_
+#ifndef CYTNX_TENSORT_TRAITS_H_
+#define CYTNX_TENSORT_TRAITS_H_
 
 #include "TensorT.hpp"
 #include "Type.hpp"
@@ -167,4 +167,4 @@ namespace cytnx {
 
 }  // namespace cytnx
 
-#endif  // CYTNX_TENSORT_TRAITS_HPP_
+#endif  // CYTNX_TENSORT_TRAITS_H_

--- a/include/TensorT_traits.hpp
+++ b/include/TensorT_traits.hpp
@@ -13,14 +13,12 @@ namespace cytnx {
 
   /// Element type concept for the supported real floating-point TensorT scalar types.
   template <class T>
-  concept RealScalar =
-    std::same_as<std::remove_cv_t<T>, cytnx_float> ||
+  concept RealScalar = std::same_as<std::remove_cv_t<T>, cytnx_float> ||
     std::same_as<std::remove_cv_t<T>, cytnx_double>;
 
   /// Element type concept for the supported complex floating-point TensorT scalar types.
   template <class T>
-  concept ComplexScalar =
-    std::same_as<std::remove_cv_t<T>, cytnx_complex64> ||
+  concept ComplexScalar = std::same_as<std::remove_cv_t<T>, cytnx_complex64> ||
     std::same_as<std::remove_cv_t<T>, cytnx_complex128>;
 
   /// Element type concept for supported real or complex floating-point TensorT scalar types.

--- a/include/cytnx.hpp
+++ b/include/cytnx.hpp
@@ -8,11 +8,7 @@
 #include "Device.hpp"
 #include "Type.hpp"
 
-#ifdef BACKEND_TORCH
-  #include "backend_torch/Type_convert.hpp"  // maybe we dont need this?
-#else
-  #include "backend/Storage.hpp"
-#endif
+#include "backend/Storage.hpp"
 
 #include "Tensor.hpp"
 #include "TensorT.hpp"
@@ -32,10 +28,7 @@
 #include "Network.hpp"
 #include "Bond.hpp"
 
-#ifdef BACKEND_TORCH
-#else
-  #include "backend/Scalar.hpp"
-#endif
+#include "backend/Scalar.hpp"
 
 #include "LinOp.hpp"
 #include "utils/is.hpp"

--- a/include/cytnx.hpp
+++ b/include/cytnx.hpp
@@ -15,6 +15,7 @@
 #endif
 
 #include "Tensor.hpp"
+#include "TensorT.hpp"
 #include "Generator.hpp"
 #include "Physics.hpp"
 #include "algo.hpp"

--- a/include/cytnx.hpp
+++ b/include/cytnx.hpp
@@ -16,6 +16,7 @@
 
 #include "Tensor.hpp"
 #include "TensorT.hpp"
+#include "TensorT_traits.hpp"
 #include "Generator.hpp"
 #include "Physics.hpp"
 #include "algo.hpp"

--- a/include/mdspan.hpp
+++ b/include/mdspan.hpp
@@ -66,11 +66,13 @@ namespace cytnx {
           : dynamic_extents_(dynamic_extents) {}
 
       static constexpr std::size_t static_extent(rank_type r) noexcept {
+        static_assert(rank() > 0, "rank-0 extents have no static extents");
         constexpr std::array<std::size_t, rank()> values{Extents...};
         return values[r];
       }
 
       constexpr index_type extent(rank_type r) const noexcept {
+        static_assert(rank() > 0, "rank-0 extents have no extents");
         constexpr std::array<std::size_t, rank()> values{Extents...};
         rank_type dynamic_index = 0;
         for (rank_type i = 0; i < r; ++i) {

--- a/include/mdspan.hpp
+++ b/include/mdspan.hpp
@@ -1,5 +1,5 @@
-#ifndef CYTNX_MDSPAN_HPP_
-#define CYTNX_MDSPAN_HPP_
+#ifndef CYTNX_MDSPAN_H_
+#define CYTNX_MDSPAN_H_
 
 #include <array>
 #include <cassert>
@@ -246,4 +246,4 @@ namespace cytnx {
   }  // namespace stdex
 }  // namespace cytnx
 
-#endif  // CYTNX_MDSPAN_HPP_
+#endif  // CYTNX_MDSPAN_H_

--- a/include/mdspan.hpp
+++ b/include/mdspan.hpp
@@ -1,0 +1,249 @@
+#ifndef CYTNX_MDSPAN_HPP_
+#define CYTNX_MDSPAN_HPP_
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+namespace cytnx {
+  namespace stdex {
+
+    inline constexpr std::size_t dynamic_extent = static_cast<std::size_t>(-1);
+
+    namespace detail {
+
+      template <std::size_t... Values>
+      struct count_dynamic_extents;
+
+      template <>
+      struct count_dynamic_extents<> {
+        static constexpr std::size_t value = 0;
+      };
+
+      template <std::size_t First, std::size_t... Rest>
+      struct count_dynamic_extents<First, Rest...> {
+        static constexpr std::size_t value =
+          (First == dynamic_extent ? 1 : 0) + count_dynamic_extents<Rest...>::value;
+      };
+
+      template <std::size_t Index, std::size_t First, std::size_t... Rest>
+      struct static_extent_at {
+        static constexpr std::size_t value = static_extent_at<Index - 1, Rest...>::value;
+      };
+
+      template <std::size_t First, std::size_t... Rest>
+      struct static_extent_at<0, First, Rest...> {
+        static constexpr std::size_t value = First;
+      };
+
+    }  // namespace detail
+
+    template <class IndexType, std::size_t... Extents>
+    class extents {
+     public:
+      using index_type = IndexType;
+      using size_type = std::make_unsigned_t<index_type>;
+      using rank_type = std::size_t;
+
+      static_assert(std::is_integral_v<index_type>, "extents index_type must be integral");
+
+      static constexpr rank_type rank() noexcept { return sizeof...(Extents); }
+      static constexpr rank_type rank_dynamic() noexcept {
+        return detail::count_dynamic_extents<Extents...>::value;
+      }
+      using dynamic_extents_type = std::array<index_type, rank_dynamic()>;
+
+      constexpr extents() noexcept {
+        static_assert(rank_dynamic() == 0, "default construction requires no dynamic extents");
+      }
+
+      template <class... IndexTypes,
+                std::enable_if_t<sizeof...(IndexTypes) == rank_dynamic(), int> = 0>
+      explicit constexpr extents(IndexTypes... dynamic_extents) noexcept
+          : dynamic_extents_{static_cast<index_type>(dynamic_extents)...} {}
+
+      explicit constexpr extents(const dynamic_extents_type& dynamic_extents) noexcept
+          : dynamic_extents_(dynamic_extents) {}
+
+      static constexpr std::size_t static_extent(rank_type r) noexcept {
+        constexpr std::array<std::size_t, rank()> values{Extents...};
+        return values[r];
+      }
+
+      constexpr index_type extent(rank_type r) const noexcept {
+        constexpr std::array<std::size_t, rank()> values{Extents...};
+        rank_type dynamic_index = 0;
+        for (rank_type i = 0; i < r; ++i) {
+          if (values[i] == dynamic_extent) ++dynamic_index;
+        }
+        return values[r] == dynamic_extent ? dynamic_extents_[dynamic_index]
+                                           : static_cast<index_type>(values[r]);
+      }
+
+     private:
+      dynamic_extents_type dynamic_extents_{};
+    };
+
+    namespace detail {
+
+      template <class IndexType, std::size_t Rank, class Sequence>
+      struct make_dextents;
+
+      template <class IndexType, std::size_t Rank, std::size_t... Indices>
+      struct make_dextents<IndexType, Rank, std::index_sequence<Indices...>> {
+        using type = extents<IndexType, ((void)Indices, dynamic_extent)...>;
+      };
+
+    }  // namespace detail
+
+    template <class IndexType, std::size_t Rank>
+    using dextents =
+      typename detail::make_dextents<IndexType, Rank, std::make_index_sequence<Rank>>::type;
+
+    template <class Extents>
+    class layout_right_mapping {
+     public:
+      using extents_type = Extents;
+      using index_type = typename extents_type::index_type;
+      using rank_type = typename extents_type::rank_type;
+
+      constexpr layout_right_mapping() noexcept = default;
+      explicit constexpr layout_right_mapping(const extents_type& extents) noexcept
+          : extents_(extents) {}
+
+      constexpr const extents_type& extents() const noexcept { return extents_; }
+      static constexpr rank_type rank() noexcept { return extents_type::rank(); }
+
+      constexpr index_type required_span_size() const noexcept {
+        index_type size = 1;
+        for (rank_type i = 0; i < rank(); ++i) size *= extents_.extent(i);
+        return size;
+      }
+
+      constexpr index_type stride(rank_type r) const noexcept {
+        index_type value = 1;
+        for (rank_type i = rank(); i-- > r + 1;) value *= extents_.extent(i);
+        return value;
+      }
+
+      template <class... Indices>
+      constexpr index_type operator()(Indices... indices) const noexcept {
+        static_assert(sizeof...(Indices) == rank(), "incorrect number of mdspan indices");
+        std::array<index_type, rank()> idx{static_cast<index_type>(indices)...};
+        index_type offset = 0;
+        for (rank_type i = 0; i < rank(); ++i) offset += idx[i] * stride(i);
+        return offset;
+      }
+
+     private:
+      extents_type extents_{};
+    };
+
+    struct layout_right {
+      template <class Extents>
+      using mapping = layout_right_mapping<Extents>;
+    };
+
+    template <class Extents>
+    class layout_stride_mapping {
+     public:
+      using extents_type = Extents;
+      using index_type = typename extents_type::index_type;
+      using rank_type = typename extents_type::rank_type;
+
+      constexpr layout_stride_mapping() noexcept = default;
+      constexpr layout_stride_mapping(const extents_type& extents,
+                                      const std::array<index_type, extents_type::rank()>& strides)
+          : extents_(extents), strides_(strides) {}
+
+      constexpr const extents_type& extents() const noexcept { return extents_; }
+      static constexpr rank_type rank() noexcept { return extents_type::rank(); }
+      constexpr index_type stride(rank_type r) const noexcept { return strides_[r]; }
+
+      constexpr index_type required_span_size() const noexcept {
+        if constexpr (rank() == 0) {
+          return 1;
+        } else {
+          index_type max_offset = 0;
+          for (rank_type i = 0; i < rank(); ++i) {
+            if (extents_.extent(i) == 0) return 0;
+            max_offset += (extents_.extent(i) - 1) * strides_[i];
+          }
+          return max_offset + 1;
+        }
+      }
+
+      template <class... Indices>
+      constexpr index_type operator()(Indices... indices) const noexcept {
+        static_assert(sizeof...(Indices) == rank(), "incorrect number of mdspan indices");
+        std::array<index_type, rank()> idx{static_cast<index_type>(indices)...};
+        index_type offset = 0;
+        for (rank_type i = 0; i < rank(); ++i) offset += idx[i] * strides_[i];
+        return offset;
+      }
+
+     private:
+      extents_type extents_{};
+      std::array<index_type, extents_type::rank()> strides_{};
+    };
+
+    struct layout_stride {
+      template <class Extents>
+      using mapping = layout_stride_mapping<Extents>;
+    };
+
+    template <class ElementType, class Extents, class LayoutPolicy = layout_right>
+    class mdspan {
+     public:
+      using element_type = ElementType;
+      using extents_type = Extents;
+      using layout_type = LayoutPolicy;
+      using mapping_type = typename layout_type::template mapping<extents_type>;
+      using index_type = typename extents_type::index_type;
+      using rank_type = typename extents_type::rank_type;
+      using data_handle_type = element_type*;
+      using reference = element_type&;
+
+      constexpr mdspan() noexcept = default;
+
+      constexpr mdspan(data_handle_type ptr, const mapping_type& mapping) noexcept
+          : ptr_(ptr), mapping_(mapping) {}
+
+      explicit constexpr mdspan(data_handle_type ptr, const extents_type& extents) noexcept
+          : ptr_(ptr), mapping_(extents) {}
+
+      template <class... IndexTypes,
+                std::enable_if_t<sizeof...(IndexTypes) == extents_type::rank_dynamic(), int> = 0>
+      explicit constexpr mdspan(data_handle_type ptr, IndexTypes... dynamic_extents) noexcept
+          : ptr_(ptr), mapping_(extents_type(static_cast<index_type>(dynamic_extents)...)) {}
+
+      static constexpr rank_type rank() noexcept { return extents_type::rank(); }
+      static constexpr rank_type rank_dynamic() noexcept { return extents_type::rank_dynamic(); }
+
+      constexpr index_type extent(rank_type r) const noexcept {
+        return mapping_.extents().extent(r);
+      }
+      constexpr index_type stride(rank_type r) const noexcept { return mapping_.stride(r); }
+      constexpr data_handle_type data_handle() const noexcept { return ptr_; }
+      constexpr const mapping_type& mapping() const noexcept { return mapping_; }
+      constexpr index_type required_span_size() const noexcept {
+        return mapping_.required_span_size();
+      }
+
+      template <class... Indices>
+      constexpr reference operator()(Indices... indices) const noexcept {
+        static_assert(sizeof...(Indices) == rank(), "incorrect number of mdspan indices");
+        return ptr_[mapping_(static_cast<index_type>(indices)...)];
+      }
+
+     private:
+      data_handle_type ptr_ = nullptr;
+      mapping_type mapping_{};
+    };
+
+  }  // namespace stdex
+}  // namespace cytnx
+
+#endif  // CYTNX_MDSPAN_HPP_

--- a/include/mdspan.hpp
+++ b/include/mdspan.hpp
@@ -55,9 +55,7 @@ namespace cytnx {
       }
       using dynamic_extents_type = std::array<index_type, rank_dynamic()>;
 
-      constexpr extents() noexcept {
-        static_assert(rank_dynamic() == 0, "default construction requires no dynamic extents");
-      }
+      constexpr extents() noexcept = default;
 
       template <class... IndexTypes,
                 std::enable_if_t<sizeof...(IndexTypes) == rank_dynamic(), int> = 0>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(
   Accessor_test.cpp
   Tensor_test.cpp
   mdspan_test.cpp
+  TensorT_test.cpp
   Storage_test.cpp
   search_tree_test.cpp
   utils_test/vec_concatenate.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   DenseUniTensor_test.cpp
   Accessor_test.cpp
   Tensor_test.cpp
+  mdspan_test.cpp
   Storage_test.cpp
   search_tree_test.cpp
   utils_test/vec_concatenate.cpp

--- a/tests/TensorT_test.cpp
+++ b/tests/TensorT_test.cpp
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+
+#include "Generator.hpp"
+#include "TensorT.hpp"
+
+namespace {
+
+  using cytnx::arange;
+  using cytnx::cytnx_double;
+  using cytnx::Device;
+  using cytnx::host_access;
+  using cytnx::HostTensorT;
+  using cytnx::make_right_tensor_t;
+  using cytnx::make_tensor_t;
+  using cytnx::Tensor;
+  using cytnx::Type;
+  using cytnx::stdex::layout_right;
+  using cytnx::stdex::layout_stride;
+
+  TEST(TensorTTest, MakeTensorTPreservesPermutedStrides) {
+    Tensor tensor = arange(2 * 3 * 4).reshape({2, 3, 4});
+    Tensor permuted = tensor.permute({1, 2, 0});
+
+    auto view = make_tensor_t<cytnx_double, 3, host_access>(permuted);
+
+    static_assert(std::is_same_v<decltype(view), HostTensorT<cytnx_double, 3, layout_stride>>);
+    EXPECT_EQ(view.dtype(), Type.Double);
+    EXPECT_EQ(view.device(), Device.cpu);
+    EXPECT_EQ(view.extent(0), 3);
+    EXPECT_EQ(view.extent(1), 4);
+    EXPECT_EQ(view.extent(2), 2);
+    EXPECT_EQ(view.stride(0), 4);
+    EXPECT_EQ(view.stride(1), 1);
+    EXPECT_EQ(view.stride(2), 12);
+    EXPECT_EQ(view(1, 2, 0), tensor.at<cytnx_double>({0, 1, 2}));
+
+    view(2, 3, 1) = 123;
+    EXPECT_EQ(tensor.at<cytnx_double>({1, 2, 3}), 123);
+  }
+
+  TEST(TensorTTest, MakeRightTensorTMutatesToContiguousLayoutRight) {
+    Tensor tensor = arange(2 * 3 * 4).reshape({2, 3, 4});
+    Tensor permuted = tensor.permute({1, 2, 0});
+
+    auto view = make_right_tensor_t<cytnx_double, 3, host_access>(permuted);
+
+    static_assert(std::is_same_v<decltype(view), HostTensorT<cytnx_double, 3, layout_right>>);
+    EXPECT_TRUE(permuted.is_contiguous());
+    EXPECT_EQ(view.extent(0), 3);
+    EXPECT_EQ(view.extent(1), 4);
+    EXPECT_EQ(view.extent(2), 2);
+    EXPECT_EQ(view.stride(0), 8);
+    EXPECT_EQ(view.stride(1), 2);
+    EXPECT_EQ(view.stride(2), 1);
+    EXPECT_EQ(view(2, 3, 1), tensor.at<cytnx_double>({1, 2, 3}));
+
+    view(2, 3, 1) = 321;
+    EXPECT_EQ(permuted.at<cytnx_double>({2, 3, 1}), 321);
+    EXPECT_EQ(tensor.at<cytnx_double>({1, 2, 3}), 23);
+  }
+
+  TEST(TensorTTest, StorageOwnerKeepsViewAliveAfterTensorIsDestroyed) {
+    HostTensorT<cytnx_double, 2, layout_stride> view;
+    {
+      Tensor tensor = arange(2 * 3).reshape({2, 3});
+      view = make_tensor_t<cytnx_double, 2>(tensor);
+    }
+
+    EXPECT_EQ(view.extent(0), 2);
+    EXPECT_EQ(view.extent(1), 3);
+    EXPECT_EQ(view(1, 2), 5);
+
+    view(1, 2) = 77;
+    EXPECT_EQ(view(1, 2), 77);
+  }
+
+  TEST(TensorTTest, RejectsWrongDtypeAndRank) {
+    Tensor tensor = arange(2 * 3).reshape({2, 3});
+
+    EXPECT_THROW((make_tensor_t<float, 2>(tensor)), std::logic_error);
+    EXPECT_THROW((make_tensor_t<cytnx_double, 3>(tensor)), std::logic_error);
+  }
+
+}  // namespace

--- a/tests/TensorT_test.cpp
+++ b/tests/TensorT_test.cpp
@@ -74,6 +74,20 @@ namespace {
     EXPECT_EQ(view(1, 2), 77);
   }
 
+  TEST(TensorTTest, LegacyStorageCanBeRecoveredFromOwnerDeleter) {
+    Tensor tensor = arange(2 * 3).reshape({2, 3});
+
+    auto view = make_tensor_t<cytnx_double, 2>(tensor);
+    auto *deleter = std::get_deleter<cytnx::tensor_t_detail::legacy_storage_deleter<cytnx_double>>(
+      view.owner().shared_ptr());
+
+    ASSERT_NE(deleter, nullptr);
+    ASSERT_TRUE(static_cast<bool>(deleter->storage()));
+    EXPECT_EQ(deleter->storage().get(), tensor._impl->storage()._impl.get());
+    EXPECT_EQ(deleter->storage()->dtype(), Type.Double);
+    EXPECT_EQ(deleter->storage()->device(), Device.cpu);
+  }
+
   TEST(TensorTTest, RejectsWrongDtypeAndRank) {
     Tensor tensor = arange(2 * 3).reshape({2, 3});
 

--- a/tests/TensorT_test.cpp
+++ b/tests/TensorT_test.cpp
@@ -4,6 +4,8 @@
 #include "TensorT.hpp"
 #include "TensorT_traits.hpp"
 
+#include <array>
+
 namespace {
 
   using cytnx::arange;
@@ -39,6 +41,44 @@ namespace {
   static_assert(std::variant_size_v<NumericTensor<2>> == 4);
   static_assert(std::variant_size_v<RealTensor<2>> == 2);
 #endif
+
+  TEST(TensorTTest, DirectAllocationCreatesOwnedContiguousStrideView) {
+    HostTensorT<cytnx_double, 2> matrix({2, 3});
+
+    static_assert(std::is_same_v<decltype(matrix), HostTensorT<cytnx_double, 2, layout_stride>>);
+    EXPECT_EQ(matrix.dtype(), Type.Double);
+    EXPECT_EQ(matrix.device(), Device.cpu);
+    EXPECT_EQ(matrix.extent(0), 2);
+    EXPECT_EQ(matrix.extent(1), 3);
+    EXPECT_EQ(matrix.stride(0), 3);
+    EXPECT_EQ(matrix.stride(1), 1);
+    EXPECT_EQ(matrix.required_span_size(), 6);
+    EXPECT_TRUE(static_cast<bool>(matrix.owner()));
+    EXPECT_EQ(matrix(1, 2), 0);
+
+    matrix(1, 2) = 17;
+    EXPECT_EQ(matrix(1, 2), 17);
+    EXPECT_THROW(to_tensor(matrix), std::logic_error);
+  }
+
+  TEST(TensorTTest, DirectAllocationSupportsLayoutRightAndArrayExtents) {
+    HostTensorT<cytnx_double, 3, layout_right> tensor(std::array<std::size_t, 3>{2, 3, 4});
+
+    EXPECT_EQ(tensor.extent(0), 2);
+    EXPECT_EQ(tensor.extent(1), 3);
+    EXPECT_EQ(tensor.extent(2), 4);
+    EXPECT_EQ(tensor.stride(0), 12);
+    EXPECT_EQ(tensor.stride(1), 4);
+    EXPECT_EQ(tensor.stride(2), 1);
+    EXPECT_EQ(tensor.required_span_size(), 24);
+
+    tensor(1, 2, 3) = 29;
+    EXPECT_EQ(tensor(1, 2, 3), 29);
+  }
+
+  TEST(TensorTTest, DirectAllocationRejectsWrongNumberOfInitializerExtents) {
+    EXPECT_THROW((HostTensorT<cytnx_double, 2>({2, 3, 4})), std::logic_error);
+  }
 
   TEST(TensorTTest, MakeTensorTPreservesPermutedStrides) {
     Tensor tensor = arange(2 * 3 * 4).reshape({2, 3, 4});

--- a/tests/TensorT_test.cpp
+++ b/tests/TensorT_test.cpp
@@ -13,6 +13,7 @@ namespace {
   using cytnx::make_right_tensor_t;
   using cytnx::make_tensor_t;
   using cytnx::Tensor;
+  using cytnx::to_tensor;
   using cytnx::Type;
   using cytnx::stdex::layout_right;
   using cytnx::stdex::layout_stride;
@@ -86,6 +87,49 @@ namespace {
     EXPECT_EQ(deleter->storage().get(), tensor._impl->storage()._impl.get());
     EXPECT_EQ(deleter->storage()->dtype(), Type.Double);
     EXPECT_EQ(deleter->storage()->device(), Device.cpu);
+  }
+
+  TEST(TensorTTest, ToTensorSharesContiguousStorage) {
+    Tensor tensor = arange(2 * 3).reshape({2, 3});
+    auto view = make_tensor_t<cytnx_double, 2>(tensor);
+
+    Tensor round_trip = to_tensor(view);
+
+    EXPECT_EQ(round_trip.shape(), tensor.shape());
+    EXPECT_TRUE(round_trip.is_contiguous());
+    EXPECT_EQ(round_trip.at<cytnx_double>({1, 2}), 5);
+
+    round_trip.at<cytnx_double>({1, 2}) = 42;
+    EXPECT_EQ(tensor.at<cytnx_double>({1, 2}), 42);
+  }
+
+  TEST(TensorTTest, ToTensorSharesPermutedStorage) {
+    Tensor tensor = arange(2 * 3 * 4).reshape({2, 3, 4});
+    Tensor permuted = tensor.permute({1, 2, 0});
+    auto view = make_tensor_t<cytnx_double, 3>(permuted);
+
+    Tensor round_trip = to_tensor(view);
+
+    EXPECT_EQ(round_trip.shape(), permuted.shape());
+    EXPECT_FALSE(round_trip.is_contiguous());
+    EXPECT_EQ(round_trip.at<cytnx_double>({2, 3, 1}), tensor.at<cytnx_double>({1, 2, 3}));
+
+    round_trip.at<cytnx_double>({2, 3, 1}) = 55;
+    EXPECT_EQ(tensor.at<cytnx_double>({1, 2, 3}), 55);
+  }
+
+  TEST(TensorTTest, ToTensorRejectsNonPermutationStrides) {
+    Tensor tensor = arange(10);
+    auto base = make_tensor_t<cytnx_double, 1>(tensor);
+
+    using extents_type = cytnx::stdex::dextents<std::size_t, 2>;
+    using mapping_type = layout_stride::mapping<extents_type>;
+    using view_type = cytnx::stdex::mdspan<cytnx_double, extents_type, layout_stride>;
+
+    view_type gapped_view(base.data(), mapping_type(extents_type(2, 3), {4, 1}));
+    HostTensorT<cytnx_double, 2, layout_stride> gapped(base.owner(), gapped_view);
+
+    EXPECT_THROW(to_tensor(gapped), std::logic_error);
   }
 
   TEST(TensorTTest, RejectsWrongDtypeAndRank) {

--- a/tests/TensorT_test.cpp
+++ b/tests/TensorT_test.cpp
@@ -50,6 +50,8 @@ namespace {
     EXPECT_EQ(matrix.device(), Device.cpu);
     EXPECT_EQ(matrix.extent(0), 2);
     EXPECT_EQ(matrix.extent(1), 3);
+    EXPECT_EQ(matrix.rows(), 2);
+    EXPECT_EQ(matrix.cols(), 3);
     EXPECT_EQ(matrix.stride(0), 3);
     EXPECT_EQ(matrix.stride(1), 1);
     EXPECT_EQ(matrix.required_span_size(), 6);
@@ -59,6 +61,17 @@ namespace {
     matrix(1, 2) = 17;
     EXPECT_EQ(matrix(1, 2), 17);
     EXPECT_THROW(to_tensor(matrix), std::logic_error);
+  }
+
+  TEST(TensorTTest, DirectAllocationSupportsRankOneSize) {
+    HostTensorT<cytnx_double, 1> vector({5});
+
+    EXPECT_EQ(vector.extent(0), 5);
+    EXPECT_EQ(vector.size(), 5);
+    EXPECT_EQ(vector.required_span_size(), 5);
+
+    vector(4) = 12;
+    EXPECT_EQ(vector(4), 12);
   }
 
   TEST(TensorTTest, DirectAllocationSupportsLayoutRightAndArrayExtents) {
@@ -74,6 +87,26 @@ namespace {
 
     tensor(1, 2, 3) = 29;
     EXPECT_EQ(tensor(1, 2, 3), 29);
+  }
+
+  TEST(TensorTTest, DirectAllocationSupportsRankZeroScalars) {
+    HostTensorT<cytnx_double, 0> zero(std::array<std::size_t, 0>{});
+
+    static_assert(decltype(zero)::rank() == 0);
+    EXPECT_EQ(zero.dtype(), Type.Double);
+    EXPECT_EQ(zero.device(), Device.cpu);
+    EXPECT_EQ(zero.required_span_size(), 1);
+    EXPECT_TRUE(static_cast<bool>(zero.owner()));
+    EXPECT_EQ(zero(), 0);
+
+    zero() = 11;
+    EXPECT_EQ(zero.value(), 11);
+
+    HostTensorT<cytnx_double, 0> scalar(3.5);
+    EXPECT_EQ(scalar(), 3.5);
+    scalar.value() = 4.5;
+    EXPECT_EQ(scalar(), 4.5);
+    EXPECT_THROW(to_tensor(scalar), std::logic_error);
   }
 
   TEST(TensorTTest, DirectAllocationRejectsWrongNumberOfInitializerExtents) {

--- a/tests/TensorT_test.cpp
+++ b/tests/TensorT_test.cpp
@@ -2,21 +2,43 @@
 
 #include "Generator.hpp"
 #include "TensorT.hpp"
+#include "TensorT_traits.hpp"
 
 namespace {
 
   using cytnx::arange;
+  using cytnx::ComplexTensor;
   using cytnx::cytnx_double;
   using cytnx::Device;
   using cytnx::host_access;
   using cytnx::HostTensorT;
   using cytnx::make_right_tensor_t;
+  using cytnx::make_tensor;
   using cytnx::make_tensor_t;
+  using cytnx::NumericTensor;
+  using cytnx::RealTensor;
   using cytnx::Tensor;
   using cytnx::to_tensor;
   using cytnx::Type;
   using cytnx::stdex::layout_right;
   using cytnx::stdex::layout_stride;
+
+  static_assert(cytnx::RealScalar<cytnx::cytnx_float>);
+  static_assert(cytnx::RealScalar<cytnx::cytnx_double>);
+  static_assert(!cytnx::RealScalar<cytnx::cytnx_complex64>);
+  static_assert(cytnx::ComplexScalar<cytnx::cytnx_complex64>);
+  static_assert(cytnx::ComplexScalar<cytnx::cytnx_complex128>);
+  static_assert(!cytnx::ComplexScalar<cytnx::cytnx_double>);
+  static_assert(cytnx::NumericScalar<cytnx::cytnx_float>);
+  static_assert(cytnx::NumericScalar<cytnx::cytnx_complex128>);
+
+#ifdef UNI_GPU
+  static_assert(std::variant_size_v<NumericTensor<2>> == 8);
+  static_assert(std::variant_size_v<RealTensor<2>> == 4);
+#else
+  static_assert(std::variant_size_v<NumericTensor<2>> == 4);
+  static_assert(std::variant_size_v<RealTensor<2>> == 2);
+#endif
 
   TEST(TensorTTest, MakeTensorTPreservesPermutedStrides) {
     Tensor tensor = arange(2 * 3 * 4).reshape({2, 3, 4});
@@ -130,6 +152,63 @@ namespace {
     HostTensorT<cytnx_double, 2, layout_stride> gapped(base.owner(), gapped_view);
 
     EXPECT_THROW(to_tensor(gapped), std::logic_error);
+  }
+
+  TEST(TensorTTest, GenericVariantFactoryDispatchesDtypeToLayoutRightHostViews) {
+    Tensor real = arange(2 * 3).reshape({2, 3});
+    auto real_view = make_tensor<RealTensor<2>>(real);
+    ASSERT_TRUE((std::holds_alternative<HostTensorT<cytnx_double, 2, layout_right>>(real_view)));
+
+    Tensor complex({2, 3}, Type.ComplexFloat);
+    auto complex_view = make_tensor<ComplexTensor<2>>(complex);
+    ASSERT_TRUE(
+      (std::holds_alternative<HostTensorT<cytnx::cytnx_complex64, 2, layout_right>>(complex_view)));
+
+    auto numeric_view = make_tensor<NumericTensor<2>>(complex);
+    ASSERT_TRUE(
+      (std::holds_alternative<HostTensorT<cytnx::cytnx_complex64, 2, layout_right>>(numeric_view)));
+  }
+
+  TEST(TensorTTest, GenericVariantFactoryWorksWithCustomVariant) {
+    using CustomTensor = std::variant<HostTensorT<cytnx_double, 3, layout_stride>,
+                                      HostTensorT<cytnx::cytnx_complex128, 3, layout_stride>>;
+
+    Tensor tensor = arange(2 * 3 * 4).reshape({2, 3, 4});
+    Tensor permuted = tensor.permute({1, 2, 0});
+
+    auto variant = make_tensor<CustomTensor>(permuted);
+
+    ASSERT_TRUE((std::holds_alternative<HostTensorT<cytnx_double, 3, layout_stride>>(variant)));
+    auto &view = std::get<HostTensorT<cytnx_double, 3, layout_stride>>(variant);
+    EXPECT_EQ(view.extent(0), 3);
+    EXPECT_EQ(view.extent(1), 4);
+    EXPECT_EQ(view.extent(2), 2);
+    EXPECT_EQ(view.stride(0), 4);
+    EXPECT_EQ(view.stride(1), 1);
+    EXPECT_EQ(view.stride(2), 12);
+
+    Tensor wrong_rank = arange(2 * 3).reshape({2, 3});
+    EXPECT_THROW((make_tensor<CustomTensor>(wrong_rank)), std::logic_error);
+  }
+
+  TEST(TensorTTest, GenericVariantFactoryDoesNotMutateConstInputForLayoutRight) {
+    Tensor tensor = arange(2 * 3 * 4).reshape({2, 3, 4});
+    Tensor permuted = tensor.permute({1, 2, 0});
+    const Tensor &input = permuted;
+
+    auto variant = make_tensor<NumericTensor<3>>(input);
+
+    ASSERT_TRUE((std::holds_alternative<HostTensorT<cytnx_double, 3, layout_right>>(variant)));
+    EXPECT_FALSE(permuted.is_contiguous());
+
+    auto &view = std::get<HostTensorT<cytnx_double, 3, layout_right>>(variant);
+    EXPECT_EQ(view.extent(0), 3);
+    EXPECT_EQ(view.extent(1), 4);
+    EXPECT_EQ(view.extent(2), 2);
+    EXPECT_EQ(view(2, 3, 1), tensor.at<cytnx_double>({1, 2, 3}));
+
+    view(2, 3, 1) = 99;
+    EXPECT_EQ(tensor.at<cytnx_double>({1, 2, 3}), 23);
   }
 
   TEST(TensorTTest, RejectsWrongDtypeAndRank) {

--- a/tests/Tensor_test.cpp
+++ b/tests/Tensor_test.cpp
@@ -205,6 +205,76 @@ TEST_F(TensorTest, permute) {
   EXPECT_THROW(Tensor({0}, Type.Double, Device.cpu, true), std::logic_error);
 }
 
+TEST_F(TensorTest, as_mdspan_contiguous_tensor) {
+  Tensor tensor = arange(2 * 3 * 4).reshape({2, 3, 4});
+
+  auto view = tensor.as_mdspan<cytnx_double, 3>();
+
+  EXPECT_EQ(view.rank(), 3);
+  EXPECT_EQ(view.extent(0), 2);
+  EXPECT_EQ(view.extent(1), 3);
+  EXPECT_EQ(view.extent(2), 4);
+  EXPECT_EQ(view.stride(0), 12);
+  EXPECT_EQ(view.stride(1), 4);
+  EXPECT_EQ(view.stride(2), 1);
+  EXPECT_EQ(view(1, 2, 3), tensor.at<cytnx_double>({1, 2, 3}));
+
+  view(1, 2, 3) = 99;
+  EXPECT_EQ(tensor.at<cytnx_double>({1, 2, 3}), 99);
+}
+
+TEST_F(TensorTest, as_mdspan_permuted_tensor_uses_mapper_strides) {
+  Tensor tensor = arange(2 * 3 * 4).reshape({2, 3, 4});
+  Tensor permuted = tensor.permute({1, 2, 0});
+
+  auto view = permuted.as_mdspan<cytnx_double, 3>();
+
+  EXPECT_EQ(view.extent(0), 3);
+  EXPECT_EQ(view.extent(1), 4);
+  EXPECT_EQ(view.extent(2), 2);
+  EXPECT_EQ(view.stride(0), 4);
+  EXPECT_EQ(view.stride(1), 1);
+  EXPECT_EQ(view.stride(2), 12);
+  EXPECT_EQ(view(1, 2, 0), tensor.at<cytnx_double>({0, 1, 2}));
+
+  view(2, 3, 1) = 123;
+  EXPECT_EQ(tensor.at<cytnx_double>({1, 2, 3}), 123);
+}
+
+TEST_F(TensorTest, as_right_mdspan_returns_layout_right_view) {
+  Tensor tensor = arange(2 * 3 * 4).reshape({2, 3, 4});
+
+  auto view = tensor.as_right_mdspan<cytnx_double, 3>();
+
+  EXPECT_EQ(view.extent(0), 2);
+  EXPECT_EQ(view.extent(1), 3);
+  EXPECT_EQ(view.extent(2), 4);
+  EXPECT_EQ(view.stride(0), 12);
+  EXPECT_EQ(view.stride(1), 4);
+  EXPECT_EQ(view.stride(2), 1);
+  EXPECT_EQ(view(1, 2, 3), tensor.at<cytnx_double>({1, 2, 3}));
+}
+
+TEST_F(TensorTest, as_right_mdspan_makes_permuted_tensor_contiguous) {
+  Tensor tensor = arange(2 * 3 * 4).reshape({2, 3, 4});
+  Tensor permuted = tensor.permute({1, 2, 0});
+
+  auto view = permuted.as_right_mdspan<cytnx_double, 3>();
+
+  EXPECT_TRUE(permuted.is_contiguous());
+  EXPECT_EQ(view.extent(0), 3);
+  EXPECT_EQ(view.extent(1), 4);
+  EXPECT_EQ(view.extent(2), 2);
+  EXPECT_EQ(view.stride(0), 8);
+  EXPECT_EQ(view.stride(1), 2);
+  EXPECT_EQ(view.stride(2), 1);
+  EXPECT_EQ(view(2, 3, 1), tensor.at<cytnx_double>({1, 2, 3}));
+
+  view(2, 3, 1) = 321;
+  EXPECT_EQ(permuted.at<cytnx_double>({2, 3, 1}), 321);
+  EXPECT_EQ(tensor.at<cytnx_double>({1, 2, 3}), 23);
+}
+
 TEST_F(TensorTest, get) {
   Tensor tmp = tzero3456(":", ":", ":", ":");
   EXPECT_EQ(tmp.shape().size(), 4);

--- a/tests/mdspan_test.cpp
+++ b/tests/mdspan_test.cpp
@@ -1,0 +1,76 @@
+#include <gtest/gtest.h>
+
+#include "mdspan.hpp"
+
+#include <array>
+#include <vector>
+
+namespace {
+
+  using cytnx::stdex::dynamic_extent;
+  using cytnx::stdex::extents;
+  using cytnx::stdex::layout_right;
+  using cytnx::stdex::layout_stride;
+  using cytnx::stdex::mdspan;
+
+  TEST(MdspanTest, StaticExtentsLayoutRightIndexing) {
+    std::array<int, 6> data{0, 1, 2, 3, 4, 5};
+    mdspan<int, extents<std::size_t, 2, 3>> view(data.data());
+
+    EXPECT_EQ(view.rank(), 2);
+    EXPECT_EQ(view.extent(0), 2);
+    EXPECT_EQ(view.extent(1), 3);
+    EXPECT_EQ(view.stride(0), 3);
+    EXPECT_EQ(view.stride(1), 1);
+    EXPECT_EQ(view.required_span_size(), 6);
+    EXPECT_EQ(view(0, 0), 0);
+    EXPECT_EQ(view(0, 2), 2);
+    EXPECT_EQ(view(1, 0), 3);
+    EXPECT_EQ(view(1, 2), 5);
+  }
+
+  TEST(MdspanTest, DynamicExtentsKeepCompileTimeRank) {
+    std::vector<double> data(12);
+    for (std::size_t i = 0; i < data.size(); ++i) data[i] = static_cast<double>(i);
+
+    mdspan<double, extents<std::size_t, dynamic_extent, 4>> view(data.data(), 3);
+
+    EXPECT_EQ(view.rank(), 2);
+    EXPECT_EQ(view.rank_dynamic(), 1);
+    EXPECT_EQ(view.extent(0), 3);
+    EXPECT_EQ(view.extent(1), 4);
+    EXPECT_EQ(view.stride(0), 4);
+    EXPECT_EQ(view.stride(1), 1);
+    EXPECT_EQ(view(2, 3), 11.0);
+  }
+
+  TEST(MdspanTest, LayoutStrideIndexing) {
+    std::array<int, 6> data{0, 1, 2, 3, 4, 5};
+    using extents_type = extents<std::size_t, 3, 2>;
+    using mapping_type = layout_stride::mapping<extents_type>;
+
+    mapping_type mapping(extents_type(), std::array<std::size_t, 2>{1, 3});
+    mdspan<int, extents_type, layout_stride> view(data.data(), mapping);
+
+    EXPECT_EQ(view.rank(), 2);
+    EXPECT_EQ(view.extent(0), 3);
+    EXPECT_EQ(view.extent(1), 2);
+    EXPECT_EQ(view.stride(0), 1);
+    EXPECT_EQ(view.stride(1), 3);
+    EXPECT_EQ(view.required_span_size(), 6);
+    EXPECT_EQ(view(0, 0), 0);
+    EXPECT_EQ(view(2, 0), 2);
+    EXPECT_EQ(view(0, 1), 3);
+    EXPECT_EQ(view(2, 1), 5);
+  }
+
+  TEST(MdspanTest, ElementAccessMutatesUnderlyingData) {
+    std::array<int, 4> data{0, 1, 2, 3};
+    mdspan<int, extents<std::size_t, 2, 2>> view(data.data());
+
+    view(1, 0) = 42;
+
+    EXPECT_EQ(data[2], 42);
+  }
+
+}  // namespace


### PR DESCRIPTION
This PR adds a small `std::mdspan`-style view layer and a typed, ranked `TensorT` view type for Cytnx `Tensor` storage.

The motivation is to create a safer intermediate representation for C++ kernels. The current `Tensor` API carries dtype, rank, layout, and device information almost entirely as runtime state. That is flexible, but it makes low-level kernels easy to misuse: the kernel has to rediscover and re-check properties that could be represented directly in the C++ type. `TensorT<T, Rank, Access, Layout>` moves the most important parts of that contract into the type system while still sharing storage with the existing `Tensor` implementation.

The PR is intentionally limited to the core view layer. It does not replace existing kernels, add LAPACK wrappers, or change public Python behavior.

## What this adds

* `include/mdspan.hpp`: a small C++20 `std::mdspan`-compatible subset in `cytnx::stdex`.
  * dynamic extents with fixed compile-time rank
  * `layout_right`
  * `layout_stride`
  * element access and stride/extent queries
* `Tensor::as_mdspan<T, Rank>()`: returns a non-owning typed `layout_stride` mdspan preserving the Tensor's current logical layout, including permuted Tensor layouts.
* `Tensor::as_right_mdspan<T, Rank>()`: mutates the Tensor to contiguous storage and returns a non-owning typed `layout_right` mdspan.
* `TensorT<T, Rank, Access, Layout>`: a typed, ranked, storage-owning Tensor view.
* `make_tensor_t<T, Rank, Access>()`: creates a `TensorT` preserving the current Tensor layout.
* `make_right_tensor_t<T, Rank, Access>()`: creates a contiguous `layout_right` `TensorT`.
* `to_tensor()`: converts a compatible `TensorT` back to a legacy `Tensor` without copying.
* Variant helpers such as `RealTensor<Rank>`, `ComplexTensor<Rank>`, `NumericTensor<Rank>`, and `make_tensor<Variant>()` for dispatching legacy `Tensor` objects to typed TensorT alternatives.

## TensorT

The `TensorT` type is the 'maximally compile-time' version of a tensor. It is templated by:
* `T` - the type (in principle this is not restricted to the 12 types supported by `cytnx::Tensor`, but could support other floating point formats, for example)
* Rank - compile-time integer indicating the number of tensor legs. An extension to dynamic rank is possible in the future, coupled with a `dynamic_mdspan`, that meets the required API of `mdspan` that is used by `TensorT` but allows a dynamic rank.
* `Access` - this denotes whether the typed view is a host CPU view or a CUDA view. The `cuda_access` class contains a device number that tracks which GPU manages the memory of the tensor.
* `Layout` - this is the `mdspan` Layout type. Typically this will be `layout_stride`, or the row-major format used by `cytnx::Tensor` in _contiguous_ mode corresponds to `layout_right`. The current prototype of the forthcoming mdspan-based LAPACK wrappers generally uses `layout_right` for dense matrix kernels, although this could be overloaded with other layouts in the future.

`TensorT` stores its data via a `std::shared_ptr<T>`. Interoperability with `cytnx::Tensor` is via a custom deleter that manages an instance of `boost::intrusive_ptr<Storage_base>`. A `TensorT` that is constructed from a `cytnx::Tensor` will share storage with it, and can be converted back to a `cytnx::Tensor`. It is also possible to construct a host `TensorT` directly, without using `boost::intrusive_ptr<Storage_base>`. This is useful for short-lived temporary data or other situations where a `TensorT` will never need to be converted to a `cytnx::Tensor`, and will be somewhat more efficient. Direct CUDA allocation is intentionally not added in this PR; that should use a CUDA-specific allocator later.

## Examples

A non-owning mdspan view of a Tensor:

```c++
cytnx::Tensor tensor({2, 3}, cytnx::Type.Double);
auto view = tensor.as_mdspan<cytnx_double, 2>();

view(1, 2) = 4.0;
```
This will generate extremely fast code, much faster than any other method I know of to access the elements of a `Tensor`.

For a permuted Tensor, `as_mdspan()` preserves the logical layout using strides:

```c++
cytnx::Tensor tensor = cytnx::arange(0, 24, 1, cytnx::Type.Double).reshape({2, 3, 4});
cytnx::Tensor permuted = tensor.permute({1, 0, 2});

auto view = permuted.as_mdspan<cytnx_double, 3>();
// view.extent(0) == 3, view.extent(1) == 2, view.extent(2) == 4
// view.stride(...) reflects the Tensor mapper metadata.
```

If a kernel requires ordinary row-major contiguous data, use `as_right_mdspan()`:

```c++
cytnx::Tensor tensor = cytnx::arange(0, 24, 1, cytnx::Type.Double).reshape({2, 3, 4});
cytnx::Tensor permuted = tensor.permute({1, 0, 2});

auto view = permuted.as_right_mdspan<cytnx_double, 3>();
// permuted has been made contiguous, and view uses layout_right.
```

A storage-owning typed TensorT view:

```c++
cytnx::Tensor tensor({2, 3}, cytnx::Type.Double);
auto view = cytnx::make_tensor_t<cytnx_double, 2>(tensor);

view(1, 2) = 5.0;
```

Unlike `as_mdspan()`, the `TensorT` view keeps the underlying storage alive even if the original `Tensor` object goes away:

```c++
cytnx::HostTensorT<cytnx_double, 2> view;
{
  cytnx::Tensor tensor({2, 3}, cytnx::Type.Double);
  view = cytnx::make_tensor_t<cytnx_double, 2>(tensor);
}

view(0, 0) = 1.0;  // storage is still owned by the TensorT view
```

It is also straightforward to construct a `TensorT` directly, without going through legacy `Tensor` storage:

```c++
cytnx::HostTensorT<cytnx_double, 2, cytnx::stdex::layout_right> matrix({2, 3});
matrix(1, 2) = 7.0;
```

Round-tripping back to legacy `Tensor` is possible when the `TensorT` layout can be represented by the current Cytnx Tensor metadata:

```c++
cytnx::Tensor tensor = cytnx::arange(0, 6, 1, cytnx::Type.Double).reshape({2, 3});
auto view = cytnx::make_tensor_t<cytnx_double, 2>(tensor);

cytnx::Tensor roundtrip = cytnx::to_tensor(view);
// roundtrip shares storage with view/tensor; no data copy is made.
```

General arbitrary strided mdspan views are not always representable by the current Tensor mapper metadata. `to_tensor()` therefore accepts contiguous row-major layouts and contiguous layouts up to a permutation of axes, and rejects non-representable stride patterns.

A variant dispatch helper can select an appropriate typed view from a runtime Tensor:

```c++
using Matrix = cytnx::NumericTensor<2>;

cytnx::Tensor tensor({4, 4}, cytnx::Type.Double);
Matrix matrix = cytnx::make_tensor<Matrix>(tensor);

std::visit([](auto &typed_matrix) {
  using T = typename std::decay_t<decltype(typed_matrix)>::element_type;
  // typed_matrix is TensorT<T, 2, ...>
}, matrix);
```

## Current limitations

This is deliberately not a full `std::mdspan` implementation. It implements the subset needed by the Tensor view work: fixed compile-time rank, dynamic extents, `layout_right`, `layout_stride`, and basic indexing/query operations.

This is compatible with Ivana's draft PR #860, which adds the reference/Kokkos mdspan implementation. If #860 lands, this PR does not need to keep its own `include/mdspan.hpp`; the Tensor/TensorT view layer should be able to use the reference implementation instead. The main adjustment would be changing the namespace where the mdspan types and layouts are found.

The first version also does not attempt to encode arbitrary offset views, submdspan, or every possible Tensor layout. Those can be added later if and when a kernel or Tensor API actually needs them.

`TensorT` currently uses a `std::shared_ptr<T>` owner. When it is created from legacy `Tensor`, the shared pointer uses a deleter that holds the existing intrusive storage pointer alive. This is an adapter around the current storage implementation, not a new storage backend.

## Where this is headed

The intended use of this layer is to make `TensorT` the C++ boundary type for kernels. The legacy `Tensor` API can remain the flexible runtime-typed interface exposed to users, while internal kernels can take arguments whose requirements are visible in the C++ function signature:

```c++
void kernel(cytnx::MatrixT<cytnx_double, cytnx::host_access, cytnx::stdex::layout_right> matrix);
```

This makes scalar type, rank, access backend, and layout part of the overload set instead of a set of runtime checks repeated inside each kernel. It also gives a cleaner way to isolate CPU and CUDA implementations: CPU kernels can take `host_access` views, CUDA kernels can take `cuda_access` views, and CPU-only code does not need scattered `#ifdef UNI_GPU` branches or runtime `device == Device.cpu` checks.

Legacy `Tensor` objects can then be lowered at the API boundary into a typed view or a typed variant, and the implementation can dispatch from there:

```c++
using Matrix = cytnx::NumericTensor<2>;
Matrix matrix = cytnx::make_tensor<Matrix>(input);
std::visit([](auto &typed_matrix) {
  // call the matching typed kernel
}, matrix);
```

The planned follow-up sequence is:

1. Add a generic kernel dispatch mechanism for fixed typed views and `std::variant`-based typed view sets. A prototype of that layer is already working locally, but it is kept out of this PR so the basic Tensor/TensorT conversion layer can be reviewed first.
2. Add mdspan-based LAPACK wrappers. The CPU-side prototype is already implemented locally, although the final naming and API surface still need some settling.
3. Add cuSOLVER backends for CUDA TensorT views, once the LAPACK-side API is stable.
4. Add a higher-level TensorT-based linalg API that can allocate new storage for output tensors, not just operate on caller-provided mdspan views.
5. Start porting existing higher-level functions to use TensorT internally.

The intended migration path is incremental. Since `Tensor` and `TensorT` can convert in both directions while sharing storage, a TensorT-based implementation can temporarily convert back to legacy `Tensor`, call an existing function, and convert back to TensorT (as long as the TensorT remains in a permutation-compatible layout). That means existing functionality does not need to be ported all at once; individual kernels and higher-level routines can move over piece by piece.

## Verification

* `cmake --build build-mdspan --target test_main -j 16`
* `./build-mdspan/tests/test_main --gtest_filter=MdspanTest.*:TensorTTest.*:TensorTest.as_mdspan*:TensorTest.as_right_mdspan*`
* `git diff --check master..HEAD`

Co-authored-by: Codex <codex@openai.com>
