### PR TITLE
fix(Tensor): harden reshape validation (multiple -1, 0-dim with -1, strong exception guarantee)

### DIFF
--- a/include/backend/Tensor_impl.hpp
+++ b/include/backend/Tensor_impl.hpp
@@ -254,48 +254,48 @@ namespace cytnx {
     }
 
     void reshape_(const std::vector<cytnx_int64> &new_shape) {
-      if (!this->_contiguous) {
-        this->contiguous_();
-      }
-      // std::vector<cytnx_uint64> result_shape(new_shape.size());
+      // validate the whole request before mutating any member so a throwing
+      // reshape_ leaves the tensor unchanged
       cytnx_uint64 new_N = 1;
       bool has_undetermine = false;
-      unsigned int Udet_id = 0;
-      // this->_shape = vec_cast<cytnx_int64,cytnx_uint64>(new_shape);
-      this->_shape.resize(new_shape.size());
+      cytnx_uint64 Udet_id = 0;
       for (cytnx_uint64 i = 0; i < new_shape.size(); i++) {
-        this->_shape[i] = new_shape[i];
-      }
-      for (int i = 0; i < new_shape.size(); i++) {
         if (new_shape[i] < 0) {
           cytnx_error_msg(
             new_shape[i] != -1, "%s",
             "[ERROR] reshape can only have dimension > 0 and one undetermine rank specify as -1");
-          cytnx_error_msg(
-            has_undetermine, "%s",
-            "[ERROR] reshape can only have dimension > 0 and one undetermine rank specify as -1");
+          cytnx_error_msg(has_undetermine, "%s",
+                          "[ERROR] reshape can have only one dimension specified as -1");
           Udet_id = i;
           has_undetermine = true;
         } else {
           new_N *= new_shape[i];
-          // result_shape[i] = new_shape[i];
         }
       }
 
       if (has_undetermine) {
+        cytnx_error_msg(
+          new_N == 0, "%s",
+          "[ERROR] reshape cannot infer the -1 dimension when another dimension is 0");
         cytnx_error_msg(new_N > this->_storage.size(), "%s",
                         "[ERROR] new shape exceed the total number of elements.");
         cytnx_error_msg(this->_storage.size() % new_N, "%s",
                         "[ERROR] unmatch size when reshape with undetermine dimension");
-        // result_shape[Udet_id] = this->_storage.size() / new_N;
-        this->_shape[Udet_id] = this->_storage.size() / new_N;
       } else {
         cytnx_error_msg(new_N != this->_storage.size(), "%s",
                         "[ERROR] new shape does not match the number of elements.");
       }
 
-      // this->_shape = result_shape;
-      // this->_mapper = std::move(vec_range(new_shape.size()));
+      if (!this->_contiguous) {
+        this->contiguous_();
+      }
+      this->_shape.resize(new_shape.size());
+      for (cytnx_uint64 i = 0; i < new_shape.size(); i++) {
+        this->_shape[i] = new_shape[i];
+      }
+      if (has_undetermine) {
+        this->_shape[Udet_id] = this->_storage.size() / new_N;
+      }
       this->_mapper.resize(new_shape.size());
       vec_range_(this->_mapper, new_shape.size());
       this->_invmapper = this->_mapper;

--- a/include/backend/Tensor_impl.hpp
+++ b/include/backend/Tensor_impl.hpp
@@ -268,14 +268,12 @@ namespace cytnx {
       }
       for (int i = 0; i < new_shape.size(); i++) {
         if (new_shape[i] < 0) {
-          if (new_shape[i] != -1)
-            cytnx_error_msg(
-              new_shape[i] != -1, "%s",
-              "[ERROR] reshape can only have dimension > 0 and one undetermine rank specify as -1");
-          if (has_undetermine)
-            cytnx_error_msg(
-              new_shape[i] != -1, "%s",
-              "[ERROR] reshape can only have dimension > 0 and one undetermine rank specify as -1");
+          cytnx_error_msg(
+            new_shape[i] != -1, "%s",
+            "[ERROR] reshape can only have dimension > 0 and one undetermine rank specify as -1");
+          cytnx_error_msg(
+            has_undetermine, "%s",
+            "[ERROR] reshape can only have dimension > 0 and one undetermine rank specify as -1");
           Udet_id = i;
           has_undetermine = true;
         } else {

--- a/tests/Tensor_test.cpp
+++ b/tests/Tensor_test.cpp
@@ -365,3 +365,13 @@ TEST(Tensor, ItemDtypeMismatchThrows) {
   EXPECT_THROW(t.item<double>(), std::logic_error);
   EXPECT_NO_THROW(t.item<float>());
 }
+
+TEST(Tensor, ReshapeRejectsMultipleUnknownDims) {
+  Tensor t = zeros({12}, Type.Double);
+  EXPECT_THROW(t.reshape({-1, -1}), std::logic_error);
+  EXPECT_THROW(t.reshape_({-1, -1}), std::logic_error);
+  EXPECT_THROW(t.reshape({-2, 6}), std::logic_error);
+  // a single -1 must keep working
+  Tensor r = t.reshape({3, -1});
+  EXPECT_EQ(r.shape(), (std::vector<cytnx_uint64>{3, 4}));
+}

--- a/tests/Tensor_test.cpp
+++ b/tests/Tensor_test.cpp
@@ -375,3 +375,21 @@ TEST(Tensor, ReshapeRejectsMultipleUnknownDims) {
   Tensor r = t.reshape({3, -1});
   EXPECT_EQ(r.shape(), (std::vector<cytnx_uint64>{3, 4}));
 }
+
+TEST(Tensor, ReshapeRejectsZeroDimWithUnknownDim) {
+  Tensor t = zeros({12}, Type.Double);
+  // new_N == 0 previously fed a modulo/division by zero (UB / SIGFPE on x86)
+  EXPECT_THROW(t.reshape({0, -1}), std::logic_error);
+  EXPECT_THROW(t.reshape_({0, -1}), std::logic_error);
+  EXPECT_THROW(t.reshape_({-1, 0}), std::logic_error);
+}
+
+TEST(Tensor, FailedReshapeLeavesShapeUnchanged) {
+  Tensor t = zeros({12}, Type.Double);
+  EXPECT_THROW(t.reshape_({7, 2}), std::logic_error);
+  EXPECT_EQ(t.shape(), (std::vector<cytnx_uint64>{12}));
+  EXPECT_THROW(t.reshape_({5, -1}), std::logic_error);
+  EXPECT_EQ(t.shape(), (std::vector<cytnx_uint64>{12}));
+  EXPECT_THROW(t.reshape_({0, -1}), std::logic_error);
+  EXPECT_EQ(t.shape(), (std::vector<cytnx_uint64>{12}));
+}


### PR DESCRIPTION
## Summary

Two commits hardening `Tensor_impl::reshape_` / `reshape` input validation:

- **Reject multiple `-1` dimensions.** The duplicate-`-1` guard tested `new_shape[i] != -1` (always false inside the negative branch) instead of `has_undetermine`, so `t.reshape({-1, -1})` was silently accepted and left a `-1` in the shape.
- **Guard division by zero for `{0, -1}`-style shapes.** With a `-1` present, the inferred dimension was computed as `storage.size() % new_N` / `/ new_N` where `new_N` is the product of the non-negative dims — a 0-sized dim made `new_N == 0`, i.e. integer division/modulo by zero (UB; SIGFPE on x86). Inferring `-1` alongside a 0-sized dimension is now rejected with a clear error.
- **Strong exception guarantee.** Validation previously ran after `_shape` was already overwritten, so a throwing `reshape_` left the tensor with inconsistent metadata (e.g. shape `{0, 18446744073709551615}` after `reshape_({0, -1})` while the storage still held 12 elements). All checks now run before any member is mutated; a failed reshape leaves the tensor unchanged.
- The duplicate-`-1` error message now says "reshape can have only one dimension specified as -1" instead of reusing the generic message.

## Tests

Three new gtests in `tests/Tensor_test.cpp` (all written red-first):

- `Tensor.ReshapeRejectsMultipleUnknownDims`
- `Tensor.ReshapeRejectsZeroDimWithUnknownDim`
- `Tensor.FailedReshapeLeavesShapeUnchanged`

Full suite on macOS/AppleClang: 1066 passed; the only failures are the 4 pre-existing `linalg_Test.*_return_err_*` SVD-truncate failures tracked in #975 (verified identical without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)