### PR TITLE
Fix TDVP code to correctly discard null singular values and bad Svd_truncate default behavior

### DIFF
--- a/example/TDVP/tdvp1_dense.py
+++ b/example/TDVP/tdvp1_dense.py
@@ -7,7 +7,6 @@ Author: Hao-Ti Hung
 """
 
 def tdvp1_XXZmodel_dense(J, Jz, hx, hz, A, chi, dt, time_step):
-
     class OneSiteOp(cytnx.LinOp):
         def __init__(self, L, M, R):
             self.anet = cytnx.Network()
@@ -170,7 +169,10 @@ def tdvp1_XXZmodel_dense(J, Jz, hx, hz, A, chi, dt, time_step):
             psi = time_evolve_Lan_f(psi, (LR[p],M,LR[p+1]), dt)
 
             psi.set_rowrank_(1) # maintain rowrank to perform the svd
-            s,_,A[p] = cytnx.linalg.Svd_truncate(psi,new_dim)
+            # Remove numerically null Schmidt vectors. Keeping zero-weight sectors
+            # in the Schmidt basis makes the TDVP tangent-space projector incomplete
+            # and ill-conditioned.
+            s,_,A[p] = cytnx.linalg.Svd_truncate(psi,new_dim,1.0e-12)
             A[p].relabel_(lbls[p]) # set the label back to be consistent
             # update LR from right to left:
             anet = cytnx.Network()
@@ -211,7 +213,10 @@ def tdvp1_XXZmodel_dense(J, Jz, hx, hz, A, chi, dt, time_step):
             psi = time_evolve_Lan_f(psi, (LR[p],M,LR[p+1]), dt)
 
             psi.set_rowrank_(2) # maintain rowrank to perform the svd
-            s,A[p],_ = cytnx.linalg.Svd_truncate(psi,new_dim)
+            # Remove numerically null Schmidt vectors. Keeping zero-weight sectors
+            # in the Schmidt basis makes the TDVP tangent-space projector incomplete
+            # and ill-conditioned.
+            s,A[p],_ = cytnx.linalg.Svd_truncate(psi,new_dim,1.0e-12)
             A[p].relabel_(lbls[p]) #set the label back to be consistent
             # update LR from left to right:
             anet = cytnx.Network()

--- a/pytests/example/TDVP/tdvp1_dense_test.py
+++ b/pytests/example/TDVP/tdvp1_dense_test.py
@@ -5,10 +5,10 @@ sys.path.append('example/TDVP/')
 from tdvp1_dense import *
 from numpy import linalg as LA
 
-def test_tdvp1_dense():
+
+def run_product_state_tdvp(chi, time_step):
     # Prepare a deterministic product state with overlap on both local Sz eigenstates.
     Nsites = 8 # Number of sites
-    chi = 2 # MPS bond dimension
     d = 2
     MPS_x = prepare_x_init_MPS(Nsites, chi, d)
 
@@ -18,8 +18,34 @@ def test_tdvp1_dense():
     hx = 0.0
     hz = -1.0
     tau = -1.0j
-    time_step = 10
     # prepare up state
-    As, Es = tdvp1_XXZmodel_dense(J, Jz, hx, hz, MPS_x, chi, tau, time_step)
+    return tdvp1_XXZmodel_dense(J, Jz, hx, hz, MPS_x, chi, tau, time_step)
+
+
+def test_tdvp1_dense():
+    Nsites = 8 # Number of sites
+    chi = 1 # MPS bond dimension
+    time_step = 17
+    As, Es = run_product_state_tdvp(chi, time_step)
     error = np.abs(Es[-1]-(-1.0*Nsites))
-    assert error < 1e-6
+
+    # For this test Hamiltonian, H = -sum_i Sz_i.  The |x> product state has
+    # ground-state weight 1 / 2**Nsites.  The first excited sector is Nsites-fold
+    # degenerate with gap 2, so after imaginary time beta the leading energy
+    # error is O(2 * Nsites * exp(-2 * beta)).
+    #
+    # The exact imaginary-time trajectory stays in the chi = 1 product-state
+    # manifold.  For Nsites = 8 and time_step = 17 this estimate is 2.742e-14.
+    # The test asserts that the TDVP error is within a factor of 20 of this
+    # scale.  As of commit 640bb4bfcc989bd9c1126ee13b3fd1c3920803e9, the
+    # observed error is at roundoff.
+    leading_energy_error = 2.0 * Nsites * np.exp(-2.0 * time_step)
+    assert error < 20.0 * leading_energy_error
+
+
+def test_tdvp1_dense_truncates_null_padded_product_state():
+    chi1_As, chi1_Es = run_product_state_tdvp(chi=1, time_step=17)
+    chi2_As, chi2_Es = run_product_state_tdvp(chi=2, time_step=17)
+
+    assert [tensor.shape() for tensor in chi2_As[-1]] == [tensor.shape() for tensor in chi1_As[-1]]
+    assert np.abs(chi2_Es[-1] - chi1_Es[-1]) < 1e-12


### PR DESCRIPTION
## Summary

This PR fixes the TDVP example so that the product-state imaginary-time evolution test actually converges.

The immediate fix is to pass an explicit `1e-12` singular-value cutoff to the two `Svd_truncate()` calls inside the TDVP sweep. The previous code used the default `Svd_truncate()` behavior, which keeps exact-zero Schmidt sectors. That is unsafe for TDVP: while null singular vectors in the basis do not change the represented MPS, they make the tangent space projector incomplete and ill-defined. This causes the example TDVP code to fail to converge.

The pytest now checks two things separately: the exact `chi = 1` product-state evolution reaches the expected ground-state energy, and the null-padded `chi = 2` representation is truncated back to the same `chi = 1` state.

This PR does not change the default behavior of `Svd_truncate()`, but the current behavior is dangerous.

## Details

This PR fixes the TDVP example code so that its SVD truncation step removes numerically null Schmidt vectors, and updates the TDVP pytest to check the intended product-state behavior more directly.

The TDVP example now passes a small fixed singular-value cutoff (`1e-12`) to the two `Svd_truncate()` calls used during TDVP sweeps. Keeping exact-zero Schmidt sectors is catastrophic for tangent-space algorithms. The tangent space projector is built from the null space of states that are orthogonal to the "kept" states in the auxiliary basis, so keeping zero-weight Schmidt sectors in the auxiliary basis prevents the tangent space algorithm from using them and makes the tangent-space projector ill-defined. For the imaginary time TDVP *smoke test* where the physical groundstate is a `chi=1` product state, on current `master` branch with `chi=2` MPS and no singular value cutoff, it does not actually converge to a stable state. The error in the energy meets the tested tolerance of `1e-6` but it is non-monotonic and even after a long time it still randomly fluctuates between around `~1e-8` and `~1e-10`. This is roughly 4-6 orders of magnitude worse than the expected convergence for this very trivial problem.

The pytest is now split into two checks:

1. The main imaginary-time TDVP test now uses the exact `chi = 1` product-state manifold. The test tolerance is derived from the spectrum of the simple Hamiltonian `H = -sum_i Sz_i`, rather than using an unexplained `1e-6` threshold.
2. A second test starts from the same `|x>` product state padded to `chi = 2` and verifies that the TDVP sweep truncates the null bond directions back to the `chi = 1` state.

For this Hamiltonian and initial state it is possible to estimate the expected error in the TDVP groundstate energy from the spectrum, and gives the leading error as `O(2 * L * exp(-2 beta))`.  For the test parameters `L = 8` and `time_step = 17`, this gives `2.742e-14`, and the assertion allows a factor of 20 over this scale.  The actual `chi = 1` error after this PR hits exact zero `0` -- the Hamiltonian is simple enough that in IEEE arithmetic it reaches the exact values.
This test has now exposed several separate issues over the recent PR stack and the choices of various parameters in the test make it clear that the original version of this test had been selected to work around multiple independent bugs, and in some cases fixing those bugs exposed another layer of bugs.

* the TDVP example code one-site `LinOp` dimension was wrong (fixed in #889). Not all of the linear algebra functions verify that the flattened dimension of the input vector actually matches `LinOp::nx()`. As a result it is likely that user code based on the supplied example TDVP code also gets this wrong. Supplying an `nx` that is too small is numerically catastrophic -- if the Krylov algorithm actually hits `nx` iterations it will falsely declare that the result is fully converged, when it might actually be far away from convergence.
* The initial state as `chi=2` works around the fact that `chi=1` fails due to the `Lanczos_Exp` implementation not correctly handling one-dimensional Krylov spaces (#887). (It is not actually a 1-dimensional space but setting `chi=1` in the test set the `LinOp` dimension to 1 due to the above `LinOp::nx` bug.)
* Various bugs or numerical errors in `Lanczos_Exp` that made it incapable of converging to the stated thresholds even for trivially small cases. Enough of these have now been resolved that the TDVP test is able to expose the next layer of bugs, in the TDVP code itself, namely:
* The TDVP example preserved null-padded MPS bond directions instead of truncating them away. This makes the tangent space projection incomplete, ill-defined and ill-conditioned. That is the focus of this PR.

## Not addressed here

- This PR does not change the global default behavior of `Svd_truncate()`. I think that needs to be fixed, as a matter of some urgency.

  The default cutoff in `Svd_truncate()` is zero, which is interpreted as keeping all singular values (up to `keepdim` cap), even if they are numerically, or actual, zero. This is not a good default, and numerically catastrophic in TDVP, or any other algorithm based on tangent spaces. The reason is that the tangent space is made up of the directions on the tensor network manifold that are perpendicular to the kept vectors (i.e. the null space of the MPS auxiliary basis). So if numerically zero singular vectors are kept in the basis, by definition they cannot be part of the tangent space, and the tangent space is incomplete. This is very serious: I have asked my student to check carefully his existing code to see if there is any call to `Svd_truncate()` with the default value or using `err=0`; if there are, then the calculations are
  highly suspicious and need to be checked carefully, potentially back over several years of work. (So far, from the code I have access to, it does not use default parameters in `Svd_truncate()`.)

  A reasonable default is probably `err=1e-12`, with a visible warning that the behavior has changed and calculations that used the previous default should be treated as numerically suspect until checked. This could be focussed to specify TDVP / tangent-space algorithms specifically as most algorithms are not suspect, although in almost all cases they will benefit from the new default. `1e-12` is small enough that it will not affect any physical observable, since the relevant scale is the square of the singular values and `1e-24` is far below numerical epsilon.

- The example TDVP code sets the `LinOp::dtype` to `ComplexDouble`, even though the Hamiltonian is purely real and for imaginary time evolution the prefactors to the exponential are real as well. The fix to this is probably to make `LinOp::dtype` a type promotion hint rather than the required dtype of the input tensor.

- In the course of making these fixes I noticed the existence of `src/tn_algo`. The `DMRG.cpp` looks like old code with some amount of code rot, but as far as I can tell it is exposed via Python bindings. I was going to include some further investigations here but it appears that the ***entire*** `tn_algo` folder is untested, rotted code. I will submit another PR to remove the associated Python bindings so it is no longer exposed to Python users.