### PR TITLE
Disable broken/unsafe Scalar operations [also a bit of memory corruption]

### DIFF
--- a/include/Type.hpp
+++ b/include/Type.hpp
@@ -158,6 +158,14 @@ namespace cytnx {
   constexpr int N_Type = std::variant_size_v<Type_list>;
   constexpr int N_fType = 5;
 
+  template <typename T>
+  inline constexpr bool is_cytnx_type_v =
+    variant_index_v<std::remove_cvref_t<T>, Type_list> < std::variant_size_v<Type_list> &&
+    !std::is_same_v<std::remove_cvref_t<T>, void>;
+
+  template <typename T>
+  concept CytnxType = is_cytnx_type_v<T>;
+
   // The friendly name of each type
   template <typename T>
   inline constexpr char* Type_names = nullptr;

--- a/include/backend/Scalar.hpp
+++ b/include/backend/Scalar.hpp
@@ -2529,17 +2529,8 @@ namespace cytnx {
 
       // When used to set elems:
       Sproxy &operator=(const Scalar &rc);
-      Sproxy &operator=(const cytnx_complex128 &rc);
-      Sproxy &operator=(const cytnx_complex64 &rc);
-      Sproxy &operator=(const cytnx_double &rc);
-      Sproxy &operator=(const cytnx_float &rc);
-      Sproxy &operator=(const cytnx_uint64 &rc);
-      Sproxy &operator=(const cytnx_int64 &rc);
-      Sproxy &operator=(const cytnx_uint32 &rc);
-      Sproxy &operator=(const cytnx_int32 &rc);
-      Sproxy &operator=(const cytnx_uint16 &rc);
-      Sproxy &operator=(const cytnx_int16 &rc);
-      Sproxy &operator=(const cytnx_bool &rc);
+      template <CytnxType T>
+      Sproxy &operator=(const T &rc);
 
       Sproxy &operator=(const Sproxy &rc);
 
@@ -2562,39 +2553,11 @@ namespace cytnx {
     /// @brief default constructor
     Scalar() : _impl(new Scalar_base()){};
 
-    // init!!
-    /// @brief init a Scalar with a cytnx::cytnx_complex128
-    Scalar(const cytnx_complex128 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
-
-    /// @brief init a Scalar with a cytnx::cytnx_complex64
-    Scalar(const cytnx_complex64 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
-
-    /// @brief init a Scalar with a cytnx::cytnx_double
-    Scalar(const cytnx_double &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
-
-    /// @brief init a Scalar with a cytnx::cytnx_float
-    Scalar(const cytnx_float &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
-
-    /// @brief init a Scalar with a cytnx::cytnx_uint64
-    Scalar(const cytnx_uint64 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
-
-    /// @brief init a Scalar with a cytnx::cytnx_int64
-    Scalar(const cytnx_int64 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
-
-    /// @brief init a Scalar with a cytnx::cytnx_uint32
-    Scalar(const cytnx_uint32 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
-
-    /// @brief init a Scalar with a cytnx::cytnx_int32
-    Scalar(const cytnx_int32 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
-
-    /// @brief init a Scalar with a cytnx::cytnx_uint16
-    Scalar(const cytnx_uint16 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
-
-    /// @brief init a Scalar with a cytnx::cytnx_int16
-    Scalar(const cytnx_int16 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
-
-    /// @brief init a Scalar with a cytnx::cytnx_bool
-    Scalar(const cytnx_bool &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    /// @brief init a Scalar with any supported cytnx element type.
+    template <CytnxType T>
+    Scalar(const T &in) : _impl(new Scalar_base()) {
+      this->Init_by_number(in);
+    }
 
     /**
      * @brief Get the max value of the Scalar with the given \p dtype.
@@ -2650,49 +2613,11 @@ namespace cytnx {
 
     // specialization of init:
     ///@cond
-    void Init_by_number(const cytnx_complex128 &in) {
+    template <CytnxType T>
+    void Init_by_number(const T &in) {
       if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new ComplexDoubleScalar(in);
-    };
-    void Init_by_number(const cytnx_complex64 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new ComplexFloatScalar(in);
-    };
-    void Init_by_number(const cytnx_double &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new DoubleScalar(in);
-    }
-    void Init_by_number(const cytnx_float &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new FloatScalar(in);
-    }
-    void Init_by_number(const cytnx_int64 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Int64Scalar(in);
-    }
-    void Init_by_number(const cytnx_uint64 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Uint64Scalar(in);
-    }
-    void Init_by_number(const cytnx_int32 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Int32Scalar(in);
-    }
-    void Init_by_number(const cytnx_uint32 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Uint32Scalar(in);
-    }
-    void Init_by_number(const cytnx_int16 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Int16Scalar(in);
-    }
-    void Init_by_number(const cytnx_uint16 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Uint16Scalar(in);
-    }
-    void Init_by_number(const cytnx_bool &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new BoolScalar(in);
+      this->_impl = __ScII.UScIInit[Type.cy_typeid(in)]();
+      this->_impl->assign_selftype(in);
     }
 
     // The copy constructor
@@ -2705,97 +2630,17 @@ namespace cytnx {
 
     /// @brief The copy assignment of the Scalar class.
     Scalar &operator=(const Scalar &rhs) {
+      if (this == &rhs) return *this;
+
       if (this->_impl != nullptr) delete this->_impl;
 
       this->_impl = rhs._impl->copy();
       return *this;
     };
 
-    // copy assignment [Number]:
-    /** @brief The copy assignment operator of the Scalar class with a given number
-     * cytnx::cytnx_complex128 \p rhs.
-     */
-    Scalar &operator=(const cytnx_complex128 &rhs) {
-      this->Init_by_number(rhs);
-      return *this;
-    }
-
-    /** @brief The copy assignment operator of the Scalar class with a given number
-     * cytnx::cytnx_complex64 \p rhs.
-     */
-    Scalar &operator=(const cytnx_complex64 &rhs) {
-      this->Init_by_number(rhs);
-      return *this;
-    }
-
-    /** @brief The copy assignment operator of the Scalar class with a given number
-     * cytnx::cytnx_double \p rhs.
-     */
-    Scalar &operator=(const cytnx_double &rhs) {
-      this->Init_by_number(rhs);
-      return *this;
-    }
-
-    /** @brief The copy assignment operator of the Scalar class with a given number
-     * cytnx::cytnx_float \p rhs.
-     */
-    Scalar &operator=(const cytnx_float &rhs) {
-      this->Init_by_number(rhs);
-      return *this;
-    }
-
-    /** @brief The copy assignment operator of the Scalar class with a given number
-     * cytnx::cytnx_uint64 \p rhs.
-     */
-    Scalar &operator=(const cytnx_uint64 &rhs) {
-      this->Init_by_number(rhs);
-      return *this;
-    }
-
-    /** @brief The copy assignment operator of the Scalar class with a given number
-     * cytnx::cytnx_int64 \p rhs.
-     */
-    Scalar &operator=(const cytnx_int64 &rhs) {
-      this->Init_by_number(rhs);
-      return *this;
-    }
-
-    /** @brief The copy assignment operator of the Scalar class with a given number
-     * cytnx::cytnx_uint32 \p rhs.
-     */
-    Scalar &operator=(const cytnx_uint32 &rhs) {
-      this->Init_by_number(rhs);
-      return *this;
-    }
-
-    /** @brief The copy assignment operator of the Scalar class with a given number
-     * cytnx::cytnx_int32 \p rhs.
-     */
-    Scalar &operator=(const cytnx_int32 &rhs) {
-      this->Init_by_number(rhs);
-      return *this;
-    }
-
-    /** @brief The copy assignment operator of the Scalar class with a given number
-     * cytnx::cytnx_uint16 \p rhs.
-     */
-    Scalar &operator=(const cytnx_uint16 &rhs) {
-      this->Init_by_number(rhs);
-      return *this;
-    }
-
-    /** @brief The copy assignment operator of the Scalar class with a given number
-     * cytnx::cytnx_int16 \p rhs.
-     */
-    Scalar &operator=(const cytnx_int16 &rhs) {
-      this->Init_by_number(rhs);
-      return *this;
-    }
-
-    /** @brief The copy assignment operator of the Scalar class with a given number
-     * cytnx::cytnx_bool \p rhs.
-     */
-    Scalar &operator=(const cytnx_bool &rhs) {
+    /// @brief The copy assignment operator with any supported cytnx element type.
+    template <CytnxType T>
+    Scalar &operator=(const T &rhs) {
       this->Init_by_number(rhs);
       return *this;
     }
@@ -2844,6 +2689,68 @@ namespace cytnx {
      * @brief Get the dtype of the Scalar (see cytnx::Type for more details).
      */
     int dtype() const { return this->_impl->_dtype; }
+
+    static bool is_integer_dtype(const int &dtype) {
+      return dtype == Type.Int64 || dtype == Type.Uint64 || dtype == Type.Int32 ||
+             dtype == Type.Uint32 || dtype == Type.Int16 || dtype == Type.Uint16;
+    }
+
+    static bool is_signed_integer_dtype(const int &dtype) {
+      return dtype == Type.Int64 || dtype == Type.Int32 || dtype == Type.Int16;
+    }
+
+    static bool is_unsigned_integer_dtype(const int &dtype) {
+      return dtype == Type.Uint64 || dtype == Type.Uint32 || dtype == Type.Uint16;
+    }
+
+    static bool has_mixed_signed_unsigned_integer_dtypes(const int &lhs_dtype,
+                                                         const int &rhs_dtype) {
+      return (is_signed_integer_dtype(lhs_dtype) && is_unsigned_integer_dtype(rhs_dtype)) ||
+             (is_unsigned_integer_dtype(lhs_dtype) && is_signed_integer_dtype(rhs_dtype));
+    }
+
+    void ensure_arithmetic_result_dtype_is_supported(const char *op) const {
+      cytnx_error_msg(
+        is_integer_dtype(this->dtype()) || this->dtype() == Type.Bool,
+        "[ERROR] Scalar %s with integer or bool result dtype is disabled because integer "
+        "Scalar arithmetic currently preserves the destination dtype and can silently truncate "
+        "or use integer division. Cast to a floating or complex dtype first.%s",
+        op, "\n");
+    }
+
+    void ensure_arithmetic_operand_dtype_is_supported(const char *op, const int &rhs_dtype) const {
+      cytnx_error_msg(this->dtype() == Type.Bool,
+                      "[ERROR] Scalar %s with bool result dtype is disabled.%s", op, "\n");
+      cytnx_error_msg(
+        is_integer_dtype(this->dtype()) && rhs_dtype != this->dtype(),
+        "[ERROR] Scalar %s with mixed integer result dtype is disabled because integer Scalar "
+        "arithmetic currently preserves the destination dtype and can silently truncate or use "
+        "integer division. Cast to a floating or complex dtype first.%s",
+        op, "\n");
+    }
+
+    void ensure_binary_arithmetic_dtypes_are_supported(const char *op, const int &lhs_dtype,
+                                                       const int &rhs_dtype) const {
+      cytnx_error_msg(this->dtype() == Type.Bool,
+                      "[ERROR] Scalar %s with bool result dtype is disabled.%s", op, "\n");
+      cytnx_error_msg(
+        is_integer_dtype(this->dtype()) &&
+          has_mixed_signed_unsigned_integer_dtypes(lhs_dtype, rhs_dtype),
+        "[ERROR] Scalar %s with mixed signed/unsigned integer result dtype is disabled because "
+        "Scalar integer promotion is not reliable for mixed signedness. Cast to a floating or "
+        "complex dtype first.%s",
+        op, "\n");
+    }
+
+    void ensure_comparison_dtypes_are_supported(const char *op, const int &lhs_dtype,
+                                                const int &rhs_dtype) const {
+      cytnx_error_msg(
+        has_mixed_signed_unsigned_integer_dtypes(lhs_dtype, rhs_dtype),
+        "[ERROR] Scalar %s with mixed signed/unsigned integer operands is disabled because "
+        "Scalar integer promotion is not reliable for mixed signedness. Cast to a floating or "
+        "complex dtype first.%s",
+        op, "\n");
+    }
 
     // print()
     /**
@@ -2894,50 +2801,74 @@ namespace cytnx {
     ///@brief The addition assignment operator of the Scalar class with a given number (template).
     template <class T>
     void operator+=(const T &rc) {
+      this->ensure_arithmetic_operand_dtype_is_supported("in-place addition", Type.cy_typeid(rc));
       this->_impl->iadd(rc);
     }
 
     ///@brief The addition assignment operator of the Scalar class with a given Scalar.
-    void operator+=(const Scalar &rhs) { this->_impl->iadd(rhs._impl); }
+    void operator+=(const Scalar &rhs) {
+      this->ensure_arithmetic_operand_dtype_is_supported("in-place addition", rhs.dtype());
+      this->_impl->iadd(rhs._impl);
+    }
 
     ///@brief The subtraction assignment operator of the Scalar class with a given number
     ///(template).
     template <class T>
     void operator-=(const T &rc) {
+      this->ensure_arithmetic_operand_dtype_is_supported("in-place subtraction",
+                                                         Type.cy_typeid(rc));
       this->_impl->isub(rc);
     }
 
     ///@brief The subtraction assignment operator of the Scalar class with a given Scalar.
-    void operator-=(const Scalar &rhs) { this->_impl->isub(rhs._impl); }
+    void operator-=(const Scalar &rhs) {
+      this->ensure_arithmetic_operand_dtype_is_supported("in-place subtraction", rhs.dtype());
+      this->_impl->isub(rhs._impl);
+    }
     template <class T>
 
     ///@brief The multiplication assignment operator of the Scalar class with a given number
     ///(template).
     void operator*=(const T &rc) {
+      this->ensure_arithmetic_operand_dtype_is_supported("in-place multiplication",
+                                                         Type.cy_typeid(rc));
       this->_impl->imul(rc);
     }
 
     ///@brief The multiplication assignment operator of the Scalar class with a given Scalar.
-    void operator*=(const Scalar &rhs) { this->_impl->imul(rhs._impl); }
+    void operator*=(const Scalar &rhs) {
+      this->ensure_arithmetic_operand_dtype_is_supported("in-place multiplication", rhs.dtype());
+      this->_impl->imul(rhs._impl);
+    }
     template <class T>
 
     /**
      * @brief The division assignment operator of the Scalar class with a given number (template).
      */
     void operator/=(const T &rc) {
+      this->ensure_arithmetic_operand_dtype_is_supported("in-place division", Type.cy_typeid(rc));
       this->_impl->idiv(rc);
     }
 
     /**
      * @brief The division assignment operator of the Scalar class with a given Scalar.
      */
-    void operator/=(const Scalar &rhs) { this->_impl->idiv(rhs._impl); }
+    void operator/=(const Scalar &rhs) {
+      this->ensure_arithmetic_operand_dtype_is_supported("in-place division", rhs.dtype());
+      this->_impl->idiv(rhs._impl);
+    }
 
     /// @brief Set the Scalar to absolute value. (inplace)
-    void iabs() { this->_impl->iabs(); }
+    void iabs() {
+      this->ensure_arithmetic_result_dtype_is_supported("absolute value");
+      this->_impl->iabs();
+    }
 
     /// @brief Set the Scalar to square root. (inplace)
-    void isqrt() { this->_impl->isqrt(); }
+    void isqrt() {
+      this->ensure_arithmetic_result_dtype_is_supported("square root");
+      this->_impl->isqrt();
+    }
 
     /**
      * @brief The member function to get the absolute value of the Scalar.
@@ -2947,6 +2878,7 @@ namespace cytnx {
      */
     Scalar abs() const {
       Scalar out = *this;
+      out.ensure_arithmetic_result_dtype_is_supported("absolute value");
       out._impl->iabs();
       return out.real();
     }
@@ -2959,6 +2891,7 @@ namespace cytnx {
      */
     Scalar sqrt() const {
       Scalar out = *this;
+      out.ensure_arithmetic_result_dtype_is_supported("square root");
       out._impl->isqrt();
       return out;
     }
@@ -2974,6 +2907,7 @@ namespace cytnx {
     bool less(const T &rc) const {
       Scalar tmp;
       int rid = Type.cy_typeid(rc);
+      this->ensure_comparison_dtypes_are_supported("comparison", this->dtype(), rid);
       if (rid < this->dtype()) {
         tmp = this->astype(rid);
         return tmp._impl->less(rc);
@@ -2990,6 +2924,7 @@ namespace cytnx {
      */
     bool less(const Scalar &rhs) const {
       Scalar tmp;
+      this->ensure_comparison_dtypes_are_supported("comparison", this->dtype(), rhs.dtype());
       if (rhs.dtype() < this->dtype()) {
         tmp = this->astype(rhs.dtype());
         return tmp._impl->less(rhs._impl);
@@ -3011,6 +2946,7 @@ namespace cytnx {
     bool leq(const T &rc) const {
       Scalar tmp;
       int rid = Type.cy_typeid(rc);
+      this->ensure_comparison_dtypes_are_supported("comparison", this->dtype(), rid);
       if (rid < this->dtype()) {
         tmp = this->astype(rid);
         return !(tmp._impl->greater(rc));
@@ -3027,6 +2963,7 @@ namespace cytnx {
      */
     bool leq(const Scalar &rhs) const {
       Scalar tmp;
+      this->ensure_comparison_dtypes_are_supported("comparison", this->dtype(), rhs.dtype());
       if (rhs.dtype() < this->dtype()) {
         tmp = this->astype(rhs.dtype());
         return !(tmp._impl->greater(rhs._impl));
@@ -3046,6 +2983,7 @@ namespace cytnx {
     bool greater(const T &rc) const {
       Scalar tmp;
       int rid = Type.cy_typeid(rc);
+      this->ensure_comparison_dtypes_are_supported("comparison", this->dtype(), rid);
       if (rid < this->dtype()) {
         tmp = this->astype(rid);
         return tmp._impl->greater(rc);
@@ -3062,6 +3000,7 @@ namespace cytnx {
      */
     bool greater(const Scalar &rhs) const {
       Scalar tmp;
+      this->ensure_comparison_dtypes_are_supported("comparison", this->dtype(), rhs.dtype());
       if (rhs.dtype() < this->dtype()) {
         tmp = this->astype(rhs.dtype());
         return tmp._impl->greater(rhs._impl);
@@ -3083,6 +3022,7 @@ namespace cytnx {
     bool geq(const T &rc) const {
       Scalar tmp;
       int rid = Type.cy_typeid(rc);
+      this->ensure_comparison_dtypes_are_supported("comparison", this->dtype(), rid);
       if (rid < this->dtype()) {
         tmp = this->astype(rid);
         return !(tmp._impl->less(rc));
@@ -3099,6 +3039,7 @@ namespace cytnx {
      */
     bool geq(const Scalar &rhs) const {
       Scalar tmp;
+      this->ensure_comparison_dtypes_are_supported("comparison", this->dtype(), rhs.dtype());
       if (rhs.dtype() < this->dtype()) {
         tmp = this->astype(rhs.dtype());
         return !(tmp._impl->less(rhs._impl));
@@ -3119,6 +3060,7 @@ namespace cytnx {
     bool eq(const T &rc) const {
       Scalar tmp;
       int rid = Type.cy_typeid(rc);
+      this->ensure_comparison_dtypes_are_supported("comparison", this->dtype(), rid);
       if (rid < this->dtype()) {
         tmp = this->astype(rid);
         return tmp._impl->eq(rc);
@@ -3153,6 +3095,7 @@ namespace cytnx {
      */
     bool eq(const Scalar &rhs) const {
       Scalar tmp;
+      this->ensure_comparison_dtypes_are_supported("comparison", this->dtype(), rhs.dtype());
       if (rhs.dtype() < this->dtype()) {
         tmp = this->astype(rhs.dtype());
         return tmp._impl->eq(rhs._impl);
@@ -3190,6 +3133,7 @@ namespace cytnx {
       } else {
         out = this->astype(rid);
       }
+      out.ensure_binary_arithmetic_dtypes_are_supported("addition", this->dtype(), rid);
       out._impl->iadd(rc);
       return out;
     }
@@ -3205,6 +3149,7 @@ namespace cytnx {
       } else {
         out = this->astype(rhs.dtype());
       }
+      out.ensure_binary_arithmetic_dtypes_are_supported("addition", this->dtype(), rhs.dtype());
       out._impl->iadd(rhs._impl);
       return out;
     }
@@ -3224,6 +3169,7 @@ namespace cytnx {
       } else {
         out = this->astype(rid);
       }
+      out.ensure_binary_arithmetic_dtypes_are_supported("multiplication", this->dtype(), rid);
       out._impl->imul(rc);
       return out;
     }
@@ -3239,6 +3185,8 @@ namespace cytnx {
       } else {
         out = this->astype(rhs.dtype());
       }
+      out.ensure_binary_arithmetic_dtypes_are_supported("multiplication", this->dtype(),
+                                                        rhs.dtype());
       out._impl->imul(rhs._impl);
       return out;
     }
@@ -3258,6 +3206,7 @@ namespace cytnx {
       } else {
         out = this->astype(rid);
       }
+      out.ensure_binary_arithmetic_dtypes_are_supported("subtraction", this->dtype(), rid);
       out._impl->isub(rc);
       return out;
     }
@@ -3273,6 +3222,7 @@ namespace cytnx {
       } else {
         out = this->astype(rhs.dtype());
       }
+      out.ensure_binary_arithmetic_dtypes_are_supported("subtraction", this->dtype(), rhs.dtype());
       out._impl->isub(rhs._impl);
       return out;
     }
@@ -3292,6 +3242,7 @@ namespace cytnx {
       } else {
         out = this->astype(rid);
       }
+      out.ensure_binary_arithmetic_dtypes_are_supported("division", this->dtype(), rid);
       out._impl->idiv(rc);
       return out;
     }
@@ -3307,6 +3258,7 @@ namespace cytnx {
       } else {
         out = this->astype(rhs.dtype());
       }
+      out.ensure_binary_arithmetic_dtypes_are_supported("division", this->dtype(), rhs.dtype());
       out._impl->idiv(rhs._impl);
       return out;
     }

--- a/src/backend/Scalar.cpp
+++ b/src/backend/Scalar.cpp
@@ -72,50 +72,24 @@ namespace cytnx {
     this->_insimpl->set_item(this->_loc, rc);
     return *this;
   }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_complex128& rc) {
+
+  template <CytnxType T>
+  Scalar::Sproxy& Scalar::Sproxy::operator=(const T& rc) {
     this->_insimpl->set_item(this->_loc, rc);
     return *this;
   }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_complex64& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
-    return *this;
-  }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_double& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
-    return *this;
-  }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_float& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
-    return *this;
-  }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_uint64& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
-    return *this;
-  }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_int64& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
-    return *this;
-  }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_uint32& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
-    return *this;
-  }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_int32& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
-    return *this;
-  }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_uint16& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
-    return *this;
-  }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_int16& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
-    return *this;
-  }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_bool& rc) {
-    this->_insimpl->set_item(this->_loc, rc);
-    return *this;
-  }
+
+  template Scalar::Sproxy& Scalar::Sproxy::operator=<cytnx_complex128>(const cytnx_complex128& rc);
+  template Scalar::Sproxy& Scalar::Sproxy::operator=<cytnx_complex64>(const cytnx_complex64& rc);
+  template Scalar::Sproxy& Scalar::Sproxy::operator=<cytnx_double>(const cytnx_double& rc);
+  template Scalar::Sproxy& Scalar::Sproxy::operator=<cytnx_float>(const cytnx_float& rc);
+  template Scalar::Sproxy& Scalar::Sproxy::operator=<cytnx_uint64>(const cytnx_uint64& rc);
+  template Scalar::Sproxy& Scalar::Sproxy::operator=<cytnx_int64>(const cytnx_int64& rc);
+  template Scalar::Sproxy& Scalar::Sproxy::operator=<cytnx_uint32>(const cytnx_uint32& rc);
+  template Scalar::Sproxy& Scalar::Sproxy::operator=<cytnx_int32>(const cytnx_int32& rc);
+  template Scalar::Sproxy& Scalar::Sproxy::operator=<cytnx_uint16>(const cytnx_uint16& rc);
+  template Scalar::Sproxy& Scalar::Sproxy::operator=<cytnx_int16>(const cytnx_int16& rc);
+  template Scalar::Sproxy& Scalar::Sproxy::operator=<cytnx_bool>(const cytnx_bool& rc);
 
   bool Scalar::Sproxy::exists() const { return this->_insimpl->dtype() != Type.Void; };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(
   Accessor_test.cpp
   Tensor_test.cpp
   Storage_test.cpp
+  Scalar_test.cpp
   search_tree_test.cpp
   utils_test/vec_concatenate.cpp
   utils_test/vec_unique.cpp

--- a/tests/Scalar_test.cpp
+++ b/tests/Scalar_test.cpp
@@ -1,0 +1,263 @@
+#include <complex>
+#include <stdexcept>
+
+#include "backend/Scalar.hpp"
+#include "gtest/gtest.h"
+
+namespace {
+
+  using cytnx::cytnx_bool;
+  using cytnx::cytnx_complex128;
+  using cytnx::cytnx_complex64;
+  using cytnx::cytnx_double;
+  using cytnx::cytnx_float;
+  using cytnx::cytnx_int16;
+  using cytnx::cytnx_int32;
+  using cytnx::cytnx_int64;
+  using cytnx::cytnx_uint16;
+  using cytnx::cytnx_uint32;
+  using cytnx::cytnx_uint64;
+  using cytnx::Scalar;
+  using cytnx::Type;
+
+  void ExpectDoubleScalarEq(const Scalar &value, double expected) {
+    EXPECT_EQ(value.dtype(), Type.Double);
+    EXPECT_DOUBLE_EQ(static_cast<cytnx_double>(value), expected);
+  }
+
+  void ExpectInt64ScalarEq(const Scalar &value, cytnx_int64 expected) {
+    EXPECT_EQ(value.dtype(), Type.Int64);
+    EXPECT_EQ(static_cast<cytnx_int64>(value), expected);
+  }
+
+  void ExpectUint64ScalarEq(const Scalar &value, cytnx_uint64 expected) {
+    EXPECT_EQ(value.dtype(), Type.Uint64);
+    EXPECT_EQ(static_cast<cytnx_uint64>(value), expected);
+  }
+
+  void ExpectComplexDoubleScalarEq(const Scalar &value, const cytnx_complex128 &expected) {
+    EXPECT_EQ(value.dtype(), Type.ComplexDouble);
+    const auto got = cytnx::complex128(value);
+    EXPECT_DOUBLE_EQ(got.real(), expected.real());
+    EXPECT_DOUBLE_EQ(got.imag(), expected.imag());
+  }
+
+  template <typename Fn>
+  void ExpectCorrectDoubleOrDisabled(Fn &&fn, double expected) {
+    testing::internal::CaptureStdout();
+    testing::internal::CaptureStderr();
+    try {
+      const Scalar value = fn();
+      static_cast<void>(testing::internal::GetCapturedStderr());
+      static_cast<void>(testing::internal::GetCapturedStdout());
+      ExpectDoubleScalarEq(value, expected);
+    } catch (const std::logic_error &) {
+      static_cast<void>(testing::internal::GetCapturedStderr());
+      static_cast<void>(testing::internal::GetCapturedStdout());
+      SUCCEED();
+    }
+  }
+
+  template <typename Fn>
+  void ExpectCorrectInt64OrDisabled(Fn &&fn, cytnx_int64 expected) {
+    testing::internal::CaptureStdout();
+    testing::internal::CaptureStderr();
+    try {
+      const Scalar value = fn();
+      static_cast<void>(testing::internal::GetCapturedStderr());
+      static_cast<void>(testing::internal::GetCapturedStdout());
+      EXPECT_EQ(static_cast<cytnx_int64>(value), expected);
+    } catch (const std::logic_error &) {
+      static_cast<void>(testing::internal::GetCapturedStderr());
+      static_cast<void>(testing::internal::GetCapturedStdout());
+      SUCCEED();
+    }
+  }
+
+  template <typename Fn>
+  void ExpectDisabled(Fn &&fn) {
+    testing::internal::CaptureStdout();
+    testing::internal::CaptureStderr();
+    try {
+      static_cast<void>(fn());
+      static_cast<void>(testing::internal::GetCapturedStderr());
+      static_cast<void>(testing::internal::GetCapturedStdout());
+      FAIL() << "Expected std::logic_error.";
+    } catch (const std::logic_error &) {
+      static_cast<void>(testing::internal::GetCapturedStderr());
+      static_cast<void>(testing::internal::GetCapturedStdout());
+      SUCCEED();
+    }
+  }
+
+}  // namespace
+
+TEST(ScalarTest, FloatingBinaryArithmeticReturnsCorrectValues) {
+  const Scalar a(cytnx_double(3.0));
+  const Scalar b(cytnx_double(2.0));
+
+  ExpectDoubleScalarEq(a + b, 5.0);
+  ExpectDoubleScalarEq(a - b, 1.0);
+  ExpectDoubleScalarEq(a * b, 6.0);
+  ExpectDoubleScalarEq(a / b, 1.5);
+}
+
+TEST(ScalarTest, ComplexBinaryArithmeticReturnsCorrectValues) {
+  const Scalar a(cytnx_complex128(3.0, 4.0));
+  const Scalar b(cytnx_complex128(1.0, -2.0));
+
+  ExpectComplexDoubleScalarEq(a + b, cytnx_complex128(4.0, 2.0));
+  ExpectComplexDoubleScalarEq(a - b, cytnx_complex128(2.0, 6.0));
+  ExpectComplexDoubleScalarEq(a * b, cytnx_complex128(11.0, -2.0));
+  ExpectComplexDoubleScalarEq(a / b, cytnx_complex128(-1.0, 2.0));
+}
+
+TEST(ScalarTest, FloatingInPlaceArithmeticReturnsCorrectValues) {
+  Scalar value(cytnx_double(3.0));
+  value += Scalar(cytnx_double(2.0));
+  ExpectDoubleScalarEq(value, 5.0);
+  value -= Scalar(cytnx_double(1.0));
+  ExpectDoubleScalarEq(value, 4.0);
+  value *= Scalar(cytnx_double(3.0));
+  ExpectDoubleScalarEq(value, 12.0);
+  value /= Scalar(cytnx_double(4.0));
+  ExpectDoubleScalarEq(value, 3.0);
+}
+
+TEST(ScalarTest, IntegerConstructionAndConversionStillWork) {
+  EXPECT_EQ(Scalar(cytnx_int64(-3)).dtype(), Type.Int64);
+  EXPECT_EQ(static_cast<cytnx_int64>(Scalar(cytnx_int64(-3))), cytnx_int64(-3));
+  EXPECT_EQ(Scalar(cytnx_uint64(3)).dtype(), Type.Uint64);
+  EXPECT_EQ(static_cast<cytnx_uint64>(Scalar(cytnx_uint64(3))), cytnx_uint64(3));
+  EXPECT_EQ(Scalar(cytnx_bool(true)).dtype(), Type.Bool);
+  EXPECT_EQ(static_cast<cytnx_bool>(Scalar(cytnx_bool(true))), true);
+}
+
+TEST(ScalarTest, CytnxTypeAssignmentPreservesInputDtype) {
+  Scalar value(cytnx_double(3.0));
+
+  value = cytnx_float(2.0);
+  EXPECT_EQ(value.dtype(), Type.Float);
+  EXPECT_FLOAT_EQ(static_cast<cytnx_float>(value), cytnx_float(2.0));
+
+  value = cytnx_int32(-4);
+  EXPECT_EQ(value.dtype(), Type.Int32);
+  EXPECT_EQ(static_cast<cytnx_int32>(value), cytnx_int32(-4));
+}
+
+TEST(ScalarTest, IntegerBinaryArithmeticIsCorrectOrDisabled) {
+  ExpectCorrectDoubleOrDisabled([] { return Scalar(cytnx_int64(3)) + Scalar(cytnx_double(2.0)); },
+                                5.0);
+  ExpectCorrectDoubleOrDisabled([] { return Scalar(cytnx_int64(3)) - Scalar(cytnx_double(2.0)); },
+                                1.0);
+  ExpectCorrectDoubleOrDisabled([] { return Scalar(cytnx_int64(3)) * Scalar(cytnx_double(2.0)); },
+                                6.0);
+  ExpectCorrectDoubleOrDisabled([] { return Scalar(cytnx_int64(3)) / Scalar(cytnx_double(2.0)); },
+                                1.5);
+}
+
+TEST(ScalarTest, SameIntegerDtypeBinaryArithmeticReturnsCorrectValues) {
+  ExpectInt64ScalarEq(Scalar(cytnx_int64(3)) + Scalar(cytnx_int64(2)), cytnx_int64(5));
+  ExpectUint64ScalarEq(Scalar(cytnx_uint64(3)) - Scalar(cytnx_uint64(2)), cytnx_uint64(1));
+  EXPECT_EQ(static_cast<cytnx_int32>(Scalar(cytnx_int32(3)) * Scalar(cytnx_int32(2))),
+            cytnx_int32(6));
+  EXPECT_EQ(static_cast<cytnx_uint32>(Scalar(cytnx_uint32(3)) / Scalar(cytnx_uint32(2))),
+            cytnx_uint32(1));
+  EXPECT_EQ(static_cast<cytnx_int16>(Scalar(cytnx_int16(3)) + Scalar(cytnx_int16(2))),
+            cytnx_int16(5));
+  EXPECT_EQ(static_cast<cytnx_uint16>(Scalar(cytnx_uint16(3)) - Scalar(cytnx_uint16(2))),
+            cytnx_uint16(1));
+}
+
+TEST(ScalarTest, MixedIntegerBinaryArithmeticIsCorrectOrDisabled) {
+  ExpectCorrectInt64OrDisabled([] { return Scalar(cytnx_int64(3)) + Scalar(cytnx_int32(2)); },
+                               cytnx_int64(5));
+  ExpectCorrectInt64OrDisabled([] { return Scalar(cytnx_uint64(3)) - Scalar(cytnx_uint32(2)); },
+                               cytnx_int64(1));
+  ExpectCorrectInt64OrDisabled([] { return Scalar(cytnx_int32(3)) * Scalar(cytnx_int16(2)); },
+                               cytnx_int64(6));
+  ExpectCorrectInt64OrDisabled([] { return Scalar(cytnx_uint32(3)) / Scalar(cytnx_uint16(2)); },
+                               cytnx_int64(1));
+}
+
+TEST(ScalarTest, MixedSignedUnsignedIntegerBinaryArithmeticIsDisabled) {
+  ExpectDisabled([] { return Scalar(cytnx_int64(3)) + Scalar(cytnx_uint64(2)); });
+  ExpectDisabled([] { return Scalar(cytnx_uint32(3)) - Scalar(cytnx_int32(2)); });
+  ExpectDisabled([] { return Scalar(cytnx_int16(3)) * Scalar(cytnx_uint16(2)); });
+}
+
+TEST(ScalarTest, SameSignednessIntegerComparisonsReturnCorrectValues) {
+  EXPECT_TRUE(Scalar(cytnx_int64(3)) > Scalar(cytnx_int32(2)));
+  EXPECT_TRUE(Scalar(cytnx_int32(3)) >= Scalar(cytnx_int16(3)));
+  EXPECT_TRUE(Scalar(cytnx_uint64(2)) < Scalar(cytnx_uint32(3)));
+  EXPECT_TRUE(Scalar(cytnx_uint32(3)) <= Scalar(cytnx_uint16(3)));
+  EXPECT_TRUE(Scalar(cytnx_int16(3)) == Scalar(cytnx_int64(3)));
+}
+
+TEST(ScalarTest, MixedSignedUnsignedIntegerComparisonsAreDisabled) {
+  ExpectDisabled([] { return Scalar(cytnx_uint64(3)) < Scalar(cytnx_int64(4)); });
+  ExpectDisabled([] { return Scalar(cytnx_int64(-1)) == Scalar(cytnx_uint64(~cytnx_uint64(0))); });
+  ExpectDisabled([] { return Scalar(cytnx_uint32(3)) >= Scalar(cytnx_int32(2)); });
+}
+
+TEST(ScalarTest, BoolBinaryArithmeticIsDisabled) {
+  ExpectDisabled([] { return Scalar(cytnx_bool(true)) + Scalar(cytnx_bool(false)); });
+}
+
+TEST(ScalarTest, SameIntegerDtypeInPlaceArithmeticReturnsCorrectValues) {
+  Scalar value(cytnx_int64(3));
+  value += Scalar(cytnx_int64(2));
+  ExpectInt64ScalarEq(value, cytnx_int64(5));
+  value -= Scalar(cytnx_int64(1));
+  ExpectInt64ScalarEq(value, cytnx_int64(4));
+  value *= Scalar(cytnx_int64(3));
+  ExpectInt64ScalarEq(value, cytnx_int64(12));
+  value /= Scalar(cytnx_int64(5));
+  ExpectInt64ScalarEq(value, cytnx_int64(2));
+
+  Scalar unsigned_value(cytnx_uint64(3));
+  unsigned_value -= Scalar(cytnx_uint64(2));
+  ExpectUint64ScalarEq(unsigned_value, cytnx_uint64(1));
+
+  Scalar int32_value(cytnx_int32(3));
+  int32_value *= Scalar(cytnx_int32(2));
+  EXPECT_EQ(static_cast<cytnx_int32>(int32_value), cytnx_int32(6));
+}
+
+TEST(ScalarTest, MixedIntegerResultInPlaceArithmeticIsDisabled) {
+  ExpectDisabled([] {
+    Scalar value(cytnx_int64(3));
+    value += Scalar(cytnx_double(2.0));
+  });
+  ExpectDisabled([] {
+    Scalar value(cytnx_uint64(3));
+    value -= Scalar(cytnx_int64(2));
+  });
+  ExpectDisabled([] {
+    Scalar value(cytnx_int32(3));
+    value *= Scalar(cytnx_int16(2));
+  });
+  ExpectDisabled([] {
+    Scalar value(cytnx_uint32(3));
+    value /= Scalar(cytnx_double(2.0));
+  });
+}
+
+TEST(ScalarTest, IntegerAbsAndSqrtAreDisabled) {
+  ExpectDisabled([] { return Scalar(cytnx_int64(-3)).abs(); });
+  ExpectDisabled([] { return Scalar(cytnx_uint64(3)).sqrt(); });
+  ExpectDisabled([] {
+    Scalar value(cytnx_int64(-3));
+    value.iabs();
+  });
+  ExpectDisabled([] {
+    Scalar value(cytnx_uint64(3));
+    value.isqrt();
+  });
+}
+
+TEST(ScalarTest, SelfAssignmentPreservesValue) {
+  Scalar value(cytnx_double(3.5));
+  value = value;
+  ExpectDoubleScalarEq(value, 3.5);
+}


### PR DESCRIPTION
This PR disables, via throwing `std::logic_error`, a few (but definitely not all) of the `Scalar` arithmetic operations that are capable of returning incorrect results. I have no idea whether any downstream code uses these operations, but since they are exposed via Python, it seems that leaving them in the library as they are is dangerous. At least this PR will make the code give a sensible error message rather than silently producing nonsense.  The disabled arithmetic is mainly mixed signed/unsigned arithmetic and mixed integer/floating-point.  Probably no one ever uses this anyway.

If any code is affected by this, the fix is to replace in-place arithmetic by out-of-place arithmetic.  Eg
```c++
Scalar a(cytnx_int64(3));
Scalar b(cytnx_double(2.0));

// Incorrect: Disabled by this PR. This used to preserve a's Int64 dtype and perform integer division.
a /= b;

// The fix is to use out-of-place arithmetic:
a = a / b;
```

This was uncovered by a cursory examination of `Scalar.hpp` source code in the aftermath of #935.  But this PR does not in any way resolve #935.

This PR also adds `tests/Scalar_tests.cpp`, since there were no tests of `Scalar` before.  It tests that some simple cases of Scalar arithmetic work as expected, and also verifies that some broken arithmetic combinations are in fact disabled.  I expect that there remain some broken combinations not fixed by this PR.

As some drive-by cleanups, this PR removes a few of the unnecessary overloaded functions and replaces them with constrained templates, using `concept CytnxType`.  This is a pattern that could be used elsewhere:

```c++
template <CytnxType T>
void foo(T x)   // foo(T) overload family only when T is one of the 11 non-void cytnx_XXXX types
{
  ///
}
```

Unfortunately it is not possible to remove the vast majority of pointless overloads, because they are `virtual` and in C++ templates cannot be virtual.

Also discovered in the course of writing this PR message:

```c++
Tensor t(..., Type.Int64);
t /= cytnx_double(2.0);
```
This actually works: it uses a completely different code path to `Scalar`: `src/Tensor.cpp:799`, which calls `linalg::Div(*this, rc)` and replaces the storage. `Div<Tensor, cytnx_double>` allocates output storage with `Type.type_promote(Type.Double, Lt.dtype())`, so the result dtype becomes Double.

But if the RHS is a `Tensor` whose `dtype` is Double,
```c++
Tensor t(..., Type.Int64);
Tensor d(..., Type.Double);
t /= d;
```
then on CPU, it goes through `linalg::iDiv` at `src/Tensor.cpp:779`. On CPU that dispatches true in-place kernels, writing back into the original integer storage. So 3 / 2.0 becomes integer-truncated 1, and `t.dtype()` stays integer.

On GPU the behavior is quite different:
```c++
Tensor t(..., Type.Int64).to(Device.cuda);
Tensor d(..., Type.Double).to(Device.cuda);
t /= d;
```
The GPU goes through the old `cuAri_ii` path in `src/linalg/iDiv.cpp:34`. For Int64 / Double, it creates `tmpo = Lt.clone()`, so `tmpo` is still Int64, but dispatches `cuDiv_internal_i64td`, whose output pointer is cast to `cytnx_double*` in `src/backend/linalg_internal_gpu/cuDiv_internal.cu:2096`.

The result is memory corruption since the `double*` data is written into a buffer with `dtype` Int64.

For integers of size smaller than the right hand side, it is also memory-unsafe and will overwrite the buffer.

I haven't submitted an issue on this.  Just another drop in the ocean...
