### PR TITLE
fix(Storage): check dtype in at<T> unconditionally (#965)

### DIFF
--- a/src/backend/Storage_base.cpp
+++ b/src/backend/Storage_base.cpp
@@ -648,11 +648,9 @@ namespace cytnx {
   //====================================================
   template <>
   float &Storage_base::at<float>(const cytnx_uint64 &idx) const {
-    if (cytnx::User_debug) {
-      cytnx_error_msg(this->dtype() != Type.Float,
-                      "[ERROR] type mismatch. try to get <float> type from raw data of type %s",
-                      Type.getname(this->dtype()).c_str());
-    }
+    cytnx_error_msg(this->dtype() != Type.Float,
+                    "[ERROR] type mismatch. try to get <float> type from raw data of type %s",
+                    Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
       cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
 
@@ -664,11 +662,9 @@ namespace cytnx {
 
   template <>
   double &Storage_base::at<double>(const cytnx_uint64 &idx) const {
-    if (cytnx::User_debug) {
-      cytnx_error_msg(this->dtype() != Type.Double,
-                      "[ERROR] type mismatch. try to get <double> type from raw data of type %s",
-                      Type.getname(this->dtype()).c_str());
-    }
+    cytnx_error_msg(this->dtype() != Type.Double,
+                    "[ERROR] type mismatch. try to get <double> type from raw data of type %s",
+                    Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
       cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
 
@@ -680,11 +676,10 @@ namespace cytnx {
 
   template <>
   std::complex<float> &Storage_base::at<std::complex<float>>(const cytnx_uint64 &idx) const {
-    if (cytnx::User_debug)
-      cytnx_error_msg(
-        this->dtype() != Type.ComplexFloat,
-        "[ERROR] type mismatch. try to get < std::complex<float> > type from raw data of type %s",
-        Type.getname(this->dtype()).c_str());
+    cytnx_error_msg(
+      this->dtype() != Type.ComplexFloat,
+      "[ERROR] type mismatch. try to get < std::complex<float> > type from raw data of type %s",
+      Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
       cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
 
@@ -696,11 +691,10 @@ namespace cytnx {
 
   template <>
   std::complex<double> &Storage_base::at<std::complex<double>>(const cytnx_uint64 &idx) const {
-    if (cytnx::User_debug)
-      cytnx_error_msg(
-        this->dtype() != Type.ComplexDouble,
-        "[ERROR] type mismatch. try to get < std::complex<double> > type from raw data of type %s",
-        Type.getname(this->dtype()).c_str());
+    cytnx_error_msg(
+      this->dtype() != Type.ComplexDouble,
+      "[ERROR] type mismatch. try to get < std::complex<double> > type from raw data of type %s",
+      Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
       cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
 
@@ -712,10 +706,9 @@ namespace cytnx {
 
   template <>
   uint32_t &Storage_base::at<uint32_t>(const cytnx_uint64 &idx) const {
-    if (cytnx::User_debug)
-      cytnx_error_msg(this->dtype() != Type.Uint32,
-                      "[ERROR] type mismatch. try to get <uint32_t> type from raw data of type %s",
-                      Type.getname(this->dtype()).c_str());
+    cytnx_error_msg(this->dtype() != Type.Uint32,
+                    "[ERROR] type mismatch. try to get <uint32_t> type from raw data of type %s",
+                    Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
       cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
 
@@ -727,10 +720,9 @@ namespace cytnx {
 
   template <>
   int32_t &Storage_base::at<int32_t>(const cytnx_uint64 &idx) const {
-    if (cytnx::User_debug)
-      cytnx_error_msg(this->dtype() != Type.Int32,
-                      "[ERROR] type mismatch. try to get <int32_t> type from raw data of type %s",
-                      Type.getname(this->dtype()).c_str());
+    cytnx_error_msg(this->dtype() != Type.Int32,
+                    "[ERROR] type mismatch. try to get <int32_t> type from raw data of type %s",
+                    Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
       cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
 
@@ -742,10 +734,9 @@ namespace cytnx {
 
   template <>
   uint64_t &Storage_base::at<uint64_t>(const cytnx_uint64 &idx) const {
-    if (cytnx::User_debug)
-      cytnx_error_msg(this->dtype() != Type.Uint64,
-                      "[ERROR] type mismatch. try to get <uint64_t> type from raw data of type %s",
-                      Type.getname(this->dtype()).c_str());
+    cytnx_error_msg(this->dtype() != Type.Uint64,
+                    "[ERROR] type mismatch. try to get <uint64_t> type from raw data of type %s",
+                    Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
       cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
 
@@ -757,10 +748,9 @@ namespace cytnx {
 
   template <>
   int64_t &Storage_base::at<int64_t>(const cytnx_uint64 &idx) const {
-    if (cytnx::User_debug)
-      cytnx_error_msg(this->dtype() != Type.Int64,
-                      "[ERROR] type mismatch. try to get <int64_t> type from raw data of type %s",
-                      Type.getname(this->dtype()).c_str());
+    cytnx_error_msg(this->dtype() != Type.Int64,
+                    "[ERROR] type mismatch. try to get <int64_t> type from raw data of type %s",
+                    Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
       cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
 
@@ -772,10 +762,9 @@ namespace cytnx {
 
   template <>
   uint16_t &Storage_base::at<uint16_t>(const cytnx_uint64 &idx) const {
-    if (cytnx::User_debug)
-      cytnx_error_msg(this->dtype() != Type.Uint16,
-                      "[ERROR] type mismatch. try to get <uint16_t> type from raw data of type %s",
-                      Type.getname(this->dtype()).c_str());
+    cytnx_error_msg(this->dtype() != Type.Uint16,
+                    "[ERROR] type mismatch. try to get <uint16_t> type from raw data of type %s",
+                    Type.getname(this->dtype()).c_str());
 
     if (idx >= this->size())
       cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
@@ -788,10 +777,9 @@ namespace cytnx {
 
   template <>
   int16_t &Storage_base::at<int16_t>(const cytnx_uint64 &idx) const {
-    if (cytnx::User_debug)
-      cytnx_error_msg(this->dtype() != Type.Int16,
-                      "[ERROR] type mismatch. try to get <int16_t> type from raw data of type %s",
-                      Type.getname(this->dtype()).c_str());
+    cytnx_error_msg(this->dtype() != Type.Int16,
+                    "[ERROR] type mismatch. try to get <int16_t> type from raw data of type %s",
+                    Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
       cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
 
@@ -803,10 +791,9 @@ namespace cytnx {
 
   template <>
   bool &Storage_base::at<bool>(const cytnx_uint64 &idx) const {
-    if (cytnx::User_debug)
-      cytnx_error_msg(this->dtype() != Type.Bool,
-                      "[ERROR] type mismatch. try to get <bool> type from raw data of type %s",
-                      Type.getname(this->dtype()).c_str());
+    cytnx_error_msg(this->dtype() != Type.Bool,
+                    "[ERROR] type mismatch. try to get <bool> type from raw data of type %s",
+                    Type.getname(this->dtype()).c_str());
 
     if (idx >= this->size())
       cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());

--- a/src/backend/Storage_base.cpp
+++ b/src/backend/Storage_base.cpp
@@ -652,7 +652,9 @@ namespace cytnx {
                     "[ERROR] type mismatch. try to get <float> type from raw data of type %s",
                     Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
-      cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
+      cytnx_error_msg(true, "[ERROR] index [%llu] out of bound [%llu]\n",
+                      static_cast<unsigned long long>(idx),
+                      static_cast<unsigned long long>(this->size()));
 
 #ifdef UNI_GPU
     cudaDeviceSynchronize();
@@ -666,7 +668,9 @@ namespace cytnx {
                     "[ERROR] type mismatch. try to get <double> type from raw data of type %s",
                     Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
-      cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
+      cytnx_error_msg(true, "[ERROR] index [%llu] out of bound [%llu]\n",
+                      static_cast<unsigned long long>(idx),
+                      static_cast<unsigned long long>(this->size()));
 
 #ifdef UNI_GPU
     cudaDeviceSynchronize();
@@ -681,7 +685,9 @@ namespace cytnx {
       "[ERROR] type mismatch. try to get < std::complex<float> > type from raw data of type %s",
       Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
-      cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
+      cytnx_error_msg(true, "[ERROR] index [%llu] out of bound [%llu]\n",
+                      static_cast<unsigned long long>(idx),
+                      static_cast<unsigned long long>(this->size()));
 
 #ifdef UNI_GPU
     cudaDeviceSynchronize();
@@ -696,7 +702,9 @@ namespace cytnx {
       "[ERROR] type mismatch. try to get < std::complex<double> > type from raw data of type %s",
       Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
-      cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
+      cytnx_error_msg(true, "[ERROR] index [%llu] out of bound [%llu]\n",
+                      static_cast<unsigned long long>(idx),
+                      static_cast<unsigned long long>(this->size()));
 
 #ifdef UNI_GPU
     cudaDeviceSynchronize();
@@ -710,7 +718,9 @@ namespace cytnx {
                     "[ERROR] type mismatch. try to get <uint32_t> type from raw data of type %s",
                     Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
-      cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
+      cytnx_error_msg(true, "[ERROR] index [%llu] out of bound [%llu]\n",
+                      static_cast<unsigned long long>(idx),
+                      static_cast<unsigned long long>(this->size()));
 
 #ifdef UNI_GPU
     cudaDeviceSynchronize();
@@ -724,7 +734,9 @@ namespace cytnx {
                     "[ERROR] type mismatch. try to get <int32_t> type from raw data of type %s",
                     Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
-      cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
+      cytnx_error_msg(true, "[ERROR] index [%llu] out of bound [%llu]\n",
+                      static_cast<unsigned long long>(idx),
+                      static_cast<unsigned long long>(this->size()));
 
 #ifdef UNI_GPU
     cudaDeviceSynchronize();
@@ -738,7 +750,9 @@ namespace cytnx {
                     "[ERROR] type mismatch. try to get <uint64_t> type from raw data of type %s",
                     Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
-      cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
+      cytnx_error_msg(true, "[ERROR] index [%llu] out of bound [%llu]\n",
+                      static_cast<unsigned long long>(idx),
+                      static_cast<unsigned long long>(this->size()));
 
 #ifdef UNI_GPU
     cudaDeviceSynchronize();
@@ -752,7 +766,9 @@ namespace cytnx {
                     "[ERROR] type mismatch. try to get <int64_t> type from raw data of type %s",
                     Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
-      cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
+      cytnx_error_msg(true, "[ERROR] index [%llu] out of bound [%llu]\n",
+                      static_cast<unsigned long long>(idx),
+                      static_cast<unsigned long long>(this->size()));
 
 #ifdef UNI_GPU
     cudaDeviceSynchronize();
@@ -767,7 +783,9 @@ namespace cytnx {
                     Type.getname(this->dtype()).c_str());
 
     if (idx >= this->size())
-      cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
+      cytnx_error_msg(true, "[ERROR] index [%llu] out of bound [%llu]\n",
+                      static_cast<unsigned long long>(idx),
+                      static_cast<unsigned long long>(this->size()));
 
 #ifdef UNI_GPU
     cudaDeviceSynchronize();
@@ -781,7 +799,9 @@ namespace cytnx {
                     "[ERROR] type mismatch. try to get <int16_t> type from raw data of type %s",
                     Type.getname(this->dtype()).c_str());
     if (idx >= this->size())
-      cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
+      cytnx_error_msg(true, "[ERROR] index [%llu] out of bound [%llu]\n",
+                      static_cast<unsigned long long>(idx),
+                      static_cast<unsigned long long>(this->size()));
 
 #ifdef UNI_GPU
     cudaDeviceSynchronize();
@@ -796,7 +816,9 @@ namespace cytnx {
                     Type.getname(this->dtype()).c_str());
 
     if (idx >= this->size())
-      cytnx_error_msg(true, "[ERROR] index [%d] out of bound [%d]\n", idx, this->size());
+      cytnx_error_msg(true, "[ERROR] index [%llu] out of bound [%llu]\n",
+                      static_cast<unsigned long long>(idx),
+                      static_cast<unsigned long long>(this->size()));
 
 #ifdef UNI_GPU
     cudaDeviceSynchronize();

--- a/tests/DenseUniTensor_test.cpp
+++ b/tests/DenseUniTensor_test.cpp
@@ -1348,10 +1348,10 @@ describe:test at
 ====================*/
 TEST_F(DenseUniTensorTest, at) {
   auto ut_src = UniTensor({Bond(3), Bond(4), Bond(2)});
-  const UniTensor cut = UniTensor({Bond(3), Bond(4), Bond(2)});
   auto loc = std::vector<cytnx_uint64>({0, 1, 0});
   for (auto dtype : dtype_list) {
     auto ut = ut_src.clone();
+    const UniTensor cut = ut_src.clone().astype(dtype);
     switch (dtype) {
       case Type.ComplexDouble: {
         ut = ut.astype(dtype);

--- a/tests/Storage_test.cpp
+++ b/tests/Storage_test.cpp
@@ -313,11 +313,20 @@ TEST_F(StorageTest, AtDtypeMismatchThrows) {
   EXPECT_NO_THROW(s.at<float>(0));
 }
 
+TEST_F(StorageTest, AtOutOfBoundMessageReportsIndexAndSize) {
+  Storage s(4, Type.Double);
+  try {
+    s.at<cytnx_double>(5);
+    FAIL() << "expected out-of-bound access to throw";
+  } catch (const std::logic_error& e) {
+    const std::string msg = e.what();
+    EXPECT_NE(msg.find("[5]"), std::string::npos) << msg;
+    EXPECT_NE(msg.find("[4]"), std::string::npos) << msg;
+  }
+}
+
 TEST_F(StorageTest, AtDtypeMismatchThrowsForAllDtypes) {
-  const std::vector<unsigned int> dtypes = {
-    Type.ComplexDouble, Type.ComplexFloat, Type.Double, Type.Float,  Type.Int64, Type.Uint64,
-    Type.Int32,         Type.Uint32,       Type.Int16,  Type.Uint16, Type.Bool};
-  for (auto dt : dtypes) {
+  for (auto dt : TestTools::dtype_list) {
     Storage s(2, dt);
     const std::string name = Type.getname(dt);
     // Every mismatching at<T> specialization must throw, so that no single

--- a/tests/Storage_test.cpp
+++ b/tests/Storage_test.cpp
@@ -305,3 +305,44 @@ TEST_F(StorageTest, FromfileCountEqualsTotalElementsReadsAll) {
   for (cytnx_uint64 i = 0; i < 4; i++)
     EXPECT_DOUBLE_EQ(loaded_explicit.at<cytnx_double>(i), loaded_default.at<cytnx_double>(i));
 }
+
+TEST_F(StorageTest, AtDtypeMismatchThrows) {
+  Storage s(4, Type.Float);
+  EXPECT_THROW(s.at<double>(0), std::logic_error);
+  EXPECT_THROW(s.at<cytnx_int64>(0), std::logic_error);
+  EXPECT_NO_THROW(s.at<float>(0));
+}
+
+TEST_F(StorageTest, AtDtypeMismatchThrowsForAllDtypes) {
+  const std::vector<unsigned int> dtypes = {
+    Type.ComplexDouble, Type.ComplexFloat, Type.Double, Type.Float,  Type.Int64, Type.Uint64,
+    Type.Int32,         Type.Uint32,       Type.Int16,  Type.Uint16, Type.Bool};
+  for (auto dt : dtypes) {
+    Storage s(2, dt);
+    const std::string name = Type.getname(dt);
+    // Every mismatching at<T> specialization must throw, so that no single
+    // specialization can silently lose its dtype check again.
+    if (dt != Type.ComplexDouble)
+      EXPECT_THROW(s.at<cytnx_complex128>(0), std::logic_error) << "storage dtype " << name;
+    if (dt != Type.ComplexFloat)
+      EXPECT_THROW(s.at<cytnx_complex64>(0), std::logic_error) << "storage dtype " << name;
+    if (dt != Type.Double)
+      EXPECT_THROW(s.at<cytnx_double>(0), std::logic_error) << "storage dtype " << name;
+    if (dt != Type.Float)
+      EXPECT_THROW(s.at<cytnx_float>(0), std::logic_error) << "storage dtype " << name;
+    if (dt != Type.Int64)
+      EXPECT_THROW(s.at<cytnx_int64>(0), std::logic_error) << "storage dtype " << name;
+    if (dt != Type.Uint64)
+      EXPECT_THROW(s.at<cytnx_uint64>(0), std::logic_error) << "storage dtype " << name;
+    if (dt != Type.Int32)
+      EXPECT_THROW(s.at<cytnx_int32>(0), std::logic_error) << "storage dtype " << name;
+    if (dt != Type.Uint32)
+      EXPECT_THROW(s.at<cytnx_uint32>(0), std::logic_error) << "storage dtype " << name;
+    if (dt != Type.Int16)
+      EXPECT_THROW(s.at<cytnx_int16>(0), std::logic_error) << "storage dtype " << name;
+    if (dt != Type.Uint16)
+      EXPECT_THROW(s.at<cytnx_uint16>(0), std::logic_error) << "storage dtype " << name;
+    if (dt != Type.Bool)
+      EXPECT_THROW(s.at<cytnx_bool>(0), std::logic_error) << "storage dtype " << name;
+  }
+}

--- a/tests/Tensor_test.cpp
+++ b/tests/Tensor_test.cpp
@@ -359,3 +359,9 @@ TEST_F(TensorTest, eye) {
 //   EXPECT_FALSE(tar3456.approx_eq(tarcomplex3456));
 //   EXPECT_TRUE(tone3456.approx_eq(tone3456.astype(Type.ComplexFloat), 1e-5));
 // }
+
+TEST(Tensor, ItemDtypeMismatchThrows) {
+  Tensor t = zeros({1}, Type.Float);
+  EXPECT_THROW(t.item<double>(), std::logic_error);
+  EXPECT_NO_THROW(t.item<float>());
+}

--- a/tests/linalg_test/Arnoldi_Ut_test.cpp
+++ b/tests/linalg_test/Arnoldi_Ut_test.cpp
@@ -275,7 +275,7 @@ TEST(Arnoldi_Gnd, Arnoldi_BK_test) {
   std::vector<UniTensor> exact_eigs = linalg::Eig(H.H);
   double lambda = -DBL_MAX;
   for (auto& block : exact_eigs[0].get_blocks_()) {
-    lambda = std::max(lambda, linalg::Max(block).item<double>());
+    lambda = std::max(lambda, double(linalg::Max(block).item().real()));
   }
   std::vector<UniTensor> eigs = linalg::Arnoldi(&H, UT_init, "LM");
   cytnx_double ev = (cytnx_double)eigs[0].get_block_()(0).item().real();


### PR DESCRIPTION
## Summary

Fixes #965.

- **Unconditional dtype check in `Storage_base::at<T>`.** Every `at<T>` specialization wrapped its dtype-mismatch check in `if (cytnx::User_debug)` (default `false`), so e.g. `Tensor({1}, Type.Float).item<double>()` reinterpreted a float buffer as double and returned garbage in normal builds. The checks now run unconditionally, matching `data<T>()` and `back<T>()`, which already checked unconditionally. Mismatched `at<T>`/`item<T>` calls now throw `std::logic_error` instead of silently type-punning.
- **Review follow-up:** the out-of-bound error in the same `at<T>` specializations formatted `cytnx_uint64` index and `unsigned long long` size through `%d` (garbage for values ≥ 2³¹, UB in the formatter) — now `%llu` with explicit casts.

## Test fallout fixed (call sites relying on the old silent behavior)

- `tests/linalg_test/Arnoldi_Ut_test.cpp`: `linalg::Max(block).item<double>()` on `linalg::Eig` output (ComplexDouble) — now reads `.item().real()`.
- `tests/DenseUniTensor_test.cpp` (`at` test): the const `cut` tensor was constructed once with default dtype but read as every dtype in the loop — now cloned per-dtype.

## Tests

- `Storage.AtDtypeMismatchThrows`, `Tensor.ItemDtypeMismatchThrows` — written red-first against the silent-garbage behavior.
- `StorageTest.AtDtypeMismatchThrowsForAllDtypes` — exhaustive 11×11 dtype/T matrix, iterating the shared `TestTools::dtype_list`.
- `StorageTest.AtOutOfBoundMessageReportsIndexAndSize` — pins the bounds-error message content.

Full suite on macOS/AppleClang: 1067 passed; the only failures are the 4 pre-existing `linalg_Test.*_return_err_*` SVD-truncate failures tracked in #975 (verified identical without this change).

A follow-up branch (in progress) consolidates the 11 copy-pasted `at<T>`/`back<T>`/`data<T>` specializations into one template body via `cy_typeid_v<T>` so no future specialization can drop the check again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)