### PR TITLE
Fix MPS.Save binding to use tn_algo::MPS as self type

### DIFF
--- a/pybind/tnalgo_py.cpp
+++ b/pybind/tnalgo_py.cpp
@@ -52,7 +52,7 @@ void tnalgo_binding(py::module &m) {
     .def("c_S_mvleft", &tn_algo::MPS::S_mvleft)
     .def("c_S_mvright", &tn_algo::MPS::S_mvright)
     .def(
-      "Save", [](cytnx::Storage &self, const std::string &fname) { self.Save(fname); },
+      "Save", [](tn_algo::MPS &self, const std::string &fname) { self.Save(fname); },
       py::arg("fname"))
     .def_static(
       "Load", [](const std::string &fname) { return cytnx::tn_algo::MPS::Load(fname); },


### PR DESCRIPTION
## Summary

`MPS.Save` was bound in `pybind/tnalgo_py.cpp` with a lambda whose first parameter (the implicit `self`) was typed `cytnx::Storage&`, even though the lambda is registered as a method on `py::class_<tn_algo::MPS>`. pybind11 requires the lambda's `self` parameter to match the bound class, so calling `mps.Save(fname)` from Python raised a `TypeError` instead of invoking `tn_algo::MPS::Save`.

```cpp
// before
.def(
  "Save", [](cytnx::Storage &self, const std::string &fname) { self.Save(fname); },
  py::arg("fname"))

// after
.def(
  "Save", [](tn_algo::MPS &self, const std::string &fname) { self.Save(fname); },
  py::arg("fname"))
```

## Test plan

- [x] `cmake --preset debug-openblas-cpu && cmake --build --preset debug-openblas-cpu --target test_main` builds cleanly
- [x] `ctest --preset cpu-only` — failures present are pre-existing and unrelated (SVD precision/fermionic edge cases); `pybind/tnalgo_py.cpp` is not linked into `test_main`
- [x] `pip install --editable '.[dev]'` rebuilt the extension module with the fix
- [x] Verified `mps.Save(...)` on an uninitialized `tn_algo::MPS` now reaches the real `tn_algo::MPS::_Save` implementation (raises the expected "Cannot save an uninitialize MPS" error from `MPS.cpp`) instead of failing immediately with a pybind11 `self`-type `TypeError`
- [x] `pytest pytests/ -q -k "not example"` — 15 passed

---
Investigated and filed by Claude (Claude Code).