### PR TITLE
fix(linalg): report only actually-dropped values in block SVD return_err

### DIFF
--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -242,6 +242,9 @@ namespace cytnx {
         smidx++;
         Smin = Sall.storage()(smidx);
       }
+      // the per-block scans below keep every value >= Smin, so an exact degeneracy at the
+      // cut is kept entirely; only values strictly below Smin are dropped.
+      smidx = CountDroppedSingularValues(Sall, smidx, Smin);
 
       // traversal each block and truncate!
       UniTensor &S = outCyT[0];
@@ -496,6 +499,14 @@ namespace cytnx {
             if (keep_dim == 0) break;  // this is needed, keep_dim can be 0
             smidx++;
             Smin = Sall.storage()(smidx);
+          }
+          if (keep_dim == 0) {
+            // the err threshold dropped every value in Sall; nothing above the cut is kept
+            smidx = Sshape;
+          } else {
+            // the per-block scans below keep every value >= Smin, so an exact degeneracy at
+            // the cut is kept entirely; only values strictly below Smin are dropped.
+            smidx = CountDroppedSingularValues(Sall, smidx, Smin);
           }
           // handle return_err!
           if (return_err) {

--- a/src/linalg/Svd_truncate.cpp
+++ b/src/linalg/Svd_truncate.cpp
@@ -192,6 +192,9 @@ namespace cytnx {
         smidx++;
         Smin = Sall.storage()(smidx);
       }
+      // the per-block scans below keep every value >= Smin, so an exact degeneracy at the
+      // cut is kept entirely; only values strictly below Smin are dropped.
+      smidx = CountDroppedSingularValues(Sall, smidx, Smin);
 
       // traversal each block and truncate!
       UniTensor &S = outCyT[0];
@@ -444,6 +447,14 @@ namespace cytnx {
             if (keep_dim == 0) break;  // this is needed, keep_dim can be 0
             smidx++;
             Smin = Sall.storage()(smidx);
+          }
+          if (keep_dim == 0) {
+            // the err threshold dropped every value in Sall; nothing above the cut is kept
+            smidx = Sshape;
+          } else {
+            // the per-block scans below keep every value >= Smin, so an exact degeneracy at
+            // the cut is kept entirely; only values strictly below Smin are dropped.
+            smidx = CountDroppedSingularValues(Sall, smidx, Smin);
           }
           // handle return_err!
           if (return_err) {

--- a/src/linalg/block_truncation_helpers.hpp
+++ b/src/linalg/block_truncation_helpers.hpp
@@ -5,6 +5,20 @@
 namespace cytnx {
   namespace linalg {
 
+    // The block truncation keeps every singular value >= Smin (the cut value selected by the
+    // keepdim/err/mindim rules), so an exact degeneracy straddling the cut enlarges the kept
+    // set beyond keepdim (see the degeneracy note in the Svd_truncate documentation). Given
+    // the ascending-sorted Sall and the cut index smidx (with Sall[smidx] == Smin), returns
+    // the number of values strictly below Smin -- the values that are actually dropped --
+    // keeping the return_err output consistent with the enlarged kept set.
+    inline cytnx_uint64 CountDroppedSingularValues(const Tensor &Sall, cytnx_uint64 smidx,
+                                                   const Scalar &Smin) {
+      while (smidx > 0 && !(Sall.storage()(smidx - 1) < Smin)) {
+        --smidx;
+      }
+      return smidx;
+    }
+
     // Returns a UniTensor holding the discarded singular values for the return_err path of
     // block truncated SVD functions (Svd_truncate, Gesvd_truncate).
     //

--- a/tests/linalg_test/linalg_test.cpp
+++ b/tests/linalg_test/linalg_test.cpp
@@ -47,9 +47,17 @@ TEST_F(linalg_Test, BkUt_Svd_truncate_return_err_returns_discarded_values) {
 
   ASSERT_EQ(full.size(), 3);
   ASSERT_EQ(trunc.size(), 4);
-  ASSERT_EQ(trunc[0].shape()[0], 5);
   ASSERT_EQ(all_svals.shape()[0], 400);
-  ASSERT_EQ(trunc[3].shape()[0], all_svals.shape()[0] - trunc[0].shape()[0]);
+  // keepdim may only be exceeded when singular values at the cut are exactly degenerate
+  // (see the degeneracy note on Svd_truncate): every extra kept value must equal the
+  // smallest value required by keepdim.
+  cytnx_uint64 kept = trunc[0].shape()[0];
+  ASSERT_GE(kept, 5);
+  ASSERT_LE(kept, all_svals.shape()[0]);
+  for (cytnx_uint64 j = all_svals.shape()[0] - kept; j < all_svals.shape()[0] - 5; j++) {
+    EXPECT_EQ(all_svals.at({j}), all_svals.at({all_svals.shape()[0] - 5}));
+  }
+  ASSERT_EQ(trunc[3].shape()[0], all_svals.shape()[0] - kept);
 
   for (cytnx_uint64 i = 0; i < trunc[3].shape()[0]; i++) {
     EXPECT_EQ(all_svals.at({trunc[3].shape()[0] - 1 - i}), trunc[3].at({i}));
@@ -63,9 +71,17 @@ TEST_F(linalg_Test, BkUt_Gesvd_truncate_return_err_returns_discarded_values) {
 
   ASSERT_EQ(full.size(), 3);
   ASSERT_EQ(trunc.size(), 4);
-  ASSERT_EQ(trunc[0].shape()[0], 5);
   ASSERT_EQ(all_svals.shape()[0], 400);
-  ASSERT_EQ(trunc[3].shape()[0], all_svals.shape()[0] - trunc[0].shape()[0]);
+  // keepdim may only be exceeded when singular values at the cut are exactly degenerate
+  // (see the degeneracy note on Svd_truncate): every extra kept value must equal the
+  // smallest value required by keepdim.
+  cytnx_uint64 kept = trunc[0].shape()[0];
+  ASSERT_GE(kept, 5);
+  ASSERT_LE(kept, all_svals.shape()[0]);
+  for (cytnx_uint64 j = all_svals.shape()[0] - kept; j < all_svals.shape()[0] - 5; j++) {
+    EXPECT_EQ(all_svals.at({j}), all_svals.at({all_svals.shape()[0] - 5}));
+  }
+  ASSERT_EQ(trunc[3].shape()[0], all_svals.shape()[0] - kept);
 
   for (cytnx_uint64 i = 0; i < trunc[3].shape()[0]; i++) {
     EXPECT_EQ(all_svals.at({trunc[3].shape()[0] - 1 - i}), trunc[3].at({i}));
@@ -80,7 +96,12 @@ TEST_F(linalg_Test, BkUt_Svd_truncate_return_err_one_returns_first_discarded_val
   ASSERT_EQ(full.size(), 3);
   ASSERT_EQ(trunc.size(), 4);
   ASSERT_EQ(trunc[3].shape()[0], 1);
-  EXPECT_EQ(all_svals.at({all_svals.shape()[0] - trunc[0].shape()[0] - 1}), trunc[3].at({0}));
+  // the kept dimension adapts to exact degeneracies at the cut (>= keepdim); the returned
+  // error is the largest singular value that was actually discarded.
+  cytnx_uint64 kept = trunc[0].shape()[0];
+  ASSERT_GE(kept, 5);
+  ASSERT_LT(kept, all_svals.shape()[0]);
+  EXPECT_EQ(all_svals.at({all_svals.shape()[0] - kept - 1}), trunc[3].at({0}));
 }
 
 TEST_F(linalg_Test, BkUt_Gesvd_truncate_return_err_one_returns_first_discarded_value) {
@@ -91,7 +112,12 @@ TEST_F(linalg_Test, BkUt_Gesvd_truncate_return_err_one_returns_first_discarded_v
   ASSERT_EQ(full.size(), 3);
   ASSERT_EQ(trunc.size(), 4);
   ASSERT_EQ(trunc[3].shape()[0], 1);
-  EXPECT_EQ(all_svals.at({all_svals.shape()[0] - trunc[0].shape()[0] - 1}), trunc[3].at({0}));
+  // the kept dimension adapts to exact degeneracies at the cut (>= keepdim); the returned
+  // error is the largest singular value that was actually discarded.
+  cytnx_uint64 kept = trunc[0].shape()[0];
+  ASSERT_GE(kept, 5);
+  ASSERT_LT(kept, all_svals.shape()[0]);
+  EXPECT_EQ(all_svals.at({all_svals.shape()[0] - kept - 1}), trunc[3].at({0}));
 }
 
 /*=====test info=====


### PR DESCRIPTION
Fixes #975.

## Summary

The block `Svd_truncate`/`Gesvd_truncate` keep every singular value `>= Smin`, so an exact (bitwise) degeneracy straddling the truncation cut enlarges the kept set beyond `keepdim` — documented behavior (see the degeneracy note on the `min_blockdim` overload in `include/linalg.hpp`). The `return_err` path, however, built the discarded-values tensor from the cut index computed *before* that enlargement, so when a tie straddled the cut:

- the tied value appeared **both** in the kept `S` and in the discarded list (kept + discarded > total), and
- `return_err == 1` returned a *kept* value as the "largest discarded" one.

This is exactly what the four `BkUt_*_return_err_*` tests tripped over on macOS arm64 + OpenBLAS: the `Svd_truncate1.cytnx` fixture is Float32 with a near-degenerate multiplet at √2, and there the 5th/6th largest singular values come out bitwise equal, so 6 values are (correctly) kept while the tests asserted exactly 5. On Linux CI the tie doesn't materialize, which is the only reason the tests passed there.

## Changes

- Add `CountDroppedSingularValues` to the shared block-truncation helpers: counts only the values strictly below `Smin`, i.e. the ones the per-block scans actually drop. Applied in both the plain and `min_blockdim` variants of `Svd_truncate` and `Gesvd_truncate`.
- In the `min_blockdim` variants, report the full remainder when the `err` threshold drops everything (`keep_dim == 0` break), instead of a stale partial count.
- Re-encode the four `BkUt_*_return_err_*` tests to the documented contract instead of an exact kept count: `kept >= keepdim`, every extra kept value must be bitwise-equal to the smallest required one (so genuine over-keeping still fails), and discarded count == total − kept. On Linux these remain as strict as before (`kept == 5` there).

## Verification

On macOS arm64 (conda-forge OpenBLAS, AppleClang), where all four tests previously failed:

- TDD sequence: tests updated first → still failed, now on the real inconsistency (reported 395 discarded vs 394 actually dropped) → library fix applied → green.
- `linalg_Test.*`: 57/57 pass (includes the four previously failing tests plus the fermionic and no-truncation `return_err` variants).
- `Svd_truncate.*` / `Gesvd_truncate.*` / `Svd.*` / `GeSvd.*` suites: 50/50 pass (covers `min_blockdim` + `return_err`, including the `keep_dim <= 0` edge).
- `Rsvd.*`: 23/23 pass.

Linux behavior is unchanged: the new code path only alters output when a bitwise tie straddles the cut, which does not occur there for this fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)