### PR TITLE
fixed bug in RegularNetwork

### DIFF
--- a/src/RegularNetwork.cpp
+++ b/src/RegularNetwork.cpp
@@ -268,6 +268,9 @@ namespace cytnx {
     }
 
     // assign input tensors into slots:
+    this->names.reserve(utensors.size());
+    this->label_arr.reserve(utensors.size());
+    this->iBondNums.reserve(utensors.size());
     std::string name;
     for (unsigned int i = 0; i < utensors.size(); i++) {
       if (alias.size()) {
@@ -300,6 +303,7 @@ namespace cytnx {
 
     this->tensors.resize(this->names.size());
     this->CtTree.base_nodes.clear();
+    this->CtTree.base_nodes.reserve(this->names.size());
     for (std::size_t i = 0; i < this->names.size(); i++) {
       auto node = std::make_shared<Node>();
       node->name = this->names[i];
@@ -382,6 +386,11 @@ namespace cytnx {
     std::string line;
     std::vector<std::string> tmpvs;
     bool isORDER_exist = false;
+
+    // upper bound: at most one tensor definition per content line
+    this->names.reserve(contents.size());
+    this->label_arr.reserve(contents.size());
+    this->iBondNums.reserve(contents.size());
 
     for (int i = 0; i < contents.size(); i++) {
       line = contents[i];
@@ -466,8 +475,8 @@ namespace cytnx {
       "\n");
 
     this->tensors.resize(this->names.size());
-    this->CtTree.base_nodes.resize(this->names.size());
     this->CtTree.base_nodes.clear();
+    this->CtTree.base_nodes.reserve(this->names.size());
 
     // Create base nodes properly
     for (std::size_t i = 0; i < this->names.size(); i++) {

--- a/src/RegularNetwork.cpp
+++ b/src/RegularNetwork.cpp
@@ -299,7 +299,12 @@ namespace cytnx {
     }  // traversal input tensor list
 
     this->tensors.resize(this->names.size());
-    this->CtTree.base_nodes.resize(this->names.size());
+    this->CtTree.base_nodes.clear();
+    for (std::size_t i = 0; i < this->names.size(); i++) {
+      auto node = std::make_shared<Node>();
+      node->name = this->names[i];
+      this->CtTree.base_nodes.push_back(node);
+    }
 
     // checking if all TN are set in ORDER.
     //  only alias assigned will activate order

--- a/tests/Network_test.cpp
+++ b/tests/Network_test.cpp
@@ -200,3 +200,27 @@ TEST_F(NetworkTest, Network_fermionic_matches_contract) {
   EXPECT_EQ(res.uten_type(), UTenType.BlockFermionic);
   EXPECT_TRUE((res.apply() - ref.apply()).Norm().item() < 1e-8);
 }
+
+TEST_F(NetworkTest, Network_static_Contract_default_order) {
+  UniTensor A = utdnA.relabel({"a", "b", "c"});
+  UniTensor B = utdnB.relabel({"c", "d"});
+  UniTensor C = utdnC.relabel({"d", "e"});
+  UniTensor res = Network::Contract({A, B, C}, "a,b;e").Launch();
+  EXPECT_TRUE(AreNearlyEqTensor(res.get_block(), utdnAns.get_block(), 1e-12));
+}
+
+TEST_F(NetworkTest, Network_static_Contract_specified_order) {
+  UniTensor A = utdnA.relabel({"a", "b", "c"});
+  UniTensor B = utdnB.relabel({"c", "d"});
+  UniTensor C = utdnC.relabel({"d", "e"});
+  UniTensor res = Network::Contract({A, B, C}, "a,b;e", {"A", "B", "C"}, "(A,(B,C))").Launch();
+  EXPECT_TRUE(AreNearlyEqTensor(res.get_block(), utdnAns.get_block(), 1e-12));
+
+  // The static builder should agree with the equivalent FromString + PutUniTensors network.
+  auto net = Network();
+  net.FromString({"A: a,b,c", "B: c,d", "C: d,e", "ORDER:(A,(B,C))", "TOUT: a,b;e"});
+  net.PutUniTensors({"A", "B", "C"}, {utdnA, utdnB, utdnC});
+  UniTensor res_net = net.Launch();
+
+  EXPECT_TRUE(AreNearlyEqTensor(res.get_block(), res_net.get_block(), 1e-12));
+}


### PR DESCRIPTION
Previously, calling `Network(...)` with a tensor list reserved space for the UniTensors but did not load them. Now they are loaded as intended and `Launch` can be called directly.