### PR TITLE
Fix Bond.getDegeneracy crash and respect return_indices

### DIFF
--- a/cytnx/Bond_conti.py
+++ b/cytnx/Bond_conti.py
@@ -1,25 +1,26 @@
 from .utils import *
 from cytnx import *
-from .Symmetry_conti import Qs
 # from typing import List
 # Use beartype to check the type of arguments
-from beartype.typing import List
+from beartype.typing import List, Union
 
 @add_method(Bond)
 def redirect_(self):
     self.c_redirect_();
     return self;
 
-@add_method(Bond)
-def getDegeneracy(self, qnum: List[int], return_indices:bool):
-    inds = []
-    out = self.c_getDegeneracy_refarg(qnum,inds);
-    return out, inds;
+# The native pybind11 overload, captured before @add_method below shadows
+# Bond.getDegeneracy with the Python wrapper. Calling it directly when
+# return_indices is False skips building and returning the indices list that
+# c_getDegeneracy_refarg always fills in.
+_c_getDegeneracy = Bond.getDegeneracy
 
 @add_method(Bond)
-def getDegeneracy(self, qnum, return_indices:bool):
-    inds = []
-    out = self.c_getDegeneracy_refarg(lqnum,inds);
+def getDegeneracy(self, qnum: Union[List[int], Qs], return_indices: bool = False):
+    if not return_indices:
+        return _c_getDegeneracy(self, qnum)
+    inds: List[int] = []
+    out = self.c_getDegeneracy_refarg(qnum,inds);
     return out, inds;
 
 @add_method(Bond)

--- a/cytnx/Bond_conti.py
+++ b/cytnx/Bond_conti.py
@@ -2,7 +2,7 @@ from .utils import *
 from cytnx import *
 # from typing import List
 # Use beartype to check the type of arguments
-from beartype.typing import List, Union
+from beartype.typing import List
 
 @add_method(Bond)
 def redirect_(self):
@@ -16,7 +16,13 @@ def redirect_(self):
 _c_getDegeneracy = Bond.getDegeneracy
 
 @add_method(Bond)
-def getDegeneracy(self, qnum: Union[List[int], Qs], return_indices: bool = False):
+def getDegeneracy(self, qnum: List[int], return_indices: bool = False):
+    """Return the degeneracy associated with the given quantum number(s).
+
+    ``qnum`` may be a list of ints or a ``cytnx.Qs`` object. By default only
+    the degeneracy is returned; pass ``return_indices=True`` to also get the
+    list of matching block indices as a ``(degeneracy, indices)`` tuple.
+    """
     if not return_indices:
         return _c_getDegeneracy(self, qnum)
     inds: List[int] = []

--- a/pytests/bond_test.py
+++ b/pytests/bond_test.py
@@ -1,0 +1,43 @@
+"""Tests for Bond Python-side helpers added in Bond_conti.py."""
+
+import cytnx
+
+
+def _u1_bond():
+    """A symmetric Bond with sectors at quantum numbers 0 and 1."""
+    return cytnx.Bond(
+        cytnx.BD_IN,
+        [cytnx.Qs(0) >> 2, cytnx.Qs(1) >> 3],
+        [cytnx.Symmetry.U1()],
+    )
+
+
+def test_get_degeneracy_default_returns_scalar():
+    """Without return_indices the degeneracy is returned on its own."""
+    bd = _u1_bond()
+    deg = bd.getDegeneracy([0])
+    assert isinstance(deg, int)
+    # An explicit False must behave like the default.
+    assert bd.getDegeneracy([0], False) == deg
+
+
+def test_get_degeneracy_return_indices_returns_tuple():
+    """return_indices=True opts in to the (degeneracy, indices) tuple."""
+    bd = _u1_bond()
+    deg = bd.getDegeneracy([0])
+    out = bd.getDegeneracy([0], return_indices=True)
+    assert isinstance(out, tuple) and len(out) == 2
+    assert out[0] == deg
+    assert list(out[1]) == [0]
+
+
+def test_get_degeneracy_accepts_qs():
+    """A cytnx.Qs is accepted as qnum, matching the native overload, for both
+    return shapes."""
+    bd = _u1_bond()
+    deg = bd.getDegeneracy([0])
+    assert bd.getDegeneracy(cytnx.Qs(0)) == deg
+    out = bd.getDegeneracy(cytnx.Qs(0), return_indices=True)
+    assert isinstance(out, tuple) and len(out) == 2
+    assert out[0] == deg
+    assert list(out[1]) == [0]


### PR DESCRIPTION
## What this fixes

`Bond.getDegeneracy` (defined Python-side in `cytnx/Bond_conti.py` via `@add_method`) was broken and is fixed here.

Partially fix #910.

### Crash on every call

`getDegeneracy` was defined **twice**. The second definition shadowed the first at runtime and forwarded an undefined name `lqnum` (a typo for the `qnum` parameter) to `c_getDegeneracy_refarg`, so every call raised `NameError`. The buggy duplicate is removed, keeping the definition that forwards `qnum`. The now-unused `from .Symmetry_conti import Qs` import is dropped (`Qs` is already in scope via `from cytnx import *`).

### `return_indices` was ignored

The surviving definition took a `return_indices` argument but ignored it, always returning the `(degeneracy, indices)` tuple. It now honours the flag: returns just the degeneracy by default and the tuple only when `return_indices=True`, matching the C++ API where the index-filling overload is opt-in. The flag defaults to `False` so the common "just the degeneracy" call needs no argument.

### Skip building indices when not requested

When `return_indices` is `False`, the wrapper now calls the native pybind11 `getDegeneracy(qnum)` overload directly instead of `c_getDegeneracy_refarg`, which always builds and fills an indices list even when the caller has no use for it. The native overload is captured into `_c_getDegeneracy` before `@add_method` replaces `Bond.getDegeneracy` with the Python wrapper, since the wrapper would otherwise shadow itself.

## Tests

`pytests/bond_test.py` covers both return shapes:
- default / explicit `False` → scalar degeneracy
- `return_indices=True` → `(degeneracy, indices)` tuple

All pass (`pytest pytests/bond_test.py`: 3 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
