### PR TITLE
fix: drop C complex.h from pybind TUs; rename macro-colliding template param

### DIFF
--- a/include/Type.hpp
+++ b/include/Type.hpp
@@ -83,13 +83,13 @@ namespace cytnx {
     struct is_complex_floating_point_impl<cuda::std::complex<T>> : std::is_floating_point<T> {};
 #endif
 
-    template <std::size_t I, typename T, typename Tuple>
+    template <std::size_t Idx, typename T, typename Tuple>
     constexpr std::size_t index_in_tuple_helper() {
-      static_assert(I < std::tuple_size_v<Tuple>, "Type not found!");
-      if constexpr (std::is_same_v<T, std::tuple_element_t<I, Tuple>>) {
-        return I;
+      static_assert(Idx < std::tuple_size_v<Tuple>, "Type not found!");
+      if constexpr (std::is_same_v<T, std::tuple_element_t<Idx, Tuple>>) {
+        return Idx;
       } else {
-        return index_in_tuple_helper<I + 1, T, Tuple>();
+        return index_in_tuple_helper<Idx + 1, T, Tuple>();
       }
     }
 

--- a/pybind/algo_py.cpp
+++ b/pybind/algo_py.cpp
@@ -12,7 +12,6 @@
 
 #include "cytnx.hpp"
 // #include "../include/cytnx_error.hpp"
-#include "complex.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/pybind/bond_py.cpp
+++ b/pybind/bond_py.cpp
@@ -12,7 +12,6 @@
 
 #include "cytnx.hpp"
 // #include "../include/cytnx_error.hpp"
-#include "complex.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/pybind/cytnx.cpp
+++ b/pybind/cytnx.cpp
@@ -12,7 +12,6 @@
 
 #include "cytnx.hpp"
 // #include "../include/cytnx_error.hpp"
-#include "complex.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/pybind/generator_py.cpp
+++ b/pybind/generator_py.cpp
@@ -12,7 +12,6 @@
 
 #include "cytnx.hpp"
 // #include "../include/cytnx_error.hpp"
-#include "complex.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/pybind/linalg_py.cpp
+++ b/pybind/linalg_py.cpp
@@ -12,7 +12,6 @@
 
 #include "cytnx.hpp"
 // #include "../include/cytnx_error.hpp"
-#include "complex.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/pybind/linop_py.cpp
+++ b/pybind/linop_py.cpp
@@ -12,7 +12,6 @@
 
 #include "cytnx.hpp"
 // #include "../include/cytnx_error.hpp"
-#include "complex.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/pybind/ncon_py.cpp
+++ b/pybind/ncon_py.cpp
@@ -12,7 +12,6 @@
 
 #include "cytnx.hpp"
 // #include "../include/cytnx_error.hpp"
-#include "complex.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/pybind/network_py.cpp
+++ b/pybind/network_py.cpp
@@ -12,7 +12,6 @@
 
 #include "cytnx.hpp"
 // #include "../include/cytnx_error.hpp"
-#include "complex.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/pybind/physics_related_py.cpp
+++ b/pybind/physics_related_py.cpp
@@ -12,7 +12,6 @@
 
 #include "cytnx.hpp"
 // #include "../include/cytnx_error.hpp"
-#include "complex.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/pybind/random_py.cpp
+++ b/pybind/random_py.cpp
@@ -12,7 +12,6 @@
 
 #include "cytnx.hpp"
 // #include "../include/cytnx_error.hpp"
-#include "complex.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/pybind/scalar_py.cpp
+++ b/pybind/scalar_py.cpp
@@ -12,7 +12,6 @@
 
 #include "cytnx.hpp"
 // #include "../include/cytnx_error.hpp"
-#include "complex.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/pybind/storage_py.cpp
+++ b/pybind/storage_py.cpp
@@ -13,7 +13,6 @@
 
 #include "cytnx.hpp"
 // #include "../include/cytnx_error.hpp"
-#include "complex.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/pybind/symmetry_py.cpp
+++ b/pybind/symmetry_py.cpp
@@ -12,7 +12,6 @@
 #include <pybind11/functional.h>
 
 #include "cytnx.hpp"
-#include "complex.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/pybind/tensor_py.cpp
+++ b/pybind/tensor_py.cpp
@@ -12,7 +12,6 @@
 
 #include "cytnx.hpp"
 // #include "../include/cytnx_error.hpp"
-#include "complex.h"
 #include "pyint_dispatch.hpp"
 
 namespace py = pybind11;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(
   Tensor_test.cpp
   Type_test.cpp
   cytnx_error_test.cpp
+  include_order_canary_test.cpp
   Tensor_strides_test.cpp
   Storage_test.cpp
   search_tree_test.cpp

--- a/tests/include_order_canary_test.cpp
+++ b/tests/include_order_canary_test.cpp
@@ -1,0 +1,16 @@
+// Regression guard for #951: cytnx public headers must stay usable in a TU
+// that sees the C complex.h macro `I` before including any cytnx header.
+#include <complex.h>
+#ifndef I
+  // libc++'s complex.h does not leak the C macro `I` in C++ mode; define it
+  // explicitly so this guard bites on every platform, not just glibc.
+  #define I (18973)
+#endif
+
+#include "cytnx.hpp"
+
+#undef I
+
+#include "gtest/gtest.h"
+
+TEST(IncludeOrderCanary, HeadersSurviveComplexHMacroI) { SUCCEED(); }


### PR DESCRIPTION
## Problem

Fixes #951. All 14 pybind TUs carried a vestigial `#include "complex.h"` — the C header that defines the macro `I` (`#define I _Complex_I`). It collides with `template <std::size_t I>` in `include/Type.hpp` and compiled only by include-order luck; any user TU including `<complex.h>` before cytnx headers broke the same way. (macOS masks the bug — libc++ shims `complex.h` to `<complex>` in C++ mode — but Linux/GCC reproduces it exactly.)

## Fix

- Removed the include from all 14 pybind TUs (none used `_Complex_I`/`creal`/`cimag`).
- Renamed the sole colliding template parameter in `include/Type.hpp` to `Idx`, hardening the public header against macro-`I` from any include order.
- `Det_internal.cpp`'s TU-local `<complex.h>` use is deliberate and untouched.

## Testing

Compile-time fix: the C++ library, full test suite (baseline pass), and the full python module (`BUILD_PYTHON=ON`) all build cleanly. The hazard was reproduced pre-fix with the real glibc macro expansion (hard parse error at the template line) and compiles clean post-fix.

Follow-ups noted during review (not in this PR): `index_in_tuple_helper` appears to be dead code, and `Det_internal.cpp:3`'s `<complex.h>` include also looks vestigial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)