### PR TITLE
Add C++ test coverage for tn_algo and fix the bugs it uncovers (#924)

### DIFF
--- a/include/tn_algo/MPS.hpp
+++ b/include/tn_algo/MPS.hpp
@@ -23,6 +23,21 @@ namespace cytnx {
   namespace tn_algo {
 
     /// @cond
+    // Canonical bond/physical labels for site `site` of a finite MPS:
+    // {"_<2k>", "_<2k+1>", "_<2k+2>"}. Adjacent sites share their virtual-bond
+    // label (site k's right label "_<2k+2>" equals site k+1's left label), and
+    // every label carries the "_" prefix reserved for cytnx-internal labels so it
+    // cannot collide with user-assigned labels on the exposed site tensors. The
+    // orthogonalization routines restore these labels after each linalg::Svd so
+    // Svd's fixed "_aux_L"/"_aux_R" bonds do not survive into the next
+    // decomposition and trip set_labels' duplicate check (issue #920).
+    inline std::vector<std::string> CanonicalSiteLabels(cytnx_int64 site) {
+      return {"_" + std::to_string(2 * site), "_" + std::to_string(2 * site + 1),
+              "_" + std::to_string(2 * site + 2)};
+    }
+    /// @endcond
+
+    /// @cond
     class MPSType_class {
      public:
       enum : int {

--- a/src/tn_algo/DMRG.cpp
+++ b/src/tn_algo/DMRG.cpp
@@ -33,8 +33,8 @@ namespace cytnx {
         UniTensor &M2 = functArgs[2];
         UniTensor &R = functArgs[3];
 
-        this->anet.FromString({"psi: -1,-2;-3,-4", "L: ;-5,-1,0", "R: ;-7,-4,3", "M1: ;-5,-6,-2,1",
-                               "M2: ;-6,-7,-3,2", "TOUT: 0,1;2,3"});
+        this->anet.FromString({"psi: -1,-2,-3,-4", "L: -5,-1,0", "R: -7,-4,3", "M1: -5,-6,-2,1",
+                               "M2: -6,-7,-3,2", "TOUT: 0,1;2,3"});
         this->anet.PutUniTensor("M2", M2);
         this->anet.PutUniTensors({"L", "M1", "R"}, {L, M1, R});
 
@@ -47,7 +47,7 @@ namespace cytnx {
         auto lbls = v.labels();
 
         this->anet.PutUniTensor("psi", v);
-        UniTensor out = this->anet.Launch(true);  // get_block_ without copy
+        UniTensor out = this->anet.Launch();  // get_block_ without copy
 
         // shifted ortho state:
         for (cytnx_int64 ir = 0; ir < this->ortho_mps.size(); ir++) {
@@ -80,8 +80,8 @@ namespace cytnx {
 
         std::vector<cytnx_int64> pshape = vec_cast<cytnx_uint64, cytnx_int64>(
           {L.shape()[1], M1.shape()[2], M2.shape()[2], R.shape()[1]});
-        this->anet.FromString({"psi: ;-1,-2,-3,-4", "L: ;-5,-1,0", "R: ;-7,-4,3", "M1: ;-5,-6,-2,1",
-                               "M2: ;-6,-7,-3,2", "TOUT: ;0,1,2,3"});
+        this->anet.FromString({"psi: -1,-2,-3,-4", "L: -5,-1,0", "R: -7,-4,3", "M1: -5,-6,-2,1",
+                               "M2: -6,-7,-3,2", "TOUT: ;0,1,2,3"});
         this->anet.PutUniTensor("M2", M2);
         this->anet.PutUniTensors({"L", "M1", "R"}, {L, M1, R});
 
@@ -97,7 +97,7 @@ namespace cytnx {
         auto psi_u = UniTensor(v_, false, 0);  // ## share memory, no copy
         psi_u.reshape_(this->shapes);
         this->anet.PutUniTensor("psi", psi_u);
-        Tensor out = this->anet.Launch(true).get_block_();  // get_block_ without copy
+        Tensor out = this->anet.Launch().get_block_();  // get_block_ without copy
         out.flatten_();  // only change meta, without copy.
 
         // shifted ortho state:
@@ -137,6 +137,16 @@ namespace cytnx {
 
     //----------------------------
 
+    // Canonical per-site MPS labels (see RegularMPS::Init): site k carries
+    // {2k, 2k+1, 2k+2}, so neighbouring sites share their virtual-bond label.
+    // Restoring these after each Svd_truncate keeps the chain consistent and
+    // stops linalg::Svd's fixed "_aux_L"/"_aux_R" bond labels from surviving
+    // into the next decomposition, where the reused label would collide and
+    // abort the sweep with a duplicated-label error (issue #920).
+    static std::vector<std::string> mps_site_labels(const cytnx_int64 &k) {
+      return {to_string(2 * k), to_string(2 * k + 1), to_string(2 * k + 2)};
+    }
+
     void DMRG_impl::initialize() {
       // initialize everything
       // 1. setting env:
@@ -168,18 +178,15 @@ namespace cytnx {
       this->LR.back() = R0;
       this->mps.Into_Lortho();
 
+      // anet = cytnx.Network("L_AMAH.net")
+      auto Lnet = Network();
+      Lnet.FromString(
+        {"L: -2,-1,-3", "A: -1,-4,1", "M: -2,0,-4,-5", "A_Conj: -3,-5,2", "TOUT: ;0,1,2"});
       for (int p = 0; p < this->mps.size() - 1; p++) {
-        // this->mps.S_mvright();
-        // anet = cytnx.Network("L_AMAH.net")
-        // anet.PutUniTensors(["L","A","A_Conj","M"],[self.LR[p],self.mps.A[p],self.mps.A[p].Conj(),self.mpo.get_op(p)],is_clone=False);
-
-        // hard coded the network:
-        auto Lenv = this->LR[p].relabel({"-2", "-1", "-3"});
-        auto tA = this->mps.data()[p].relabel({"-1", "-4", "1"});
-        auto tAc = this->mps.data()[p].Conj();
-        tAc.relabel_({"-3", "-5", "2"});
-        auto M = this->mpo.get_op(p).relabel({"-2", "0", "-4", "-5"});
-        this->LR[p + 1] = Network::Contract({Lenv, tA, tAc, M}, ";0,1,2").Launch(true);
+        Lnet.PutUniTensors(
+          {"L", "A", "A_Conj", "M"},
+          {this->LR[p], this->mps.data()[p], this->mps.data()[p].Conj(), this->mpo.get_op(p)});
+        this->LR[p + 1] = Lnet.Launch();
       }
       // this->mps.S_mvright();
 
@@ -204,13 +211,13 @@ namespace cytnx {
 
         // anet = cytnx.Network("hL_AMAH.net")
         auto anet = Network();
-        anet.FromString({"hL: ;-1,-2", "Av: -1,-4;1", "Ap: -2,-4;2", "TOUT: ;1,2"});
+        anet.FromString({"hL: -1,-2", "Av: -1,-4,1", "Ap: -2,-4,2", "TOUT: ;1,2"});
         for (cytnx_int64 p = 0; p < this->mps.size() - 1; p++) {
           // anet.PutUniTensors(["hL","Av","Ap"],[hLR[p],self.mps.A[p],omps.A[p].Conj()],is_clone=False);
 
           anet.PutUniTensors({"hL", "Av", "Ap"},
                              {hLR[p], this->mps.data()[p], omps.data()[p].Conj()});
-          hLR[p + 1] = anet.Launch(true);
+          hLR[p + 1] = anet.Launch();
         }
       }
 
@@ -271,17 +278,17 @@ namespace cytnx {
         // anet = cytnx.Network("hL_AA_hR.net");
         auto anet = Network();
         anet.FromString({
-          "hL: ;-1,1",
-          "psi: ;1,2,3,4",
-          "hR: ;-2,4",
+          "hL: -1,1",
+          "psi: 1,2,3,4",
+          "hR: -2,4",
           "TOUT: ;-1,2,3,-2",
         });
 
         for (cytnx_int64 ip = 0; ip < this->ortho_mps.size(); ip++) {
           auto opsi = Contract(this->ortho_mps[ip].data()[p], this->ortho_mps[ip].data()[p + 1]);
-          opsi.set_rowrank(0);
+          opsi.set_rowrank_(0);
           anet.PutUniTensors({"hL", "psi", "hR"}, {this->hLRs[ip][p], opsi, this->hLRs[ip][p + 2]});
-          auto out = anet.Launch(true).get_block_();
+          auto out = anet.Launch().get_block_();
           omps.push_back(out);
           omps.back().flatten_();
         }
@@ -302,42 +309,47 @@ namespace cytnx {
         auto s = outU[0];
         this->mps.data()[p] = outU[1];
         this->mps.data()[p + 1] = outU[2];
+        // restore canonical labels so the Svd "_aux_L"/"_aux_R" bonds do not
+        // survive into the next site's decomposition (issue #920).
+        this->mps.data()[p + 1].relabel_(mps_site_labels(p + 1));
 
         auto slabel = s.labels();
         s = s / s.get_block_().Norm().item();
         s.relabel_(slabel);
 
         this->mps.data()[p] = Contract(this->mps.data()[p], s);  // absorb s into next neighbor
+        this->mps.data()[p].relabel_(mps_site_labels(p));
         this->mps.S_loc() = p;
 
         // update LR from right to left:
         // anet = cytnx.Network("R_AMAH.net")
         anet.FromString(
-          {"R: ;-2,-1,-3", "B: 1;-4,-1", "M: ;0,-2,-4,-5", "B_Conj: 2;-5,-3", "TOUT: ;0,1,2"});
+          {"R: -2,-1,-3", "B: 1,-4,-1", "M: 0,-2,-4,-5", "B_Conj: 2,-5,-3", "TOUT: ;0,1,2"});
 
         anet.PutUniTensors({"R", "B", "M", "B_Conj"},
                            {this->LR[p + 2], this->mps.data()[p + 1], this->mpo.get_op(p + 1),
                             this->mps.data()[p + 1].Conj()});
-        this->LR[p + 1] = anet.Launch(true);
+        this->LR[p + 1] = anet.Launch();
 
         // update hLR from right to left for excited states:
         // anet = cytnx.Network("hR_AMAH.net")
-        anet.FromString({"hR: ;-1,-2", "Bv: 1;-4,-1", "Bp: 2,-4;-2", "TOUT: ;1,2"});
+        anet.FromString({"hR: -1,-2", "Bv: 1,-4,-1", "Bp: 2,-4,-2", "TOUT: ;1,2"});
 
         for (cytnx_int64 ip = 0; ip < this->ortho_mps.size(); ip++) {
           auto omps = this->ortho_mps[ip];
           anet.PutUniTensors({"hR", "Bv", "Bp"}, {this->hLRs[ip][p + 2], this->mps.data()[p + 1],
                                                   omps.data()[p + 1].Conj()});
-          this->hLRs[ip][p + 1] = anet.Launch(true);
+          this->hLRs[ip][p + 1] = anet.Launch();
         }
         // print('Sweep[r->l]: %d/%d, Loc:%d,Energy: %f'%(k,numsweeps,p,Ekeep[-1]))
         if (verbose) std::cout << "Energy: " << std::setprecision(13) << Entemp << std::endl;
 
       }  // r->l
 
-      this->mps.data()[0].set_rowrank(1);
+      this->mps.data()[0].set_rowrank_(1);
       auto tout = linalg::Svd(this->mps.data()[0], true);
       this->mps.data()[0] = tout[2];
+      this->mps.data()[0].relabel_(mps_site_labels(0));
       this->mps.S_loc() = -1;
 
       // a.2 Optimize from left-to-right:
@@ -386,17 +398,17 @@ namespace cytnx {
         // anet = cytnx.Network("hL_AA_hR.net");
         auto anet = Network();
         anet.FromString({
-          "hL: ;-1,1",
-          "psi: ;1,2,3,4",
-          "hR: ;-2,4",
+          "hL: -1,1",
+          "psi: 1,2,3,4",
+          "hR: -2,4",
           "TOUT: ;-1,2,3,-2",
         });
 
         for (cytnx_int64 ip = 0; ip < this->ortho_mps.size(); ip++) {
           auto opsi = Contract(this->ortho_mps[ip].data()[p], this->ortho_mps[ip].data()[p + 1]);
-          opsi.set_rowrank(0);
+          opsi.set_rowrank_(0);
           anet.PutUniTensors({"hL", "psi", "hR"}, {this->hLRs[ip][p], opsi, this->hLRs[ip][p + 2]});
-          omps.push_back(anet.Launch(true).get_block_());
+          omps.push_back(anet.Launch().get_block_());
           omps.back().flatten_();
         }
 
@@ -416,6 +428,9 @@ namespace cytnx {
         this->mps.data()[p] = outU[1];
         this->mps.data()[p + 1] = outU[2];
         // s,self.mps.A[p],self.mps.A[p+1] = cytnx.linalg.Svd_truncate(psi,new_dim)
+        // restore canonical labels so the Svd "_aux_L"/"_aux_R" bonds do not
+        // survive into the next site's decomposition (issue #920).
+        this->mps.data()[p].relabel_(mps_site_labels(p));
 
         auto slabel = s.labels();
         s = s / s.get_block_().Norm().item();
@@ -423,33 +438,35 @@ namespace cytnx {
 
         this->mps.data()[p + 1] =
           Contract(s, this->mps.data()[p + 1]);  // absorb s into next neighbor.
+        this->mps.data()[p + 1].relabel_(mps_site_labels(p + 1));
         this->mps.S_loc() = p + 1;
 
         // anet = cytnx.Network("L_AMAH.net");
         anet.FromString(
-          {"L: ;-2,-1,-3", "A: -1,-4;1", "M: ;-2,0,-4,-5", "A_Conj: -3,-5;2", "TOUT: ;0,1,2"});
+          {"L: -2,-1,-3", "A: -1,-4,1", "M: -2,0,-4,-5", "A_Conj: -3,-5,2", "TOUT: ;0,1,2"});
 
         anet.PutUniTensors(
           {"L", "A", "A_Conj", "M"},
           {this->LR[p], this->mps.data()[p], this->mps.data()[p].Conj(), this->mpo.get_op(p)});
-        this->LR[p + 1] = anet.Launch(true);
+        this->LR[p + 1] = anet.Launch();
 
         // update hLR when calculate excited state:
         // anet = cytnx.Network("hL_AMAH.net");
-        anet.FromString({"hL: ;-1,-2", "Av: -1,-4;1", "Ap: -2,-4;2", "TOUT: ;1,2"});
+        anet.FromString({"hL: -1,-2", "Av: -1,-4,1", "Ap: -2,-4,2", "TOUT: ;1,2"});
         for (cytnx_int64 ip = 0; ip < this->ortho_mps.size(); ip++) {
           auto omps = this->ortho_mps[ip];
           anet.PutUniTensors({"hL", "Av", "Ap"},
                              {this->hLRs[ip][p], this->mps.data()[p], omps.data()[p].Conj()});
-          this->hLRs[ip][p + 1] = anet.Launch(true);
+          this->hLRs[ip][p + 1] = anet.Launch();
         }
         // print('Sweep[l->r]: %d of %d, Loc: %d,Energy: %f' % (k, numsweeps, p, Ekeep[-1]))
         if (verbose) std::cout << "Energy: " << std::setprecision(13) << Entemp << std::endl;
       }
 
-      this->mps.data().back().set_rowrank(2);
+      this->mps.data().back().set_rowrank_(2);
       tout = linalg::Svd(this->mps.data().back(), true);  // last one.
       this->mps.data().back() = tout[1];
+      this->mps.data().back().relabel_(mps_site_labels(this->mps.data().size() - 1));
       this->mps.S_loc() = this->mps.data().size();
 
       return Entemp;
@@ -506,22 +523,22 @@ namespace cytnx {
         // anet = cytnx.Network("hL_AA_hR.net");
         auto anet = Network();
         anet.FromString({
-          "hL: ;-1,1",
-          "psi: ;1,2,3,4",
-          "hR: ;-2,4",
+          "hL: -1,1",
+          "psi: 1,2,3,4",
+          "hR: -2,4",
           "TOUT: -1,2;3,-2",
         });
 
         for (cytnx_int64 ip = 0; ip < this->ortho_mps.size(); ip++) {
           auto opsi = Contract(this->ortho_mps[ip].data()[p], this->ortho_mps[ip].data()[p + 1]);
-          opsi.set_rowrank(0);
+          opsi.set_rowrank_(0);
           anet.PutUniTensors({"hL", "psi", "hR"}, {this->hLRs[ip][p], opsi, this->hLRs[ip][p + 2]});
-          auto out = anet.Launch(true);
+          auto out = anet.Launch();
           omps.push_back(out);
           // omps.back().flatten_();
         }
 
-        psi.set_rowrank(2);
+        psi.set_rowrank_(2);
         auto out = optimize_psi_new(
           psi, {this->LR[p], this->mpo.get_op(p), this->mpo.get_op(p + 1), this->LR[p + 2]}, maxit,
           krydim, omps, this->weight);
@@ -539,42 +556,47 @@ namespace cytnx {
         auto s = outU[0];
         this->mps.data()[p] = outU[1];
         this->mps.data()[p + 1] = outU[2];
+        // restore canonical labels so the Svd "_aux_L"/"_aux_R" bonds do not
+        // survive into the next site's decomposition (issue #920).
+        this->mps.data()[p + 1].relabel_(mps_site_labels(p + 1));
 
         auto slabel = s.labels();
         s = s / s.get_block_().Norm().item();
         s.relabel_(slabel);
 
         this->mps.data()[p] = Contract(this->mps.data()[p], s);  // absorb s into next neighbor
+        this->mps.data()[p].relabel_(mps_site_labels(p));
         this->mps.S_loc() = p;
 
         // update LR from right to left:
         // anet = cytnx.Network("R_AMAH.net")
         anet.FromString(
-          {"R: ;-2,-1,-3", "B: 1;-4,-1", "M: ;0,-2,-4,-5", "B_Conj: 2;-5,-3", "TOUT: ;0,1,2"});
+          {"R: -2,-1,-3", "B: 1,-4,-1", "M: 0,-2,-4,-5", "B_Conj: 2,-5,-3", "TOUT: ;0,1,2"});
 
         anet.PutUniTensors({"R", "B", "M", "B_Conj"},
                            {this->LR[p + 2], this->mps.data()[p + 1], this->mpo.get_op(p + 1),
                             this->mps.data()[p + 1].Conj()});
-        this->LR[p + 1] = anet.Launch(true);
+        this->LR[p + 1] = anet.Launch();
 
         // update hLR from right to left for excited states:
         // anet = cytnx.Network("hR_AMAH.net")
-        anet.FromString({"hR: ;-1,-2", "Bv: 1;-4,-1", "Bp: 2,-4;-2", "TOUT: ;1,2"});
+        anet.FromString({"hR: -1,-2", "Bv: 1,-4,-1", "Bp: 2,-4,-2", "TOUT: ;1,2"});
 
         for (cytnx_int64 ip = 0; ip < this->ortho_mps.size(); ip++) {
           auto omps = this->ortho_mps[ip];
           anet.PutUniTensors({"hR", "Bv", "Bp"}, {this->hLRs[ip][p + 2], this->mps.data()[p + 1],
                                                   omps.data()[p + 1].Conj()});
-          this->hLRs[ip][p + 1] = anet.Launch(true);
+          this->hLRs[ip][p + 1] = anet.Launch();
         }
         // print('Sweep[r->l]: %d/%d, Loc:%d,Energy: %f'%(k,numsweeps,p,Ekeep[-1]))
         if (verbose) std::cout << "Energy: " << std::setprecision(13) << Entemp << std::endl;
 
       }  // r->l
 
-      this->mps.data()[0].set_rowrank(1);
+      this->mps.data()[0].set_rowrank_(1);
       auto tout = linalg::Svd(this->mps.data()[0], true);
       this->mps.data()[0] = tout[2];
+      this->mps.data()[0].relabel_(mps_site_labels(0));
       this->mps.S_loc() = -1;
 
       // a.2 Optimize from left-to-right:
@@ -622,21 +644,21 @@ namespace cytnx {
         // anet = cytnx.Network("hL_AA_hR.net");
         auto anet = Network();
         anet.FromString({
-          "hL: ;-1,1",
-          "psi: ;1,2,3,4",
-          "hR: ;-2,4",
+          "hL: -1,1",
+          "psi: 1,2,3,4",
+          "hR: -2,4",
           "TOUT: -1,2;3,-2",
         });
 
         for (cytnx_int64 ip = 0; ip < this->ortho_mps.size(); ip++) {
           auto opsi = Contract(this->ortho_mps[ip].data()[p], this->ortho_mps[ip].data()[p + 1]);
-          opsi.set_rowrank(0);
+          opsi.set_rowrank_(0);
           anet.PutUniTensors({"hL", "psi", "hR"}, {this->hLRs[ip][p], opsi, this->hLRs[ip][p + 2]});
-          omps.push_back(anet.Launch(true));
+          omps.push_back(anet.Launch());
           // omps.back().flatten_();
         }
 
-        psi.set_rowrank(2);
+        psi.set_rowrank_(2);
         auto out = optimize_psi_new(
           psi, {this->LR[p], this->mpo.get_op(p), this->mpo.get_op(p + 1), this->LR[p + 2]}, maxit,
           krydim, omps, this->weight);
@@ -651,6 +673,9 @@ namespace cytnx {
         this->mps.data()[p] = outU[1];
         this->mps.data()[p + 1] = outU[2];
         // s,self.mps.A[p],self.mps.A[p+1] = cytnx.linalg.Svd_truncate(psi,new_dim)
+        // restore canonical labels so the Svd "_aux_L"/"_aux_R" bonds do not
+        // survive into the next site's decomposition (issue #920).
+        this->mps.data()[p].relabel_(mps_site_labels(p));
 
         auto slabel = s.labels();
         s = s / s.get_block_().Norm().item();
@@ -658,33 +683,35 @@ namespace cytnx {
 
         this->mps.data()[p + 1] =
           Contract(s, this->mps.data()[p + 1]);  // absorb s into next neighbor.
+        this->mps.data()[p + 1].relabel_(mps_site_labels(p + 1));
         this->mps.S_loc() = p + 1;
 
         // anet = cytnx.Network("L_AMAH.net");
         anet.FromString(
-          {"L: ;-2,-1,-3", "A: -1,-4;1", "M: ;-2,0,-4,-5", "A_Conj: -3,-5;2", "TOUT: ;0,1,2"});
+          {"L: -2,-1,-3", "A: -1,-4,1", "M: -2,0,-4,-5", "A_Conj: -3,-5,2", "TOUT: ;0,1,2"});
 
         anet.PutUniTensors(
           {"L", "A", "A_Conj", "M"},
           {this->LR[p], this->mps.data()[p], this->mps.data()[p].Conj(), this->mpo.get_op(p)});
-        this->LR[p + 1] = anet.Launch(true);
+        this->LR[p + 1] = anet.Launch();
 
         // update hLR when calculate excited state:
         // anet = cytnx.Network("hL_AMAH.net");
-        anet.FromString({"hL: ;-1,-2", "Av: -1,-4;1", "Ap: -2,-4;2", "TOUT: ;1,2"});
+        anet.FromString({"hL: -1,-2", "Av: -1,-4,1", "Ap: -2,-4,2", "TOUT: ;1,2"});
         for (cytnx_int64 ip = 0; ip < this->ortho_mps.size(); ip++) {
           auto omps = this->ortho_mps[ip];
           anet.PutUniTensors({"hL", "Av", "Ap"},
                              {this->hLRs[ip][p], this->mps.data()[p], omps.data()[p].Conj()});
-          this->hLRs[ip][p + 1] = anet.Launch(true);
+          this->hLRs[ip][p + 1] = anet.Launch();
         }
         // print('Sweep[l->r]: %d of %d, Loc: %d,Energy: %f' % (k, numsweeps, p, Ekeep[-1]))
         if (verbose) std::cout << "Energy: " << std::setprecision(13) << Entemp << std::endl;
       }
 
-      this->mps.data().back().set_rowrank(2);
+      this->mps.data().back().set_rowrank_(2);
       tout = linalg::Svd(this->mps.data().back(), true);  // last one.
       this->mps.data().back() = tout[1];
+      this->mps.data().back().relabel_(mps_site_labels(this->mps.data().size() - 1));
       this->mps.S_loc() = this->mps.data().size();
 
       return Entemp;

--- a/src/tn_algo/DMRG.cpp
+++ b/src/tn_algo/DMRG.cpp
@@ -137,16 +137,6 @@ namespace cytnx {
 
     //----------------------------
 
-    // Canonical per-site MPS labels (see RegularMPS::Init): site k carries
-    // {2k, 2k+1, 2k+2}, so neighbouring sites share their virtual-bond label.
-    // Restoring these after each Svd_truncate keeps the chain consistent and
-    // stops linalg::Svd's fixed "_aux_L"/"_aux_R" bond labels from surviving
-    // into the next decomposition, where the reused label would collide and
-    // abort the sweep with a duplicated-label error (issue #920).
-    static std::vector<std::string> mps_site_labels(const cytnx_int64 &k) {
-      return {to_string(2 * k), to_string(2 * k + 1), to_string(2 * k + 2)};
-    }
-
     void DMRG_impl::initialize() {
       // initialize everything
       // 1. setting env:
@@ -178,8 +168,7 @@ namespace cytnx {
       this->LR.back() = R0;
       this->mps.Into_Lortho();
 
-      // anet = cytnx.Network("L_AMAH.net")
-      auto Lnet = Network();
+      Network Lnet;
       Lnet.FromString(
         {"L: -2,-1,-3", "A: -1,-4,1", "M: -2,0,-4,-5", "A_Conj: -3,-5,2", "TOUT: ;0,1,2"});
       for (int p = 0; p < this->mps.size() - 1; p++) {
@@ -288,7 +277,7 @@ namespace cytnx {
           auto opsi = Contract(this->ortho_mps[ip].data()[p], this->ortho_mps[ip].data()[p + 1]);
           opsi.set_rowrank_(0);
           anet.PutUniTensors({"hL", "psi", "hR"}, {this->hLRs[ip][p], opsi, this->hLRs[ip][p + 2]});
-          auto out = anet.Launch().get_block_();
+          Tensor out = anet.Launch().get_block_();
           omps.push_back(out);
           omps.back().flatten_();
         }
@@ -311,14 +300,14 @@ namespace cytnx {
         this->mps.data()[p + 1] = outU[2];
         // restore canonical labels so the Svd "_aux_L"/"_aux_R" bonds do not
         // survive into the next site's decomposition (issue #920).
-        this->mps.data()[p + 1].relabel_(mps_site_labels(p + 1));
+        this->mps.data()[p + 1].relabel_(CanonicalSiteLabels(p + 1));
 
         auto slabel = s.labels();
         s = s / s.get_block_().Norm().item();
         s.relabel_(slabel);
 
         this->mps.data()[p] = Contract(this->mps.data()[p], s);  // absorb s into next neighbor
-        this->mps.data()[p].relabel_(mps_site_labels(p));
+        this->mps.data()[p].relabel_(CanonicalSiteLabels(p));
         this->mps.S_loc() = p;
 
         // update LR from right to left:
@@ -349,7 +338,7 @@ namespace cytnx {
       this->mps.data()[0].set_rowrank_(1);
       auto tout = linalg::Svd(this->mps.data()[0], true);
       this->mps.data()[0] = tout[2];
-      this->mps.data()[0].relabel_(mps_site_labels(0));
+      this->mps.data()[0].relabel_(CanonicalSiteLabels(0));
       this->mps.S_loc() = -1;
 
       // a.2 Optimize from left-to-right:
@@ -430,7 +419,7 @@ namespace cytnx {
         // s,self.mps.A[p],self.mps.A[p+1] = cytnx.linalg.Svd_truncate(psi,new_dim)
         // restore canonical labels so the Svd "_aux_L"/"_aux_R" bonds do not
         // survive into the next site's decomposition (issue #920).
-        this->mps.data()[p].relabel_(mps_site_labels(p));
+        this->mps.data()[p].relabel_(CanonicalSiteLabels(p));
 
         auto slabel = s.labels();
         s = s / s.get_block_().Norm().item();
@@ -438,7 +427,7 @@ namespace cytnx {
 
         this->mps.data()[p + 1] =
           Contract(s, this->mps.data()[p + 1]);  // absorb s into next neighbor.
-        this->mps.data()[p + 1].relabel_(mps_site_labels(p + 1));
+        this->mps.data()[p + 1].relabel_(CanonicalSiteLabels(p + 1));
         this->mps.S_loc() = p + 1;
 
         // anet = cytnx.Network("L_AMAH.net");
@@ -466,7 +455,7 @@ namespace cytnx {
       this->mps.data().back().set_rowrank_(2);
       tout = linalg::Svd(this->mps.data().back(), true);  // last one.
       this->mps.data().back() = tout[1];
-      this->mps.data().back().relabel_(mps_site_labels(this->mps.data().size() - 1));
+      this->mps.data().back().relabel_(CanonicalSiteLabels(this->mps.data().size() - 1));
       this->mps.S_loc() = this->mps.data().size();
 
       return Entemp;
@@ -558,14 +547,14 @@ namespace cytnx {
         this->mps.data()[p + 1] = outU[2];
         // restore canonical labels so the Svd "_aux_L"/"_aux_R" bonds do not
         // survive into the next site's decomposition (issue #920).
-        this->mps.data()[p + 1].relabel_(mps_site_labels(p + 1));
+        this->mps.data()[p + 1].relabel_(CanonicalSiteLabels(p + 1));
 
         auto slabel = s.labels();
         s = s / s.get_block_().Norm().item();
         s.relabel_(slabel);
 
         this->mps.data()[p] = Contract(this->mps.data()[p], s);  // absorb s into next neighbor
-        this->mps.data()[p].relabel_(mps_site_labels(p));
+        this->mps.data()[p].relabel_(CanonicalSiteLabels(p));
         this->mps.S_loc() = p;
 
         // update LR from right to left:
@@ -596,7 +585,7 @@ namespace cytnx {
       this->mps.data()[0].set_rowrank_(1);
       auto tout = linalg::Svd(this->mps.data()[0], true);
       this->mps.data()[0] = tout[2];
-      this->mps.data()[0].relabel_(mps_site_labels(0));
+      this->mps.data()[0].relabel_(CanonicalSiteLabels(0));
       this->mps.S_loc() = -1;
 
       // a.2 Optimize from left-to-right:
@@ -675,7 +664,7 @@ namespace cytnx {
         // s,self.mps.A[p],self.mps.A[p+1] = cytnx.linalg.Svd_truncate(psi,new_dim)
         // restore canonical labels so the Svd "_aux_L"/"_aux_R" bonds do not
         // survive into the next site's decomposition (issue #920).
-        this->mps.data()[p].relabel_(mps_site_labels(p));
+        this->mps.data()[p].relabel_(CanonicalSiteLabels(p));
 
         auto slabel = s.labels();
         s = s / s.get_block_().Norm().item();
@@ -683,7 +672,7 @@ namespace cytnx {
 
         this->mps.data()[p + 1] =
           Contract(s, this->mps.data()[p + 1]);  // absorb s into next neighbor.
-        this->mps.data()[p + 1].relabel_(mps_site_labels(p + 1));
+        this->mps.data()[p + 1].relabel_(CanonicalSiteLabels(p + 1));
         this->mps.S_loc() = p + 1;
 
         // anet = cytnx.Network("L_AMAH.net");
@@ -711,7 +700,7 @@ namespace cytnx {
       this->mps.data().back().set_rowrank_(2);
       tout = linalg::Svd(this->mps.data().back(), true);  // last one.
       this->mps.data().back() = tout[1];
-      this->mps.data().back().relabel_(mps_site_labels(this->mps.data().size() - 1));
+      this->mps.data().back().relabel_(CanonicalSiteLabels(this->mps.data().size() - 1));
       this->mps.S_loc() = this->mps.data().size();
 
       return Entemp;

--- a/src/tn_algo/RegularMPS.cpp
+++ b/src/tn_algo/RegularMPS.cpp
@@ -200,6 +200,18 @@ namespace cytnx {
      }
      */
 
+    // Canonical per-site labels assigned by RegularMPS::Init: site k carries
+    // {2k, 2k+1, 2k+2}, so neighbouring sites share their virtual-bond label
+    // (site k's right label 2k+2 equals site k+1's left label). Every routine
+    // that rebuilds a site tensor through linalg::Svd restores these labels
+    // afterwards. This keeps the MPS in a predictable labelling and, crucially,
+    // stops Svd's fixed "_aux_L"/"_aux_R" bond labels from surviving into the
+    // next decomposition, where the reused generic label would collide and trip
+    // set_labels' duplicate check (issue #920).
+    static std::vector<std::string> _site_labels(const cytnx_int64 &k) {
+      return {to_string(2 * k), to_string(2 * k + 1), to_string(2 * k + 2)};
+    }
+
     void RegularMPS::Into_Lortho() {
       if (this->S_loc == this->_TNs.size()) return;
 
@@ -215,9 +227,12 @@ namespace cytnx {
         this->_TNs[p] = out[1];
         auto vt = out[2];
         this->_TNs[p + 1] = Contract(Contract(s, vt), this->_TNs[p + 1]);
+        this->_TNs[p].relabel_(_site_labels(p));
+        this->_TNs[p + 1].relabel_(_site_labels(p + 1));
       }
       auto out = linalg::Svd(this->_TNs.back(), true);
       this->_TNs.back() = out[1];
+      this->_TNs.back().relabel_(_site_labels(this->_TNs.size() - 1));
       this->S_loc = this->_TNs.size();
     }
 
@@ -228,7 +243,7 @@ namespace cytnx {
         this->S_loc += 1;
         return;
       } else {
-        this->_TNs[this->S_loc].set_rowrank(2);
+        this->_TNs[this->S_loc].set_rowrank_(2);
         auto out = linalg::Svd(this->_TNs[this->S_loc]);
         auto s = out[0];
         this->_TNs[this->S_loc] = out[1];
@@ -236,7 +251,9 @@ namespace cytnx {
         // boundary:
         if (this->S_loc != this->_TNs.size() - 1) {
           this->_TNs[this->S_loc + 1] = Contract(Contract(s, vt), this->_TNs[this->S_loc + 1]);
+          this->_TNs[this->S_loc + 1].relabel_(_site_labels(this->S_loc + 1));
         }
+        this->_TNs[this->S_loc].relabel_(_site_labels(this->S_loc));
         this->S_loc += 1;
       }
     }
@@ -248,7 +265,7 @@ namespace cytnx {
         this->S_loc -= 1;
         return;
       } else {
-        this->_TNs[this->S_loc].set_rowrank(1);
+        this->_TNs[this->S_loc].set_rowrank_(1);
         auto out = linalg::Svd(this->_TNs[this->S_loc]);
         auto s = out[0];
         auto u = out[1];
@@ -257,7 +274,9 @@ namespace cytnx {
         // boundary:
         if (this->S_loc != 0) {
           this->_TNs[this->S_loc - 1] = Contract(this->_TNs[this->S_loc - 1], Contract(u, s));
+          this->_TNs[this->S_loc - 1].relabel_(_site_labels(this->S_loc - 1));
         }
+        this->_TNs[this->S_loc].relabel_(_site_labels(this->S_loc));
         this->S_loc -= 1;
       }
     }

--- a/src/tn_algo/RegularMPS.cpp
+++ b/src/tn_algo/RegularMPS.cpp
@@ -46,19 +46,20 @@ namespace cytnx {
 
     Scalar RegularMPS::norm() const {
       // Accumulate the <psi|psi> left environment site by site. L carries two
-      // open legs, "a" on the ket and "b" on the bra, living on the current
+      // open legs, "_a" on the ket and "_b" on the bra, living on the current
       // virtual bond; it is seeded as the 1x1 identity on the trivial left
       // boundary. For each rank-3 site tensor [left, phys, right] the ket leg
-      // contracts onto "a", the bra leg onto "b", and the physical legs onto
-      // each other, leaving the next virtual bond open as the new {a, b}. Seed
+      // contracts onto "_a", the bra leg onto "_b", and the physical legs onto
+      // each other, leaving the next virtual bond open as the new {_a, _b}. Seed
       // L on the same device as the MPS so the contractions stay on-device.
       int device = this->_TNs.empty() ? Device.cpu : this->_TNs[0].device();
-      UniTensor L = UniTensor(ones({1, 1}, Type.Double, device), false, 1).relabel({"a", "b"});
-      for (auto Ai : this->_TNs) {
-        auto tA = Ai.relabel({"a", "p", "r"});
-        auto tAc = Ai.Conj().relabel({"b", "p", "rc"});
-        L = Contract(Contract(L, tA), tAc);  // {a, b} -> {r, rc}
-        L.relabel_({"a", "b"});
+      UniTensor L = UniTensor(ones({1, 1}, Type.Double, device), /*is_diag=*/false, /*rowrank=*/1)
+                      .relabel({"_a", "_b"});
+      for (const UniTensor &Ai : this->_TNs) {
+        UniTensor tA = Ai.relabel({"_a", "_p", "_r"});
+        UniTensor tAc = Ai.Conj().relabel({"_b", "_p", "_rc"});
+        L = Contract(Contract(L, tA), tAc);  // {_a, _b} -> {_r, _rc}
+        L.relabel_({"_a", "_b"});
       }
       return L.Trace().item();
     }
@@ -79,6 +80,7 @@ namespace cytnx {
       this->_TNs.resize(N);
       this->_TNs[0] = UniTensor(
         cytnx::random::normal({1, vphys_dim[0], min(chi, vphys_dim[0])}, 0., 1.), false, 2);
+      this->_TNs[0].relabel_(CanonicalSiteLabels(0));
       cytnx_uint64 dim1, dim2, dim3;
 
       cytnx_uint64 DR = 1;
@@ -108,7 +110,7 @@ namespace cytnx {
           dim3 = std::min(std::min(chi, cytnx_uint64(dim1 * dim2)), DR);
         }
         this->_TNs[k] = UniTensor(random::normal({dim1, dim2, dim3}, 0., 1., -1), false, 2);
-        this->_TNs[k].relabel_({to_string(2 * k), to_string(2 * k + 1), to_string(2 * k + 2)});
+        this->_TNs[k].relabel_(CanonicalSiteLabels(k));
       }
       this->S_loc = -1;
       this->Into_Lortho();
@@ -137,6 +139,7 @@ namespace cytnx {
       this->_TNs[0] = UniTensor(cytnx::zeros({1, vphys_dim[0], min(chi, vphys_dim[0])}), false, 2);
       this->_TNs[0].get_block_()(":", select[0], ":") =
         random::normal({1, this->_TNs[0].shape()[2]}, 0., 1.);
+      this->_TNs[0].relabel_(CanonicalSiteLabels(0));
 
       cytnx_uint64 dim1, dim2, dim3;
 
@@ -169,7 +172,7 @@ namespace cytnx {
         this->_TNs[k].get_block_()(":", select[k]) = random::normal({dim1, dim3}, 0., 1.);
 
         // this->_TNs[k] = UniTensor(random::normal({dim1, dim2, dim3},0.,1.,-1,99),2);
-        this->_TNs[k].relabel_({to_string(2 * k), to_string(2 * k + 1), to_string(2 * k + 2)});
+        this->_TNs[k].relabel_(CanonicalSiteLabels(k));
       }
       this->S_loc = -1;
       this->Into_Lortho();
@@ -202,18 +205,6 @@ namespace cytnx {
      }
      */
 
-    // Canonical per-site labels assigned by RegularMPS::Init: site k carries
-    // {2k, 2k+1, 2k+2}, so neighbouring sites share their virtual-bond label
-    // (site k's right label 2k+2 equals site k+1's left label). Every routine
-    // that rebuilds a site tensor through linalg::Svd restores these labels
-    // afterwards. This keeps the MPS in a predictable labelling and, crucially,
-    // stops Svd's fixed "_aux_L"/"_aux_R" bond labels from surviving into the
-    // next decomposition, where the reused generic label would collide and trip
-    // set_labels' duplicate check (issue #920).
-    static std::vector<std::string> _site_labels(const cytnx_int64 &k) {
-      return {to_string(2 * k), to_string(2 * k + 1), to_string(2 * k + 2)};
-    }
-
     void RegularMPS::Into_Lortho() {
       if (this->S_loc == this->_TNs.size()) return;
 
@@ -229,12 +220,12 @@ namespace cytnx {
         this->_TNs[p] = out[1];
         auto vt = out[2];
         this->_TNs[p + 1] = Contract(Contract(s, vt), this->_TNs[p + 1]);
-        this->_TNs[p].relabel_(_site_labels(p));
-        this->_TNs[p + 1].relabel_(_site_labels(p + 1));
+        this->_TNs[p].relabel_(CanonicalSiteLabels(p));
+        this->_TNs[p + 1].relabel_(CanonicalSiteLabels(p + 1));
       }
       auto out = linalg::Svd(this->_TNs.back(), true);
       this->_TNs.back() = out[1];
-      this->_TNs.back().relabel_(_site_labels(this->_TNs.size() - 1));
+      this->_TNs.back().relabel_(CanonicalSiteLabels(this->_TNs.size() - 1));
       this->S_loc = this->_TNs.size();
     }
 
@@ -253,9 +244,9 @@ namespace cytnx {
         // boundary:
         if (this->S_loc != this->_TNs.size() - 1) {
           this->_TNs[this->S_loc + 1] = Contract(Contract(s, vt), this->_TNs[this->S_loc + 1]);
-          this->_TNs[this->S_loc + 1].relabel_(_site_labels(this->S_loc + 1));
+          this->_TNs[this->S_loc + 1].relabel_(CanonicalSiteLabels(this->S_loc + 1));
         }
-        this->_TNs[this->S_loc].relabel_(_site_labels(this->S_loc));
+        this->_TNs[this->S_loc].relabel_(CanonicalSiteLabels(this->S_loc));
         this->S_loc += 1;
       }
     }
@@ -276,9 +267,9 @@ namespace cytnx {
         // boundary:
         if (this->S_loc != 0) {
           this->_TNs[this->S_loc - 1] = Contract(this->_TNs[this->S_loc - 1], Contract(u, s));
-          this->_TNs[this->S_loc - 1].relabel_(_site_labels(this->S_loc - 1));
+          this->_TNs[this->S_loc - 1].relabel_(CanonicalSiteLabels(this->S_loc - 1));
         }
-        this->_TNs[this->S_loc].relabel_(_site_labels(this->S_loc));
+        this->_TNs[this->S_loc].relabel_(CanonicalSiteLabels(this->S_loc));
         this->S_loc -= 1;
       }
     }

--- a/src/tn_algo/RegularMPS.cpp
+++ b/src/tn_algo/RegularMPS.cpp
@@ -45,17 +45,18 @@ namespace cytnx {
     }
 
     Scalar RegularMPS::norm() const {
-      UniTensor L;
+      // Accumulate the <psi|psi> left environment site by site. L carries two
+      // open legs, "a" on the ket and "b" on the bra, living on the current
+      // virtual bond; it is seeded as the 1x1 identity on the trivial left
+      // boundary. For each rank-3 site tensor [left, phys, right] the ket leg
+      // contracts onto "a", the bra leg onto "b", and the physical legs onto
+      // each other, leaving the next virtual bond open as the new {a, b}.
+      UniTensor L = UniTensor(ones({1, 1}), false, 1).relabel({"a", "b"});
       for (auto Ai : this->_TNs) {
-        if (L.uten_type() == UTenType.Void) {
-          auto tA = Ai.relabel({"0", "1", "2"});
-          L = Contract(tA, tA.Dagger().relabel("0", "-2"));
-        } else {
-          L.relabel_({"2", "-2"});
-          auto tA = Ai.relabel({"2", "3", "4"});
-          L = Contract(tA, L);
-          L = Contract(L, tA.Dagger().relabel({"-4", "-2", "3"}));
-        }
+        auto tA = Ai.relabel({"a", "p", "r"});
+        auto tAc = Ai.Conj().relabel({"b", "p", "rc"});
+        L = Contract(Contract(L, tA), tAc);  // {a, b} -> {r, rc}
+        L.relabel_({"a", "b"});
       }
       return L.Trace().item();
     }

--- a/src/tn_algo/RegularMPS.cpp
+++ b/src/tn_algo/RegularMPS.cpp
@@ -50,8 +50,10 @@ namespace cytnx {
       // virtual bond; it is seeded as the 1x1 identity on the trivial left
       // boundary. For each rank-3 site tensor [left, phys, right] the ket leg
       // contracts onto "a", the bra leg onto "b", and the physical legs onto
-      // each other, leaving the next virtual bond open as the new {a, b}.
-      UniTensor L = UniTensor(ones({1, 1}), false, 1).relabel({"a", "b"});
+      // each other, leaving the next virtual bond open as the new {a, b}. Seed
+      // L on the same device as the MPS so the contractions stay on-device.
+      int device = this->_TNs.empty() ? Device.cpu : this->_TNs[0].device();
+      UniTensor L = UniTensor(ones({1, 1}, Type.Double, device), false, 1).relabel({"a", "b"});
       for (auto Ai : this->_TNs) {
         auto tA = Ai.relabel({"a", "p", "r"});
         auto tAc = Ai.Conj().relabel({"b", "p", "rc"});

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,9 @@ add_executable(
   linalg_test/linalg_test.cpp
   linalg_test/sum_test.cpp
   linalg_test/Vectordot_test.cpp
+  tn_algo_test/MPS_test.cpp
+  tn_algo_test/MPO_test.cpp
+  tn_algo_test/DMRG_test.cpp
   algo_test/Hsplit_test.cpp
   algo_test/Hstack_test.cpp
   algo_test/Vsplit_test.cpp

--- a/tests/tn_algo_test/DMRG_test.cpp
+++ b/tests/tn_algo_test/DMRG_test.cpp
@@ -6,14 +6,11 @@
 #include "cytnx.hpp"
 #include "tn_algo_test/tfim_mpo.hpp"
 
-using namespace cytnx;
-using namespace cytnx::tn_algo;
-
 namespace {
 
-  MPO BuildTfimMpo(int num_sites, double coupling, double field) {
-    MPO mpo;
-    UniTensor bulk = TfimTest::MakeMpoTensor(coupling, field);
+  cytnx::tn_algo::MPO BuildTfimMpo(int num_sites, double coupling, double field) {
+    cytnx::tn_algo::MPO mpo;
+    cytnx::UniTensor bulk = TfimTest::MakeMpoTensor(coupling, field);
     for (int site = 0; site < num_sites; site++) mpo.append(bulk);
     return mpo;
   }
@@ -25,12 +22,12 @@ namespace {
   TEST(DMRG, GroundStateEnergyMatchesExact) {
     int num_sites = 6;
     double coupling = 1.0, field = 0.5;
-    cytnx_uint64 bond_dim = 16;
+    cytnx::cytnx_uint64 bond_dim = 16;
 
-    MPO mpo = BuildTfimMpo(num_sites, coupling, field);
-    MPS mps(num_sites, 2, bond_dim);
+    cytnx::tn_algo::MPO mpo = BuildTfimMpo(num_sites, coupling, field);
+    cytnx::tn_algo::MPS mps(num_sites, 2, bond_dim);
 
-    DMRG dmrg(mpo, mps);
+    cytnx::tn_algo::DMRG dmrg(mpo, mps);
     dmrg.initialize();
 
     double energy = 0.0;
@@ -46,12 +43,12 @@ namespace {
   TEST(DMRG, GroundStateEnergyMatchesExactV2) {
     int num_sites = 6;
     double coupling = 1.0, field = 0.5;
-    cytnx_uint64 bond_dim = 16;
+    cytnx::cytnx_uint64 bond_dim = 16;
 
-    MPO mpo = BuildTfimMpo(num_sites, coupling, field);
-    MPS mps(num_sites, 2, bond_dim);
+    cytnx::tn_algo::MPO mpo = BuildTfimMpo(num_sites, coupling, field);
+    cytnx::tn_algo::MPS mps(num_sites, 2, bond_dim);
 
-    DMRG dmrg(mpo, mps);
+    cytnx::tn_algo::DMRG dmrg(mpo, mps);
     dmrg.initialize();
 
     double energy = 0.0;
@@ -68,12 +65,12 @@ namespace {
   TEST(DMRG, GroundStateEnergyCriticalPoint) {
     int num_sites = 8;
     double coupling = 1.0, field = 1.0;  // critical TFIM
-    cytnx_uint64 bond_dim = 24;
+    cytnx::cytnx_uint64 bond_dim = 24;
 
-    MPO mpo = BuildTfimMpo(num_sites, coupling, field);
-    MPS mps(num_sites, 2, bond_dim);
+    cytnx::tn_algo::MPO mpo = BuildTfimMpo(num_sites, coupling, field);
+    cytnx::tn_algo::MPS mps(num_sites, 2, bond_dim);
 
-    DMRG dmrg(mpo, mps);
+    cytnx::tn_algo::DMRG dmrg(mpo, mps);
     dmrg.initialize();
 
     double energy = 0.0;

--- a/tests/tn_algo_test/DMRG_test.cpp
+++ b/tests/tn_algo_test/DMRG_test.cpp
@@ -1,4 +1,6 @@
 #include <cmath>
+#include <iostream>
+#include <sstream>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -135,6 +137,34 @@ namespace {
 
     double exact = TfimTest::ExactGroundEnergy(num_sites, coupling, field);
     EXPECT_NEAR(energy, exact, 1e-6) << "DMRG energy " << energy << " vs exact " << exact;
+  }
+
+  // sweep() and sweepv2() guard their per-step progress logging behind
+  // `if (verbose)`. Every other test passes verbose=false, leaving those
+  // branches untaken. Drive a tiny system with verbose=true to exercise them;
+  // std::cout is redirected to a local buffer so the logging does not pollute
+  // the test output.
+  TEST(DMRG, VerboseLoggingRuns) {
+    int num_sites = 3;
+    cytnx::tn_algo::MPO mpo = BuildTfimMpo(num_sites, 1.0, 0.5);
+
+    cytnx::tn_algo::MPS mps_sweep(num_sites, 2, 8);
+    cytnx::tn_algo::DMRG dmrg_sweep(mpo, mps_sweep);
+    dmrg_sweep.initialize();
+
+    cytnx::tn_algo::MPS mps_sweepv2(num_sites, 2, 8);
+    cytnx::tn_algo::DMRG dmrg_sweepv2(mpo, mps_sweepv2);
+    dmrg_sweepv2.initialize();
+
+    std::ostringstream sink;
+    std::streambuf *saved_cout = std::cout.rdbuf(sink.rdbuf());
+    EXPECT_NO_THROW({
+      for (int sweep = 0; sweep < 2; sweep++) dmrg_sweep.sweep(/*verbose=*/true, 100, 4);
+      for (int sweep = 0; sweep < 2; sweep++) dmrg_sweepv2.sweepv2(/*verbose=*/true, 100, 4);
+    });
+    std::cout.rdbuf(saved_cout);
+
+    EXPECT_FALSE(sink.str().empty()) << "verbose=true produced no progress logging";
   }
 
 }  // namespace

--- a/tests/tn_algo_test/DMRG_test.cpp
+++ b/tests/tn_algo_test/DMRG_test.cpp
@@ -1,0 +1,89 @@
+#include <cmath>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "cytnx.hpp"
+#include "tn_algo_test/tfim_mpo.hpp"
+
+using namespace cytnx;
+using namespace cytnx::tn_algo;
+using namespace testing;
+
+namespace DMRGTest {
+
+  static MPO BuildTfimMPO(int N, double J, double h) {
+    MPO mpo;
+    auto W = TfimTest::TfimW(J, h);
+    for (int i = 0; i < N; i++) mpo.append(W);
+    return mpo;
+  }
+
+  // DMRG must converge to the exact ground-state energy of the dense
+  // Hamiltonian. Both the MPO fed to DMRG and the reference Hamiltonian are
+  // built from the same TFIM definition, so any disagreement points at the
+  // tn_algo implementation rather than at a model mismatch.
+  TEST(DMRG, GroundStateEnergyMatchesExact) {
+    int N = 6;
+    double J = 1.0, h = 0.5;
+    cytnx_uint64 chi = 16;
+
+    auto mpo = BuildTfimMPO(N, J, h);
+    MPS mps(N, 2, chi);
+
+    auto dmrg = DMRG(mpo, mps);
+    dmrg.initialize();
+
+    double energy = 0.0;
+    for (int sweep = 0; sweep < 8; sweep++) {
+      energy = double(dmrg.sweep(/*verbose=*/false, /*maxit=*/200, /*krydim=*/4));
+    }
+
+    double exact = TfimTest::ExactGroundEnergy(N, J, h);
+    EXPECT_NEAR(energy, exact, 1e-6) << "DMRG energy " << energy << " vs exact " << exact;
+  }
+
+  // The UniTensor-based sweep (sweepv2) must reach the same ground-state energy.
+  TEST(DMRG, GroundStateEnergyMatchesExactV2) {
+    int N = 6;
+    double J = 1.0, h = 0.5;
+    cytnx_uint64 chi = 16;
+
+    auto mpo = BuildTfimMPO(N, J, h);
+    MPS mps(N, 2, chi);
+
+    auto dmrg = DMRG(mpo, mps);
+    dmrg.initialize();
+
+    double energy = 0.0;
+    for (int sweep = 0; sweep < 8; sweep++) {
+      energy = double(dmrg.sweepv2(/*verbose=*/false, /*maxit=*/200, /*krydim=*/4));
+    }
+
+    double exact = TfimTest::ExactGroundEnergy(N, J, h);
+    EXPECT_NEAR(energy, exact, 1e-6) << "DMRG (v2) energy " << energy << " vs exact " << exact;
+  }
+
+  // A second, more strongly transverse-field point to guard against accidental
+  // agreement at one coupling.
+  TEST(DMRG, GroundStateEnergyCriticalPoint) {
+    int N = 8;
+    double J = 1.0, h = 1.0;  // critical TFIM
+    cytnx_uint64 chi = 24;
+
+    auto mpo = BuildTfimMPO(N, J, h);
+    MPS mps(N, 2, chi);
+
+    auto dmrg = DMRG(mpo, mps);
+    dmrg.initialize();
+
+    double energy = 0.0;
+    for (int sweep = 0; sweep < 10; sweep++) {
+      energy = double(dmrg.sweep(/*verbose=*/false, /*maxit=*/300, /*krydim=*/4));
+    }
+
+    double exact = TfimTest::ExactGroundEnergy(N, J, h);
+    EXPECT_NEAR(energy, exact, 1e-6) << "DMRG energy " << energy << " vs exact " << exact;
+  }
+
+}  // namespace DMRGTest

--- a/tests/tn_algo_test/DMRG_test.cpp
+++ b/tests/tn_algo_test/DMRG_test.cpp
@@ -8,14 +8,13 @@
 
 using namespace cytnx;
 using namespace cytnx::tn_algo;
-using namespace testing;
 
-namespace DMRGTest {
+namespace {
 
-  static MPO BuildTfimMPO(int N, double J, double h) {
+  MPO BuildTfimMpo(int num_sites, double coupling, double field) {
     MPO mpo;
-    auto W = TfimTest::TfimW(J, h);
-    for (int i = 0; i < N; i++) mpo.append(W);
+    UniTensor bulk = TfimTest::MakeMpoTensor(coupling, field);
+    for (int site = 0; site < num_sites; site++) mpo.append(bulk);
     return mpo;
   }
 
@@ -24,14 +23,14 @@ namespace DMRGTest {
   // built from the same TFIM definition, so any disagreement points at the
   // tn_algo implementation rather than at a model mismatch.
   TEST(DMRG, GroundStateEnergyMatchesExact) {
-    int N = 6;
-    double J = 1.0, h = 0.5;
-    cytnx_uint64 chi = 16;
+    int num_sites = 6;
+    double coupling = 1.0, field = 0.5;
+    cytnx_uint64 bond_dim = 16;
 
-    auto mpo = BuildTfimMPO(N, J, h);
-    MPS mps(N, 2, chi);
+    MPO mpo = BuildTfimMpo(num_sites, coupling, field);
+    MPS mps(num_sites, 2, bond_dim);
 
-    auto dmrg = DMRG(mpo, mps);
+    DMRG dmrg(mpo, mps);
     dmrg.initialize();
 
     double energy = 0.0;
@@ -39,20 +38,20 @@ namespace DMRGTest {
       energy = double(dmrg.sweep(/*verbose=*/false, /*maxit=*/200, /*krydim=*/4));
     }
 
-    double exact = TfimTest::ExactGroundEnergy(N, J, h);
+    double exact = TfimTest::ExactGroundEnergy(num_sites, coupling, field);
     EXPECT_NEAR(energy, exact, 1e-6) << "DMRG energy " << energy << " vs exact " << exact;
   }
 
   // The UniTensor-based sweep (sweepv2) must reach the same ground-state energy.
   TEST(DMRG, GroundStateEnergyMatchesExactV2) {
-    int N = 6;
-    double J = 1.0, h = 0.5;
-    cytnx_uint64 chi = 16;
+    int num_sites = 6;
+    double coupling = 1.0, field = 0.5;
+    cytnx_uint64 bond_dim = 16;
 
-    auto mpo = BuildTfimMPO(N, J, h);
-    MPS mps(N, 2, chi);
+    MPO mpo = BuildTfimMpo(num_sites, coupling, field);
+    MPS mps(num_sites, 2, bond_dim);
 
-    auto dmrg = DMRG(mpo, mps);
+    DMRG dmrg(mpo, mps);
     dmrg.initialize();
 
     double energy = 0.0;
@@ -60,21 +59,21 @@ namespace DMRGTest {
       energy = double(dmrg.sweepv2(/*verbose=*/false, /*maxit=*/200, /*krydim=*/4));
     }
 
-    double exact = TfimTest::ExactGroundEnergy(N, J, h);
+    double exact = TfimTest::ExactGroundEnergy(num_sites, coupling, field);
     EXPECT_NEAR(energy, exact, 1e-6) << "DMRG (v2) energy " << energy << " vs exact " << exact;
   }
 
   // A second, more strongly transverse-field point to guard against accidental
   // agreement at one coupling.
   TEST(DMRG, GroundStateEnergyCriticalPoint) {
-    int N = 8;
-    double J = 1.0, h = 1.0;  // critical TFIM
-    cytnx_uint64 chi = 24;
+    int num_sites = 8;
+    double coupling = 1.0, field = 1.0;  // critical TFIM
+    cytnx_uint64 bond_dim = 24;
 
-    auto mpo = BuildTfimMPO(N, J, h);
-    MPS mps(N, 2, chi);
+    MPO mpo = BuildTfimMpo(num_sites, coupling, field);
+    MPS mps(num_sites, 2, bond_dim);
 
-    auto dmrg = DMRG(mpo, mps);
+    DMRG dmrg(mpo, mps);
     dmrg.initialize();
 
     double energy = 0.0;
@@ -82,8 +81,8 @@ namespace DMRGTest {
       energy = double(dmrg.sweep(/*verbose=*/false, /*maxit=*/300, /*krydim=*/4));
     }
 
-    double exact = TfimTest::ExactGroundEnergy(N, J, h);
+    double exact = TfimTest::ExactGroundEnergy(num_sites, coupling, field);
     EXPECT_NEAR(energy, exact, 1e-6) << "DMRG energy " << energy << " vs exact " << exact;
   }
 
-}  // namespace DMRGTest
+}  // namespace

--- a/tests/tn_algo_test/DMRG_test.cpp
+++ b/tests/tn_algo_test/DMRG_test.cpp
@@ -60,6 +60,61 @@ namespace {
     EXPECT_NEAR(energy, exact, 1e-6) << "DMRG (v2) energy " << energy << " vs exact " << exact;
   }
 
+  // Passing a previously found state as ortho_mps must steer DMRG to the next
+  // excited state instead, exercising the excited-state penalty-weight branches
+  // in both sweep() and sweepv2() (the loops over ortho_mps/hLRs).
+  TEST(DMRG, ExcitedStateEnergyMatchesExactSweep) {
+    int num_sites = 4;
+    double coupling = 0.5, field = 1.0;  // paramagnetic phase: gapped, non-degenerate
+    cytnx::cytnx_uint64 bond_dim = 16;
+
+    cytnx::tn_algo::MPO mpo = BuildTfimMpo(num_sites, coupling, field);
+
+    cytnx::tn_algo::MPS ground_mps(num_sites, 2, bond_dim);
+    cytnx::tn_algo::DMRG ground_dmrg(mpo, ground_mps);
+    ground_dmrg.initialize();
+    for (int sweep = 0; sweep < 8; sweep++) ground_dmrg.sweep(/*verbose=*/false, 200, 4);
+
+    cytnx::tn_algo::MPS excited_mps(num_sites, 2, bond_dim);
+    cytnx::tn_algo::DMRG excited_dmrg(mpo, excited_mps, {ground_mps}, /*weight=*/30);
+    excited_dmrg.initialize();
+
+    double energy = 0.0;
+    for (int sweep = 0; sweep < 8; sweep++) {
+      energy = double(excited_dmrg.sweep(/*verbose=*/false, /*maxit=*/200, /*krydim=*/4));
+    }
+
+    double exact = TfimTest::ExactFirstExcitedEnergy(num_sites, coupling, field);
+    EXPECT_NEAR(energy, exact, 1e-6) << "DMRG excited energy " << energy << " vs exact " << exact;
+  }
+
+  // Same excited-state check through the UniTensor-based sweepv2() path.
+  TEST(DMRG, ExcitedStateEnergyMatchesExactSweepV2) {
+    int num_sites = 4;
+    double coupling = 0.5, field = 1.0;
+    cytnx::cytnx_uint64 bond_dim = 16;
+
+    cytnx::tn_algo::MPO mpo = BuildTfimMpo(num_sites, coupling, field);
+
+    cytnx::tn_algo::MPS ground_mps(num_sites, 2, bond_dim);
+    cytnx::tn_algo::DMRG ground_dmrg(mpo, ground_mps);
+    ground_dmrg.initialize();
+    for (int sweep = 0; sweep < 8; sweep++) ground_dmrg.sweepv2(/*verbose=*/false, 200, 4);
+
+    cytnx::tn_algo::MPS excited_mps(num_sites, 2, bond_dim);
+    cytnx::tn_algo::DMRG excited_dmrg(mpo, excited_mps, {ground_mps}, /*weight=*/30);
+    excited_dmrg.initialize();
+
+    double energy = 0.0;
+    for (int sweep = 0; sweep < 8; sweep++) {
+      energy = double(excited_dmrg.sweepv2(/*verbose=*/false, /*maxit=*/200, /*krydim=*/4));
+    }
+
+    double exact = TfimTest::ExactFirstExcitedEnergy(num_sites, coupling, field);
+    EXPECT_NEAR(energy, exact, 1e-6)
+      << "DMRG (v2) excited energy " << energy << " vs exact " << exact;
+  }
+
   // A second, more strongly transverse-field point to guard against accidental
   // agreement at one coupling.
   TEST(DMRG, GroundStateEnergyCriticalPoint) {

--- a/tests/tn_algo_test/MPO_test.cpp
+++ b/tests/tn_algo_test/MPO_test.cpp
@@ -7,64 +7,62 @@
 #include "cytnx.hpp"
 #include "tn_algo_test/tfim_mpo.hpp"
 
-using namespace cytnx;
-using namespace cytnx::tn_algo;
-
 namespace {
 
   // Contract a matrix-product operator into its dense 2^num_sites matrix, closing
   // the open virtual bonds with the boundary vectors (e_0 on the left,
   // e_{bond_dim-1} on the right) used by the tn_algo DMRG driver.
-  Tensor MpoToDense(const std::vector<UniTensor> &mpo_tensors) {
+  cytnx::Tensor MpoToDense(const std::vector<cytnx::UniTensor> &mpo_tensors) {
     int num_sites = static_cast<int>(mpo_tensors.size());
-    cytnx_uint64 bond_dim = mpo_tensors[0].shape()[0];
+    cytnx::cytnx_uint64 bond_dim = mpo_tensors[0].shape()[0];
 
-    Tensor left_boundary = zeros({bond_dim});
+    cytnx::Tensor left_boundary = cytnx::zeros({bond_dim});
     left_boundary.at<double>({0}) = 1.0;
-    Tensor right_boundary = zeros({bond_dim});
+    cytnx::Tensor right_boundary = cytnx::zeros({bond_dim});
     right_boundary.at<double>({bond_dim - 1}) = 1.0;
 
-    UniTensor contracted =
-      UniTensor(left_boundary, /*is_diag=*/false, /*rowrank=*/0).relabel({"v0"});
+    cytnx::UniTensor contracted =
+      cytnx::UniTensor(left_boundary, /*is_diag=*/false, /*rowrank=*/0).relabel({"v0"});
     for (int site = 0; site < num_sites; site++) {
-      UniTensor w =
+      cytnx::UniTensor w =
         mpo_tensors[site].relabel({"v" + std::to_string(site), "v" + std::to_string(site + 1),
                                    "o" + std::to_string(site), "i" + std::to_string(site)});
-      contracted = Contract(contracted, w);
+      contracted = cytnx::Contract(contracted, w);
     }
-    contracted = Contract(contracted, UniTensor(right_boundary, /*is_diag=*/false, /*rowrank=*/0)
-                                        .relabel({"v" + std::to_string(num_sites)}));
+    contracted =
+      cytnx::Contract(contracted, cytnx::UniTensor(right_boundary, /*is_diag=*/false, /*rowrank=*/0)
+                                    .relabel({"v" + std::to_string(num_sites)}));
 
     std::vector<std::string> order;
     for (int site = 0; site < num_sites; site++) order.push_back("o" + std::to_string(site));
     for (int site = 0; site < num_sites; site++) order.push_back("i" + std::to_string(site));
     contracted = contracted.permute(order);
 
-    Tensor block = contracted.get_block_();
+    cytnx::Tensor block = contracted.get_block_();
     block.contiguous_();
-    cytnx_uint64 dimension = 1;
+    cytnx::cytnx_uint64 dimension = 1;
     for (int site = 0; site < num_sites; site++) dimension *= 2;
     block.reshape_({dimension, dimension});
     return block;
   }
 
-  bool TensorsClose(const Tensor &lhs, const Tensor &rhs, double tol = 1e-10) {
+  bool TensorsClose(const cytnx::Tensor &lhs, const cytnx::Tensor &rhs, double tol = 1e-10) {
     if (lhs.shape() != rhs.shape()) return false;
     return (lhs - rhs).Norm().item<double>() < tol;
   }
 
-  MPO BuildTfimMpo(int num_sites, double coupling, double field) {
-    MPO mpo;
-    UniTensor bulk = TfimTest::MakeMpoTensor(coupling, field);
+  cytnx::tn_algo::MPO BuildTfimMpo(int num_sites, double coupling, double field) {
+    cytnx::tn_algo::MPO mpo;
+    cytnx::UniTensor bulk = TfimTest::MakeMpoTensor(coupling, field);
     for (int site = 0; site < num_sites; site++) mpo.append(bulk);
     return mpo;
   }
 
   TEST(MPO, AppendAndAccess) {
-    MPO mpo = BuildTfimMpo(5, 1.0, 0.5);
+    cytnx::tn_algo::MPO mpo = BuildTfimMpo(5, 1.0, 0.5);
     EXPECT_EQ(mpo.size(), 5u);
     EXPECT_EQ(mpo.get_all().size(), 5u);
-    for (cytnx_uint64 site = 0; site < mpo.size(); site++) {
+    for (cytnx::cytnx_uint64 site = 0; site < mpo.size(); site++) {
       EXPECT_EQ(mpo.get_op(site).rank(), 4u);
       EXPECT_EQ(mpo.get_op(site).shape()[0], 3u);
       EXPECT_EQ(mpo.get_op(site).shape()[1], 3u);
@@ -74,13 +72,13 @@ namespace {
   }
 
   TEST(MPO, GetOpOutOfBoundThrows) {
-    MPO mpo = BuildTfimMpo(3, 1.0, 0.5);
+    cytnx::tn_algo::MPO mpo = BuildTfimMpo(3, 1.0, 0.5);
     EXPECT_ANY_THROW({ mpo.get_op(3); });
   }
 
   TEST(MPO, Assign) {
-    MPO mpo;
-    UniTensor bulk = TfimTest::MakeMpoTensor(1.0, 0.5);
+    cytnx::tn_algo::MPO mpo;
+    cytnx::UniTensor bulk = TfimTest::MakeMpoTensor(1.0, 0.5);
     mpo.assign(4, bulk);
     EXPECT_EQ(mpo.size(), 4u);
   }
@@ -91,9 +89,9 @@ namespace {
   TEST(MPO, ContractsToCorrectHamiltonian) {
     for (int num_sites : {2, 3, 4}) {
       double coupling = 1.0, field = 0.5;
-      MPO mpo = BuildTfimMpo(num_sites, coupling, field);
-      Tensor mpo_hamiltonian = MpoToDense(mpo.get_all());
-      Tensor reference_hamiltonian = TfimTest::DenseHamiltonian(num_sites, coupling, field);
+      cytnx::tn_algo::MPO mpo = BuildTfimMpo(num_sites, coupling, field);
+      cytnx::Tensor mpo_hamiltonian = MpoToDense(mpo.get_all());
+      cytnx::Tensor reference_hamiltonian = TfimTest::DenseHamiltonian(num_sites, coupling, field);
       EXPECT_TRUE(TensorsClose(mpo_hamiltonian, reference_hamiltonian))
         << "MPO-contracted Hamiltonian differs from reference for num_sites=" << num_sites;
     }

--- a/tests/tn_algo_test/MPO_test.cpp
+++ b/tests/tn_algo_test/MPO_test.cpp
@@ -1,0 +1,101 @@
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "cytnx.hpp"
+#include "tn_algo_test/tfim_mpo.hpp"
+
+using namespace cytnx;
+using namespace cytnx::tn_algo;
+using namespace testing;
+
+namespace MPOTest {
+
+  // Contract a matrix-product operator into its dense 2^N x 2^N matrix, closing
+  // the open virtual bonds with the boundary vectors (e_0 on the left, e_{Dw-1}
+  // on the right) used by the tn_algo DMRG driver.
+  static Tensor MpoToDense(const std::vector<UniTensor> &Ws) {
+    int N = static_cast<int>(Ws.size());
+    cytnx_uint64 Dw = Ws[0].shape()[0];
+
+    auto Lv = zeros({Dw});
+    Lv.at<double>({0}) = 1.0;
+    auto Rv = zeros({Dw});
+    Rv.at<double>({Dw - 1}) = 1.0;
+
+    UniTensor res = UniTensor(Lv, false, 0).relabel({"v0"});
+    for (int k = 0; k < N; k++) {
+      auto w = Ws[k].relabel({"v" + std::to_string(k), "v" + std::to_string(k + 1),
+                              "o" + std::to_string(k), "i" + std::to_string(k)});
+      res = Contract(res, w);
+    }
+    res = Contract(res, UniTensor(Rv, false, 0).relabel({"v" + std::to_string(N)}));
+
+    std::vector<std::string> order;
+    for (int k = 0; k < N; k++) order.push_back("o" + std::to_string(k));
+    for (int k = 0; k < N; k++) order.push_back("i" + std::to_string(k));
+    res = res.permute(order);
+
+    auto blk = res.get_block_();
+    blk.contiguous_();
+    cytnx_uint64 dim = 1;
+    for (int i = 0; i < N; i++) dim *= 2;
+    blk.reshape_({dim, dim});
+    return blk;
+  }
+
+  static bool TensorsClose(const Tensor &a, const Tensor &b, double tol = 1e-10) {
+    if (a.shape() != b.shape()) return false;
+    auto diff = (a - b).Norm().item<double>();
+    return diff < tol;
+  }
+
+  static MPO BuildTfimMPO(int N, double J, double h) {
+    MPO mpo;
+    auto W = TfimTest::TfimW(J, h);
+    for (int i = 0; i < N; i++) mpo.append(W);
+    return mpo;
+  }
+
+  TEST(MPO, AppendAndAccess) {
+    MPO mpo = BuildTfimMPO(5, 1.0, 0.5);
+    EXPECT_EQ(mpo.size(), 5u);
+    EXPECT_EQ(mpo.get_all().size(), 5u);
+    for (cytnx_uint64 i = 0; i < mpo.size(); i++) {
+      EXPECT_EQ(mpo.get_op(i).rank(), 4u);
+      EXPECT_EQ(mpo.get_op(i).shape()[0], 3u);
+      EXPECT_EQ(mpo.get_op(i).shape()[1], 3u);
+      EXPECT_EQ(mpo.get_op(i).shape()[2], 2u);
+      EXPECT_EQ(mpo.get_op(i).shape()[3], 2u);
+    }
+  }
+
+  TEST(MPO, GetOpOutOfBoundThrows) {
+    MPO mpo = BuildTfimMPO(3, 1.0, 0.5);
+    EXPECT_ANY_THROW({ mpo.get_op(3); });
+  }
+
+  TEST(MPO, Assign) {
+    MPO mpo;
+    auto W = TfimTest::TfimW(1.0, 0.5);
+    mpo.assign(4, W);
+    EXPECT_EQ(mpo.size(), 4u);
+  }
+
+  // The MPO must encode exactly the intended Hamiltonian: contracting the chain
+  // with the boundary vectors has to reproduce the dense matrix assembled
+  // independently from Pauli operators.
+  TEST(MPO, ContractsToCorrectHamiltonian) {
+    for (int N : {2, 3, 4}) {
+      double J = 1.0, h = 0.5;
+      auto mpo = BuildTfimMPO(N, J, h);
+      auto H_mpo = MpoToDense(mpo.get_all());
+      auto H_ref = TfimTest::DenseH(N, J, h);
+      EXPECT_TRUE(TensorsClose(H_mpo, H_ref))
+        << "MPO-contracted Hamiltonian differs from reference for N=" << N;
+    }
+  }
+
+}  // namespace MPOTest

--- a/tests/tn_algo_test/MPO_test.cpp
+++ b/tests/tn_algo_test/MPO_test.cpp
@@ -9,78 +9,79 @@
 
 using namespace cytnx;
 using namespace cytnx::tn_algo;
-using namespace testing;
 
-namespace MPOTest {
+namespace {
 
-  // Contract a matrix-product operator into its dense 2^N x 2^N matrix, closing
-  // the open virtual bonds with the boundary vectors (e_0 on the left, e_{Dw-1}
-  // on the right) used by the tn_algo DMRG driver.
-  static Tensor MpoToDense(const std::vector<UniTensor> &Ws) {
-    int N = static_cast<int>(Ws.size());
-    cytnx_uint64 Dw = Ws[0].shape()[0];
+  // Contract a matrix-product operator into its dense 2^num_sites matrix, closing
+  // the open virtual bonds with the boundary vectors (e_0 on the left,
+  // e_{bond_dim-1} on the right) used by the tn_algo DMRG driver.
+  Tensor MpoToDense(const std::vector<UniTensor> &mpo_tensors) {
+    int num_sites = static_cast<int>(mpo_tensors.size());
+    cytnx_uint64 bond_dim = mpo_tensors[0].shape()[0];
 
-    auto Lv = zeros({Dw});
-    Lv.at<double>({0}) = 1.0;
-    auto Rv = zeros({Dw});
-    Rv.at<double>({Dw - 1}) = 1.0;
+    Tensor left_boundary = zeros({bond_dim});
+    left_boundary.at<double>({0}) = 1.0;
+    Tensor right_boundary = zeros({bond_dim});
+    right_boundary.at<double>({bond_dim - 1}) = 1.0;
 
-    UniTensor res = UniTensor(Lv, false, 0).relabel({"v0"});
-    for (int k = 0; k < N; k++) {
-      auto w = Ws[k].relabel({"v" + std::to_string(k), "v" + std::to_string(k + 1),
-                              "o" + std::to_string(k), "i" + std::to_string(k)});
-      res = Contract(res, w);
+    UniTensor contracted =
+      UniTensor(left_boundary, /*is_diag=*/false, /*rowrank=*/0).relabel({"v0"});
+    for (int site = 0; site < num_sites; site++) {
+      UniTensor w =
+        mpo_tensors[site].relabel({"v" + std::to_string(site), "v" + std::to_string(site + 1),
+                                   "o" + std::to_string(site), "i" + std::to_string(site)});
+      contracted = Contract(contracted, w);
     }
-    res = Contract(res, UniTensor(Rv, false, 0).relabel({"v" + std::to_string(N)}));
+    contracted = Contract(contracted, UniTensor(right_boundary, /*is_diag=*/false, /*rowrank=*/0)
+                                        .relabel({"v" + std::to_string(num_sites)}));
 
     std::vector<std::string> order;
-    for (int k = 0; k < N; k++) order.push_back("o" + std::to_string(k));
-    for (int k = 0; k < N; k++) order.push_back("i" + std::to_string(k));
-    res = res.permute(order);
+    for (int site = 0; site < num_sites; site++) order.push_back("o" + std::to_string(site));
+    for (int site = 0; site < num_sites; site++) order.push_back("i" + std::to_string(site));
+    contracted = contracted.permute(order);
 
-    auto blk = res.get_block_();
-    blk.contiguous_();
-    cytnx_uint64 dim = 1;
-    for (int i = 0; i < N; i++) dim *= 2;
-    blk.reshape_({dim, dim});
-    return blk;
+    Tensor block = contracted.get_block_();
+    block.contiguous_();
+    cytnx_uint64 dimension = 1;
+    for (int site = 0; site < num_sites; site++) dimension *= 2;
+    block.reshape_({dimension, dimension});
+    return block;
   }
 
-  static bool TensorsClose(const Tensor &a, const Tensor &b, double tol = 1e-10) {
-    if (a.shape() != b.shape()) return false;
-    auto diff = (a - b).Norm().item<double>();
-    return diff < tol;
+  bool TensorsClose(const Tensor &lhs, const Tensor &rhs, double tol = 1e-10) {
+    if (lhs.shape() != rhs.shape()) return false;
+    return (lhs - rhs).Norm().item<double>() < tol;
   }
 
-  static MPO BuildTfimMPO(int N, double J, double h) {
+  MPO BuildTfimMpo(int num_sites, double coupling, double field) {
     MPO mpo;
-    auto W = TfimTest::TfimW(J, h);
-    for (int i = 0; i < N; i++) mpo.append(W);
+    UniTensor bulk = TfimTest::MakeMpoTensor(coupling, field);
+    for (int site = 0; site < num_sites; site++) mpo.append(bulk);
     return mpo;
   }
 
   TEST(MPO, AppendAndAccess) {
-    MPO mpo = BuildTfimMPO(5, 1.0, 0.5);
+    MPO mpo = BuildTfimMpo(5, 1.0, 0.5);
     EXPECT_EQ(mpo.size(), 5u);
     EXPECT_EQ(mpo.get_all().size(), 5u);
-    for (cytnx_uint64 i = 0; i < mpo.size(); i++) {
-      EXPECT_EQ(mpo.get_op(i).rank(), 4u);
-      EXPECT_EQ(mpo.get_op(i).shape()[0], 3u);
-      EXPECT_EQ(mpo.get_op(i).shape()[1], 3u);
-      EXPECT_EQ(mpo.get_op(i).shape()[2], 2u);
-      EXPECT_EQ(mpo.get_op(i).shape()[3], 2u);
+    for (cytnx_uint64 site = 0; site < mpo.size(); site++) {
+      EXPECT_EQ(mpo.get_op(site).rank(), 4u);
+      EXPECT_EQ(mpo.get_op(site).shape()[0], 3u);
+      EXPECT_EQ(mpo.get_op(site).shape()[1], 3u);
+      EXPECT_EQ(mpo.get_op(site).shape()[2], 2u);
+      EXPECT_EQ(mpo.get_op(site).shape()[3], 2u);
     }
   }
 
   TEST(MPO, GetOpOutOfBoundThrows) {
-    MPO mpo = BuildTfimMPO(3, 1.0, 0.5);
+    MPO mpo = BuildTfimMpo(3, 1.0, 0.5);
     EXPECT_ANY_THROW({ mpo.get_op(3); });
   }
 
   TEST(MPO, Assign) {
     MPO mpo;
-    auto W = TfimTest::TfimW(1.0, 0.5);
-    mpo.assign(4, W);
+    UniTensor bulk = TfimTest::MakeMpoTensor(1.0, 0.5);
+    mpo.assign(4, bulk);
     EXPECT_EQ(mpo.size(), 4u);
   }
 
@@ -88,14 +89,14 @@ namespace MPOTest {
   // with the boundary vectors has to reproduce the dense matrix assembled
   // independently from Pauli operators.
   TEST(MPO, ContractsToCorrectHamiltonian) {
-    for (int N : {2, 3, 4}) {
-      double J = 1.0, h = 0.5;
-      auto mpo = BuildTfimMPO(N, J, h);
-      auto H_mpo = MpoToDense(mpo.get_all());
-      auto H_ref = TfimTest::DenseH(N, J, h);
-      EXPECT_TRUE(TensorsClose(H_mpo, H_ref))
-        << "MPO-contracted Hamiltonian differs from reference for N=" << N;
+    for (int num_sites : {2, 3, 4}) {
+      double coupling = 1.0, field = 0.5;
+      MPO mpo = BuildTfimMpo(num_sites, coupling, field);
+      Tensor mpo_hamiltonian = MpoToDense(mpo.get_all());
+      Tensor reference_hamiltonian = TfimTest::DenseHamiltonian(num_sites, coupling, field);
+      EXPECT_TRUE(TensorsClose(mpo_hamiltonian, reference_hamiltonian))
+        << "MPO-contracted Hamiltonian differs from reference for num_sites=" << num_sites;
     }
   }
 
-}  // namespace MPOTest
+}  // namespace

--- a/tests/tn_algo_test/MPS_test.cpp
+++ b/tests/tn_algo_test/MPS_test.cpp
@@ -6,9 +6,8 @@
 
 using namespace cytnx;
 using namespace cytnx::tn_algo;
-using namespace testing;
 
-namespace MPSTest {
+namespace {
 
   // Contract a rank-3 MPS site tensor A (shape [left, phys, right], rowrank 2)
   // with its own conjugate over the (left, phys) indices. For a left-orthonormal
@@ -156,4 +155,4 @@ namespace MPSTest {
     EXPECT_NEAR(double(mps.norm()), n_before, 1e-12);
   }
 
-}  // namespace MPSTest
+}  // namespace

--- a/tests/tn_algo_test/MPS_test.cpp
+++ b/tests/tn_algo_test/MPS_test.cpp
@@ -4,36 +4,33 @@
 
 #include "cytnx.hpp"
 
-using namespace cytnx;
-using namespace cytnx::tn_algo;
-
 namespace {
 
   // Contract a rank-3 MPS site tensor A (shape [left, phys, right], rowrank 2)
   // with its own conjugate over the (left, phys) indices. For a left-orthonormal
   // tensor the result is the identity on the (right, right') bond.
-  static UniTensor LeftGram(const UniTensor &A) {
+  cytnx::UniTensor LeftGram(const cytnx::UniTensor &A) {
     auto a = A.relabel({"L", "P", "R"});
     auto ac = A.Conj().relabel({"L", "P", "Rp"});
-    return Contract(a, ac);  // -> {R, Rp}
+    return cytnx::Contract(a, ac);  // -> {R, Rp}
   }
 
   // Contract a rank-3 MPS site tensor A over the (phys, right) indices with its
   // conjugate. For a right-orthonormal tensor the result is the identity on the
   // (left, left') bond.
-  static UniTensor RightGram(const UniTensor &A) {
+  cytnx::UniTensor RightGram(const cytnx::UniTensor &A) {
     auto a = A.relabel({"L", "P", "R"});
     auto ac = A.Conj().relabel({"Lp", "P", "R"});
-    return Contract(a, ac);  // -> {L, Lp}
+    return cytnx::Contract(a, ac);  // -> {L, Lp}
   }
 
-  static bool IsIdentity(const UniTensor &G, double tol = 1e-9) {
+  bool IsIdentity(const cytnx::UniTensor &G, double tol = 1e-9) {
     auto blk = G.get_block_();
     auto shape = blk.shape();
     if (shape.size() != 2 || shape[0] != shape[1]) return false;
-    cytnx_uint64 D = shape[0];
-    for (cytnx_uint64 i = 0; i < D; i++) {
-      for (cytnx_uint64 j = 0; j < D; j++) {
+    cytnx::cytnx_uint64 D = shape[0];
+    for (cytnx::cytnx_uint64 i = 0; i < D; i++) {
+      for (cytnx::cytnx_uint64 j = 0; j < D; j++) {
         double expected = (i == j) ? 1.0 : 0.0;
         if (std::abs(blk.at<double>({i, j}) - expected) > tol) return false;
       }
@@ -45,17 +42,17 @@ namespace {
   // regular MPS ran Into_Lortho(), whose chained Svd calls reused the fixed
   // "_aux_L"/"_aux_R" bond labels and aborted with a duplicated-label error.
   TEST(MPS, RegularConstructionDoesNotCrash) {
-    EXPECT_NO_THROW({ MPS mps(4, 2, 8); });
-    EXPECT_NO_THROW({ MPS mps(8, 2, 16); });
-    EXPECT_NO_THROW({ MPS mps(6, 3, 5); });
+    EXPECT_NO_THROW({ cytnx::tn_algo::MPS mps(4, 2, 8); });
+    EXPECT_NO_THROW({ cytnx::tn_algo::MPS mps(8, 2, 16); });
+    EXPECT_NO_THROW({ cytnx::tn_algo::MPS mps(6, 3, 5); });
   }
 
   TEST(MPS, RegularConstructionMetadata) {
-    MPS mps(5, 2, 8);
+    cytnx::tn_algo::MPS mps(5, 2, 8);
     EXPECT_EQ(mps.size(), 5u);
     EXPECT_EQ(mps.mps_type(), 0);  // RegularMPS
     EXPECT_EQ(mps.virt_dim(), 8);
-    for (cytnx_uint64 i = 0; i < mps.size(); i++) {
+    for (cytnx::cytnx_uint64 i = 0; i < mps.size(); i++) {
       EXPECT_EQ(mps.data()[i].rank(), 3u);
       EXPECT_EQ(mps.phys_dim(i), 2);
     }
@@ -67,9 +64,9 @@ namespace {
   // After Init(), the MPS is left-orthogonalized with the orthogonality center
   // swept off the right edge, so every site tensor must be left-orthonormal.
   TEST(MPS, ConstructionIsLeftOrthonormal) {
-    MPS mps(6, 2, 8);
-    EXPECT_EQ(mps.S_loc(), static_cast<cytnx_int64>(mps.size()));
-    for (cytnx_uint64 p = 0; p < mps.size(); p++) {
+    cytnx::tn_algo::MPS mps(6, 2, 8);
+    EXPECT_EQ(mps.S_loc(), static_cast<cytnx::cytnx_int64>(mps.size()));
+    for (cytnx::cytnx_uint64 p = 0; p < mps.size(); p++) {
       EXPECT_TRUE(IsIdentity(LeftGram(mps.data()[p])))
         << "site " << p << " is not left-orthonormal";
     }
@@ -78,18 +75,18 @@ namespace {
   // The final Svd in Into_Lortho() discards the singular values of the right
   // edge, so a freshly constructed MPS is normalized to one.
   TEST(MPS, ConstructionIsNormalized) {
-    MPS mps(6, 2, 8);
+    cytnx::tn_algo::MPS mps(6, 2, 8);
     double n = double(mps.norm());
     EXPECT_NEAR(n, 1.0, 1e-9);
   }
 
   TEST(MPS, NonUniformPhysDim) {
-    std::vector<cytnx_uint64> phys = {2, 3, 2, 4};
-    MPS mps;
+    std::vector<cytnx::cytnx_uint64> phys = {2, 3, 2, 4};
+    cytnx::tn_algo::MPS mps;
     EXPECT_NO_THROW({ mps.Init(4, phys, 10); });
     ASSERT_EQ(mps.size(), 4u);
-    for (cytnx_uint64 i = 0; i < phys.size(); i++) {
-      EXPECT_EQ(mps.phys_dim(i), static_cast<cytnx_int64>(phys[i]));
+    for (cytnx::cytnx_uint64 i = 0; i < phys.size(); i++) {
+      EXPECT_EQ(mps.phys_dim(i), static_cast<cytnx::cytnx_int64>(phys[i]));
       EXPECT_TRUE(IsIdentity(LeftGram(mps.data()[i])))
         << "site " << i << " is not left-orthonormal";
     }
@@ -99,12 +96,12 @@ namespace {
   // Init_Msector also funnels through Into_Lortho() and was equally affected by
   // the #920 label collision.
   TEST(MPS, InitMsectorDoesNotCrash) {
-    MPS mps;
-    std::vector<cytnx_uint64> phys = {2, 2, 2, 2};
-    std::vector<cytnx_int64> select = {0, 1, 0, 1};
+    cytnx::tn_algo::MPS mps;
+    std::vector<cytnx::cytnx_uint64> phys = {2, 2, 2, 2};
+    std::vector<cytnx::cytnx_int64> select = {0, 1, 0, 1};
     EXPECT_NO_THROW({ mps.Init_Msector(4, phys, 8, select); });
     EXPECT_EQ(mps.size(), 4u);
-    for (cytnx_uint64 p = 0; p < mps.size(); p++) {
+    for (cytnx::cytnx_uint64 p = 0; p < mps.size(); p++) {
       EXPECT_TRUE(IsIdentity(LeftGram(mps.data()[p])))
         << "site " << p << " is not left-orthonormal";
     }
@@ -115,7 +112,7 @@ namespace {
   // the represented state (and hence its norm) unchanged, and it must not hit
   // the same chained-Svd label collision as Into_Lortho().
   TEST(MPS, OrthoCenterSweepPreservesNorm) {
-    MPS mps(6, 2, 8);
+    cytnx::tn_algo::MPS mps(6, 2, 8);
     double n0 = double(mps.norm());
     ASSERT_NEAR(n0, 1.0, 1e-9);
 
@@ -127,7 +124,7 @@ namespace {
 
     // ... and back to the right edge again.
     EXPECT_NO_THROW({
-      while (mps.S_loc() < static_cast<cytnx_int64>(mps.size())) mps.S_mvright();
+      while (mps.S_loc() < static_cast<cytnx::cytnx_int64>(mps.size())) mps.S_mvright();
     });
     EXPECT_NEAR(double(mps.norm()), 1.0, 1e-9);
   }
@@ -135,23 +132,23 @@ namespace {
   // After fully sweeping the center to the left edge, every site tensor must be
   // right-orthonormal.
   TEST(MPS, SweepLeftIsRightOrthonormal) {
-    MPS mps(6, 2, 8);
+    cytnx::tn_algo::MPS mps(6, 2, 8);
     while (mps.S_loc() > -1) mps.S_mvleft();
     EXPECT_EQ(mps.S_loc(), -1);
-    for (cytnx_uint64 p = 0; p < mps.size(); p++) {
+    for (cytnx::cytnx_uint64 p = 0; p < mps.size(); p++) {
       EXPECT_TRUE(IsIdentity(RightGram(mps.data()[p])))
         << "site " << p << " is not right-orthonormal";
     }
   }
 
   TEST(MPS, CloneIsIndependent) {
-    MPS mps(4, 2, 8);
-    MPS cp = mps.clone();
+    cytnx::tn_algo::MPS mps(4, 2, 8);
+    cytnx::tn_algo::MPS cp = mps.clone();
     ASSERT_EQ(cp.size(), mps.size());
     // Mutating the clone's center must not change the original.
     double n_before = double(mps.norm());
     cp.S_mvleft();
-    EXPECT_EQ(mps.S_loc(), static_cast<cytnx_int64>(mps.size()));
+    EXPECT_EQ(mps.S_loc(), static_cast<cytnx::cytnx_int64>(mps.size()));
     EXPECT_NEAR(double(mps.norm()), n_before, 1e-12);
   }
 

--- a/tests/tn_algo_test/MPS_test.cpp
+++ b/tests/tn_algo_test/MPS_test.cpp
@@ -1,0 +1,159 @@
+#include <cmath>
+
+#include "gtest/gtest.h"
+
+#include "cytnx.hpp"
+
+using namespace cytnx;
+using namespace cytnx::tn_algo;
+using namespace testing;
+
+namespace MPSTest {
+
+  // Contract a rank-3 MPS site tensor A (shape [left, phys, right], rowrank 2)
+  // with its own conjugate over the (left, phys) indices. For a left-orthonormal
+  // tensor the result is the identity on the (right, right') bond.
+  static UniTensor LeftGram(const UniTensor &A) {
+    auto a = A.relabel({"L", "P", "R"});
+    auto ac = A.Conj().relabel({"L", "P", "Rp"});
+    return Contract(a, ac);  // -> {R, Rp}
+  }
+
+  // Contract a rank-3 MPS site tensor A over the (phys, right) indices with its
+  // conjugate. For a right-orthonormal tensor the result is the identity on the
+  // (left, left') bond.
+  static UniTensor RightGram(const UniTensor &A) {
+    auto a = A.relabel({"L", "P", "R"});
+    auto ac = A.Conj().relabel({"Lp", "P", "R"});
+    return Contract(a, ac);  // -> {L, Lp}
+  }
+
+  static bool IsIdentity(const UniTensor &G, double tol = 1e-9) {
+    auto blk = G.get_block_();
+    auto shape = blk.shape();
+    if (shape.size() != 2 || shape[0] != shape[1]) return false;
+    cytnx_uint64 D = shape[0];
+    for (cytnx_uint64 i = 0; i < D; i++) {
+      for (cytnx_uint64 j = 0; j < D; j++) {
+        double expected = (i == j) ? 1.0 : 0.0;
+        if (std::abs(blk.at<double>({i, j}) - expected) > tol) return false;
+      }
+    }
+    return true;
+  }
+
+  // Regression test for the construction crash reported in #920: building a
+  // regular MPS ran Into_Lortho(), whose chained Svd calls reused the fixed
+  // "_aux_L"/"_aux_R" bond labels and aborted with a duplicated-label error.
+  TEST(MPS, RegularConstructionDoesNotCrash) {
+    EXPECT_NO_THROW({ MPS mps(4, 2, 8); });
+    EXPECT_NO_THROW({ MPS mps(8, 2, 16); });
+    EXPECT_NO_THROW({ MPS mps(6, 3, 5); });
+  }
+
+  TEST(MPS, RegularConstructionMetadata) {
+    MPS mps(5, 2, 8);
+    EXPECT_EQ(mps.size(), 5u);
+    EXPECT_EQ(mps.mps_type(), 0);  // RegularMPS
+    EXPECT_EQ(mps.virt_dim(), 8);
+    for (cytnx_uint64 i = 0; i < mps.size(); i++) {
+      EXPECT_EQ(mps.data()[i].rank(), 3u);
+      EXPECT_EQ(mps.phys_dim(i), 2);
+    }
+    // Open boundary conditions: outermost virtual bonds are trivial.
+    EXPECT_EQ(mps.data().front().shape()[0], 1u);
+    EXPECT_EQ(mps.data().back().shape()[2], 1u);
+  }
+
+  // After Init(), the MPS is left-orthogonalized with the orthogonality center
+  // swept off the right edge, so every site tensor must be left-orthonormal.
+  TEST(MPS, ConstructionIsLeftOrthonormal) {
+    MPS mps(6, 2, 8);
+    EXPECT_EQ(mps.S_loc(), static_cast<cytnx_int64>(mps.size()));
+    for (cytnx_uint64 p = 0; p < mps.size(); p++) {
+      EXPECT_TRUE(IsIdentity(LeftGram(mps.data()[p])))
+        << "site " << p << " is not left-orthonormal";
+    }
+  }
+
+  // The final Svd in Into_Lortho() discards the singular values of the right
+  // edge, so a freshly constructed MPS is normalized to one.
+  TEST(MPS, ConstructionIsNormalized) {
+    MPS mps(6, 2, 8);
+    double n = double(mps.norm());
+    EXPECT_NEAR(n, 1.0, 1e-9);
+  }
+
+  TEST(MPS, NonUniformPhysDim) {
+    std::vector<cytnx_uint64> phys = {2, 3, 2, 4};
+    MPS mps;
+    EXPECT_NO_THROW({ mps.Init(4, phys, 10); });
+    ASSERT_EQ(mps.size(), 4u);
+    for (cytnx_uint64 i = 0; i < phys.size(); i++) {
+      EXPECT_EQ(mps.phys_dim(i), static_cast<cytnx_int64>(phys[i]));
+      EXPECT_TRUE(IsIdentity(LeftGram(mps.data()[i])))
+        << "site " << i << " is not left-orthonormal";
+    }
+    EXPECT_NEAR(double(mps.norm()), 1.0, 1e-9);
+  }
+
+  // Init_Msector also funnels through Into_Lortho() and was equally affected by
+  // the #920 label collision.
+  TEST(MPS, InitMsectorDoesNotCrash) {
+    MPS mps;
+    std::vector<cytnx_uint64> phys = {2, 2, 2, 2};
+    std::vector<cytnx_int64> select = {0, 1, 0, 1};
+    EXPECT_NO_THROW({ mps.Init_Msector(4, phys, 8, select); });
+    EXPECT_EQ(mps.size(), 4u);
+    for (cytnx_uint64 p = 0; p < mps.size(); p++) {
+      EXPECT_TRUE(IsIdentity(LeftGram(mps.data()[p])))
+        << "site " << p << " is not left-orthonormal";
+    }
+    EXPECT_NEAR(double(mps.norm()), 1.0, 1e-9);
+  }
+
+  // Sweeping the orthogonality center is a gauge transformation: it must leave
+  // the represented state (and hence its norm) unchanged, and it must not hit
+  // the same chained-Svd label collision as Into_Lortho().
+  TEST(MPS, OrthoCenterSweepPreservesNorm) {
+    MPS mps(6, 2, 8);
+    double n0 = double(mps.norm());
+    ASSERT_NEAR(n0, 1.0, 1e-9);
+
+    // Sweep the center from the right edge all the way to the left edge.
+    EXPECT_NO_THROW({
+      while (mps.S_loc() > -1) mps.S_mvleft();
+    });
+    EXPECT_NEAR(double(mps.norm()), 1.0, 1e-9);
+
+    // ... and back to the right edge again.
+    EXPECT_NO_THROW({
+      while (mps.S_loc() < static_cast<cytnx_int64>(mps.size())) mps.S_mvright();
+    });
+    EXPECT_NEAR(double(mps.norm()), 1.0, 1e-9);
+  }
+
+  // After fully sweeping the center to the left edge, every site tensor must be
+  // right-orthonormal.
+  TEST(MPS, SweepLeftIsRightOrthonormal) {
+    MPS mps(6, 2, 8);
+    while (mps.S_loc() > -1) mps.S_mvleft();
+    EXPECT_EQ(mps.S_loc(), -1);
+    for (cytnx_uint64 p = 0; p < mps.size(); p++) {
+      EXPECT_TRUE(IsIdentity(RightGram(mps.data()[p])))
+        << "site " << p << " is not right-orthonormal";
+    }
+  }
+
+  TEST(MPS, CloneIsIndependent) {
+    MPS mps(4, 2, 8);
+    MPS cp = mps.clone();
+    ASSERT_EQ(cp.size(), mps.size());
+    // Mutating the clone's center must not change the original.
+    double n_before = double(mps.norm());
+    cp.S_mvleft();
+    EXPECT_EQ(mps.S_loc(), static_cast<cytnx_int64>(mps.size()));
+    EXPECT_NEAR(double(mps.norm()), n_before, 1e-12);
+  }
+
+}  // namespace MPSTest

--- a/tests/tn_algo_test/tfim_mpo.hpp
+++ b/tests/tn_algo_test/tfim_mpo.hpp
@@ -49,9 +49,9 @@ namespace TfimTest {
     auto Z = PauliZ();
     auto X = PauliX();
     auto W = zeros({3, 3, 2, 2});
-    auto put = [&](int a, int b, const Tensor& op) {
-      for (int s = 0; s < 2; s++)
-        for (int t = 0; t < 2; t++) W.at<double>({a, b, s, t}) = op.at<double>({s, t});
+    auto put = [&](cytnx_uint64 a, cytnx_uint64 b, const Tensor& op) {
+      for (cytnx_uint64 s = 0; s < 2; s++)
+        for (cytnx_uint64 t = 0; t < 2; t++) W.at<double>({a, b, s, t}) = op.at<double>({s, t});
     };
     put(0, 0, I);
     put(0, 1, Z);

--- a/tests/tn_algo_test/tfim_mpo.hpp
+++ b/tests/tn_algo_test/tfim_mpo.hpp
@@ -9,7 +9,7 @@
 // Shared helpers for the tn_algo tests built around the open-boundary
 // transverse-field Ising model (TFIM)
 //
-//     H = -J * sum_i Z_i Z_{i+1} - h * sum_i X_i.
+//     H = -coupling * sum_i Z_i Z_{i+1} - field * sum_i X_i.
 //
 // The matrix-product operator is encoded in the boundary convention used by
 // cytnx::tn_algo::DMRG_impl::initialize(), which fixes the left boundary vector
@@ -17,88 +17,92 @@
 // index. With the bond-dimension-3 upper-triangular form below, the same bulk
 // tensor can be reused at every site:
 //
-//     W[vL, vR] =  [ I    Z    -hX ]
-//                  [ 0    0    -JZ ]
-//                  [ 0    0     I  ]
+//     W[vL, vR] =  [ I        Z            -field*X ]
+//                  [ 0        0            -coupling*Z ]
+//                  [ 0        0             I  ]
 //
 // so that  e_0 * W * W * ... * W * e_2  reproduces H.
 namespace TfimTest {
 
   // Single-site spin-1/2 operators as 2x2 dense Tensors (Z and X are real and
   // symmetric, so the operator in/out leg order is irrelevant for this model).
-  inline cytnx::Tensor PauliI() { return cytnx::eye(2); }
+  inline cytnx::Tensor Identity() { return cytnx::eye(2); }
 
   inline cytnx::Tensor PauliZ() {
-    auto Z = cytnx::zeros({2, 2});
-    Z.at<double>({0, 0}) = 1.0;
-    Z.at<double>({1, 1}) = -1.0;
-    return Z;
+    auto pauli_z = cytnx::zeros({2, 2});
+    pauli_z.at<double>({0, 0}) = 1.0;
+    pauli_z.at<double>({1, 1}) = -1.0;
+    return pauli_z;
   }
 
   inline cytnx::Tensor PauliX() {
-    auto X = cytnx::zeros({2, 2});
-    X.at<double>({0, 1}) = 1.0;
-    X.at<double>({1, 0}) = 1.0;
-    return X;
+    auto pauli_x = cytnx::zeros({2, 2});
+    pauli_x.at<double>({0, 1}) = 1.0;
+    pauli_x.at<double>({1, 0}) = 1.0;
+    return pauli_x;
   }
 
   // The single reusable bulk MPO tensor with legs [vL, vR, phys_out, phys_in].
-  inline cytnx::UniTensor TfimW(double J, double h) {
+  inline cytnx::UniTensor MakeMpoTensor(double coupling, double field) {
     using namespace cytnx;
-    auto I = PauliI();
-    auto Z = PauliZ();
-    auto X = PauliX();
-    auto W = zeros({3, 3, 2, 2});
-    auto put = [&](cytnx_uint64 a, cytnx_uint64 b, const Tensor& op) {
-      for (cytnx_uint64 s = 0; s < 2; s++)
-        for (cytnx_uint64 t = 0; t < 2; t++) W.at<double>({a, b, s, t}) = op.at<double>({s, t});
+    Tensor identity = Identity();
+    Tensor pauli_z = PauliZ();
+    Tensor pauli_x = PauliX();
+    Tensor w = zeros({3, 3, 2, 2});
+    auto put = [&](cytnx_uint64 row, cytnx_uint64 col, const Tensor& op) {
+      for (cytnx_uint64 out_index = 0; out_index < 2; out_index++)
+        for (cytnx_uint64 in_index = 0; in_index < 2; in_index++)
+          w.at<double>({row, col, out_index, in_index}) = op.at<double>({out_index, in_index});
     };
-    put(0, 0, I);
-    put(0, 1, Z);
-    put(0, 2, -h * X);
-    put(1, 2, -J * Z);
-    put(2, 2, I);
-    return UniTensor(W, false, 0);
+    put(0, 0, identity);
+    put(0, 1, pauli_z);
+    put(0, 2, -field * pauli_x);
+    put(1, 2, -coupling * pauli_z);
+    put(2, 2, identity);
+    return UniTensor(w, /*is_diag=*/false, /*rowrank=*/0);
   }
 
-  // Embed a per-site operator map into the full 2^N dimensional Hilbert space by
-  // a chain of Kronecker products (site 0 is the most significant index).
-  inline cytnx::Tensor Embed(int N, const std::vector<std::pair<int, cytnx::Tensor>>& ops) {
+  // Embed a per-site operator map into the full 2^num_sites dimensional Hilbert
+  // space by a chain of Kronecker products (site 0 is the most significant index).
+  inline cytnx::Tensor Embed(int num_sites,
+                             const std::vector<std::pair<int, cytnx::Tensor>>& site_operators) {
     using namespace cytnx;
-    Tensor acc = ones({1, 1});  // 1x1 identity seed
-    for (int site = 0; site < N; site++) {
-      Tensor op = PauliI();
-      for (const auto& kv : ops)
-        if (kv.first == site) op = kv.second;
-      acc = linalg::Kron(acc, op);
+    Tensor embedded = ones({1, 1});  // 1x1 identity seed
+    for (int site = 0; site < num_sites; site++) {
+      Tensor site_operator = Identity();
+      for (const auto& placement : site_operators)
+        if (placement.first == site) site_operator = placement.second;
+      embedded = linalg::Kron(embedded, site_operator);
     }
-    return acc;
+    return embedded;
   }
 
-  // Dense 2^N x 2^N Hamiltonian assembled directly from Pauli operators.
-  inline cytnx::Tensor DenseH(int N, double J, double h) {
+  // Dense 2^num_sites x 2^num_sites Hamiltonian assembled directly from Pauli
+  // operators.
+  inline cytnx::Tensor DenseHamiltonian(int num_sites, double coupling, double field) {
     using namespace cytnx;
-    cytnx_uint64 dim = 1;
-    for (int i = 0; i < N; i++) dim *= 2;
-    Tensor H = zeros({dim, dim});
-    for (int i = 0; i + 1 < N; i++) {
-      H += (-J) * Embed(N, {{i, PauliZ()}, {i + 1, PauliZ()}});
+    cytnx_uint64 dimension = 1;
+    for (int site = 0; site < num_sites; site++) dimension *= 2;
+    Tensor hamiltonian = zeros({dimension, dimension});
+    for (int site = 0; site + 1 < num_sites; site++) {
+      hamiltonian += (-coupling) * Embed(num_sites, {{site, PauliZ()}, {site + 1, PauliZ()}});
     }
-    for (int i = 0; i < N; i++) {
-      H += (-h) * Embed(N, {{i, PauliX()}});
+    for (int site = 0; site < num_sites; site++) {
+      hamiltonian += (-field) * Embed(num_sites, {{site, PauliX()}});
     }
-    return H;
+    return hamiltonian;
   }
 
   // Lowest eigenvalue of the dense Hamiltonian (exact ground-state energy).
-  inline double ExactGroundEnergy(int N, double J, double h) {
+  inline double ExactGroundEnergy(int num_sites, double coupling, double field) {
     using namespace cytnx;
-    auto H = DenseH(N, J, h);
-    auto eig = linalg::Eigh(H, false);  // eigenvalues only
-    auto evals = eig[0];
-    double gs = evals.at<double>({0});
-    for (cytnx_uint64 i = 1; i < evals.shape()[0]; i++) gs = std::min(gs, evals.at<double>({i}));
-    return gs;
+    Tensor hamiltonian = DenseHamiltonian(num_sites, coupling, field);
+    std::vector<Tensor> eigh = linalg::Eigh(hamiltonian, false);  // eigenvalues only
+    Tensor eigenvalues = eigh[0];
+    double ground_energy = eigenvalues.at<double>({0});
+    for (cytnx_uint64 i = 1; i < eigenvalues.shape()[0]; i++)
+      ground_energy = std::min(ground_energy, eigenvalues.at<double>({i}));
+    return ground_energy;
   }
 
 }  // namespace TfimTest

--- a/tests/tn_algo_test/tfim_mpo.hpp
+++ b/tests/tn_algo_test/tfim_mpo.hpp
@@ -1,6 +1,7 @@
 #ifndef CYTNX_TESTS_TN_ALGO_TFIM_MPO_H_
 #define CYTNX_TESTS_TN_ALGO_TFIM_MPO_H_
 
+#include <algorithm>
 #include <vector>
 #include <string>
 
@@ -90,15 +91,27 @@ namespace TfimTest {
     return hamiltonian;
   }
 
-  // Lowest eigenvalue of the dense Hamiltonian (exact ground-state energy).
-  inline double ExactGroundEnergy(int num_sites, double coupling, double field) {
+  // Eigenvalues of the dense Hamiltonian, sorted from lowest to highest.
+  inline std::vector<double> SortedEigenvalues(int num_sites, double coupling, double field) {
     cytnx::Tensor hamiltonian = DenseHamiltonian(num_sites, coupling, field);
     std::vector<cytnx::Tensor> eigh = cytnx::linalg::Eigh(hamiltonian, false);  // eigenvalues only
     cytnx::Tensor eigenvalues = eigh[0];
-    double ground_energy = eigenvalues.at<double>({0});
-    for (cytnx::cytnx_uint64 i = 1; i < eigenvalues.shape()[0]; i++)
-      ground_energy = std::min(ground_energy, eigenvalues.at<double>({i}));
-    return ground_energy;
+    std::vector<double> values(eigenvalues.shape()[0]);
+    for (cytnx::cytnx_uint64 i = 0; i < eigenvalues.shape()[0]; i++)
+      values[i] = eigenvalues.at<double>({i});
+    std::sort(values.begin(), values.end());
+    return values;
+  }
+
+  // Lowest eigenvalue of the dense Hamiltonian (exact ground-state energy).
+  inline double ExactGroundEnergy(int num_sites, double coupling, double field) {
+    return SortedEigenvalues(num_sites, coupling, field).front();
+  }
+
+  // Second-lowest eigenvalue of the dense Hamiltonian (exact first-excited-state
+  // energy).
+  inline double ExactFirstExcitedEnergy(int num_sites, double coupling, double field) {
+    return SortedEigenvalues(num_sites, coupling, field).at(1);
   }
 
 }  // namespace TfimTest

--- a/tests/tn_algo_test/tfim_mpo.hpp
+++ b/tests/tn_algo_test/tfim_mpo.hpp
@@ -44,14 +44,13 @@ namespace TfimTest {
 
   // The single reusable bulk MPO tensor with legs [vL, vR, phys_out, phys_in].
   inline cytnx::UniTensor MakeMpoTensor(double coupling, double field) {
-    using namespace cytnx;
-    Tensor identity = Identity();
-    Tensor pauli_z = PauliZ();
-    Tensor pauli_x = PauliX();
-    Tensor w = zeros({3, 3, 2, 2});
-    auto put = [&](cytnx_uint64 row, cytnx_uint64 col, const Tensor& op) {
-      for (cytnx_uint64 out_index = 0; out_index < 2; out_index++)
-        for (cytnx_uint64 in_index = 0; in_index < 2; in_index++)
+    cytnx::Tensor identity = Identity();
+    cytnx::Tensor pauli_z = PauliZ();
+    cytnx::Tensor pauli_x = PauliX();
+    cytnx::Tensor w = cytnx::zeros({3, 3, 2, 2});
+    auto put = [&](cytnx::cytnx_uint64 row, cytnx::cytnx_uint64 col, const cytnx::Tensor &op) {
+      for (cytnx::cytnx_uint64 out_index = 0; out_index < 2; out_index++)
+        for (cytnx::cytnx_uint64 in_index = 0; in_index < 2; in_index++)
           w.at<double>({row, col, out_index, in_index}) = op.at<double>({out_index, in_index});
     };
     put(0, 0, identity);
@@ -59,20 +58,19 @@ namespace TfimTest {
     put(0, 2, -field * pauli_x);
     put(1, 2, -coupling * pauli_z);
     put(2, 2, identity);
-    return UniTensor(w, /*is_diag=*/false, /*rowrank=*/0);
+    return cytnx::UniTensor(w, /*is_diag=*/false, /*rowrank=*/0);
   }
 
   // Embed a per-site operator map into the full 2^num_sites dimensional Hilbert
   // space by a chain of Kronecker products (site 0 is the most significant index).
   inline cytnx::Tensor Embed(int num_sites,
-                             const std::vector<std::pair<int, cytnx::Tensor>>& site_operators) {
-    using namespace cytnx;
-    Tensor embedded = ones({1, 1});  // 1x1 identity seed
+                             const std::vector<std::pair<int, cytnx::Tensor>> &site_operators) {
+    cytnx::Tensor embedded = cytnx::ones({1, 1});  // 1x1 identity seed
     for (int site = 0; site < num_sites; site++) {
-      Tensor site_operator = Identity();
-      for (const auto& placement : site_operators)
+      cytnx::Tensor site_operator = Identity();
+      for (const auto &placement : site_operators)
         if (placement.first == site) site_operator = placement.second;
-      embedded = linalg::Kron(embedded, site_operator);
+      embedded = cytnx::linalg::Kron(embedded, site_operator);
     }
     return embedded;
   }
@@ -80,10 +78,9 @@ namespace TfimTest {
   // Dense 2^num_sites x 2^num_sites Hamiltonian assembled directly from Pauli
   // operators.
   inline cytnx::Tensor DenseHamiltonian(int num_sites, double coupling, double field) {
-    using namespace cytnx;
-    cytnx_uint64 dimension = 1;
+    cytnx::cytnx_uint64 dimension = 1;
     for (int site = 0; site < num_sites; site++) dimension *= 2;
-    Tensor hamiltonian = zeros({dimension, dimension});
+    cytnx::Tensor hamiltonian = cytnx::zeros({dimension, dimension});
     for (int site = 0; site + 1 < num_sites; site++) {
       hamiltonian += (-coupling) * Embed(num_sites, {{site, PauliZ()}, {site + 1, PauliZ()}});
     }
@@ -95,12 +92,11 @@ namespace TfimTest {
 
   // Lowest eigenvalue of the dense Hamiltonian (exact ground-state energy).
   inline double ExactGroundEnergy(int num_sites, double coupling, double field) {
-    using namespace cytnx;
-    Tensor hamiltonian = DenseHamiltonian(num_sites, coupling, field);
-    std::vector<Tensor> eigh = linalg::Eigh(hamiltonian, false);  // eigenvalues only
-    Tensor eigenvalues = eigh[0];
+    cytnx::Tensor hamiltonian = DenseHamiltonian(num_sites, coupling, field);
+    std::vector<cytnx::Tensor> eigh = cytnx::linalg::Eigh(hamiltonian, false);  // eigenvalues only
+    cytnx::Tensor eigenvalues = eigh[0];
     double ground_energy = eigenvalues.at<double>({0});
-    for (cytnx_uint64 i = 1; i < eigenvalues.shape()[0]; i++)
+    for (cytnx::cytnx_uint64 i = 1; i < eigenvalues.shape()[0]; i++)
       ground_energy = std::min(ground_energy, eigenvalues.at<double>({i}));
     return ground_energy;
   }

--- a/tests/tn_algo_test/tfim_mpo.hpp
+++ b/tests/tn_algo_test/tfim_mpo.hpp
@@ -1,0 +1,106 @@
+#ifndef CYTNX_TESTS_TN_ALGO_TFIM_MPO_H_
+#define CYTNX_TESTS_TN_ALGO_TFIM_MPO_H_
+
+#include <vector>
+#include <string>
+
+#include "cytnx.hpp"
+
+// Shared helpers for the tn_algo tests built around the open-boundary
+// transverse-field Ising model (TFIM)
+//
+//     H = -J * sum_i Z_i Z_{i+1} - h * sum_i X_i.
+//
+// The matrix-product operator is encoded in the boundary convention used by
+// cytnx::tn_algo::DMRG_impl::initialize(), which fixes the left boundary vector
+// to the first virtual index and the right boundary vector to the last virtual
+// index. With the bond-dimension-3 upper-triangular form below, the same bulk
+// tensor can be reused at every site:
+//
+//     W[vL, vR] =  [ I    Z    -hX ]
+//                  [ 0    0    -JZ ]
+//                  [ 0    0     I  ]
+//
+// so that  e_0 * W * W * ... * W * e_2  reproduces H.
+namespace TfimTest {
+
+  // Single-site spin-1/2 operators as 2x2 dense Tensors (Z and X are real and
+  // symmetric, so the operator in/out leg order is irrelevant for this model).
+  inline cytnx::Tensor PauliI() { return cytnx::eye(2); }
+
+  inline cytnx::Tensor PauliZ() {
+    auto Z = cytnx::zeros({2, 2});
+    Z.at<double>({0, 0}) = 1.0;
+    Z.at<double>({1, 1}) = -1.0;
+    return Z;
+  }
+
+  inline cytnx::Tensor PauliX() {
+    auto X = cytnx::zeros({2, 2});
+    X.at<double>({0, 1}) = 1.0;
+    X.at<double>({1, 0}) = 1.0;
+    return X;
+  }
+
+  // The single reusable bulk MPO tensor with legs [vL, vR, phys_out, phys_in].
+  inline cytnx::UniTensor TfimW(double J, double h) {
+    using namespace cytnx;
+    auto I = PauliI();
+    auto Z = PauliZ();
+    auto X = PauliX();
+    auto W = zeros({3, 3, 2, 2});
+    auto put = [&](int a, int b, const Tensor& op) {
+      for (int s = 0; s < 2; s++)
+        for (int t = 0; t < 2; t++) W.at<double>({a, b, s, t}) = op.at<double>({s, t});
+    };
+    put(0, 0, I);
+    put(0, 1, Z);
+    put(0, 2, -h * X);
+    put(1, 2, -J * Z);
+    put(2, 2, I);
+    return UniTensor(W, false, 0);
+  }
+
+  // Embed a per-site operator map into the full 2^N dimensional Hilbert space by
+  // a chain of Kronecker products (site 0 is the most significant index).
+  inline cytnx::Tensor Embed(int N, const std::vector<std::pair<int, cytnx::Tensor>>& ops) {
+    using namespace cytnx;
+    Tensor acc = ones({1, 1});  // 1x1 identity seed
+    for (int site = 0; site < N; site++) {
+      Tensor op = PauliI();
+      for (const auto& kv : ops)
+        if (kv.first == site) op = kv.second;
+      acc = linalg::Kron(acc, op);
+    }
+    return acc;
+  }
+
+  // Dense 2^N x 2^N Hamiltonian assembled directly from Pauli operators.
+  inline cytnx::Tensor DenseH(int N, double J, double h) {
+    using namespace cytnx;
+    cytnx_uint64 dim = 1;
+    for (int i = 0; i < N; i++) dim *= 2;
+    Tensor H = zeros({dim, dim});
+    for (int i = 0; i + 1 < N; i++) {
+      H += (-J) * Embed(N, {{i, PauliZ()}, {i + 1, PauliZ()}});
+    }
+    for (int i = 0; i < N; i++) {
+      H += (-h) * Embed(N, {{i, PauliX()}});
+    }
+    return H;
+  }
+
+  // Lowest eigenvalue of the dense Hamiltonian (exact ground-state energy).
+  inline double ExactGroundEnergy(int N, double J, double h) {
+    using namespace cytnx;
+    auto H = DenseH(N, J, h);
+    auto eig = linalg::Eigh(H, false);  // eigenvalues only
+    auto evals = eig[0];
+    double gs = evals.at<double>({0});
+    for (cytnx_uint64 i = 1; i < evals.shape()[0]; i++) gs = std::min(gs, evals.at<double>({i}));
+    return gs;
+  }
+
+}  // namespace TfimTest
+
+#endif  // CYTNX_TESTS_TN_ALGO_TFIM_MPO_H_


### PR DESCRIPTION
## Summary

Addresses the "add C++ test coverage" part of #924 for `src/tn_algo`, and fixes every bug the new tests uncovered (starting with #920). The previously untested C++ implementation of `RegularMPS`, `MPO`/`RegularMPO`, and `DMRG` is now exercised and corrected.

All 16 new tests pass on both the **OpenBLAS** (`debug-openblas-cpu`) and **MKL** (`debug-mkl-cpu`) CPU backends, with AddressSanitizer and leak detection enabled.

## Tests added (`tests/tn_algo_test/`)

- **MPS** (9): regular construction (regression for the #920 crash), metadata/open-boundary shapes, left-orthonormality after `Init`, normalization, non-uniform physical dimensions, `Init_Msector`, orthogonality-center sweeps via `S_mvleft`/`S_mvright` (norm invariance + right-orthonormality), and clone independence.
- **MPO** (4): `append`/`assign`/`get_op` container behaviour, out-of-bound access, and a check that contracting the MPO down to a dense matrix reproduces a transverse-field Ising (TFIM) Hamiltonian assembled independently from Pauli operators.
- **DMRG** (3): convergence to the exact ground-state energy (from dense diagonalization of the same TFIM Hamiltonian) for both `sweep()` and `sweepv2()`, at two field strengths.

A shared `tfim_mpo.hpp` helper builds the TFIM MPO tensors, the dense reference Hamiltonian, and its exact ground-state energy.

## Bugs fixed

1. **`RegularMPS::norm`** was broken for any virtual bond dimension > 1 (mismatched-dimension Tensordot); rewrote it as an explicit `<ψ|ψ>` transfer-matrix contraction that works for any bond dimension.
2. **#920 label collision** in `Into_Lortho` (and the same class of bug in `S_mvright`/`S_mvleft`): `linalg::Svd`'s fixed `_aux_L`/`_aux_R` bond labels survived into the next decomposition and tripped `set_labels`' duplicate check. Fixed by restoring the canonical per-site labels `{2k, 2k+1, 2k+2}` after each `Svd`. Also fixed a separate no-op where the const `set_rowrank` (returns a copy) was used instead of in-place `set_rowrank_`.
3. **DMRG** was written against older cytnx APIs and crashed before completing a sweep: `Launch(true)` selected an unsupported Fermion network; the static `Network::Contract().Launch()` segfaults (unallocated contraction tree); the `;` rowrank syntax in network strings is no longer parsed; `set_rowrank` no-ops; and `Svd_truncate`'s `_aux_*` labels collided across sites. All fixed; DMRG now converges.

## Notes / scope

- #924 mentions `SymMPS.cpp`, but there is **no `SymMPS`** anywhere in the codebase — the C++ `MPS` only has `RegularMPS` and `iMPS` implementations. Coverage targets what actually exists.
- The Python-binding redesign (part 3 of #924) is **not** included here; this PR is the C++ testing + bug-fix groundwork that part 3 depends on.
- The full test suite has **pre-existing, unrelated** AddressSanitizer aborts in `UniTensor::_Load` (SVD-family data-loading tests) and `OptimalTreeSolver` (`SearchTreeTest`); these reproduce on the unmodified tree and are outside `tn_algo`, so they are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)