### PR TITLE
fix(Tensor): scalar in-place arithmetic mutates storage in place

### DIFF
--- a/src/Tensor.cpp
+++ b/src/Tensor.cpp
@@ -546,6 +546,25 @@ namespace cytnx {
     return out;
   }
 
+  namespace {
+    // Wrap a scalar as a shape-{1} Tensor on `device` so scalar in-place
+    // arithmetic reuses the iAdd/iSub/iMul/iDiv kernels (which broadcast a
+    // length-1 RHS and mutate LHS storage in place). See #906.
+    template <class T>
+    Tensor _scalar_as_rank1_tensor(const T &rc, const int device) {
+      Tensor s({1}, Type.cy_typeid(rc), Device.cpu);
+      s.storage().at<T>(0) = rc;
+      if (device != Device.cpu) s = s.to(device);
+      return s;
+    }
+    Tensor _scalar_as_rank1_tensor(const Scalar &rc, const int device) {
+      Tensor s({1}, rc.dtype(), Device.cpu);
+      s.item() = rc;  // Sproxy assignment
+      if (device != Device.cpu) s = s.to(device);
+      return s;
+    }
+  }  // namespace
+
   ///@cond
   // +=
   template <>
@@ -560,62 +579,62 @@ namespace cytnx {
   }
   template <>
   Tensor &Tensor::operator+=<cytnx_complex128>(const cytnx_complex128 &rc) {
-    this->_impl->storage() = cytnx::linalg::Add(*this, rc)._impl->storage();
+    cytnx::linalg::iAdd(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator+=<cytnx_complex64>(const cytnx_complex64 &rc) {
-    this->_impl->storage() = cytnx::linalg::Add(*this, rc)._impl->storage();
+    cytnx::linalg::iAdd(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator+=<cytnx_double>(const cytnx_double &rc) {
-    this->_impl->storage() = cytnx::linalg::Add(*this, rc)._impl->storage();
+    cytnx::linalg::iAdd(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator+=<cytnx_float>(const cytnx_float &rc) {
-    this->_impl->storage() = cytnx::linalg::Add(*this, rc)._impl->storage();
+    cytnx::linalg::iAdd(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator+=<cytnx_int64>(const cytnx_int64 &rc) {
-    this->_impl->storage() = cytnx::linalg::Add(*this, rc)._impl->storage();
+    cytnx::linalg::iAdd(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator+=<cytnx_uint64>(const cytnx_uint64 &rc) {
-    this->_impl->storage() = cytnx::linalg::Add(*this, rc)._impl->storage();
+    cytnx::linalg::iAdd(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator+=<cytnx_int32>(const cytnx_int32 &rc) {
-    this->_impl->storage() = cytnx::linalg::Add(*this, rc)._impl->storage();
+    cytnx::linalg::iAdd(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator+=<cytnx_uint32>(const cytnx_uint32 &rc) {
-    this->_impl->storage() = cytnx::linalg::Add(*this, rc)._impl->storage();
+    cytnx::linalg::iAdd(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator+=<cytnx_int16>(const cytnx_int16 &rc) {
-    this->_impl->storage() = cytnx::linalg::Add(*this, rc)._impl->storage();
+    cytnx::linalg::iAdd(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator+=<cytnx_uint16>(const cytnx_uint16 &rc) {
-    this->_impl->storage() = cytnx::linalg::Add(*this, rc)._impl->storage();
+    cytnx::linalg::iAdd(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator+=<cytnx_bool>(const cytnx_bool &rc) {
-    this->_impl->storage() = cytnx::linalg::Add(*this, rc)._impl->storage();
+    cytnx::linalg::iAdd(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator+=<Scalar>(const Scalar &rc) {
-    this->_impl->storage() = cytnx::linalg::Add(*this, rc)._impl->storage();
+    cytnx::linalg::iAdd(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
@@ -635,62 +654,62 @@ namespace cytnx {
   }
   template <>
   Tensor &Tensor::operator-=<cytnx_complex128>(const cytnx_complex128 &rc) {
-    this->_impl->storage() = cytnx::linalg::Sub(*this, rc)._impl->storage();
+    cytnx::linalg::iSub(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator-=<cytnx_complex64>(const cytnx_complex64 &rc) {
-    this->_impl->storage() = cytnx::linalg::Sub(*this, rc)._impl->storage();
+    cytnx::linalg::iSub(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator-=<cytnx_double>(const cytnx_double &rc) {
-    this->_impl->storage() = cytnx::linalg::Sub(*this, rc)._impl->storage();
+    cytnx::linalg::iSub(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator-=<cytnx_float>(const cytnx_float &rc) {
-    this->_impl->storage() = cytnx::linalg::Sub(*this, rc)._impl->storage();
+    cytnx::linalg::iSub(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator-=<cytnx_int64>(const cytnx_int64 &rc) {
-    this->_impl->storage() = cytnx::linalg::Sub(*this, rc)._impl->storage();
+    cytnx::linalg::iSub(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator-=<cytnx_uint64>(const cytnx_uint64 &rc) {
-    this->_impl->storage() = cytnx::linalg::Sub(*this, rc)._impl->storage();
+    cytnx::linalg::iSub(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator-=<cytnx_int32>(const cytnx_int32 &rc) {
-    this->_impl->storage() = cytnx::linalg::Sub(*this, rc)._impl->storage();
+    cytnx::linalg::iSub(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator-=<cytnx_uint32>(const cytnx_uint32 &rc) {
-    this->_impl->storage() = cytnx::linalg::Sub(*this, rc)._impl->storage();
+    cytnx::linalg::iSub(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator-=<cytnx_int16>(const cytnx_int16 &rc) {
-    this->_impl->storage() = cytnx::linalg::Sub(*this, rc)._impl->storage();
+    cytnx::linalg::iSub(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator-=<cytnx_uint16>(const cytnx_uint16 &rc) {
-    this->_impl->storage() = cytnx::linalg::Sub(*this, rc)._impl->storage();
+    cytnx::linalg::iSub(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator-=<cytnx_bool>(const cytnx_bool &rc) {
-    this->_impl->storage() = cytnx::linalg::Sub(*this, rc)._impl->storage();
+    cytnx::linalg::iSub(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator-=<Scalar>(const Scalar &rc) {
-    this->_impl->storage() = cytnx::linalg::Sub(*this, rc)._impl->storage();
+    cytnx::linalg::iSub(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
@@ -710,62 +729,62 @@ namespace cytnx {
   }
   template <>
   Tensor &Tensor::operator*=<cytnx_complex128>(const cytnx_complex128 &rc) {
-    this->_impl->storage() = cytnx::linalg::Mul(*this, rc)._impl->storage();
+    cytnx::linalg::iMul(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator*=<cytnx_complex64>(const cytnx_complex64 &rc) {
-    this->_impl->storage() = cytnx::linalg::Mul(*this, rc)._impl->storage();
+    cytnx::linalg::iMul(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator*=<cytnx_double>(const cytnx_double &rc) {
-    this->_impl->storage() = cytnx::linalg::Mul(*this, rc)._impl->storage();
+    cytnx::linalg::iMul(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator*=<cytnx_float>(const cytnx_float &rc) {
-    this->_impl->storage() = cytnx::linalg::Mul(*this, rc)._impl->storage();
+    cytnx::linalg::iMul(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator*=<cytnx_int64>(const cytnx_int64 &rc) {
-    this->_impl->storage() = cytnx::linalg::Mul(*this, rc)._impl->storage();
+    cytnx::linalg::iMul(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator*=<cytnx_uint64>(const cytnx_uint64 &rc) {
-    this->_impl->storage() = cytnx::linalg::Mul(*this, rc)._impl->storage();
+    cytnx::linalg::iMul(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator*=<cytnx_int32>(const cytnx_int32 &rc) {
-    this->_impl->storage() = cytnx::linalg::Mul(*this, rc)._impl->storage();
+    cytnx::linalg::iMul(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator*=<cytnx_uint32>(const cytnx_uint32 &rc) {
-    this->_impl->storage() = cytnx::linalg::Mul(*this, rc)._impl->storage();
+    cytnx::linalg::iMul(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator*=<cytnx_int16>(const cytnx_int16 &rc) {
-    this->_impl->storage() = cytnx::linalg::Mul(*this, rc)._impl->storage();
+    cytnx::linalg::iMul(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator*=<cytnx_uint16>(const cytnx_uint16 &rc) {
-    this->_impl->storage() = cytnx::linalg::Mul(*this, rc)._impl->storage();
+    cytnx::linalg::iMul(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator*=<cytnx_bool>(const cytnx_bool &rc) {
-    this->_impl->storage() = cytnx::linalg::Mul(*this, rc)._impl->storage();
+    cytnx::linalg::iMul(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator*=<Scalar>(const Scalar &rc) {
-    this->_impl->storage() = cytnx::linalg::Mul(*this, rc)._impl->storage();
+    cytnx::linalg::iMul(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
@@ -786,62 +805,62 @@ namespace cytnx {
   }
   template <>
   Tensor &Tensor::operator/=<cytnx_complex128>(const cytnx_complex128 &rc) {
-    this->_impl->storage() = cytnx::linalg::Div(*this, rc)._impl->storage();
+    cytnx::linalg::iDiv(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator/=<cytnx_complex64>(const cytnx_complex64 &rc) {
-    this->_impl->storage() = cytnx::linalg::Div(*this, rc)._impl->storage();
+    cytnx::linalg::iDiv(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator/=<cytnx_double>(const cytnx_double &rc) {
-    this->_impl->storage() = cytnx::linalg::Div(*this, rc)._impl->storage();
+    cytnx::linalg::iDiv(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator/=<cytnx_float>(const cytnx_float &rc) {
-    this->_impl->storage() = cytnx::linalg::Div(*this, rc)._impl->storage();
+    cytnx::linalg::iDiv(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator/=<cytnx_int64>(const cytnx_int64 &rc) {
-    this->_impl->storage() = cytnx::linalg::Div(*this, rc)._impl->storage();
+    cytnx::linalg::iDiv(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator/=<cytnx_uint64>(const cytnx_uint64 &rc) {
-    this->_impl->storage() = cytnx::linalg::Div(*this, rc)._impl->storage();
+    cytnx::linalg::iDiv(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator/=<cytnx_int32>(const cytnx_int32 &rc) {
-    this->_impl->storage() = cytnx::linalg::Div(*this, rc)._impl->storage();
+    cytnx::linalg::iDiv(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator/=<cytnx_uint32>(const cytnx_uint32 &rc) {
-    this->_impl->storage() = cytnx::linalg::Div(*this, rc)._impl->storage();
+    cytnx::linalg::iDiv(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator/=<cytnx_int16>(const cytnx_int16 &rc) {
-    this->_impl->storage() = cytnx::linalg::Div(*this, rc)._impl->storage();
+    cytnx::linalg::iDiv(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator/=<cytnx_uint16>(const cytnx_uint16 &rc) {
-    this->_impl->storage() = cytnx::linalg::Div(*this, rc)._impl->storage();
+    cytnx::linalg::iDiv(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator/=<cytnx_bool>(const cytnx_bool &rc) {
-    this->_impl->storage() = cytnx::linalg::Div(*this, rc)._impl->storage();
+    cytnx::linalg::iDiv(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>
   Tensor &Tensor::operator/=<Scalar>(const Scalar &rc) {
-    this->_impl->storage() = cytnx::linalg::Div(*this, rc)._impl->storage();
+    cytnx::linalg::iDiv(*this, _scalar_as_rank1_tensor(rc, this->device()));
     return *this;
   }
   template <>

--- a/src/linalg/iArithmetic_visit.hpp
+++ b/src/linalg/iArithmetic_visit.hpp
@@ -17,11 +17,11 @@ namespace cytnx {
           if constexpr (op_code == 0) {
             cytnx_error_msg(true, "[ERROR][iadd] Cannot perform real+=complex%s", "\n");
           } else if constexpr (op_code == 1) {
-            cytnx_error_msg(true, "[ERROR][imul] Cannot perform real+=complex%s", "\n");
+            cytnx_error_msg(true, "[ERROR][imul] Cannot perform real*=complex%s", "\n");
           } else if constexpr (op_code == 2) {
-            cytnx_error_msg(true, "[ERROR][isub] Cannot perform real+=complex%s", "\n");
+            cytnx_error_msg(true, "[ERROR][isub] Cannot perform real-=complex%s", "\n");
           } else if constexpr (op_code == 3) {
-            cytnx_error_msg(true, "[ERROR][idiv] Cannot perform real+=complex%s", "\n");
+            cytnx_error_msg(true, "[ERROR][idiv] Cannot perform real/=complex%s", "\n");
           }
         } else {
           if constexpr (op_code == 0) {

--- a/tests/Tensor_test.cpp
+++ b/tests/Tensor_test.cpp
@@ -467,3 +467,19 @@ TEST(Tensor, CytnxScalarInplaceAddKeepsStorageSharing) {
   EXPECT_TRUE(is(a.storage(), b.storage()));
   EXPECT_DOUBLE_EQ(b.storage().at<double>(1), 2.5);
 }
+
+TEST(Tensor, ScalarInplaceRealTimesComplexErrorNamesOperator) {
+  Tensor a = zeros({2}, Type.Double);
+  try {
+    a *= cytnx_complex128(0, 1);
+    FAIL() << "expected real *= complex to throw";
+  } catch (const std::logic_error &e) {
+    EXPECT_NE(std::string(e.what()).find("*="), std::string::npos) << e.what();
+  }
+  try {
+    a /= cytnx_complex128(0, 1);
+    FAIL() << "expected real /= complex to throw";
+  } catch (const std::logic_error &e) {
+    EXPECT_NE(std::string(e.what()).find("/="), std::string::npos) << e.what();
+  }
+}

--- a/tests/Tensor_test.cpp
+++ b/tests/Tensor_test.cpp
@@ -393,3 +393,77 @@ TEST(Tensor, FailedReshapeLeavesShapeUnchanged) {
   EXPECT_THROW(t.reshape_({0, -1}), std::logic_error);
   EXPECT_EQ(t.shape(), (std::vector<cytnx_uint64>{12}));
 }
+
+// NOTE: `Tensor b = a;` makes `b` an alias of the *same* Tensor_impl as `a`
+// (Tensor's copy ctor just copies the intrusive_ptr), so `is(a.storage(),
+// b.storage())` would trivially read the same Storage field twice and could
+// never observe the #906 detach bug. To exercise a genuine "two independent
+// Tensor handles sharing one Storage" scenario (e.g. what a view/slice would
+// produce), we build `b` via Tensor::from_storage(a.storage()), which creates
+// a brand-new Tensor_impl whose _storage is a copy of the Storage handle
+// (same underlying Storage_base, distinct Tensor_impl).
+TEST(Tensor, ScalarInplaceAddKeepsStorageSharing) {
+  Tensor a = zeros({4}, Type.Double);
+  Tensor b = Tensor::from_storage(a.storage());  // distinct Tensor_impl, shared Storage
+  ASSERT_TRUE(is(a.storage(), b.storage()));
+  a += 1.0;
+  EXPECT_TRUE(is(a.storage(), b.storage()));
+  EXPECT_DOUBLE_EQ(b.storage().at<double>(0), 1.0);
+}
+
+TEST(Tensor, ScalarInplaceOpsPreserveDtype) {
+  Tensor a = ones({2}, Type.Float);
+  a += 1.0;  // double scalar must not promote the tensor
+  a -= 0.5;
+  a *= 2.0;
+  a /= 3.0;
+  EXPECT_EQ(a.dtype(), Type.Float);
+  EXPECT_FLOAT_EQ(a.storage().at<float>(0), 1.0f);
+}
+
+TEST(Tensor, ScalarInplaceRealPlusComplexThrows) {
+  Tensor a = zeros({2}, Type.Double);
+  EXPECT_THROW(a += cytnx_complex128(0, 1), std::logic_error);
+  EXPECT_THROW(a -= cytnx_complex128(0, 1), std::logic_error);
+  EXPECT_THROW(a *= cytnx_complex128(0, 1), std::logic_error);
+  EXPECT_THROW(a /= cytnx_complex128(0, 1), std::logic_error);
+}
+
+TEST(Tensor, ScalarInplaceIntTensorTruncatesFractionalScalar) {
+  Tensor a = ones({2}, Type.Int64);
+  a += 2.7;  // was: promoted to Double (3.7); now: stays Int64, truncates
+  EXPECT_EQ(a.dtype(), Type.Int64);
+  EXPECT_EQ(a.storage().at<cytnx_int64>(0), 3);
+}
+
+// Mirrors the actual #906 report through public API: permute() produces a
+// distinct Tensor_impl sharing the same Storage (Tensor_impl::permute does
+// `out->_storage = this->_storage`) flagged non-contiguous, so this also
+// exercises the non-contiguous scalar broadcast path of iAdd.
+TEST(Tensor, ScalarInplaceOnPermutedViewMutatesSharedStorage) {
+  Tensor a = zeros({2, 3}, Type.Double);
+  Tensor v = a.permute({1, 0});  // distinct impl, shared storage, non-contiguous
+  ASSERT_FALSE(v.is_contiguous());
+  ASSERT_TRUE(is(a.storage(), v.storage()));
+  v += 1.0;
+  EXPECT_TRUE(is(a.storage(), v.storage()));
+  EXPECT_DOUBLE_EQ(a.storage().at<double>(0), 1.0);
+}
+
+TEST(Tensor, ScalarInplaceSubMulDivKeepStorageSharing) {
+  Tensor a = ones({3}, Type.Double);
+  Tensor b = Tensor::from_storage(a.storage());
+  a -= 0.5;
+  a *= 4.0;
+  a /= 2.0;
+  EXPECT_TRUE(is(a.storage(), b.storage()));
+  EXPECT_DOUBLE_EQ(b.storage().at<double>(2), 1.0);
+}
+
+TEST(Tensor, CytnxScalarInplaceAddKeepsStorageSharing) {
+  Tensor a = zeros({2}, Type.Double);
+  Tensor b = Tensor::from_storage(a.storage());
+  a += Scalar(2.5);
+  EXPECT_TRUE(is(a.storage(), b.storage()));
+  EXPECT_DOUBLE_EQ(b.storage().at<double>(1), 2.5);
+}


### PR DESCRIPTION
## Problem

Part of #906. `t += 1.0` (and `-=`, `*=`, `/=` with any scalar or `cytnx::Scalar`) replaced the tensor's Storage with a freshly computed one:

```cpp
this->_impl->storage() = cytnx::linalg::Add(*this, rc)._impl->storage();
```

Any view sharing that storage (from `permute()`, contiguous `reshape()`, `from_storage()`) silently detached, while `t += tensor` mutated in place — the two paths disagreed on aliasing semantics.

## Fix

Scalar RHS now routes through the same `iAdd/iSub/iMul/iDiv` kernels via a shape-`{1}` wrapper tensor (the kernels already broadcast a length-1 RHS and mutate LHS storage in place). All 48 scalar specializations rewritten; the `Tensor`/`Tproxy`/`Sproxy` specializations are untouched.

## Deliberate behavior changes

- Views sharing storage stay attached (the bug fix).
- LHS dtype is preserved: `Float tensor += 1.0` stays `Float` (previously promoted to `Double`); integer LHS truncates fractional scalars — both matching the existing tensor-RHS in-place behavior and numpy's scalar rules.
- `real_tensor ⊙= complex_scalar` now throws instead of silently promoting the tensor to complex.

The GPU `iAdd` path can still rebind on promotion; that remains tracked under #906.

## Testing

Seven new gtests: storage-sharing preserved for all four ops (including through a real non-contiguous `permute()` view), dtype preservation, integer truncation pinned, `real ⊙= complex` throws for all four ops, and `cytnx::Scalar` RHS. Red-state verified against the old code (a shared view read `0` after `+=` — update lost). Full suite passes at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)