### PR TITLE
replace NULL by nullptr

### DIFF
--- a/src/backend/StorageImplementation.cpp
+++ b/src/backend/StorageImplementation.cpp
@@ -817,7 +817,7 @@ namespace cytnx {
 
   template <typename DType>
   StorageImplementation<DType>::~StorageImplementation() {
-    if (this->data() != NULL) {
+    if (this->data() != nullptr) {
       if (this->device() == Device.cpu) {
         free(this->data());
       } else {

--- a/src/backend/Storage_base.cpp
+++ b/src/backend/Storage_base.cpp
@@ -94,14 +94,14 @@ namespace cytnx {
     if (dtype == this->dtype()) return boost::intrusive_ptr<Storage_base>(this);
 
     if (this->device() == Device.cpu) {
-      if (utils_internal::uii.ElemCast[this->dtype()][dtype] == NULL) {
+      if (utils_internal::uii.ElemCast[this->dtype()][dtype] == nullptr) {
         cytnx_error_msg(true, "[ERROR] not support type with dtype=%d", dtype);
       } else {
         utils_internal::uii.ElemCast[this->dtype()][dtype](this, out, this->size(), 1);
       }
     } else {
 #ifdef UNI_GPU
-      if (utils_internal::uii.cuElemCast[this->dtype()][dtype] == NULL) {
+      if (utils_internal::uii.cuElemCast[this->dtype()][dtype] == nullptr) {
         cytnx_error_msg(true, "[ERROR] not support type with dtype=%d", dtype);
       } else {
         utils_internal::uii.cuElemCast[this->dtype()][dtype](this, out, this->size(),
@@ -333,14 +333,14 @@ namespace cytnx {
     }
 
     if (this->device() == Device.cpu) {
-      if (utils_internal::uii.SetElems_ii[in->dtype()][this->dtype()] == NULL) {
+      if (utils_internal::uii.SetElems_ii[in->dtype()][this->dtype()] == nullptr) {
         cytnx_error_msg(true, "[ERROR] %s", "cannot assign complex element to real container.\n");
       }
       utils_internal::uii.SetElems_ii[in->dtype()][this->dtype()](
         in->data(), this->data(), c_offj, new_offj, locators, TotalElem, is_scalar);
     } else {
 #ifdef UNI_GPU
-      if (utils_internal::uii.cuSetElems_ii[in->dtype()][this->dtype()] == NULL) {
+      if (utils_internal::uii.cuSetElems_ii[in->dtype()][this->dtype()] == nullptr) {
         cytnx_error_msg(true, "%s", "[ERROR] %s",
                         "cannot assign complex element to real container.\n");
       }
@@ -392,14 +392,14 @@ namespace cytnx {
     }
 
     if (this->device() == Device.cpu) {
-      if (utils_internal::uii.SetElems_conti_ii[in->dtype()][this->dtype()] == NULL) {
+      if (utils_internal::uii.SetElems_conti_ii[in->dtype()][this->dtype()] == nullptr) {
         cytnx_error_msg(true, "[ERROR] %s", "cannot assign complex element to real container.\n");
       }
       utils_internal::uii.SetElems_conti_ii[in->dtype()][this->dtype()](
         in->data(), this->data(), c_offj, new_offj, locators, TotalElem, Nunit, is_scalar);
     } else {
 #ifdef UNI_GPU
-      if (utils_internal::uii.cuSetElems_conti_ii[in->dtype()][this->dtype()] == NULL) {
+      if (utils_internal::uii.cuSetElems_conti_ii[in->dtype()][this->dtype()] == nullptr) {
         cytnx_error_msg(true, "[ERROR] %s", "cannot assign complex element to real container.\n");
       }
       checkCudaErrors(cudaSetDevice(this->device()));

--- a/src/backend/linalg_internal_cpu/Gesvd_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Gesvd_internal.cpp
@@ -14,7 +14,7 @@ namespace cytnx {
                            const cytnx_int64 &N) {
       char jobu, jobv;
 
-      // if U and vT are NULL ptr, then it will not be computed.
+      // if U and vT are nullptr, then it will not be computed.
       jobu = (U->dtype() == Type.Void) ? 'N' : 'S';
       jobv = (vT->dtype() == Type.Void) ? 'N' : 'S';
 
@@ -43,7 +43,7 @@ namespace cytnx {
                            const cytnx_int64 &N) {
       char jobu, jobv;
 
-      // if U and vT are NULL ptr, then it will not be computed.
+      // if U and vT are nullptr, then it will not be computed.
       jobu = (U->dtype() == Type.Void) ? 'N' : 'S';
       jobv = (vT->dtype() == Type.Void) ? 'N' : 'S';
 

--- a/src/backend/linalg_internal_cpu/Gesvd_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Gesvd_internal.cpp
@@ -14,7 +14,7 @@ namespace cytnx {
                            const cytnx_int64 &N) {
       char jobu, jobv;
 
-      // if U and vT are nullptr, then it will not be computed.
+      // if U and vT are void, then it will not be computed.
       jobu = (U->dtype() == Type.Void) ? 'N' : 'S';
       jobv = (vT->dtype() == Type.Void) ? 'N' : 'S';
 
@@ -43,7 +43,7 @@ namespace cytnx {
                            const cytnx_int64 &N) {
       char jobu, jobv;
 
-      // if U and vT are nullptr, then it will not be computed.
+      // if U and vT are void, then it will not be computed.
       jobu = (U->dtype() == Type.Void) ? 'N' : 'S';
       jobv = (vT->dtype() == Type.Void) ? 'N' : 'S';
 

--- a/src/backend/linalg_internal_cpu/Sdd_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Sdd_internal.cpp
@@ -14,7 +14,7 @@ namespace cytnx {
                          const cytnx_int64 &N) {
       // char jobu, jobv;
 
-      // // if U and vT are nullptr, then it will not be computed.
+      // // if U and vT are void, then it will not be computed.
       // jobu = (U->dtype() == Type.Void) ? 'N' : 'S';
       // jobv = (vT->dtype() == Type.Void) ? 'N' : 'S';
 

--- a/src/backend/linalg_internal_cpu/Sdd_internal.cpp
+++ b/src/backend/linalg_internal_cpu/Sdd_internal.cpp
@@ -14,7 +14,7 @@ namespace cytnx {
                          const cytnx_int64 &N) {
       // char jobu, jobv;
 
-      // // if U and vT are NULL ptr, then it will not be computed.
+      // // if U and vT are nullptr, then it will not be computed.
       // jobu = (U->dtype() == Type.Void) ? 'N' : 'S';
       // jobv = (vT->dtype() == Type.Void) ? 'N' : 'S';
 
@@ -32,10 +32,10 @@ namespace cytnx {
       }
       void *UMem =
         (U->data() ? U->data()
-                   : (jobz == 'S' ? malloc(max * max * sizeof(cytnx_complex128)) : NULL));
+                   : (jobz == 'S' ? malloc(max * max * sizeof(cytnx_complex128)) : nullptr));
       void *vTMem =
         (vT->data() ? vT->data()
-                    : (jobz == 'S' ? malloc(max * max * sizeof(cytnx_complex128)) : NULL));
+                    : (jobz == 'S' ? malloc(max * max * sizeof(cytnx_complex128)) : nullptr));
 
       // double *superb = (double *)malloc(sizeof(double) * (min - 1));
 
@@ -80,11 +80,12 @@ namespace cytnx {
       if (U->dtype() == Type.Void and vT->dtype() == Type.Void) {
         jobz = 'N';
       }
-      void *UMem = (U->data() ? U->data()
-                              : (jobz == 'S' ? malloc(max * max * sizeof(cytnx_complex64)) : NULL));
+      void *UMem =
+        (U->data() ? U->data()
+                   : (jobz == 'S' ? malloc(max * max * sizeof(cytnx_complex64)) : nullptr));
       void *vTMem =
         (vT->data() ? vT->data()
-                    : (jobz == 'S' ? malloc(max * max * sizeof(cytnx_complex64)) : NULL));
+                    : (jobz == 'S' ? malloc(max * max * sizeof(cytnx_complex64)) : nullptr));
 
       // double *superb = (double *)malloc(sizeof(double) * (min - 1));
       // info = LAPACKE_dgesvd(LAPACK_COL_MAJOR, jobv, jobu, N, M, Mij, ldA, (cytnx_double *)S->Mem,
@@ -126,10 +127,11 @@ namespace cytnx {
       if (U->dtype() == Type.Void and vT->dtype() == Type.Void) {
         jobz = 'N';
       }
-      void *UMem =
-        (U->data() ? U->data() : (jobz == 'S' ? malloc(max * max * sizeof(cytnx_double)) : NULL));
+      void *UMem = (U->data() ? U->data()
+                              : (jobz == 'S' ? malloc(max * max * sizeof(cytnx_double)) : nullptr));
       void *vTMem =
-        (vT->data() ? vT->data() : (jobz == 'S' ? malloc(max * max * sizeof(cytnx_double)) : NULL));
+        (vT->data() ? vT->data()
+                    : (jobz == 'S' ? malloc(max * max * sizeof(cytnx_double)) : nullptr));
 
       // double *superb = (double *)malloc(sizeof(double) * (min - 1));
       // info = LAPACKE_dgesvd(LAPACK_COL_MAJOR, jobv, jobu, N, M, Mij, ldA, (cytnx_double *)S->Mem,
@@ -173,9 +175,10 @@ namespace cytnx {
         jobz = 'N';
       }
       void *UMem =
-        (U->data() ? U->data() : (jobz == 'S' ? malloc(max * max * sizeof(cytnx_float)) : NULL));
+        (U->data() ? U->data() : (jobz == 'S' ? malloc(max * max * sizeof(cytnx_float)) : nullptr));
       void *vTMem =
-        (vT->data() ? vT->data() : (jobz == 'S' ? malloc(max * max * sizeof(cytnx_float)) : NULL));
+        (vT->data() ? vT->data()
+                    : (jobz == 'S' ? malloc(max * max * sizeof(cytnx_float)) : nullptr));
 
       // double *superb = (double *)malloc(sizeof(double) * (min - 1));
       // info = LAPACKE_dgesvd(LAPACK_COL_MAJOR, jobv, jobu, N, M, Mij, ldA, (cytnx_double *)S->Mem,

--- a/src/backend/linalg_internal_gpu/cuDet_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuDet_internal.cu
@@ -26,7 +26,7 @@ namespace cytnx {
       checkCudaErrors(cudaMalloc((void**)&devInfo, sizeof(int)));
 
       int workspace_size = 0;
-      cuDoubleComplex* workspace = NULL;
+      cuDoubleComplex* workspace = nullptr;
       cusolverDnZgetrf_bufferSize(cusolverH, L, L, _in, L, &workspace_size);
       checkCudaErrors(cudaMalloc((void**)&workspace, workspace_size * sizeof(cuDoubleComplex)));
 
@@ -73,7 +73,7 @@ namespace cytnx {
       checkCudaErrors(cudaMalloc((void**)&devInfo, sizeof(int)));
 
       int workspace_size = 0;
-      cuFloatComplex* workspace = NULL;
+      cuFloatComplex* workspace = nullptr;
       cusolverDnCgetrf_bufferSize(cusolverH, L, L, _in, L, &workspace_size);
       checkCudaErrors(cudaMalloc((void**)&workspace, workspace_size * sizeof(cuFloatComplex)));
 
@@ -120,7 +120,7 @@ namespace cytnx {
       checkCudaErrors(cudaMalloc((void**)&devInfo, sizeof(int)));
 
       int workspace_size = 0;
-      cytnx_double* workspace = NULL;
+      cytnx_double* workspace = nullptr;
       cusolverDnDgetrf_bufferSize(cusolverH, L, L, _in, L, &workspace_size);
       checkCudaErrors(cudaMalloc((void**)&workspace, workspace_size * sizeof(cytnx_double)));
 
@@ -167,7 +167,7 @@ namespace cytnx {
       checkCudaErrors(cudaMalloc((void**)&devInfo, sizeof(int)));
 
       int workspace_size = 0;
-      cytnx_float* workspace = NULL;
+      cytnx_float* workspace = nullptr;
       cusolverDnSgetrf_bufferSize(cusolverH, L, L, _in, L, &workspace_size);
       checkCudaErrors(cudaMalloc((void**)&workspace, workspace_size * sizeof(cytnx_float)));
 

--- a/src/backend/linalg_internal_gpu/cuEig_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuEig_internal.cu
@@ -13,8 +13,8 @@ namespace cytnx {
     void cuEig_internal_cd(const boost::intrusive_ptr<Storage_base> &in,
                            boost::intrusive_ptr<Storage_base> &e,
                            boost::intrusive_ptr<Storage_base> &v, const cytnx_int64 &L) {
-      cusolverDnHandle_t cusolverH = NULL;
-      cudaStream_t stream = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
+      cudaStream_t stream = nullptr;
       cusolverDnCreate(&cusolverH);
       cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking);
       cusolverDnSetStream(cusolverH, stream);
@@ -25,8 +25,8 @@ namespace cytnx {
       cudaMemcpy(d_A, in->Mem, sizeof(cuDoubleComplex) * L * L, cudaMemcpyHostToDevice);
 
       int lwork = 0;
-      cusolverDnZgeev_bufferSize(cusolverH, CUSOLVER_EIG_MODE_VECTOR, L, d_A, L, d_W, d_V, L, NULL,
-                                 1, &lwork);
+      cusolverDnZgeev_bufferSize(cusolverH, CUSOLVER_EIG_MODE_VECTOR, L, d_A, L, d_W, d_V, L,
+                                 nullptr, 1, &lwork);
       cuDoubleComplex *d_work;
       cudaMalloc((void **)&d_work, sizeof(cuDoubleComplex) * lwork);
 
@@ -34,7 +34,7 @@ namespace cytnx {
       cudaMalloc((void **)&devInfo, sizeof(int));
 
       cusolverDnZgeev(cusolverH, CUSOLVER_EIG_MODE_VECTOR, CUBLAS_OP_N, L, d_A, L, d_W, d_V, L,
-                      NULL, 1, d_work, lwork, devInfo);
+                      nullptr, 1, d_work, lwork, devInfo);
 
       cudaMemcpy(e->Mem, d_W, sizeof(cuDoubleComplex) * L, cudaMemcpyDeviceToHost);
       if (v->dtype() != Type.Void) {
@@ -53,8 +53,8 @@ namespace cytnx {
     void cuEig_internal_cf(const boost::intrusive_ptr<Storage_base> &in,
                            boost::intrusive_ptr<Storage_base> &e,
                            boost::intrusive_ptr<Storage_base> &v, const cytnx_int64 &L) {
-      cusolverDnHandle_t cusolverH = NULL;
-      cudaStream_t stream = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
+      cudaStream_t stream = nullptr;
       cusolverDnCreate(&cusolverH);
       cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking);
       cusolverDnSetStream(cusolverH, stream);
@@ -65,8 +65,8 @@ namespace cytnx {
       cudaMemcpy(d_A, in->Mem, sizeof(cuFloatComplex) * L * L, cudaMemcpyHostToDevice);
 
       int lwork = 0;
-      cusolverDnCgeev_bufferSize(cusolverH, CUSOLVER_EIG_MODE_VECTOR, L, d_A, L, d_W, d_V, L, NULL,
-                                 1, &lwork);
+      cusolverDnCgeev_bufferSize(cusolverH, CUSOLVER_EIG_MODE_VECTOR, L, d_A, L, d_W, d_V, L,
+                                 nullptr, 1, &lwork);
       cuFloatComplex *d_work;
       cudaMalloc((void **)&d_work, sizeof(cuFloatComplex) * lwork);
 
@@ -74,7 +74,7 @@ namespace cytnx {
       cudaMalloc((void **)&devInfo, sizeof(int));
 
       cusolverDnCgeev(cusolverH, CUSOLVER_EIG_MODE_VECTOR, CUBLAS_OP_N, L, d_A, L, d_W, d_V, L,
-                      NULL, 1, d_work, lwork, devInfo);
+                      nullptr, 1, d_work, lwork, devInfo);
 
       cudaMemcpy(e->Mem, d_W, sizeof(cuFloatComplex) * L, cudaMemcpyDeviceToHost);
       if (v->dtype() != Type.Void) {
@@ -93,8 +93,8 @@ namespace cytnx {
     void cuEig_internal_d(const boost::intrusive_ptr<Storage_base> &in,
                           boost::intrusive_ptr<Storage_base> &e,
                           boost::intrusive_ptr<Storage_base> &v, const cytnx_int64 &L) {
-      cusolverDnHandle_t cusolverH = NULL;
-      cudaStream_t stream = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
+      cudaStream_t stream = nullptr;
       cusolverDnCreate(&cusolverH);
       cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking);
       cusolverDnSetStream(cusolverH, stream);
@@ -105,8 +105,8 @@ namespace cytnx {
       cudaMemcpy(d_A, in->Mem, sizeof(double) * L * L, cudaMemcpyHostToDevice);
 
       int lwork = 0;
-      cusolverDnDgeev_bufferSize(cusolverH, CUSOLVER_EIG_MODE_VECTOR, L, d_A, L, d_W, d_V, L, NULL,
-                                 1, &lwork);
+      cusolverDnDgeev_bufferSize(cusolverH, CUSOLVER_EIG_MODE_VECTOR, L, d_A, L, d_W, d_V, L,
+                                 nullptr, 1, &lwork);
       double *d_work;
       cudaMalloc((void **)&d_work, sizeof(double) * lwork);
 
@@ -114,7 +114,7 @@ namespace cytnx {
       cudaMalloc((void **)&devInfo, sizeof(int));
 
       cusolverDnDgeev(cusolverH, CUSOLVER_EIG_MODE_VECTOR, CUBLAS_OP_N, L, d_A, L, d_W, d_V, L,
-                      NULL, 1, d_work, lwork, devInfo);
+                      nullptr, 1, d_work, lwork, devInfo);
 
       cudaMemcpy(e->Mem, d_W, sizeof(double) * L, cudaMemcpyDeviceToHost);
       if (v->dtype() != Type.Void) {
@@ -133,8 +133,8 @@ namespace cytnx {
     void cuEig_internal_f(const boost::intrusive_ptr<Storage_base> &in,
                           boost::intrusive_ptr<Storage_base> &e,
                           boost::intrusive_ptr<Storage_base> &v, const cytnx_int64 &L) {
-      cusolverDnHandle_t cusolverH = NULL;
-      cudaStream_t stream = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
+      cudaStream_t stream = nullptr;
       cusolverDnCreate(&cusolverH);
       cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking);
       cusolverDnSetStream(cusolverH, stream);
@@ -145,8 +145,8 @@ namespace cytnx {
       cudaMemcpy(d_A, in->Mem, sizeof(float) * L * L, cudaMemcpyHostToDevice);
 
       int lwork = 0;
-      cusolverDnSgeev_bufferSize(cusolverH, CUSOLVER_EIG_MODE_VECTOR, L, d_A, L, d_W, d_V, L, NULL,
-                                 1, &lwork);
+      cusolverDnSgeev_bufferSize(cusolverH, CUSOLVER_EIG_MODE_VECTOR, L, d_A, L, d_W, d_V, L,
+                                 nullptr, 1, &lwork);
       float *d_work;
       cudaMalloc((void **)&d_work, sizeof(float) * lwork);
 
@@ -154,7 +154,7 @@ namespace cytnx {
       cudaMalloc((void **)&devInfo, sizeof(int));
 
       cusolverDnSgeev(cusolverH, CUSOLVER_EIG_MODE_VECTOR, CUBLAS_OP_N, L, d_A, L, d_W, d_V, L,
-                      NULL, 1, d_work, lwork, devInfo);
+                      nullptr, 1, d_work, lwork, devInfo);
 
       cudaMemcpy(e->Mem, d_W, sizeof(float) * L, cudaMemcpyDeviceToHost);
       if (v->dtype() != Type.Void) {

--- a/src/backend/linalg_internal_gpu/cuEigh_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuEigh_internal.cu
@@ -15,11 +15,11 @@ namespace cytnx {
       if (v->dtype() == Type.Void) jobz = CUSOLVER_EIG_MODE_NOVECTOR;
 
       // create handles:
-      cusolverDnHandle_t cusolverH = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cytnx_complex128 *tA;
-      if (v != NULL) {
+      if (v != nullptr) {
         tA = (cytnx_complex128 *)v->data();
         checkCudaErrors(cudaMemcpy(v->data(), in->data(),
                                    sizeof(cytnx_complex128) * cytnx_uint64(L) * L,
@@ -68,11 +68,11 @@ namespace cytnx {
       if (v->dtype() == Type.Void) jobz = CUSOLVER_EIG_MODE_NOVECTOR;
 
       // create handles:
-      cusolverDnHandle_t cusolverH = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cytnx_complex64 *tA;
-      if (v != NULL) {
+      if (v != nullptr) {
         tA = (cytnx_complex64 *)v->data();
         checkCudaErrors(cudaMemcpy(v->data(), in->data(),
                                    sizeof(cytnx_complex64) * cytnx_uint64(L) * L,
@@ -121,7 +121,7 @@ namespace cytnx {
       if (v->dtype() == Type.Void) jobz = CUSOLVER_EIG_MODE_NOVECTOR;
 
       // create handles:
-      cusolverDnHandle_t cusolverH = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cytnx_double *tA;
@@ -172,7 +172,7 @@ namespace cytnx {
       if (v->dtype() == Type.Void) jobz = CUSOLVER_EIG_MODE_NOVECTOR;
 
       // create handles:
-      cusolverDnHandle_t cusolverH = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cytnx_float *tA;

--- a/src/backend/linalg_internal_gpu/cuEigh_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuEigh_internal.cu
@@ -19,7 +19,7 @@ namespace cytnx {
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cytnx_complex128 *tA;
-      if (v != nullptr) {
+      if (v->dtype() != Type.Void) {
         tA = (cytnx_complex128 *)v->data();
         checkCudaErrors(cudaMemcpy(v->data(), in->data(),
                                    sizeof(cytnx_complex128) * cytnx_uint64(L) * L,
@@ -72,7 +72,7 @@ namespace cytnx {
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cytnx_complex64 *tA;
-      if (v != nullptr) {
+      if (v->dtype() != Type.Void) {
         tA = (cytnx_complex64 *)v->data();
         checkCudaErrors(cudaMemcpy(v->data(), in->data(),
                                    sizeof(cytnx_complex64) * cytnx_uint64(L) * L,

--- a/src/backend/linalg_internal_gpu/cuGeSvd_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuGeSvd_internal.cu
@@ -14,7 +14,7 @@ namespace cytnx {
       using data_type = cytnx_complex128;
       using d_data_type = cuDoubleComplex;
       cusolverEigMode_t jobz;
-      // if U and vT are nullptr, then it will not be computed.
+      // if U and vT are void, then it will not be computed.
       jobz = (U->dtype() == Type.Void and vT->dtype() == Type.Void) ? CUSOLVER_EIG_MODE_NOVECTOR
                                                                     : CUSOLVER_EIG_MODE_VECTOR;
 
@@ -102,7 +102,7 @@ namespace cytnx {
       using data_type = cytnx_complex64;
       using d_data_type = cuFloatComplex;
       cusolverEigMode_t jobz;
-      // if U and vT are nullptr, then it will not be computed.
+      // if U and vT are void, then it will not be computed.
       jobz = (U->dtype() == Type.Void and vT->dtype() == Type.Void) ? CUSOLVER_EIG_MODE_NOVECTOR
                                                                     : CUSOLVER_EIG_MODE_VECTOR;
 
@@ -189,7 +189,7 @@ namespace cytnx {
                             const cytnx_int64 &N) {
       using data_type = cytnx_double;
       cusolverEigMode_t jobz;
-      // if U and vT are nullptr, then it will not be computed.
+      // if U and vT are void, then it will not be computed.
       jobz = (U->dtype() == Type.Void and vT->dtype() == Type.Void) ? CUSOLVER_EIG_MODE_NOVECTOR
                                                                     : CUSOLVER_EIG_MODE_VECTOR;
 
@@ -275,7 +275,7 @@ namespace cytnx {
                             const cytnx_int64 &N) {
       using data_type = cytnx_float;
       cusolverEigMode_t jobz;
-      // if U and vT are nullptr, then it will not be computed.
+      // if U and vT are void, then it will not be computed.
       jobz = (U->dtype() == Type.Void and vT->dtype() == Type.Void) ? CUSOLVER_EIG_MODE_NOVECTOR
                                                                     : CUSOLVER_EIG_MODE_VECTOR;
 

--- a/src/backend/linalg_internal_gpu/cuGeSvd_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuGeSvd_internal.cu
@@ -14,7 +14,7 @@ namespace cytnx {
       using data_type = cytnx_complex128;
       using d_data_type = cuDoubleComplex;
       cusolverEigMode_t jobz;
-      // if U and vT are NULL ptr, then it will not be computed.
+      // if U and vT are nullptr, then it will not be computed.
       jobz = (U->dtype() == Type.Void and vT->dtype() == Type.Void) ? CUSOLVER_EIG_MODE_NOVECTOR
                                                                     : CUSOLVER_EIG_MODE_VECTOR;
 
@@ -22,7 +22,7 @@ namespace cytnx {
       cytnx_int32 econ = 1; /* i.e. 'S' in gesvd  */
 
       // create handles:
-      cusolverDnHandle_t cusolverH = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cuDoubleComplex *Mij;
@@ -47,7 +47,7 @@ namespace cytnx {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR)
           checkCudaErrors(cudaMalloc(&vTMem, max * max * sizeof(data_type)));
       }
-      gesvdjInfo_t gesvdj_params = NULL;
+      gesvdjInfo_t gesvdj_params = nullptr;
       // const double tol = 1.e-14;
       // const int max_sweeps = 100;
       checkCudaErrors(cusolverDnCreateGesvdjInfo(&gesvdj_params));
@@ -102,7 +102,7 @@ namespace cytnx {
       using data_type = cytnx_complex64;
       using d_data_type = cuFloatComplex;
       cusolverEigMode_t jobz;
-      // if U and vT are NULL ptr, then it will not be computed.
+      // if U and vT are nullptr, then it will not be computed.
       jobz = (U->dtype() == Type.Void and vT->dtype() == Type.Void) ? CUSOLVER_EIG_MODE_NOVECTOR
                                                                     : CUSOLVER_EIG_MODE_VECTOR;
 
@@ -110,7 +110,7 @@ namespace cytnx {
       cytnx_int32 econ = 1; /* i.e. 'S' in gesvd  */
 
       // create handles:
-      cusolverDnHandle_t cusolverH = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cuDoubleComplex *Mij;
@@ -135,7 +135,7 @@ namespace cytnx {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR)
           checkCudaErrors(cudaMalloc(&vTMem, max * max * sizeof(data_type)));
       }
-      gesvdjInfo_t gesvdj_params = NULL;
+      gesvdjInfo_t gesvdj_params = nullptr;
       // const double tol = 1.e-14;
       // const int max_sweeps = 100;
       checkCudaErrors(cusolverDnCreateGesvdjInfo(&gesvdj_params));
@@ -189,7 +189,7 @@ namespace cytnx {
                             const cytnx_int64 &N) {
       using data_type = cytnx_double;
       cusolverEigMode_t jobz;
-      // if U and vT are NULL ptr, then it will not be computed.
+      // if U and vT are nullptr, then it will not be computed.
       jobz = (U->dtype() == Type.Void and vT->dtype() == Type.Void) ? CUSOLVER_EIG_MODE_NOVECTOR
                                                                     : CUSOLVER_EIG_MODE_VECTOR;
 
@@ -197,7 +197,7 @@ namespace cytnx {
       cytnx_int32 econ = 1; /* i.e. 'S' in gesvd  */
 
       // create handles:
-      cusolverDnHandle_t cusolverH = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cuDoubleComplex *Mij;
@@ -222,7 +222,7 @@ namespace cytnx {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR)
           checkCudaErrors(cudaMalloc(&vTMem, max * max * sizeof(data_type)));
       }
-      gesvdjInfo_t gesvdj_params = NULL;
+      gesvdjInfo_t gesvdj_params = nullptr;
       // const double tol = 1.e-14;
       // const int max_sweeps = 100;
       checkCudaErrors(cusolverDnCreateGesvdjInfo(&gesvdj_params));
@@ -275,7 +275,7 @@ namespace cytnx {
                             const cytnx_int64 &N) {
       using data_type = cytnx_float;
       cusolverEigMode_t jobz;
-      // if U and vT are NULL ptr, then it will not be computed.
+      // if U and vT are nullptr, then it will not be computed.
       jobz = (U->dtype() == Type.Void and vT->dtype() == Type.Void) ? CUSOLVER_EIG_MODE_NOVECTOR
                                                                     : CUSOLVER_EIG_MODE_VECTOR;
 
@@ -283,7 +283,7 @@ namespace cytnx {
       cytnx_int32 econ = 1; /* i.e. 'S' in gesvd  */
 
       // create handles:
-      cusolverDnHandle_t cusolverH = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cuDoubleComplex *Mij;
@@ -308,7 +308,7 @@ namespace cytnx {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR)
           checkCudaErrors(cudaMalloc(&vTMem, max * max * sizeof(data_type)));
       }
-      gesvdjInfo_t gesvdj_params = NULL;
+      gesvdjInfo_t gesvdj_params = nullptr;
       // const double tol = 1.e-14;
       // const int max_sweeps = 100;
       checkCudaErrors(cusolverDnCreateGesvdjInfo(&gesvdj_params));

--- a/src/backend/linalg_internal_gpu/cuGemm_Batch_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuGemm_Batch_internal.cu
@@ -50,7 +50,7 @@ namespace cytnx {
               break;
           }
           // create handles:
-          cublasHandle_t cublasH = NULL;
+          cublasHandle_t cublasH = nullptr;
           checkCudaErrors(cublasCreate(&cublasH));
           checkCudaErrors(cublasZgemm(
             cublasH, transa, transb, m_array[i], n_array[i], k_array[i],
@@ -107,7 +107,7 @@ namespace cytnx {
               break;
           }
           // create handles:
-          cublasHandle_t cublasH = NULL;
+          cublasHandle_t cublasH = nullptr;
           checkCudaErrors(cublasCreate(&cublasH));
           checkCudaErrors(cublasCgemm(cublasH, transa, transb, m_array[i], n_array[i], k_array[i],
                                       (cuFloatComplex *)&alphas[i], (cuFloatComplex *)a_array[idx],
@@ -164,7 +164,7 @@ namespace cytnx {
               break;
           }
           // create handles:
-          cublasHandle_t cublasH = NULL;
+          cublasHandle_t cublasH = nullptr;
           checkCudaErrors(cublasCreate(&cublasH));
           checkCudaErrors(cublasDgemm(
             cublasH, transa, transb, m_array[i], n_array[i], k_array[i], (cytnx_double *)&alphas[i],
@@ -220,7 +220,7 @@ namespace cytnx {
               break;
           }
           // create handles:
-          cublasHandle_t cublasH = NULL;
+          cublasHandle_t cublasH = nullptr;
           checkCudaErrors(cublasCreate(&cublasH));
           checkCudaErrors(cublasSgemm(
             cublasH, transa, transb, m_array[i], n_array[i], k_array[i], (cytnx_float *)&alphas[i],

--- a/src/backend/linalg_internal_gpu/cuGemm_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuGemm_internal.cu
@@ -12,7 +12,7 @@ namespace cytnx {
                             const cytnx_int64 &Comm, const cytnx_int64 &Nr, const Scalar &a,
                             const Scalar &b) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       cytnx_complex128 alpha = complex128(a), beta = complex128(b);
 
@@ -34,7 +34,7 @@ namespace cytnx {
                             const cytnx_int64 &Comm, const cytnx_int64 &Nr, const Scalar &a,
                             const Scalar &b) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       cytnx_complex64 alpha = complex64(a), beta = complex64(b);
 
@@ -57,7 +57,7 @@ namespace cytnx {
                            const cytnx_int64 &Comm, const cytnx_int64 &Nr, const Scalar &a,
                            const Scalar &b) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       cytnx_double alpha = double(a), beta = double(b);
 
@@ -78,7 +78,7 @@ namespace cytnx {
                            const cytnx_int64 &Comm, const cytnx_int64 &Nr, const Scalar &a,
                            const Scalar &b) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       cytnx_float alpha = float(a), beta = float(b);
 

--- a/src/backend/linalg_internal_gpu/cuGer_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuGer_internal.cu
@@ -10,7 +10,7 @@ namespace cytnx {
                            const boost::intrusive_ptr<Storage_base> &x,
                            const boost::intrusive_ptr<Storage_base> &y, const Scalar &a) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       cytnx_complex128 alpha = complex128(a);
 
@@ -28,7 +28,7 @@ namespace cytnx {
                            const boost::intrusive_ptr<Storage_base> &x,
                            const boost::intrusive_ptr<Storage_base> &y, const Scalar &a) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       cytnx_complex64 alpha = complex64(a);
 
@@ -46,7 +46,7 @@ namespace cytnx {
                           const boost::intrusive_ptr<Storage_base> &x,
                           const boost::intrusive_ptr<Storage_base> &y, const Scalar &a) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       cytnx_double alpha = cytnx_double(a);
 
@@ -64,7 +64,7 @@ namespace cytnx {
                           const boost::intrusive_ptr<Storage_base> &x,
                           const boost::intrusive_ptr<Storage_base> &y, const Scalar &a) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       cytnx_float alpha = cytnx_float(a);
 

--- a/src/backend/linalg_internal_gpu/cuInvM_inplace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuInvM_inplace_internal.cu
@@ -8,13 +8,13 @@ namespace cytnx {
 
     void cuInvM_inplace_internal_d(boost::intrusive_ptr<Storage_base> &ten, const cytnx_int64 &L) {
       // create handles:
-      cusolverDnHandle_t cusolverH = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cytnx_int32 *ipiv;
       cytnx_int32 info;
       cytnx_int32 lwork = 0;
-      cytnx_double *d_work = NULL;
+      cytnx_double *d_work = nullptr;
       cytnx_int32 *devinfo;
       checkCudaErrors(cudaMalloc((void **)&ipiv, (L + 1) * sizeof(cytnx_int32)));
       checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
@@ -58,13 +58,13 @@ namespace cytnx {
     }
     void cuInvM_inplace_internal_f(boost::intrusive_ptr<Storage_base> &ten, const cytnx_int64 &L) {
       // create handles:
-      cusolverDnHandle_t cusolverH = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cytnx_int32 *ipiv;
       cytnx_int32 info;
       cytnx_int32 lwork = 0;
-      cytnx_float *d_work = NULL;
+      cytnx_float *d_work = nullptr;
       cytnx_int32 *devinfo;
       checkCudaErrors(cudaMalloc((void **)&ipiv, (L + 1) * sizeof(cytnx_int32)));
       checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
@@ -108,13 +108,13 @@ namespace cytnx {
     }
     void cuInvM_inplace_internal_cd(boost::intrusive_ptr<Storage_base> &ten, const cytnx_int64 &L) {
       // create handles:
-      cusolverDnHandle_t cusolverH = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cytnx_int32 *ipiv;
       cytnx_int32 info;
       cytnx_int32 lwork = 0;
-      cytnx_complex128 *d_work = NULL;
+      cytnx_complex128 *d_work = nullptr;
       cytnx_int32 *devinfo;
       checkCudaErrors(cudaMalloc((void **)&ipiv, (L + 1) * sizeof(cytnx_int32)));
       checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
@@ -160,13 +160,13 @@ namespace cytnx {
 
     void cuInvM_inplace_internal_cf(boost::intrusive_ptr<Storage_base> &ten, const cytnx_int64 &L) {
       // create handles:
-      cusolverDnHandle_t cusolverH = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cytnx_int32 *ipiv;
       cytnx_int32 info;
       cytnx_int32 lwork = 0;
-      cytnx_complex64 *d_work = NULL;
+      cytnx_complex64 *d_work = nullptr;
       cytnx_int32 *devinfo;
       checkCudaErrors(cudaMalloc((void **)&ipiv, (L + 1) * sizeof(cytnx_int32)));
       checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));

--- a/src/backend/linalg_internal_gpu/cuMatmul_dg_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuMatmul_dg_internal.cu
@@ -36,7 +36,7 @@ namespace cytnx {
                                  const cytnx_int64 &Ml, const cytnx_int64 &Comm,
                                  const cytnx_int64 &Nr, const int &diag_L) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       // cytnx_complex128 alpha = cytnx_complex128(1,0), beta=cytnx_complex128(0,0);
 
@@ -61,7 +61,7 @@ namespace cytnx {
                                  const cytnx_int64 &Ml, const cytnx_int64 &Comm,
                                  const cytnx_int64 &Nr, const int &diag_L) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       // cytnx_complex64 alpha = cytnx_complex64(1,0), beta=cytnx_complex64(0,0);
 
@@ -87,7 +87,7 @@ namespace cytnx {
                                 const cytnx_int64 &Ml, const cytnx_int64 &Comm,
                                 const cytnx_int64 &Nr, const int &diag_L) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       // cytnx_double alpha = 1, beta=0;
 
@@ -113,7 +113,7 @@ namespace cytnx {
                                 const cytnx_int64 &Ml, const cytnx_int64 &Comm,
                                 const cytnx_int64 &Nr, const int &diag_L) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       // cytnx_float alpha = 1, beta=0;
 

--- a/src/backend/linalg_internal_gpu/cuMatmul_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuMatmul_internal.cu
@@ -26,7 +26,7 @@ namespace cytnx {
                               const boost::intrusive_ptr<Storage_base> &inr, const cytnx_int64 &Ml,
                               const cytnx_int64 &Comm, const cytnx_int64 &Nr) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       cytnx_complex128 alpha = cytnx_complex128(1, 0), beta = cytnx_complex128(0, 0);
 
@@ -47,7 +47,7 @@ namespace cytnx {
                               const boost::intrusive_ptr<Storage_base> &inr, const cytnx_int64 &Ml,
                               const cytnx_int64 &Comm, const cytnx_int64 &Nr) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       cytnx_complex64 alpha = cytnx_complex64(1, 0), beta = cytnx_complex64(0, 0);
 
@@ -69,7 +69,7 @@ namespace cytnx {
                              const boost::intrusive_ptr<Storage_base> &inr, const cytnx_int64 &Ml,
                              const cytnx_int64 &Comm, const cytnx_int64 &Nr) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       cytnx_double alpha = 1, beta = 0;
 
@@ -89,7 +89,7 @@ namespace cytnx {
                              const boost::intrusive_ptr<Storage_base> &inr, const cytnx_int64 &Ml,
                              const cytnx_int64 &Comm, const cytnx_int64 &Nr) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       cytnx_float alpha = 1, beta = 0;
 

--- a/src/backend/linalg_internal_gpu/cuMatvec_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuMatvec_internal.cu
@@ -26,7 +26,7 @@ namespace cytnx {
                               const boost::intrusive_ptr<Storage_base> &inr, const cytnx_int64 &Ml,
                               const cytnx_int64 &Nr) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       cytnx_complex128 alpha = cytnx_complex128(1, 0), beta = cytnx_complex128(0, 0);
 
@@ -48,7 +48,7 @@ namespace cytnx {
                               const boost::intrusive_ptr<Storage_base> &inr, const cytnx_int64 &Ml,
                               const cytnx_int64 &Nr) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       cytnx_complex64 alpha = cytnx_complex64(1, 0), beta = cytnx_complex64(0, 0);
 
@@ -71,7 +71,7 @@ namespace cytnx {
                              const boost::intrusive_ptr<Storage_base> &inr, const cytnx_int64 &Ml,
                              const cytnx_int64 &Nr) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       cytnx_double alpha = 1, beta = 0;
 
@@ -93,7 +93,7 @@ namespace cytnx {
                              const boost::intrusive_ptr<Storage_base> &inr, const cytnx_int64 &Ml,
                              const cytnx_int64 &Nr) {
       // create handles:
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       cytnx_float alpha = 1, beta = 0;
 

--- a/src/backend/linalg_internal_gpu/cuNorm_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuNorm_internal.cu
@@ -10,7 +10,7 @@ namespace cytnx {
 
     /// cuNorm
     void cuNorm_internal_cd(void *out, const boost::intrusive_ptr<Storage_base> &Rin) {
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
 
       checkCudaErrors(
@@ -19,7 +19,7 @@ namespace cytnx {
       cublasDestroy(cublasH);
     }
     void cuNorm_internal_cf(void *out, const boost::intrusive_ptr<Storage_base> &Rin) {
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
 
       checkCudaErrors(
@@ -28,7 +28,7 @@ namespace cytnx {
       cublasDestroy(cublasH);
     }
     void cuNorm_internal_d(void *out, const boost::intrusive_ptr<Storage_base> &Rin) {
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
 
       checkCudaErrors(cublasDnrm2(cublasH, Rin->size(), (double *)Rin->data(), 1, (double *)out));
@@ -36,7 +36,7 @@ namespace cytnx {
       cublasDestroy(cublasH);
     }
     void cuNorm_internal_f(void *out, const boost::intrusive_ptr<Storage_base> &Rin) {
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
       checkCudaErrors(cublasSnrm2(cublasH, Rin->size(), (float *)Rin->data(), 1, (float *)out));
       cublasDestroy(cublasH);

--- a/src/backend/linalg_internal_gpu/cuQuantumGeSvd_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuQuantumGeSvd_internal.cu
@@ -333,7 +333,7 @@ namespace cytnx {
       cutensornetTensorDescriptor_t descTensorU;
       cutensornetTensorDescriptor_t descTensorV;
 
-      const int64_t *strides = NULL;  // assuming fortran layout for all tensors
+      const int64_t *strides = nullptr;  // assuming fortran layout for all tensors
 
       HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides,
                                                      modesT.data(), typeData, &descTensorIn));
@@ -577,7 +577,7 @@ namespace cytnx {
       cutensornetTensorDescriptor_t descTensorU;
       cutensornetTensorDescriptor_t descTensorV;
 
-      const int64_t *strides = NULL;  // assuming fortran layout for all tensors
+      const int64_t *strides = nullptr;  // assuming fortran layout for all tensors
 
       HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides,
                                                      modesT.data(), typeData, &descTensorIn));
@@ -821,7 +821,7 @@ namespace cytnx {
       cutensornetTensorDescriptor_t descTensorU;
       cutensornetTensorDescriptor_t descTensorV;
 
-      const int64_t *strides = NULL;  // assuming fortran layout for all tensors
+      const int64_t *strides = nullptr;  // assuming fortran layout for all tensors
 
       HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides,
                                                      modesT.data(), typeData, &descTensorIn));
@@ -1065,7 +1065,7 @@ namespace cytnx {
       cutensornetTensorDescriptor_t descTensorU;
       cutensornetTensorDescriptor_t descTensorV;
 
-      const int64_t *strides = NULL;  // assuming fortran layout for all tensors
+      const int64_t *strides = nullptr;  // assuming fortran layout for all tensors
 
       HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides,
                                                      modesT.data(), typeData, &descTensorIn));

--- a/src/backend/linalg_internal_gpu/cuQuantumQr_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuQuantumQr_internal.cu
@@ -127,7 +127,7 @@ namespace cytnx {
       cutensornetTensorDescriptor_t descTensorQ;
       cutensornetTensorDescriptor_t descTensorR;
 
-      const int64_t *strides = NULL;  // assuming fortran layout for all tensors
+      const int64_t *strides = nullptr;  // assuming fortran layout for all tensors
 
       HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides,
                                                      modesT.data(), typeData, &descTensorIn));
@@ -265,7 +265,7 @@ namespace cytnx {
       cutensornetTensorDescriptor_t descTensorQ;
       cutensornetTensorDescriptor_t descTensorR;
 
-      const int64_t *strides = NULL;  // assuming fortran layout for all tensors
+      const int64_t *strides = nullptr;  // assuming fortran layout for all tensors
 
       HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides,
                                                      modesT.data(), typeData, &descTensorIn));
@@ -402,7 +402,7 @@ namespace cytnx {
       cutensornetTensorDescriptor_t descTensorQ;
       cutensornetTensorDescriptor_t descTensorR;
 
-      const int64_t *strides = NULL;  // assuming fortran layout for all tensors
+      const int64_t *strides = nullptr;  // assuming fortran layout for all tensors
 
       HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides,
                                                      modesT.data(), typeData, &descTensorIn));
@@ -539,7 +539,7 @@ namespace cytnx {
       cutensornetTensorDescriptor_t descTensorQ;
       cutensornetTensorDescriptor_t descTensorR;
 
-      const int64_t *strides = NULL;  // assuming fortran layout for all tensors
+      const int64_t *strides = nullptr;  // assuming fortran layout for all tensors
 
       HANDLE_ERROR(cutensornetCreateTensorDescriptor(handle, numModesIn, extentT.data(), strides,
                                                      modesT.data(), typeData, &descTensorIn));

--- a/src/backend/linalg_internal_gpu/cuSvd_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuSvd_internal.cu
@@ -17,7 +17,7 @@ namespace cytnx {
       assert(sizeof(cuDoubleComplex) == sizeof(cytnx_complex128));
 
       cusolverEigMode_t jobz;
-      // if U and vT are NULL ptr, then it will not be computed.
+      // if U and vT are nullptr, then it will not be computed.
       jobz = (U->dtype() == Type.Void and vT->dtype() == Type.Void) ? CUSOLVER_EIG_MODE_NOVECTOR
                                                                     : CUSOLVER_EIG_MODE_VECTOR;
 
@@ -25,7 +25,7 @@ namespace cytnx {
       cytnx_int32 econ = 1; /* i.e. 'S' in gesvd  */
 
       // create handles:
-      cusolverDnHandle_t cusolverH = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cuDoubleComplex *Mij;
@@ -56,7 +56,7 @@ namespace cytnx {
       void *h_work = nullptr; /* host workspace for getrf */
       cytnx_double h_err_sigma;
       // query working space :
-      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH, NULL, /* params */
+      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH, nullptr, /* params */
                                                    jobz, econ, N, M, cuda_data_type, /* dataTypeA */
                                                    Mij, ldA, cuda_data_typeR, /* dataTypeS */
                                                    S->data(), cuda_data_type, /* dataTypeU */
@@ -81,7 +81,7 @@ namespace cytnx {
 
       cytnx_int32 info;
       /// compute:
-      cusolverDnXgesvdp(cusolverH, NULL, /* params */
+      cusolverDnXgesvdp(cusolverH, nullptr, /* params */
                         jobz, econ, N, M, cuda_data_type, /* dataTypeA */
                         Mij, ldA, cuda_data_typeR, /* dataTypeS */
                         S->data(), cuda_data_type, /* dataTypeU */
@@ -127,7 +127,7 @@ namespace cytnx {
       assert(sizeof(cuFloatComplex) == sizeof(cytnx_complex64));
 
       cusolverEigMode_t jobz;
-      // if U and vT are NULL ptr, then it will not be computed.
+      // if U and vT are nullptr, then it will not be computed.
       jobz = (U->dtype() == Type.Void and vT->dtype() == Type.Void) ? CUSOLVER_EIG_MODE_NOVECTOR
                                                                     : CUSOLVER_EIG_MODE_VECTOR;
 
@@ -135,7 +135,7 @@ namespace cytnx {
       cytnx_int32 econ = 1; /* i.e. 'S' in gesvd  */
 
       // create handles:
-      cusolverDnHandle_t cusolverH = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cuDoubleComplex *Mij;
@@ -167,7 +167,7 @@ namespace cytnx {
       void *h_work = nullptr; /* host workspace for getrf */
       cytnx_double h_err_sigma;
       // query working space :
-      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH, NULL, /* params */
+      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH, nullptr, /* params */
                                                    jobz, econ, N, M, cuda_data_type, /* dataTypeA */
                                                    Mij, ldA, cuda_data_typeR, /* dataTypeS */
                                                    S->data(), cuda_data_type, /* dataTypeU */
@@ -192,7 +192,7 @@ namespace cytnx {
 
       cytnx_int32 info;
       /// compute:
-      cusolverDnXgesvdp(cusolverH, NULL, /* params */
+      cusolverDnXgesvdp(cusolverH, nullptr, /* params */
                         jobz, econ, N, M, cuda_data_type, /* dataTypeA */
                         Mij, ldA, cuda_data_typeR, /* dataTypeS */
                         S->data(), cuda_data_type, /* dataTypeU */
@@ -237,7 +237,7 @@ namespace cytnx {
       cudaDataType cuda_data_typeR = CUDA_R_64F;
 
       cusolverEigMode_t jobz;
-      // if U and vT are NULL ptr, then it will not be computed.
+      // if U and vT are nullptr, then it will not be computed.
       jobz = (U->dtype() == Type.Void and vT->dtype() == Type.Void) ? CUSOLVER_EIG_MODE_NOVECTOR
                                                                     : CUSOLVER_EIG_MODE_VECTOR;
 
@@ -245,7 +245,7 @@ namespace cytnx {
       cytnx_int32 econ = 1; /* i.e. 'S' in gesvd  */
 
       // create handles:
-      cusolverDnHandle_t cusolverH = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cuDoubleComplex *Mij;
@@ -277,7 +277,7 @@ namespace cytnx {
       void *h_work = nullptr; /* host workspace for getrf */
       cytnx_double h_err_sigma;
       // query working space :
-      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH, NULL, /* params */
+      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH, nullptr, /* params */
                                                    jobz, econ, N, M, cuda_data_type, /* dataTypeA */
                                                    Mij, ldA, cuda_data_typeR, /* dataTypeS */
                                                    S->data(), cuda_data_type, /* dataTypeU */
@@ -302,7 +302,7 @@ namespace cytnx {
 
       cytnx_int32 info;
       /// compute:
-      cusolverDnXgesvdp(cusolverH, NULL, /* params */
+      cusolverDnXgesvdp(cusolverH, nullptr, /* params */
                         jobz, econ, N, M, cuda_data_type, /* dataTypeA */
                         Mij, ldA, cuda_data_typeR, /* dataTypeS */
                         S->data(), cuda_data_type, /* dataTypeU */
@@ -346,7 +346,7 @@ namespace cytnx {
       cudaDataType cuda_data_typeR = CUDA_R_32F;
 
       cusolverEigMode_t jobz;
-      // if U and vT are NULL ptr, then it will not be computed.
+      // if U and vT are nullptr, then it will not be computed.
       jobz = (U->dtype() == Type.Void and vT->dtype() == Type.Void) ? CUSOLVER_EIG_MODE_NOVECTOR
                                                                     : CUSOLVER_EIG_MODE_VECTOR;
 
@@ -354,7 +354,7 @@ namespace cytnx {
       cytnx_int32 econ = 1; /* i.e. 'S' in gesvd  */
 
       // create handles:
-      cusolverDnHandle_t cusolverH = NULL;
+      cusolverDnHandle_t cusolverH = nullptr;
       checkCudaErrors(cusolverDnCreate(&cusolverH));
 
       cuDoubleComplex *Mij;
@@ -386,7 +386,7 @@ namespace cytnx {
       void *h_work = nullptr; /* host workspace for getrf */
       cytnx_double h_err_sigma;
       // query working space :
-      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH, NULL, /* params */
+      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH, nullptr, /* params */
                                                    jobz, econ, N, M, cuda_data_type, /* dataTypeA */
                                                    Mij, ldA, cuda_data_typeR, /* dataTypeS */
                                                    S->data(), cuda_data_type, /* dataTypeU */
@@ -411,7 +411,7 @@ namespace cytnx {
 
       cytnx_int32 info;
       /// compute:
-      cusolverDnXgesvdp(cusolverH, NULL, /* params */
+      cusolverDnXgesvdp(cusolverH, nullptr, /* params */
                         jobz, econ, N, M, cuda_data_type, /* dataTypeA */
                         Mij, ldA, cuda_data_typeR, /* dataTypeS */
                         S->data(), cuda_data_type, /* dataTypeU */

--- a/src/backend/linalg_internal_gpu/cuSvd_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuSvd_internal.cu
@@ -17,7 +17,7 @@ namespace cytnx {
       assert(sizeof(cuDoubleComplex) == sizeof(cytnx_complex128));
 
       cusolverEigMode_t jobz;
-      // if U and vT are nullptr, then it will not be computed.
+      // if U and vT are void, then it will not be computed.
       jobz = (U->dtype() == Type.Void and vT->dtype() == Type.Void) ? CUSOLVER_EIG_MODE_NOVECTOR
                                                                     : CUSOLVER_EIG_MODE_VECTOR;
 
@@ -127,7 +127,7 @@ namespace cytnx {
       assert(sizeof(cuFloatComplex) == sizeof(cytnx_complex64));
 
       cusolverEigMode_t jobz;
-      // if U and vT are nullptr, then it will not be computed.
+      // if U and vT are void, then it will not be computed.
       jobz = (U->dtype() == Type.Void and vT->dtype() == Type.Void) ? CUSOLVER_EIG_MODE_NOVECTOR
                                                                     : CUSOLVER_EIG_MODE_VECTOR;
 
@@ -237,7 +237,7 @@ namespace cytnx {
       cudaDataType cuda_data_typeR = CUDA_R_64F;
 
       cusolverEigMode_t jobz;
-      // if U and vT are nullptr, then it will not be computed.
+      // if U and vT are void, then it will not be computed.
       jobz = (U->dtype() == Type.Void and vT->dtype() == Type.Void) ? CUSOLVER_EIG_MODE_NOVECTOR
                                                                     : CUSOLVER_EIG_MODE_VECTOR;
 
@@ -346,7 +346,7 @@ namespace cytnx {
       cudaDataType cuda_data_typeR = CUDA_R_32F;
 
       cusolverEigMode_t jobz;
-      // if U and vT are nullptr, then it will not be computed.
+      // if U and vT are void, then it will not be computed.
       jobz = (U->dtype() == Type.Void and vT->dtype() == Type.Void) ? CUSOLVER_EIG_MODE_NOVECTOR
                                                                     : CUSOLVER_EIG_MODE_VECTOR;
 

--- a/src/backend/linalg_internal_gpu/cuTensordot_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTensordot_internal.cu
@@ -113,17 +113,17 @@ namespace cytnx {
       cytnx_uint64 defaultAlignment = 256;
       cutensorTensorDescriptor_t descL;
       HANDLE_ERROR(cutensorCreateTensorDescriptor(handle, &descL, nlabelL, extentL.data(),
-                                                  NULL, /*stride*/
+                                                  nullptr, /*stride*/
                                                   type, defaultAlignment));
 
       cutensorTensorDescriptor_t descR;
       HANDLE_ERROR(cutensorCreateTensorDescriptor(handle, &descR, nlabelR, extentR.data(),
-                                                  NULL, /*stride*/
+                                                  nullptr, /*stride*/
                                                   type, defaultAlignment));
 
       cutensorTensorDescriptor_t descOut;
       HANDLE_ERROR(cutensorCreateTensorDescriptor(handle, &descOut, nlabelOut, extentOut.data(),
-                                                  NULL, /*stride*/
+                                                  nullptr, /*stride*/
                                                   type, defaultAlignment));
 
       /*******************************

--- a/src/backend/linalg_internal_gpu/cuVectordot_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuVectordot_internal.cu
@@ -12,7 +12,7 @@ namespace cytnx {
                                  const boost::intrusive_ptr<Storage_base> &Lin,
                                  const boost::intrusive_ptr<Storage_base> &Rin,
                                  const unsigned long long &len, const bool &is_conj) {
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
 
       cuDoubleComplex *_out = (cuDoubleComplex *)out->data();
@@ -71,7 +71,7 @@ namespace cytnx {
                                  const boost::intrusive_ptr<Storage_base> &Lin,
                                  const boost::intrusive_ptr<Storage_base> &Rin,
                                  const unsigned long long &len, const bool &is_conj) {
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
 
       cuFloatComplex *_out = (cuFloatComplex *)out->data();
@@ -130,7 +130,7 @@ namespace cytnx {
                                 const boost::intrusive_ptr<Storage_base> &Lin,
                                 const boost::intrusive_ptr<Storage_base> &Rin,
                                 const unsigned long long &len, const bool &is_conj) {
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
 
       cytnx_double *_out = (cytnx_double *)out->data();
@@ -184,7 +184,7 @@ namespace cytnx {
                                 const boost::intrusive_ptr<Storage_base> &Lin,
                                 const boost::intrusive_ptr<Storage_base> &Rin,
                                 const unsigned long long &len, const bool &is_conj) {
-      cublasHandle_t cublasH = NULL;
+      cublasHandle_t cublasH = nullptr;
       checkCudaErrors(cublasCreate(&cublasH));
 
       cytnx_float *_out = (cytnx_float *)out->data();

--- a/src/backend/linalg_internal_interface.cpp
+++ b/src/backend/linalg_internal_interface.cpp
@@ -227,7 +227,7 @@ namespace cytnx {
       Trace_ii[Type.Bool] = Trace_internal_b;
 
       //================
-      Outer_ii = vector<vector<Outerfunc_oii>>(N_Type, vector<Outerfunc_oii>(N_Type, NULL));
+      Outer_ii = vector<vector<Outerfunc_oii>>(N_Type, vector<Outerfunc_oii>(N_Type, nullptr));
 
       Outer_ii[Type.ComplexDouble][Type.ComplexDouble] = Outer_internal_cdtcd;
       Outer_ii[Type.ComplexDouble][Type.ComplexFloat] = Outer_internal_cdtcf;
@@ -720,7 +720,7 @@ namespace cytnx {
       cuTrace_ii[Type.Bool] = cuTrace_internal_b;
       //================
 
-      cuOuter_ii = vector<vector<Outerfunc_oii>>(N_Type, vector<Outerfunc_oii>(N_Type, NULL));
+      cuOuter_ii = vector<vector<Outerfunc_oii>>(N_Type, vector<Outerfunc_oii>(N_Type, nullptr));
 
       cuOuter_ii[Type.ComplexDouble][Type.ComplexDouble] = cuOuter_internal_cdtcd;
       cuOuter_ii[Type.ComplexDouble][Type.ComplexFloat] = cuOuter_internal_cdtcf;

--- a/src/backend/random_internal_interface.cpp
+++ b/src/backend/random_internal_interface.cpp
@@ -7,27 +7,27 @@ namespace cytnx {
 
     random_internal_interface::random_internal_interface() {
       /// function signature.
-      Normal = vector<Rnd_io>(N_fType, NULL);
+      Normal = vector<Rnd_io>(N_fType, nullptr);
       Normal[Type.ComplexDouble] = Rng_normal_cpu_cd;
       Normal[Type.ComplexFloat] = Rng_normal_cpu_cf;
       Normal[Type.Double] = Rng_normal_cpu_d;
       Normal[Type.Float] = Rng_normal_cpu_f;
 
       /// function signature.
-      Uniform = vector<Rnd_io>(N_fType, NULL);
+      Uniform = vector<Rnd_io>(N_fType, nullptr);
       Uniform[Type.ComplexDouble] = Rng_uniform_cpu_cd;
       Uniform[Type.ComplexFloat] = Rng_uniform_cpu_cf;
       Uniform[Type.Double] = Rng_uniform_cpu_d;
       Uniform[Type.Float] = Rng_uniform_cpu_f;
 
 #ifdef UNI_GPU
-      cuNormal = vector<Rnd_io>(N_fType, NULL);
+      cuNormal = vector<Rnd_io>(N_fType, nullptr);
       cuNormal[Type.ComplexDouble] = cuRng_normal_cd;
       cuNormal[Type.ComplexFloat] = cuRng_normal_cf;
       cuNormal[Type.Double] = cuRng_normal_d;
       cuNormal[Type.Float] = cuRng_normal_f;
 
-      cuUniform = vector<Rnd_io>(N_fType, NULL);
+      cuUniform = vector<Rnd_io>(N_fType, nullptr);
       cuUniform[Type.ComplexDouble] = cuRng_uniform_cd;
       cuUniform[Type.ComplexFloat] = cuRng_uniform_cf;
       cuUniform[Type.Double] = cuRng_uniform_d;

--- a/src/backend/utils_internal_cpu/Alloc_cpu.cpp
+++ b/src/backend/utils_internal_cpu/Alloc_cpu.cpp
@@ -6,14 +6,14 @@ namespace cytnx {
   namespace utils_internal {
     void* Calloc_cpu(const cytnx_uint64& N, const cytnx_uint64& perelem_bytes) {
       void* tmp = calloc(N, perelem_bytes);
-      cytnx_error_msg(((tmp == NULL) && (N > 0)), "[ERROR][calloc] Memory allocation failed.%s",
+      cytnx_error_msg(((tmp == nullptr) && (N > 0)), "[ERROR][calloc] Memory allocation failed.%s",
                       "\n");
       return tmp;
     }
     void* Malloc_cpu(const cytnx_uint64& bytes) {
       void* tmp = malloc(bytes);
-      cytnx_error_msg(((tmp == NULL) && (bytes > 0)), "[ERROR][malloc] Memory allocation failed.%s",
-                      "\n");
+      cytnx_error_msg(((tmp == nullptr) && (bytes > 0)),
+                      "[ERROR][malloc] Memory allocation failed.%s", "\n");
       return tmp;
     }
   }  // namespace utils_internal

--- a/src/backend/utils_internal_cpu/Movemem_cpu.cpp
+++ b/src/backend/utils_internal_cpu/Movemem_cpu.cpp
@@ -108,8 +108,8 @@ namespace cytnx {
       if (in->size() > 64) {
         std::vector<int> perm(mapper.begin(), mapper.end());
         std::vector<int> size(old_shape.begin(), old_shape.end());
-        auto plan = hptt::create_plan(&perm[0], perm.size(), 1, src, &size[0], NULL, 0, des, NULL,
-                                      hptt::ESTIMATE, cytnx::Device.Ncpus, nullptr, true);
+        auto plan = hptt::create_plan(&perm[0], perm.size(), 1, src, &size[0], nullptr, 0, des,
+                                      nullptr, hptt::ESTIMATE, cytnx::Device.Ncpus, nullptr, true);
         plan->execute();
         accu_old = in->size();
       } else {

--- a/src/backend/utils_internal_gpu/cuMovemem_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuMovemem_gpu.cu
@@ -242,12 +242,12 @@ namespace cytnx {
       cytnx_uint64 defaultAlignment = 256;
       cutensorTensorDescriptor_t descA;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descA, size.size(), size.data(),
-                                                     NULL /* stride */, cutensor_data_type,
+                                                     nullptr /* stride */, cutensor_data_type,
                                                      defaultAlignment));
 
       cutensorTensorDescriptor_t descC;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descC, new_size.size(),
-                                                     new_size.data(), NULL /* stride */,
+                                                     new_size.data(), nullptr /* stride */,
                                                      cutensor_data_type, defaultAlignment));
       cutensorOperationDescriptor_t desc;
       checkCudaErrors(cutensorCreatePermutation(handle, &desc, descA, ori.data(),

--- a/src/backend/utils_internal_gpu/cuTNPerm_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuTNPerm_gpu.cu
@@ -56,12 +56,12 @@ namespace cytnx {
       cytnx_uint64 defaultAlignment = 256;
       cutensorTensorDescriptor_t descA;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descA, size.size(), size.data(),
-                                                     NULL /* stride */, CUTENSOR_C_64F,
+                                                     nullptr /* stride */, CUTENSOR_C_64F,
                                                      defaultAlignment));
 
       cutensorTensorDescriptor_t descC;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descC, new_size.size(),
-                                                     new_size.data(), NULL /* stride */,
+                                                     new_size.data(), nullptr /* stride */,
                                                      CUTENSOR_C_64F, defaultAlignment));
       cutensorOperationDescriptor_t desc;
       checkCudaErrors(cutensorCreatePermutation(handle, &desc, descA, ori.data(),
@@ -194,12 +194,12 @@ namespace cytnx {
       cytnx_uint64 defaultAlignment = 256;
       cutensorTensorDescriptor_t descA;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descA, size.size(), size.data(),
-                                                     NULL /* stride */, CUTENSOR_C_32F,
+                                                     nullptr /* stride */, CUTENSOR_C_32F,
                                                      defaultAlignment));
 
       cutensorTensorDescriptor_t descC;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descC, new_size.size(),
-                                                     new_size.data(), NULL /* stride */,
+                                                     new_size.data(), nullptr /* stride */,
                                                      CUTENSOR_C_32F, defaultAlignment));
       cutensorOperationDescriptor_t desc;
       checkCudaErrors(cutensorCreatePermutation(handle, &desc, descA, ori.data(),
@@ -331,12 +331,12 @@ namespace cytnx {
       cytnx_uint64 defaultAlignment = 256;
       cutensorTensorDescriptor_t descA;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descA, size.size(), size.data(),
-                                                     NULL /* stride */, CUTENSOR_R_64I,
+                                                     nullptr /* stride */, CUTENSOR_R_64I,
                                                      defaultAlignment));
 
       cutensorTensorDescriptor_t descC;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descC, new_size.size(),
-                                                     new_size.data(), NULL /* stride */,
+                                                     new_size.data(), nullptr /* stride */,
                                                      CUTENSOR_R_64I, defaultAlignment));
       cutensorOperationDescriptor_t desc;
       checkCudaErrors(cutensorCreatePermutation(handle, &desc, descA, ori.data(),
@@ -469,12 +469,12 @@ namespace cytnx {
       cytnx_uint64 defaultAlignment = 256;
       cutensorTensorDescriptor_t descA;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descA, size.size(), size.data(),
-                                                     NULL /* stride */, CUTENSOR_R_32F,
+                                                     nullptr /* stride */, CUTENSOR_R_32F,
                                                      defaultAlignment));
 
       cutensorTensorDescriptor_t descC;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descC, new_size.size(),
-                                                     new_size.data(), NULL /* stride */,
+                                                     new_size.data(), nullptr /* stride */,
                                                      CUTENSOR_R_32F, defaultAlignment));
       cutensorOperationDescriptor_t desc;
       checkCudaErrors(cutensorCreatePermutation(handle, &desc, descA, ori.data(),
@@ -604,12 +604,12 @@ namespace cytnx {
       cytnx_uint64 defaultAlignment = 256;
       cutensorTensorDescriptor_t descA;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descA, size.size(), size.data(),
-                                                     NULL /* stride */, CUTENSOR_R_64F,
+                                                     nullptr /* stride */, CUTENSOR_R_64F,
                                                      defaultAlignment));
 
       cutensorTensorDescriptor_t descC;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descC, new_size.size(),
-                                                     new_size.data(), NULL /* stride */,
+                                                     new_size.data(), nullptr /* stride */,
                                                      CUTENSOR_R_64F, defaultAlignment));
       cutensorOperationDescriptor_t desc;
       checkCudaErrors(cutensorCreatePermutation(handle, &desc, descA, ori.data(),
@@ -738,12 +738,12 @@ namespace cytnx {
       cytnx_uint64 defaultAlignment = 256;
       cutensorTensorDescriptor_t descA;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descA, size.size(), size.data(),
-                                                     NULL /* stride */, CUTENSOR_R_64U,
+                                                     nullptr /* stride */, CUTENSOR_R_64U,
                                                      defaultAlignment));
 
       cutensorTensorDescriptor_t descC;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descC, new_size.size(),
-                                                     new_size.data(), NULL /* stride */,
+                                                     new_size.data(), nullptr /* stride */,
                                                      CUTENSOR_R_64U, defaultAlignment));
       cutensorOperationDescriptor_t desc;
       checkCudaErrors(cutensorCreatePermutation(handle, &desc, descA, ori.data(),
@@ -872,12 +872,12 @@ namespace cytnx {
       cytnx_uint64 defaultAlignment = 256;
       cutensorTensorDescriptor_t descA;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descA, size.size(), size.data(),
-                                                     NULL /* stride */, CUTENSOR_R_32I,
+                                                     nullptr /* stride */, CUTENSOR_R_32I,
                                                      defaultAlignment));
 
       cutensorTensorDescriptor_t descC;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descC, new_size.size(),
-                                                     new_size.data(), NULL /* stride */,
+                                                     new_size.data(), nullptr /* stride */,
                                                      CUTENSOR_R_32I, defaultAlignment));
       cutensorOperationDescriptor_t desc;
       checkCudaErrors(cutensorCreatePermutation(handle, &desc, descA, ori.data(),
@@ -1008,12 +1008,12 @@ namespace cytnx {
       cytnx_uint64 defaultAlignment = 256;
       cutensorTensorDescriptor_t descA;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descA, size.size(), size.data(),
-                                                     NULL /* stride */, CUTENSOR_R_32U,
+                                                     nullptr /* stride */, CUTENSOR_R_32U,
                                                      defaultAlignment));
 
       cutensorTensorDescriptor_t descC;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descC, new_size.size(),
-                                                     new_size.data(), NULL /* stride */,
+                                                     new_size.data(), nullptr /* stride */,
                                                      CUTENSOR_R_32U, defaultAlignment));
       cutensorOperationDescriptor_t desc;
       checkCudaErrors(cutensorCreatePermutation(handle, &desc, descA, ori.data(),
@@ -1142,12 +1142,12 @@ namespace cytnx {
       cytnx_uint64 defaultAlignment = 256;
       cutensorTensorDescriptor_t descA;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descA, size.size(), size.data(),
-                                                     NULL /* stride */, CUTENSOR_R_16U,
+                                                     nullptr /* stride */, CUTENSOR_R_16U,
                                                      defaultAlignment));
 
       cutensorTensorDescriptor_t descC;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descC, new_size.size(),
-                                                     new_size.data(), NULL /* stride */,
+                                                     new_size.data(), nullptr /* stride */,
                                                      CUTENSOR_R_16U, defaultAlignment));
       cutensorOperationDescriptor_t desc;
       checkCudaErrors(cutensorCreatePermutation(handle, &desc, descA, ori.data(),
@@ -1275,12 +1275,12 @@ namespace cytnx {
       cytnx_uint64 defaultAlignment = 256;
       cutensorTensorDescriptor_t descA;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descA, size.size(), size.data(),
-                                                     NULL /* stride */, CUTENSOR_R_16I,
+                                                     nullptr /* stride */, CUTENSOR_R_16I,
                                                      defaultAlignment));
 
       cutensorTensorDescriptor_t descC;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descC, new_size.size(),
-                                                     new_size.data(), NULL /* stride */,
+                                                     new_size.data(), nullptr /* stride */,
                                                      CUTENSOR_R_16I, defaultAlignment));
       cutensorOperationDescriptor_t desc;
       checkCudaErrors(cutensorCreatePermutation(handle, &desc, descA, ori.data(),
@@ -1409,12 +1409,12 @@ namespace cytnx {
       cytnx_uint64 defaultAlignment = 256;
       cutensorTensorDescriptor_t descA;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descA, size.size(), size.data(),
-                                                     NULL /* stride */, CUTENSOR_R_8I,
+                                                     nullptr /* stride */, CUTENSOR_R_8I,
                                                      defaultAlignment));
 
       cutensorTensorDescriptor_t descC;
       checkCudaErrors(cutensorCreateTensorDescriptor(handle, &descC, new_size.size(),
-                                                     new_size.data(), NULL /* stride */,
+                                                     new_size.data(), nullptr /* stride */,
                                                      CUTENSOR_R_8I, defaultAlignment));
       cutensorOperationDescriptor_t desc;
       checkCudaErrors(cutensorCreatePermutation(handle, &desc, descA, ori.data(),

--- a/src/backend/utils_internal_interface.cpp
+++ b/src/backend/utils_internal_interface.cpp
@@ -5,7 +5,7 @@ namespace cytnx {
   namespace utils_internal {
 
     utils_internal_interface::utils_internal_interface() {
-      blocks_mvelems_ii.resize(N_Type, NULL);
+      blocks_mvelems_ii.resize(N_Type, nullptr);
       // blocks_mvelems_ii[Type.ComplexDouble] = blocks_mvelems_cd;
       // blocks_mvelems_ii[Type.ComplexFloat ] = blocks_mvelems_cf;
       blocks_mvelems_ii[Type.Double] = blocks_mvelems_d;
@@ -17,7 +17,7 @@ namespace cytnx {
       // blocks_mvelems_ii[Type.Uint16       ] = blocks_mvelems_u16;
       // blocks_mvelems_ii[Type.Int16        ] = blocks_mvelems_i16;
       // blocks_mvelems_ii[Type.Bool         ] = blocks_mvelems_b;
-      ElemCast = vector<vector<ElemCast_io>>(N_Type, vector<ElemCast_io>(N_Type, NULL));
+      ElemCast = vector<vector<ElemCast_io>>(N_Type, vector<ElemCast_io>(N_Type, nullptr));
       ElemCast[Type.ComplexDouble][Type.ComplexDouble] = Cast_cpu_cdtcd;
       ElemCast[Type.ComplexDouble][Type.ComplexFloat] = Cast_cpu_cdtcf;
       // ElemCast[Type.ComplexDouble][Type.Double       ] = Cast_cpu_invalid;
@@ -151,7 +151,7 @@ namespace cytnx {
       ElemCast[Type.Bool][Type.Bool] = Cast_cpu_btb;
 
       //
-      SetArange_ii.resize(N_Type, NULL);
+      SetArange_ii.resize(N_Type, nullptr);
       SetArange_ii[Type.ComplexDouble] = SetArange_cpu_cd;
       SetArange_ii[Type.ComplexFloat] = SetArange_cpu_cf;
       SetArange_ii[Type.Double] = SetArange_cpu_d;
@@ -165,7 +165,7 @@ namespace cytnx {
       SetArange_ii[Type.Bool] = SetArange_cpu_b;
 
       //
-      GetElems_ii.resize(N_Type, NULL);
+      GetElems_ii.resize(N_Type, nullptr);
       GetElems_ii[Type.ComplexDouble] = GetElems_cpu_cd;
       GetElems_ii[Type.ComplexFloat] = GetElems_cpu_cf;
       GetElems_ii[Type.Double] = GetElems_cpu_d;
@@ -179,7 +179,7 @@ namespace cytnx {
       GetElems_ii[Type.Bool] = GetElems_cpu_b;
 
       //
-      GetElems_conti_ii.resize(N_Type, NULL);
+      GetElems_conti_ii.resize(N_Type, nullptr);
       GetElems_conti_ii[Type.ComplexDouble] = GetElems_contiguous_cpu_cd;
       GetElems_conti_ii[Type.ComplexFloat] = GetElems_contiguous_cpu_cf;
       GetElems_conti_ii[Type.Double] = GetElems_contiguous_cpu_d;
@@ -193,7 +193,7 @@ namespace cytnx {
       GetElems_conti_ii[Type.Bool] = GetElems_contiguous_cpu_b;
 
       //
-      SetElems_ii = vector<vector<SetElems_io>>(N_Type, vector<SetElems_io>(N_Type, NULL));
+      SetElems_ii = vector<vector<SetElems_io>>(N_Type, vector<SetElems_io>(N_Type, nullptr));
       SetElems_ii[Type.ComplexDouble][Type.ComplexDouble] = SetElems_cpu_cdtcd;
       SetElems_ii[Type.ComplexDouble][Type.ComplexFloat] = SetElems_cpu_cdtcf;
       // SetElems_ii[Type.ComplexDouble][Type.Double       ] = SetElems_cpu_invalid;
@@ -321,7 +321,7 @@ namespace cytnx {
       SetElems_ii[Type.Bool][Type.Bool] = SetElems_cpu_btb;
 
       SetElems_conti_ii =
-        vector<vector<SetElems_conti_io>>(N_Type, vector<SetElems_conti_io>(N_Type, NULL));
+        vector<vector<SetElems_conti_io>>(N_Type, vector<SetElems_conti_io>(N_Type, nullptr));
       SetElems_conti_ii[Type.ComplexDouble][Type.ComplexDouble] = SetElems_conti_cpu_cdtcd;
       SetElems_conti_ii[Type.ComplexDouble][Type.ComplexFloat] = SetElems_conti_cpu_cdtcf;
       // SetElems_conti_ii[Type.ComplexDouble][Type.Double       ] = SetElems_conti_cpu_invalid;
@@ -449,7 +449,7 @@ namespace cytnx {
       SetElems_conti_ii[Type.Bool][Type.Bool] = SetElems_conti_cpu_btb;
 
 #ifdef UNI_GPU
-      cuElemCast = vector<vector<ElemCast_io>>(N_Type, vector<ElemCast_io>(N_Type, NULL));
+      cuElemCast = vector<vector<ElemCast_io>>(N_Type, vector<ElemCast_io>(N_Type, nullptr));
 
       cuElemCast[Type.ComplexDouble][Type.ComplexDouble] = cuCast_gpu_cdtcd;
       cuElemCast[Type.ComplexDouble][Type.ComplexFloat] = cuCast_gpu_cdtcf;
@@ -577,7 +577,7 @@ namespace cytnx {
       cuElemCast[Type.Bool][Type.Uint16] = cuCast_gpu_btu16;
       cuElemCast[Type.Bool][Type.Bool] = cuCast_gpu_btb;
 
-      cuSetArange_ii.resize(N_Type, NULL);
+      cuSetArange_ii.resize(N_Type, nullptr);
       cuSetArange_ii[Type.ComplexDouble] = cuSetArange_gpu_cd;
       cuSetArange_ii[Type.ComplexFloat] = cuSetArange_gpu_cf;
       cuSetArange_ii[Type.Double] = cuSetArange_gpu_d;
@@ -590,7 +590,7 @@ namespace cytnx {
       cuSetArange_ii[Type.Int16] = cuSetArange_gpu_i16;
       cuSetArange_ii[Type.Bool] = cuSetArange_gpu_b;
 
-      cuGetElems_ii.resize(N_Type, NULL);
+      cuGetElems_ii.resize(N_Type, nullptr);
       cuGetElems_ii[Type.ComplexDouble] = cuGetElems_gpu_cd;
       cuGetElems_ii[Type.ComplexFloat] = cuGetElems_gpu_cf;
       cuGetElems_ii[Type.Double] = cuGetElems_gpu_d;
@@ -603,7 +603,7 @@ namespace cytnx {
       cuGetElems_ii[Type.Int16] = cuGetElems_gpu_i16;
       cuGetElems_ii[Type.Bool] = cuGetElems_gpu_b;
 
-      cuGetElems_conti_ii.resize(N_Type, NULL);
+      cuGetElems_conti_ii.resize(N_Type, nullptr);
       cuGetElems_conti_ii[Type.ComplexDouble] = cuGetElems_contiguous_gpu_cd;
       cuGetElems_conti_ii[Type.ComplexFloat] = cuGetElems_contiguous_gpu_cf;
       cuGetElems_conti_ii[Type.Double] = cuGetElems_contiguous_gpu_d;
@@ -617,7 +617,7 @@ namespace cytnx {
       cuGetElems_conti_ii[Type.Bool] = cuGetElems_contiguous_gpu_b;
 
       //
-      cuSetElems_ii = vector<vector<SetElems_io>>(N_Type, vector<SetElems_io>(N_Type, NULL));
+      cuSetElems_ii = vector<vector<SetElems_io>>(N_Type, vector<SetElems_io>(N_Type, nullptr));
       cuSetElems_ii[Type.ComplexDouble][Type.ComplexDouble] = cuSetElems_gpu_cdtcd;
       cuSetElems_ii[Type.ComplexDouble][Type.ComplexFloat] = cuSetElems_gpu_cdtcf;
       // cuSetElems_ii[Type.ComplexDouble][Type.Double       ] = cuSetElems_gpu_invalid;
@@ -746,7 +746,7 @@ namespace cytnx {
 
       //
       cuSetElems_conti_ii =
-        vector<vector<SetElems_conti_io>>(N_Type, vector<SetElems_conti_io>(N_Type, NULL));
+        vector<vector<SetElems_conti_io>>(N_Type, vector<SetElems_conti_io>(N_Type, nullptr));
       cuSetElems_conti_ii[Type.ComplexDouble][Type.ComplexDouble] = cuSetElems_conti_gpu_cdtcd;
       cuSetElems_conti_ii[Type.ComplexDouble][Type.ComplexFloat] = cuSetElems_conti_gpu_cdtcf;
       // cuSetElems_conti_ii[Type.ComplexDouble][Type.Double       ] = cuSetElems_conti_gpu_invalid;

--- a/src/utils/cutensornet.cu
+++ b/src/utils/cutensornet.cu
@@ -176,7 +176,7 @@ namespace cytnx {
         tmp_extents[idx][j] = uts[idx].shape()[numModesIn[idx] - 1 - j];
       }
       extentsIn[idx] = tmp_extents[idx].data();
-      stridesIn[idx] = NULL;
+      stridesIn[idx] = nullptr;
     }
   }
 
@@ -282,8 +282,8 @@ namespace cytnx {
     HANDLE_ERROR(cutensornetCreateNetworkDescriptor(
       (const cutensornetHandle_t)handle, numInputs, (const int32_t *)numModesIn.data(),
       (const int64_t **)extentsIn.data(), (const int64_t **)stridesIn.data(),
-      (const int32_t **)modesIn.data(), NULL, nmodeR, (const int64_t *)extentR.data(),
-      /*stridesOut = */ NULL, (const int32_t *)modesR.data(), typeData, typeCompute, &descNet));
+      (const int32_t **)modesIn.data(), nullptr, nmodeR, (const int64_t *)extentR.data(),
+      /*stridesOut = */ nullptr, (const int32_t *)modesR.data(), typeData, typeCompute, &descNet));
     if (verbose)
       printf("Initialized the cuTensorNet library and created a tensor network descriptor\n");
     return descNet;
@@ -389,7 +389,7 @@ namespace cytnx {
     // HANDLE_CUDA_ERROR(cudaStreamSynchronize(stream));
     HANDLE_ERROR(cutensornetContractSlices(
       handle, plan, rawDataIn_d.data(), R_d, accumulateOutput, workDesc,
-      sliceGroup,  // alternatively, NULL can also be used to contract over all
+      sliceGroup,  // alternatively, nullptr can also be used to contract over all
                    // slices instead of specifying a sliceGroup object
       stream));
     HANDLE_CUDA_ERROR(cudaStreamSynchronize(stream));


### PR DESCRIPTION
Issue found in #952.

Besides mechanical renaiming:
In `src/backend/linalg_internal_gpu/cuEigh_internal.cu`, the `_cd`/`_cf` variants change the type guard from `if (v != NULL)` to `if (v->dtype() != Type.Void)`. This matches the other variants and truly catches void tensors, while the previous guard never threw.