### PR TITLE
fix(tests): compile the test suite warning-clean on AppleClang

### DIFF
--- a/tests/BlockUniTensor_test.cpp
+++ b/tests/BlockUniTensor_test.cpp
@@ -121,9 +121,9 @@ TEST_F(BlockUniTensorTest, is_blockform) {
 }
 TEST_F(BlockUniTensorTest, clone) {
   UniTensor cloned = UT_pB_ans.clone();
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 9; j++)
-      for (cytnx_int64 k = 1; k < 30; k++) {
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 9; j++)
+      for (cytnx_uint64 k = 1; k < 30; k++) {
         EXPECT_EQ(cloned.at({i, j, k}).exists(), UT_pB_ans.at({i, j, k}).exists());
         if (cloned.at({i, j, k}).exists()) EXPECT_EQ(cloned.at({i, j, k}), UT_pB_ans.at({i, j, k}));
       }
@@ -278,9 +278,9 @@ TEST_F(BlockUniTensorTest, permute1) {
   // rank-3 tensor
   std::vector<cytnx_int64> a = {1, 2, 0};
   auto permuted = UT_permute_1.permute(a, -1);
-  for (cytnx_int64 i = 0; i < 10; i++)
-    for (cytnx_int64 j = 0; j < 6; j++)
-      for (cytnx_int64 k = 0; k < 10; k++) {
+  for (cytnx_uint64 i = 0; i < 10; i++)
+    for (cytnx_uint64 j = 0; j < 6; j++)
+      for (cytnx_uint64 k = 0; k < 10; k++) {
         EXPECT_EQ(permuted.at({i, j, k}).exists(), UT_permute_ans1.at({i, j, k}).exists());
         if (permuted.at({i, j, k}).exists())
           EXPECT_EQ(double(permuted.at({i, j, k}).real()),
@@ -292,8 +292,8 @@ TEST_F(BlockUniTensorTest, permute2) {
   std::vector<cytnx_int64> a = {1, 0};
   auto permuted = UT_permute_2.permute(a, -1);
 
-  for (cytnx_int64 j = 0; j < 10; j++)
-    for (cytnx_int64 k = 0; k < 10; k++) {
+  for (cytnx_uint64 j = 0; j < 10; j++)
+    for (cytnx_uint64 k = 0; k < 10; k++) {
       EXPECT_EQ(permuted.at({j, k}).exists(), UT_permute_ans2.at({j, k}).exists());
       if (permuted.at({j, k}).exists())
         EXPECT_EQ(double(permuted.at({j, k}).real()), double(UT_permute_ans2.at({j, k}).real()));
@@ -305,9 +305,9 @@ TEST_F(BlockUniTensorTest, permute_1) {
   std::vector<cytnx_int64> a = {1, 2, 0};
   auto permuted = UT_permute_1.clone();
   permuted.permute_(a, -1);
-  for (cytnx_int64 i = 0; i < 10; i++)
-    for (cytnx_int64 j = 0; j < 6; j++)
-      for (cytnx_int64 k = 0; k < 10; k++) {
+  for (cytnx_uint64 i = 0; i < 10; i++)
+    for (cytnx_uint64 j = 0; j < 6; j++)
+      for (cytnx_uint64 k = 0; k < 10; k++) {
         EXPECT_EQ(permuted.at({i, j, k}).exists(), UT_permute_ans1.at({i, j, k}).exists());
         if (permuted.at({i, j, k}).exists())
           EXPECT_EQ(double(permuted.at({i, j, k}).real()),
@@ -319,8 +319,8 @@ TEST_F(BlockUniTensorTest, permute_2) {
   std::vector<cytnx_int64> a = {1, 0};
   auto permuted = UT_permute_2.clone();
   permuted.permute_(a, -1);
-  for (cytnx_int64 j = 0; j < 10; j++)
-    for (cytnx_int64 k = 0; k < 10; k++) {
+  for (cytnx_uint64 j = 0; j < 10; j++)
+    for (cytnx_uint64 k = 0; k < 10; k++) {
       EXPECT_EQ(permuted.at({j, k}).exists(), UT_permute_ans2.at({j, k}).exists());
       if (permuted.at({j, k}).exists())
         EXPECT_EQ(double(permuted.at({j, k}).real()), double(UT_permute_ans2.at({j, k}).real()));
@@ -441,9 +441,9 @@ TEST_F(BlockUniTensorTest, put_block_byidx) {
   UT_pB.put_block(t1a, 1);
   UT_pB.put_block(t1b, 2);
   UT_pB.put_block(t2, 3);
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 9; j++)
-      for (cytnx_int64 k = 1; k < 30; k++) {
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 9; j++)
+      for (cytnx_uint64 k = 1; k < 30; k++) {
         EXPECT_EQ(UT_pB.at({i, j, k}).exists(), UT_pB_ans.at({i, j, k}).exists());
         if (UT_pB.at({i, j, k}).exists()) EXPECT_EQ(UT_pB.at({i, j, k}), UT_pB_ans.at({i, j, k}));
       }
@@ -466,9 +466,9 @@ TEST_F(BlockUniTensorTest, put_block__byidx) {
   UT_pB.put_block_(t1a, 1);
   UT_pB.put_block_(t1b, 2);
   UT_pB.put_block_(t2, 3);
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 9; j++)
-      for (cytnx_int64 k = 1; k < 30; k++) {
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 9; j++)
+      for (cytnx_uint64 k = 1; k < 30; k++) {
         EXPECT_EQ(UT_pB.at({i, j, k}).exists(), UT_pB_ans.at({i, j, k}).exists());
         if (UT_pB.at({i, j, k}).exists()) EXPECT_EQ(UT_pB.at({i, j, k}), UT_pB_ans.at({i, j, k}));
       }
@@ -491,9 +491,9 @@ TEST_F(BlockUniTensorTest, put_block_byqnum) {
   UT_pB.put_block(t1a, {0, 1, 1});
   UT_pB.put_block(t1b, {1, 0, 1});
   UT_pB.put_block(t2, {1, 1, 2});
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 9; j++)
-      for (cytnx_int64 k = 1; k < 30; k++) {
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 9; j++)
+      for (cytnx_uint64 k = 1; k < 30; k++) {
         EXPECT_EQ(UT_pB.at({i, j, k}).exists(), UT_pB_ans.at({i, j, k}).exists());
         if (UT_pB.at({i, j, k}).exists()) EXPECT_EQ(UT_pB.at({i, j, k}), UT_pB_ans.at({i, j, k}));
       }
@@ -516,9 +516,9 @@ TEST_F(BlockUniTensorTest, put_block__byqnum) {
   UT_pB.put_block_(t1a, {0, 1, 1});
   UT_pB.put_block_(t1b, {1, 0, 1});
   UT_pB.put_block_(t2, {1, 1, 2});
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 9; j++)
-      for (cytnx_int64 k = 1; k < 30; k++) {
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 9; j++)
+      for (cytnx_uint64 k = 1; k < 30; k++) {
         EXPECT_EQ(UT_pB.at({i, j, k}).exists(), UT_pB_ans.at({i, j, k}).exists());
         if (UT_pB.at({i, j, k}).exists()) EXPECT_EQ(UT_pB.at({i, j, k}), UT_pB_ans.at({i, j, k}));
       }
@@ -634,10 +634,10 @@ TEST_F(BlockUniTensorTest, Add) {
   //     }
   BUT4 = BUT4.Load(data_dir + "OriginalBUT.cytnx");
   auto out2 = BUT4.Add(BUT4_2);
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 11; j++)
-      for (cytnx_int64 k = 0; k < 3; k++)
-        for (cytnx_int64 l = 0; l < 5; l++)
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 11; j++)
+      for (cytnx_uint64 k = 0; k < 3; k++)
+        for (cytnx_uint64 l = 0; l < 5; l++)
           if (out2.at({i, j, k, l}).exists()) {
             EXPECT_DOUBLE_EQ(double(out2.at({i, j, k, l}).real()),
                              double(BUTpT2.at({i, j, k, l}).real()));
@@ -645,10 +645,10 @@ TEST_F(BlockUniTensorTest, Add) {
                              double(BUTpT2.at({i, j, k, l}).imag()));
           }
   BUT4.Add_(BUT4_2);
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 11; j++)
-      for (cytnx_int64 k = 0; k < 3; k++)
-        for (cytnx_int64 l = 0; l < 5; l++)
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 11; j++)
+      for (cytnx_uint64 k = 0; k < 3; k++)
+        for (cytnx_uint64 l = 0; l < 5; l++)
           if (BUT4.at({i, j, k, l}).exists()) {
             EXPECT_DOUBLE_EQ(double(BUT4.at({i, j, k, l}).real()),
                              double(BUTpT2.at({i, j, k, l}).real()));
@@ -659,10 +659,10 @@ TEST_F(BlockUniTensorTest, Add) {
 
 TEST_F(BlockUniTensorTest, Mul) {
   auto out = BUT4.Mul(9);
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 11; j++)
-      for (cytnx_int64 k = 0; k < 3; k++)
-        for (cytnx_int64 l = 0; l < 5; l++)
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 11; j++)
+      for (cytnx_uint64 k = 0; k < 3; k++)
+        for (cytnx_uint64 l = 0; l < 5; l++)
           if (out.at({i, j, k, l}).exists()) {
             EXPECT_DOUBLE_EQ(double(out.at({i, j, k, l}).real()),
                              double(BUTm9.at({i, j, k, l}).real()));
@@ -670,10 +670,10 @@ TEST_F(BlockUniTensorTest, Mul) {
                              double(BUTm9.at({i, j, k, l}).imag()));
           }
   BUT4.Mul_(9);
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 11; j++)
-      for (cytnx_int64 k = 0; k < 3; k++)
-        for (cytnx_int64 l = 0; l < 5; l++)
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 11; j++)
+      for (cytnx_uint64 k = 0; k < 3; k++)
+        for (cytnx_uint64 l = 0; l < 5; l++)
           if (BUT4.at({i, j, k, l}).exists()) {
             EXPECT_DOUBLE_EQ(double(BUT4.at({i, j, k, l}).real()),
                              double(BUTm9.at({i, j, k, l}).real()));
@@ -705,10 +705,10 @@ TEST_F(BlockUniTensorTest, Sub) {
   //     }
   BUT4 = BUT4.Load(data_dir + "OriginalBUT.cytnx");
   auto out2 = BUT4.Sub(BUT4_2);
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 11; j++)
-      for (cytnx_int64 k = 0; k < 3; k++)
-        for (cytnx_int64 l = 0; l < 5; l++)
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 11; j++)
+      for (cytnx_uint64 k = 0; k < 3; k++)
+        for (cytnx_uint64 l = 0; l < 5; l++)
           if (out2.at({i, j, k, l}).exists()) {
             EXPECT_DOUBLE_EQ(double(out2.at({i, j, k, l}).real()),
                              double(BUTsT2.at({i, j, k, l}).real()));
@@ -716,10 +716,10 @@ TEST_F(BlockUniTensorTest, Sub) {
                              double(BUTsT2.at({i, j, k, l}).imag()));
           }
   BUT4.Sub_(BUT4_2);
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 11; j++)
-      for (cytnx_int64 k = 0; k < 3; k++)
-        for (cytnx_int64 l = 0; l < 5; l++)
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 11; j++)
+      for (cytnx_uint64 k = 0; k < 3; k++)
+        for (cytnx_uint64 l = 0; l < 5; l++)
           if (BUT4.at({i, j, k, l}).exists()) {
             EXPECT_DOUBLE_EQ(double(BUT4.at({i, j, k, l}).real()),
                              double(BUTsT2.at({i, j, k, l}).real()));
@@ -730,10 +730,10 @@ TEST_F(BlockUniTensorTest, Sub) {
 
 TEST_F(BlockUniTensorTest, Div) {
   auto out = BUT4.Div(9);
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 11; j++)
-      for (cytnx_int64 k = 0; k < 3; k++)
-        for (cytnx_int64 l = 0; l < 5; l++)
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 11; j++)
+      for (cytnx_uint64 k = 0; k < 3; k++)
+        for (cytnx_uint64 l = 0; l < 5; l++)
           if (out.at({i, j, k, l}).exists()) {
             EXPECT_DOUBLE_EQ(double(out.at({i, j, k, l}).real()),
                              double(BUTd9.at({i, j, k, l}).real()));
@@ -741,10 +741,10 @@ TEST_F(BlockUniTensorTest, Div) {
                              double(BUTd9.at({i, j, k, l}).imag()));
           }
   BUT4.Div_(9);
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 11; j++)
-      for (cytnx_int64 k = 0; k < 3; k++)
-        for (cytnx_int64 l = 0; l < 5; l++)
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 11; j++)
+      for (cytnx_uint64 k = 0; k < 3; k++)
+        for (cytnx_uint64 l = 0; l < 5; l++)
           if (BUT4.at({i, j, k, l}).exists()) {
             EXPECT_DOUBLE_EQ(double(BUT4.at({i, j, k, l}).real()),
                              double(BUTd9.at({i, j, k, l}).real()));
@@ -803,7 +803,7 @@ TEST_F(BlockUniTensorTest, Norm) {
 
   cytnx_double tmp = double(UT_diag.Norm().at({0}).real());
   cytnx_double ans = 0;
-  for (cytnx_int64 i = 0; i < UT_diag.bonds()[0].qnums().size(); i++) {
+  for (cytnx_uint64 i = 0; i < UT_diag.bonds()[0].qnums().size(); i++) {
     cytnx_uint64 deg = UT_diag.bonds()[0]._impl->_degs[i];
     for (int j = 0; j < deg; j++) ans += (i + 1) * (i + 1);
   }
@@ -824,10 +824,10 @@ TEST_F(BlockUniTensorTest, Inv) {
   tmp.Inv_(clip);  // test inline version
   EXPECT_TRUE(AreEqUniTensor(BUT4.Inv(clip), tmp));
   tmp = BUT4.clone();
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 11; j++)
-      for (cytnx_int64 k = 0; k < 3; k++)
-        for (cytnx_int64 l = 0; l < 5; l++) {
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 11; j++)
+      for (cytnx_uint64 k = 0; k < 3; k++)
+        for (cytnx_uint64 l = 0; l < 5; l++) {
           auto proxy = tmp.at({i, j, k, l});
           if (proxy.exists()) {
             Scalar val = proxy;
@@ -851,10 +851,10 @@ TEST_F(BlockUniTensorTest, Pow) {
   EXPECT_TRUE(AreEqUniTensor(BUT4.Pow(2.3), tmp));
   for (double p = 0.; p < 1.6; p += 0.5) {
     tmp = BUT4.clone();
-    for (cytnx_int64 i = 0; i < 5; i++)
-      for (cytnx_int64 j = 0; j < 11; j++)
-        for (cytnx_int64 k = 0; k < 3; k++)
-          for (cytnx_int64 l = 0; l < 5; l++) {
+    for (cytnx_uint64 i = 0; i < 5; i++)
+      for (cytnx_uint64 j = 0; j < 11; j++)
+        for (cytnx_uint64 k = 0; k < 3; k++)
+          for (cytnx_uint64 l = 0; l < 5; l++) {
             auto proxy = tmp.at({i, j, k, l});
             if (proxy.exists()) {
               Scalar val = proxy;
@@ -868,10 +868,10 @@ TEST_F(BlockUniTensorTest, Pow) {
 
 TEST_F(BlockUniTensorTest, Conj) {
   auto tmp = BUT4.Conj();
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 11; j++)
-      for (cytnx_int64 k = 0; k < 3; k++)
-        for (cytnx_int64 l = 0; l < 5; l++)
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 11; j++)
+      for (cytnx_uint64 k = 0; k < 3; k++)
+        for (cytnx_uint64 l = 0; l < 5; l++)
           if (BUT4.at({i, j, k, l}).exists()) {
             // EXPECT_TRUE(Scalar(tmp.at({i-1,j-1,k-1,l-1})-BUconjT4.at({i-1,j-1,k-1,l-1})).abs()<1e-5);
             EXPECT_DOUBLE_EQ(double(tmp.at({i, j, k, l}).real()),
@@ -881,10 +881,10 @@ TEST_F(BlockUniTensorTest, Conj) {
           }
   tmp = BUT4.clone();
   tmp.Conj_();
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 11; j++)
-      for (cytnx_int64 k = 0; k < 3; k++)
-        for (cytnx_int64 l = 0; l < 5; l++)
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 11; j++)
+      for (cytnx_uint64 k = 0; k < 3; k++)
+        for (cytnx_uint64 l = 0; l < 5; l++)
           if (BUT4.at({i, j, k, l}).exists()) {
             // EXPECT_TRUE(Scalar(BUT4.at({i-1,j-1,k-1,l-1})-BUconjT4.at({i-1,j-1,k-1,l-1})).abs()<1e-5);
             EXPECT_DOUBLE_EQ(double(BUT4.at({i, j, k, l}).real()),
@@ -894,9 +894,9 @@ TEST_F(BlockUniTensorTest, Conj) {
           }
 
   tmp = UT_diag_cplx.Conj();
-  for (cytnx_int64 i = 0; i < UT_diag.bonds()[0].qnums().size(); i++) {
+  for (cytnx_uint64 i = 0; i < UT_diag.bonds()[0].qnums().size(); i++) {
     cytnx_uint64 deg = UT_diag.bonds()[0]._impl->_degs[i];
-    for (cytnx_int64 j = 0; j < deg; j++) {
+    for (cytnx_uint64 j = 0; j < deg; j++) {
       EXPECT_DOUBLE_EQ(double(tmp.get_block_(i).at({j}).real()),
                        double(UT_diag_cplx.get_block_(i).at({j}).real()));
       EXPECT_DOUBLE_EQ(double(tmp.get_block_(i).at({j}).imag()),
@@ -937,8 +937,8 @@ TEST_F(BlockUniTensorTest, Transpose) {
 
 TEST_F(BlockUniTensorTest, Trace) {
   auto tmp = BUT4.Trace(0, 3);
-  for (cytnx_int64 j = 0; j < 11; j++)
-    for (cytnx_int64 k = 0; k < 3; k++)
+  for (cytnx_uint64 j = 0; j < 11; j++)
+    for (cytnx_uint64 k = 0; k < 3; k++)
       if (BUtrT4.at({j, k}).exists()) {
         // EXPECT_TRUE(Scalar(tmp.at({j-1,k-1})-BUtrT4.at({j-1,k-1})).abs()<1e-5);
         EXPECT_DOUBLE_EQ(double(tmp.at({j, k}).real()), double(BUtrT4.at({j, k}).real()));
@@ -946,7 +946,7 @@ TEST_F(BlockUniTensorTest, Trace) {
       }
   tmp = UT_diag.Trace(0, 1);
   cytnx_double ans = 0;
-  for (cytnx_int64 i = 0; i < UT_diag.bonds()[0].qnums().size(); i++) {
+  for (cytnx_uint64 i = 0; i < UT_diag.bonds()[0].qnums().size(); i++) {
     cytnx_uint64 deg = UT_diag.bonds()[0]._impl->_degs[i];
     for (int j = 0; j < deg; j++) ans += i + 1;
   }
@@ -996,10 +996,10 @@ TEST_F(BlockUniTensorTest, Dagger) {
             std::vector<std::vector<cytnx_int64>>({{0, 2}, {1, 5}, {1, 6}, {0, 1}}));
 
   tmp = BUT4.Dagger().set_name("BUT4.Dagger");
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 11; j++)
-      for (cytnx_int64 k = 0; k < 3; k++)
-        for (cytnx_int64 l = 0; l < 5; l++) {
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 11; j++)
+      for (cytnx_uint64 k = 0; k < 3; k++)
+        for (cytnx_uint64 l = 0; l < 5; l++) {
           if (BUT4.at({i, j, k, l}).exists()) {
             EXPECT_DOUBLE_EQ(double(tmp.at({l, k, j, i}).real()),
                              double(BUT4.at({i, j, k, l}).real()));
@@ -1011,10 +1011,10 @@ TEST_F(BlockUniTensorTest, Dagger) {
         }
   tmp = BUT4.clone();
   tmp.Dagger_();
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 11; j++)
-      for (cytnx_int64 k = 0; k < 3; k++)
-        for (cytnx_int64 l = 0; l < 5; l++) {
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 11; j++)
+      for (cytnx_uint64 k = 0; k < 3; k++)
+        for (cytnx_uint64 l = 0; l < 5; l++) {
           if (BUT4.at({i, j, k, l}).exists()) {
             // EXPECT_TRUE(Scalar(BUT4.at({i-1,j-1,k-1,l-1})-BUconjT4.at({i-1,j-1,k-1,l-1})).abs()<1e-5);
             EXPECT_DOUBLE_EQ(double(BUT4.at({i, j, k, l}).real()),
@@ -1031,9 +1031,9 @@ TEST_F(BlockUniTensorTest, Dagger) {
   EXPECT_EQ(tmp.bonds()[0].type(), BD_IN);
   EXPECT_EQ(tmp.bonds()[1].type(), BD_OUT);
   EXPECT_EQ(tmp.bonds()[2].type(), BD_OUT);
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 9; j++)
-      for (cytnx_int64 k = 0; k < 30; k++) {
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 9; j++)
+      for (cytnx_uint64 k = 0; k < 30; k++) {
         if (UT_pB.at({i, j, k}).exists()) {
           EXPECT_DOUBLE_EQ(double(tmp.at({k, j, i}).real()), double(UT_pB.at({i, j, k}).real()));
         } else {
@@ -1042,9 +1042,9 @@ TEST_F(BlockUniTensorTest, Dagger) {
       }
 
   tmp = UT_diag_cplx.Dagger();
-  for (cytnx_int64 i = 0; i < UT_diag_cplx.bonds()[0].qnums().size(); i++) {
+  for (cytnx_uint64 i = 0; i < UT_diag_cplx.bonds()[0].qnums().size(); i++) {
     cytnx_uint64 deg = UT_diag_cplx.bonds()[0]._impl->_degs[i];
-    for (cytnx_int64 j = 0; j < deg; j++) {
+    for (cytnx_uint64 j = 0; j < deg; j++) {
       EXPECT_DOUBLE_EQ(double(tmp.get_block_(i).at({j}).real()),
                        double(UT_diag_cplx.get_block_(i).at({j}).real()));
       EXPECT_DOUBLE_EQ(double(tmp.get_block_(i).at({j}).imag()),
@@ -1054,10 +1054,10 @@ TEST_F(BlockUniTensorTest, Dagger) {
 }
 
 TEST_F(BlockUniTensorTest, elem_exist) {
-  for (cytnx_int64 i = 0; i < 5; i++)
-    for (cytnx_int64 j = 0; j < 11; j++)
-      for (cytnx_int64 k = 0; k < 3; k++)
-        for (cytnx_int64 l = 0; l < 5; l++)
+  for (cytnx_uint64 i = 0; i < 5; i++)
+    for (cytnx_uint64 j = 0; j < 11; j++)
+      for (cytnx_uint64 k = 0; k < 3; k++)
+        for (cytnx_uint64 l = 0; l < 5; l++)
           if (BUT4.elem_exists({i, j, k, l})) {
             cytnx_int64 _a;
             std::vector<cytnx_uint64> _b;
@@ -1068,10 +1068,10 @@ TEST_F(BlockUniTensorTest, elem_exist) {
                       0);
           }
 
-  cytnx_int64 offset = 0;
-  for (cytnx_int64 i = 0; i < UT_diag_cplx.bonds()[0].qnums().size(); i++) {
+  cytnx_uint64 offset = 0;
+  for (cytnx_uint64 i = 0; i < UT_diag_cplx.bonds()[0].qnums().size(); i++) {
     cytnx_uint64 deg = UT_diag_cplx.bonds()[0]._impl->_degs[i];
-    for (cytnx_int64 j = 0; j < deg; j++) {
+    for (cytnx_uint64 j = 0; j < deg; j++) {
       EXPECT_TRUE(UT_diag_cplx.elem_exists({offset + j, offset + j}));
       EXPECT_DOUBLE_EQ(double(UT_diag_cplx.at({offset + j, offset + j}).real()), double(i + 1));
       EXPECT_DOUBLE_EQ(double(UT_diag_cplx.at({offset + j, offset + j}).imag()), double(i + 1));

--- a/tests/BlockUniTensor_test.h
+++ b/tests/BlockUniTensor_test.h
@@ -156,7 +156,7 @@ class BlockUniTensorTest : public ::testing::Test {
 
     for (size_t i = 0; i < UT_diag.bonds()[0].qnums().size(); i++) {
       cytnx_uint64 deg = UT_diag.bonds()[0]._impl->_degs[i];
-      UT_diag.get_block_(i).fill(i + 1);
+      UT_diag.get_block_(i).fill(static_cast<cytnx_double>(i + 1));
     }
     using namespace std::complex_literals;
     for (size_t i = 0; i < UT_diag_cplx.bonds()[0].qnums().size(); i++) {

--- a/tests/linalg_test/Lanczos_Gnd_test.cpp
+++ b/tests/linalg_test/Lanczos_Gnd_test.cpp
@@ -47,7 +47,8 @@ namespace {
    private:
     UniTensor L_, R_, O_;
     Network net_;
-    std::vector<UniTensor> CreateLRO(const int D, const int d, const int dw) {
+    std::vector<UniTensor> CreateLRO(const cytnx_uint64 D, const cytnx_uint64 d,
+                                     const cytnx_uint64 dw) {
       double low = -1.0, high = 1.0;
       int seed = 0;
       UniTensor L =
@@ -64,7 +65,7 @@ namespace {
       return {L, R, O};
     }
 
-    UniTensor Create_UTinit(const int D, const int d) {
+    UniTensor Create_UTinit(const cytnx_uint64 D, const cytnx_uint64 d) {
       double low = -1.0, high = 1.0;
       int seed = 0;
       UniTensor psi =
@@ -340,7 +341,7 @@ TEST(Lanczos_Ut, err_crit_negative) {
 TEST(Lanczos_Ut, nx_not_match) {
   LinOp op = LinOp("mv", 30);
   double low = -1.0, high = 1.0;
-  int D = 5, d = 2;
+  cytnx_uint64 D = 5, d = 2;
   UniTensor psi = UniTensor::uniform({D, d, D}, low, high);
   try {
     unsigned long long maxiter = 1000;

--- a/tests/linalg_test/Vectordot_test.cpp
+++ b/tests/linalg_test/Vectordot_test.cpp
@@ -20,7 +20,7 @@ namespace {
     auto tmp_mul = linalg::Mul(tmp, r);
     Tensor ans = Tensor({1}, tmp_mul.dtype());
     ans.at({0}) = 0;
-    for (int i = 0; i < len; ++i) {
+    for (cytnx_uint64 i = 0; i < len; ++i) {
       ans += tmp_mul.at({i});
     }
     double tol = (tmp_mul.dtype() == Type.Float || Type.ComplexFloat) ? 1.0e-4 : 1.0e-12;
@@ -30,7 +30,7 @@ namespace {
     return TestTools::AreNearlyEqTensor(ans, out, tol);
   }
 
-  Tensor InitTensor(const int len, const unsigned int dtype, const int seed = 0) {
+  Tensor InitTensor(const cytnx_uint64 len, const unsigned int dtype, const int seed = 0) {
     Tensor t;
     if (Type.is_float(dtype)) {
       double low = -1.0;

--- a/tests/linalg_test/linalg_test.h
+++ b/tests/linalg_test/linalg_test.h
@@ -416,7 +416,7 @@ inline std::vector<std::pair<double, UniTensor>> ferm_dense_lowest(const UniTens
     e.at(comps[i]) = 1.0;
     basis[i] = e;
   }
-  Tensor M = zeros({(cytnx_int64)n, (cytnx_int64)n});
+  Tensor M = zeros({n, n});
   for (cytnx_uint64 c = 0; c < n; c++) {
     UniTensor w = ferm_ada_apply(A, basis[c]);
     for (cytnx_uint64 j = 0; j < n; j++) M.at({j, c}) = ferm_fdot_real(basis[j], w);

--- a/tests/utils/getNconParameter.h
+++ b/tests/utils/getNconParameter.h
@@ -1,4 +1,11 @@
-#include <bits/stdc++.h>
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
 #include "cytnx.hpp"
 
 std::pair<std::vector<cytnx::UniTensor>, std::vector<std::vector<cytnx::cytnx_int64>>>


### PR DESCRIPTION
## Summary

`cmake -DRUN_TESTS=ON` fails to build on macOS because AppleClang treats `-Wc++11-narrowing` as a hard error, while CI's GCC only warns for same-width signed→unsigned narrowing in braced initializer lists. This PR fixes all such sites in the test sources by using the correct unsigned index types (no behavior change — every converted variable counts up from 0 or 1 and is used only as a `vector<cytnx_uint64>` locator/shape element), plus two additional macOS-only compile blockers that surfaced once clang got past its error limit.

Relates to #857 (test-hygiene work).

## Changes

- **tests/BlockUniTensor_test.cpp** — ~99 index-loop counters (and the `offset` accumulator) `cytnx_int64` → `cytnx_uint64`; they feed `at()`, `elem_exists()`, and `_fx_locate_elem()` locators, all of which take `std::vector<cytnx_uint64>`.
- **tests/linalg_test/Lanczos_Gnd_test.cpp** — `CreateLRO`/`Create_UTinit` shape parameters and one local `D, d` pair `int` → `cytnx_uint64` (feed `UniTensor::uniform` shape lists).
- **tests/linalg_test/Vectordot_test.cpp** — `InitTensor` length parameter and its summation loop counter `int` → `cytnx_uint64`.
- **tests/linalg_test/linalg_test.h** — drop wrong-direction `(cytnx_int64)` casts in a `zeros()` shape list; `n` is already `cytnx_uint64` and `zeros` takes `vector<cytnx_uint64>`.
- **tests/BlockUniTensor_test.h** — cast the `fill(i + 1)` argument to `cytnx_double`: on macOS `size_t` is `unsigned long`, which matches none of the nine `fill()` overloads exactly, making the call ambiguous (on Linux `size_t` == `cytnx_uint64`, so CI never sees this).
- **tests/utils/getNconParameter.h** — replace the GCC-internal `<bits/stdc++.h>` umbrella header (absent in AppleClang/libc++) with the standard headers actually used.

## Verification (macOS arm64, AppleClang, `-DRUN_TESTS=ON -DBUILD_PYTHON=OFF -DUSE_MKL=OFF -DUSE_HPTT=OFF -DUSE_CUDA=OFF`)

- Full `test_main` build from a clean configure completes with zero warnings/errors in the test sources.
- Affected suites pass: BlockUniTensorTest 66/66, Vectordot 6/6, NconTest 3/3; full suite excluding ARPACK-dependent families: **982 passed / 4 failed / 23 skipped of 997**.
- The 4 failures (`linalg_Test.BkUt_{Svd,Gesvd}_truncate_return_err_*`) and the segfaults in every `linalg::Lanczos`/`Arnoldi` test (null deref inside ARPACK `dsaupd_`) are pre-existing macOS runtime issues on untouched code paths — previously invisible because the suite never compiled on macOS. They likely deserve their own issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)