### PR TITLE
Fix pre-existing clang-format violations in linalg_internal_interface.cpp

### DIFF
--- a/src/backend/linalg_internal_interface.cpp
+++ b/src/backend/linalg_internal_interface.cpp
@@ -225,8 +225,8 @@ namespace cytnx {
       Trace_ii[Type.Bool] = Trace_internal_b;
 
       //================
-      Outer_ii =
-        std::vector<std::vector<Outerfunc_oii>>(N_Type, std::vector<Outerfunc_oii>(N_Type, nullptr));
+      Outer_ii = std::vector<std::vector<Outerfunc_oii>>(
+        N_Type, std::vector<Outerfunc_oii>(N_Type, nullptr));
 
       Outer_ii[Type.ComplexDouble][Type.ComplexDouble] = Outer_internal_cdtcd;
       Outer_ii[Type.ComplexDouble][Type.ComplexFloat] = Outer_internal_cdtcf;
@@ -720,8 +720,8 @@ namespace cytnx {
       cuTrace_ii[Type.Bool] = cuTrace_internal_b;
       //================
 
-      cuOuter_ii =
-        std::vector<std::vector<Outerfunc_oii>>(N_Type, std::vector<Outerfunc_oii>(N_Type, nullptr));
+      cuOuter_ii = std::vector<std::vector<Outerfunc_oii>>(
+        N_Type, std::vector<Outerfunc_oii>(N_Type, nullptr));
 
       cuOuter_ii[Type.ComplexDouble][Type.ComplexDouble] = cuOuter_internal_cdtcd;
       cuOuter_ii[Type.ComplexDouble][Type.ComplexFloat] = cuOuter_internal_cdtcf;


### PR DESCRIPTION
## Summary

- Reflow the `Outer_ii` and `cuOuter_ii` assignment expressions in `src/backend/linalg_internal_interface.cpp` (lines 228-229 and 723-724) to match `clang-format-14` output, the version pinned by `.github/workflows/clang-format-check.yml`.
- Both expressions previously broke the line right after `=`, leaving a line over the 100-column limit; clang-format-14 instead breaks inside the `std::vector<...>(` argument list.
- No semantic change — confirmed with `git diff --ignore-all-space`, which shows no content differences once line-wrap position is ignored.

## Context

These two violations are pre-existing on `master`. `git blame` traces them to commit `bb2e1b29` ("removed using namespace std; from all src files; added missing std:: prefix"), part of PR #952 ("Remove namespace std", merged into `master`): adding the `std::` prefix to `vector<std::vector<Outerfunc_oii>>(...)` pushed both lines past the formatter's wrap point, and the line break was never re-run through clang-format-14 before merging.

## Test plan

- [x] Verified with `clang-format-14 -style=file -output-replacements-xml` that the file now has zero replacements
- [x] Re-ran the same check across every `.cpp`/`.h`/`.hpp` file under `src/` and `include/` to confirm no other formatting violations are introduced or remain
- [x] Confirmed the diff is whitespace-only via `git diff --ignore-all-space`
