### PR TITLE
fix(error): bounded formatting, namespaced impl, single-report errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,13 +249,6 @@ target_include_directories(cytnx SYSTEM
 )
 
 target_compile_options(cytnx PUBLIC -Wformat=0 -w -fsized-deallocation)
-if(MSVC)
-  # cytnx_error.hpp's cytnx_error_msg / cytnx_warning_msg macros use __VA_OPT__,
-  # which MSVC only supports under its conforming preprocessor; /std:c++20 alone
-  # does NOT enable it. PUBLIC so downstream code that uses the error macros gets
-  # it too. See the #983 review.
-  target_compile_options(cytnx PUBLIC /Zc:preprocessor)
-endif()
 add_subdirectory(src)
 
 if(USE_DEBUG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,13 @@ target_include_directories(cytnx SYSTEM
 )
 
 target_compile_options(cytnx PUBLIC -Wformat=0 -w -fsized-deallocation)
+if(MSVC)
+  # cytnx_error.hpp's cytnx_error_msg / cytnx_warning_msg macros use __VA_OPT__,
+  # which MSVC only supports under its conforming preprocessor; /std:c++20 alone
+  # does NOT enable it. PUBLIC so downstream code that uses the error macros gets
+  # it too. See the #983 review.
+  target_compile_options(cytnx PUBLIC /Zc:preprocessor)
+endif()
 add_subdirectory(src)
 
 if(USE_DEBUG)

--- a/include/Type.hpp
+++ b/include/Type.hpp
@@ -463,7 +463,7 @@ namespace cytnx {
 
   extern int __blasINTsize__;
 
-  extern bool User_debug;
+  // User_debug is declared in cytnx_error.hpp (included above); no need to redeclare it here.
 
 }  // namespace cytnx
 

--- a/include/cytnx_error.hpp
+++ b/include/cytnx_error.hpp
@@ -41,6 +41,7 @@ namespace cytnx {
   namespace internal {
 
     inline std::string vformat_message(char const *format, va_list args) {
+      if (format == nullptr) return std::string();
       va_list args_copy;
       va_copy(args_copy, args);
       const int n = std::vsnprintf(nullptr, 0, format, args_copy);
@@ -55,16 +56,19 @@ namespace cytnx {
                                       int line, const std::string &msg) {
       std::string out;
       out.reserve(msg.size() + 256);
+      // kind/func/file come from macro literals / CYTNX_FUNC_NAME / __FILE__ (or
+      // std::source_location), so they are non-null in practice; fall back defensively so a
+      // misuse can never turn report composition itself into undefined behavior.
       out += "\n# Cytnx ";
-      out += kind;
+      out += kind ? kind : "error";
       out += " occur at ";
-      out += func;
+      out += func ? func : "unknown";
       out += "\n# ";
-      out += kind;
+      out += kind ? kind : "error";
       out += ": ";
       out += msg;
       out += "\n# file : ";
-      out += file;
+      out += file ? file : "unknown";
       out += " (";
       out += std::to_string(line);
       out += ")";

--- a/include/cytnx_error.hpp
+++ b/include/cytnx_error.hpp
@@ -21,11 +21,9 @@
   #define CYTNX_HAS_EXECINFO 0
 #endif
 
-#ifdef _MSC_VER
-  #define CYTNX_FUNC_NAME __FUNCSIG__
-#else
-  #define CYTNX_FUNC_NAME __PRETTY_FUNCTION__
-#endif
+// Full function signature for error reports. __PRETTY_FUNCTION__ is a GCC/Clang
+// extension; those are the only supported compilers (Linux/macOS, and Windows via WSL).
+#define CYTNX_FUNC_NAME __PRETTY_FUNCTION__
 
 namespace cytnx {
 

--- a/include/cytnx_error.hpp
+++ b/include/cytnx_error.hpp
@@ -8,6 +8,7 @@
 
 #include <iostream>
 #include <stdexcept>
+#include <string>
 
 #if defined(__has_include)
   #if __has_include(<execinfo.h>)
@@ -21,66 +22,107 @@
 #endif
 
 #ifdef _MSC_VER
-  #define __PRETTY_FUNCTION__ __FUNCTION__
+  #define CYTNX_FUNC_NAME __FUNCSIG__
+#else
+  #define CYTNX_FUNC_NAME __PRETTY_FUNCTION__
 #endif
 
-#define cytnx_error_msg(is_true, format, ...)                                               \
-  {                                                                                         \
-    if (is_true)                                                                            \
-      error_msg(__PRETTY_FUNCTION__, __FILE__, __LINE__, (is_true), (format), __VA_ARGS__); \
-  }
-static inline void error_msg(char const *const func, const char *const file, int const line,
-                             bool is_true, char const *format, ...) {
-  // try {
-  if (is_true) {
-    va_list args;
-    char output_str[1024];
-    char msg[512];
-    va_start(args, format);
-    vsprintf(msg, format, args);
-    sprintf(output_str, "\n# Cytnx error occur at %s\n# error: %s\n# file : %s (%d)", func, msg,
-            file, line);
-    va_end(args);
-    // std::cerr << output_str << std::endl;
-    std::cerr << output_str << std::endl;
-#if CYTNX_HAS_EXECINFO
-    std::cerr << "Stack trace:" << std::endl;
-    void *array[10];
-    std::size_t size;
-    size = backtrace(array, 10);
-    char **strings = backtrace_symbols(array, size);
-    for (std::size_t i = 0; i < size; i++) {
-      std::cerr << strings[i] << std::endl;
+namespace cytnx {
+
+  extern bool User_debug;  // defined in src/Type.cpp
+
+  // Exception thrown by cytnx_error_msg. Derives std::logic_error for
+  // backward compatibility with existing catch/EXPECT_THROW sites.
+  class error : public std::logic_error {
+   public:
+    using std::logic_error::logic_error;
+  };
+
+  namespace internal {
+
+    inline std::string vformat_message(char const *format, va_list args) {
+      va_list args_copy;
+      va_copy(args_copy, args);
+      const int n = std::vsnprintf(nullptr, 0, format, args_copy);
+      va_end(args_copy);
+      if (n < 0) return std::string(format);
+      std::string msg(static_cast<std::size_t>(n), '\0');
+      std::vsnprintf(msg.data(), msg.size() + 1, format, args);
+      return msg;
     }
-    free(strings);
+
+    inline std::string compose_report(char const *kind, char const *func, char const *file,
+                                      int line, const std::string &msg) {
+      std::string out;
+      out.reserve(msg.size() + 256);
+      out += "\n# Cytnx ";
+      out += kind;
+      out += " occur at ";
+      out += func;
+      out += "\n# ";
+      out += kind;
+      out += ": ";
+      out += msg;
+      out += "\n# file : ";
+      out += file;
+      out += " (";
+      out += std::to_string(line);
+      out += ")";
+      return out;
+    }
+
+    inline void print_backtrace_if_debug() {
+      if (!cytnx::User_debug) return;
+#if CYTNX_HAS_EXECINFO
+      std::cerr << "Stack trace:" << std::endl;
+      void *array[10];
+      const int size = backtrace(array, 10);
+      char **strings = backtrace_symbols(array, size);
+      if (strings != nullptr) {
+        for (int i = 0; i < size; i++) std::cerr << strings[i] << std::endl;
+        free(strings);
+      }
 #else
-    std::cerr << "Stack trace is unavailable on this platform/compiler." << std::endl;
+      std::cerr << "Stack trace is unavailable on this platform/compiler." << std::endl;
 #endif
-    throw std::logic_error(output_str);
-  }
-  // } catch (const char *output_msg) {
-  //   std::cerr << output_msg << std::endl;
-  // }
-}
-#define cytnx_warning_msg(is_true, format, ...)                                               \
-  {                                                                                           \
-    if (is_true)                                                                              \
-      warning_msg(__PRETTY_FUNCTION__, __FILE__, __LINE__, (is_true), (format), __VA_ARGS__); \
-  }
-static inline void warning_msg(char const *const func, const char *const file, int const line,
-                               bool is_true, char const *format, ...) {
-  if (is_true) {
-    va_list args;
-    char output_str[1024];
-    char msg[512];
-    va_start(args, format);
-    vsprintf(msg, format, args);
-    sprintf(output_str, "\n# Cytnx warning occur at %s\n# warning: %s\n# file : %s (%d)", func, msg,
-            file, line);
-    va_end(args);
-    std::cerr << output_str << std::endl;
-  }
-}
+    }
+
+    [[noreturn]] inline void error_msg_impl(char const *func, char const *file, int line,
+                                            char const *format, ...) {
+      va_list args;
+      va_start(args, format);
+      const std::string msg = vformat_message(format, args);
+      va_end(args);
+      const std::string report = compose_report("error", func, file, line, msg);
+      print_backtrace_if_debug();
+      throw cytnx::error(report);
+    }
+
+    inline void warning_msg_impl(char const *func, char const *file, int line, char const *format,
+                                 ...) {
+      va_list args;
+      va_start(args, format);
+      const std::string msg = vformat_message(format, args);
+      va_end(args);
+      std::cerr << compose_report("warning", func, file, line, msg) << std::endl;
+    }
+
+  }  // namespace internal
+}  // namespace cytnx
+
+#define cytnx_error_msg(is_true, format, ...)                                \
+  do {                                                                       \
+    if (is_true)                                                             \
+      ::cytnx::internal::error_msg_impl(CYTNX_FUNC_NAME, __FILE__, __LINE__, \
+                                        (format)__VA_OPT__(, ) __VA_ARGS__); \
+  } while (0)
+
+#define cytnx_warning_msg(is_true, format, ...)                                \
+  do {                                                                         \
+    if (is_true)                                                               \
+      ::cytnx::internal::warning_msg_impl(CYTNX_FUNC_NAME, __FILE__, __LINE__, \
+                                          (format)__VA_OPT__(, ) __VA_ARGS__); \
+  } while (0)
 
 #if defined(UNI_GPU)
 

--- a/include/utils/checked_cast.hpp
+++ b/include/utils/checked_cast.hpp
@@ -27,9 +27,10 @@ namespace cytnx {
       cytnx_uint64 value, const char *name,
       std::source_location location = std::source_location::current()) {
       if (value > static_cast<cytnx_uint64>(std::numeric_limits<cytnx_int64>::max())) {
-        error_msg(location.function_name(), location.file_name(), static_cast<int>(location.line()),
-                  true, "[ERROR] %s=%llu exceeds cytnx_int64 max.\n", name,
-                  static_cast<unsigned long long>(value));
+        cytnx::internal::error_msg_impl(location.function_name(), location.file_name(),
+                                        static_cast<int>(location.line()),
+                                        "[ERROR] %s=%llu exceeds cytnx_int64 max.\n", name,
+                                        static_cast<unsigned long long>(value));
       }
       return static_cast<cytnx_int64>(value);
     }

--- a/include/utils/checked_cast.hpp
+++ b/include/utils/checked_cast.hpp
@@ -27,10 +27,10 @@ namespace cytnx {
       cytnx_uint64 value, const char *name,
       std::source_location location = std::source_location::current()) {
       if (value > static_cast<cytnx_uint64>(std::numeric_limits<cytnx_int64>::max())) {
-        cytnx::internal::error_msg_impl(location.function_name(), location.file_name(),
-                                        static_cast<int>(location.line()),
-                                        "[ERROR] %s=%llu exceeds cytnx_int64 max.\n", name,
-                                        static_cast<unsigned long long>(value));
+        cytnx::internal::error_msg_impl(
+          location.function_name(), location.file_name(), static_cast<int>(location.line()),
+          "[ERROR] %s=%llu exceeds cytnx_int64 max.\n", name ? name : "value",
+          static_cast<unsigned long long>(value));
       }
       return static_cast<cytnx_int64>(value);
     }

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -74,7 +74,7 @@ namespace cytnx {
                                                 Nelem);
   #else
       cytnx_error_msg(true, "[ERROR] fatal internal, %s",
-                      " [arange] the container is on gpu without CUDA support!%s", "\n")
+                      " [arange] the container is on gpu without CUDA support!%s", "\n");
   #endif
     }
 
@@ -109,7 +109,7 @@ namespace cytnx {
                                                 Nelem);
   #else
       cytnx_error_msg(true, "[ERROR] fatal internal, %s",
-                      " [arange] the container is on gpu without CUDA support!%s", "\n")
+                      " [arange] the container is on gpu without CUDA support!%s", "\n");
   #endif
     }
     return out;

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -74,7 +74,7 @@ namespace cytnx {
                                                 Nelem);
   #else
       cytnx_error_msg(true, "[ERROR] fatal internal, %s",
-                      " [arange] the container is on gpu without CUDA support!%s", "\n");
+                      " [arange] the container is on gpu without CUDA support!");
   #endif
     }
 
@@ -109,7 +109,7 @@ namespace cytnx {
                                                 Nelem);
   #else
       cytnx_error_msg(true, "[ERROR] fatal internal, %s",
-                      " [arange] the container is on gpu without CUDA support!%s", "\n");
+                      " [arange] the container is on gpu without CUDA support!");
   #endif
     }
     return out;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(
   Accessor_test.cpp
   Tensor_test.cpp
   Type_test.cpp
+  cytnx_error_test.cpp
   Tensor_strides_test.cpp
   Storage_test.cpp
   search_tree_test.cpp

--- a/tests/cytnx_error_test.cpp
+++ b/tests/cytnx_error_test.cpp
@@ -1,0 +1,66 @@
+#include <stdexcept>
+#include <string>
+
+#include "cytnx.hpp"
+#include "gtest/gtest.h"
+
+TEST(CytnxError, LongMessagesDoNotOverflow) {
+  std::string big(5000, 'x');
+  try {
+    cytnx_error_msg(true, "%s", big.c_str());
+    FAIL() << "expected throw";
+  } catch (const std::logic_error &e) {
+    EXPECT_NE(std::string(e.what()).find("xxxx"), std::string::npos);
+    EXPECT_GE(std::string(e.what()).size(), big.size());
+  }
+}
+
+TEST(CytnxError, ThrowsCytnxErrorType) {
+  EXPECT_THROW(cytnx_error_msg(true, "boom%s", ""), cytnx::error);
+  EXPECT_THROW(cytnx_error_msg(true, "boom%s", ""), std::logic_error);
+}
+
+TEST(CytnxError, FalseConditionDoesNotThrow) {
+  EXPECT_NO_THROW(cytnx_error_msg(false, "never%s", ""));
+}
+
+TEST(CytnxError, MacroIsSafeInIfElse) {
+  bool flag = false;
+  if (flag)
+    cytnx_error_msg(true, "unreachable%s", "");
+  else
+    SUCCEED();
+}
+
+TEST(CytnxError, ConditionEvaluatedOnce) {
+  int n = 0;
+  cytnx_error_msg((++n, false), "never%s", "");
+  EXPECT_EQ(n, 1);
+}
+
+TEST(CytnxError, EmptyFormattedMessageIsEmpty) {
+  try {
+    cytnx_error_msg(true, "%s", "");
+    FAIL() << "expected throw";
+  } catch (const cytnx::error &e) {
+    EXPECT_EQ(std::string(e.what()).find("%s"), std::string::npos);
+  }
+}
+
+TEST(CytnxError, ZeroVarargCallCompilesAndThrows) {
+  EXPECT_THROW(cytnx_error_msg(true, "plain message"), cytnx::error);
+}
+
+TEST(CytnxError, WarningDoesNotThrow) {
+  EXPECT_NO_THROW(cytnx_warning_msg(true, "just a warning%s", ""));
+}
+
+TEST(CytnxError, PercentLiteralFormatsCorrectly) {
+  try {
+    cytnx_error_msg(true, "100%%");
+    FAIL() << "expected throw";
+  } catch (const cytnx::error &e) {
+    EXPECT_NE(std::string(e.what()).find("100%"), std::string::npos);
+    EXPECT_EQ(std::string(e.what()).find("100%%"), std::string::npos);
+  }
+}

--- a/tests/cytnx_error_test.cpp
+++ b/tests/cytnx_error_test.cpp
@@ -97,3 +97,39 @@ TEST(CytnxError, CheckedCastNullNameDoesNotCrash) {
     static_cast<cytnx::cytnx_uint64>(std::numeric_limits<cytnx::cytnx_int64>::max()) + 1;
   EXPECT_THROW(cytnx::internal::CheckedCastToInt64(too_big, nullptr), std::logic_error);
 }
+
+// Single-report: an error throws only -- with User_debug off it writes nothing to stderr
+// (the backtrace is gated behind User_debug), so throw-heavy suites don't spam the logs.
+TEST(CytnxError, ErrorDoesNotEchoToStderr) {
+  const bool prev = cytnx::User_debug;
+  cytnx::User_debug = false;
+  testing::internal::CaptureStderr();
+  EXPECT_THROW(cytnx_error_msg(true, "boom%s", ""), cytnx::error);
+  const std::string captured = testing::internal::GetCapturedStderr();
+  cytnx::User_debug = prev;
+  EXPECT_TRUE(captured.empty()) << "error unexpectedly wrote to stderr: " << captured;
+}
+
+// Warnings do not throw and are reported to stderr.
+TEST(CytnxError, WarningEchoesToStderr) {
+  testing::internal::CaptureStderr();
+  cytnx_warning_msg(true, "heads up%s", "");
+  const std::string captured = testing::internal::GetCapturedStderr();
+  EXPECT_NE(captured.find("heads up"), std::string::npos);
+  EXPECT_NE(captured.find("Cytnx warning"), std::string::npos);
+}
+
+// The macro-expanded report carries the call-site function, file, and line.
+TEST(CytnxError, ReportCarriesFuncFileLine) {
+  try {
+    cytnx_error_msg(true, "located%s", "");
+    FAIL() << "expected throw";
+  } catch (const cytnx::error &e) {
+    const std::string w = e.what();
+    EXPECT_NE(w.find("located"), std::string::npos);  // the message
+    EXPECT_NE(w.find(" occur at "), std::string::npos);  // function section
+    EXPECT_NE(w.find("ReportCarriesFuncFileLine"), std::string::npos);  // CYTNX_FUNC_NAME
+    EXPECT_NE(w.find("# file : "), std::string::npos);  // file section
+    EXPECT_NE(w.find("cytnx_error_test"), std::string::npos);  // __FILE__
+  }
+}

--- a/tests/cytnx_error_test.cpp
+++ b/tests/cytnx_error_test.cpp
@@ -1,7 +1,10 @@
+#include <cstdarg>
+#include <limits>
 #include <stdexcept>
 #include <string>
 
 #include "cytnx.hpp"
+#include "utils/checked_cast.hpp"
 #include "gtest/gtest.h"
 
 TEST(CytnxError, LongMessagesDoNotOverflow) {
@@ -63,4 +66,34 @@ TEST(CytnxError, PercentLiteralFormatsCorrectly) {
     EXPECT_NE(std::string(e.what()).find("100%"), std::string::npos);
     EXPECT_EQ(std::string(e.what()).find("100%%"), std::string::npos);
   }
+}
+
+namespace {
+  std::string CallVformat(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    std::string s = cytnx::internal::vformat_message(fmt, ap);
+    va_end(ap);
+    return s;
+  }
+}  // namespace
+
+// A null format must not be dereferenced (vsnprintf(nullptr,...)/std::string(nullptr) are UB).
+TEST(CytnxError, NullFormatDoesNotCrash) { EXPECT_EQ(CallVformat(nullptr), std::string()); }
+
+// Report composition must tolerate null kind/func/file (they are non-null in practice, but a
+// report composer should never itself be UB).
+TEST(CytnxError, ComposeReportToleratesNulls) {
+  std::string r = cytnx::internal::compose_report(nullptr, nullptr, nullptr, 42, "boom");
+  EXPECT_NE(r.find("boom"), std::string::npos);
+  EXPECT_NE(r.find("error"), std::string::npos);  // kind fallback
+  EXPECT_NE(r.find("unknown"), std::string::npos);  // func / file fallback
+}
+
+// A null `name` must not reach the %s conversion; it throws (not crashes) on overflow.
+TEST(CytnxError, CheckedCastNullNameDoesNotCrash) {
+  EXPECT_NO_THROW(cytnx::internal::CheckedCastToInt64(5, nullptr));
+  const cytnx::cytnx_uint64 too_big =
+    static_cast<cytnx::cytnx_uint64>(std::numeric_limits<cytnx::cytnx_int64>::max()) + 1;
+  EXPECT_THROW(cytnx::internal::CheckedCastToInt64(too_big, nullptr), std::logic_error);
 }


### PR DESCRIPTION
## Problem

`include/cytnx_error.hpp` had several long-standing hazards:
- `vsprintf`/`sprintf` into fixed 512/1024-byte stack buffers — unbounded; long messages (tensor shapes/labels) overflow the stack.
- `error_msg`/`warning_msg` were `static inline` free functions at global namespace in a public header.
- The macros expanded to bare `{...}` blocks — dangling-else hazard, and the condition was evaluated twice.
- Errors printed the full report to stderr and then threw (double reporting; stack-trace spam in test logs).
- `#define __PRETTY_FUNCTION__ __FUNCTION__` on MSVC defined a reserved identifier (related to #460).

## Fix

Two commits:
1. Call-site normalization (compiles under the old macro): the sweep found only two missing trailing semicolons (`src/Generator.cpp`).
2. The rewrite: size-measured `vsnprintf` into `std::string`; impls in `cytnx::internal`; `do{}while(0)` macros with single condition evaluation and `__VA_OPT__` (zero-vararg calls now legal — the `"%s",""` idiom is no longer required going forward); new `cytnx::error` deriving `std::logic_error` (all existing catch sites keep working); throw-only reporting with the backtrace gated behind `cytnx::User_debug`; `CYTNX_FUNC_NAME` (`__FUNCSIG__` on MSVC) instead of redefining `__PRETTY_FUNCTION__`. The report text format is unchanged. The one direct caller of the old free function (`include/utils/checked_cast.hpp`) is adapted with identical semantics.

## Testing

Nine new gtests: 5000-char messages don't overflow and arrive intact in `what()`, exception type, if/else safety, single evaluation of the condition, zero-vararg calls, `%%` literals, empty formatted messages, and warnings not throwing. Throw-heavy suites no longer spam `# Cytnx error` to stderr. Full suite passes at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)