### PR TITLE
feat(pybind): release the GIL around expensive linalg/contract calls

### DIFF
--- a/pybind/linalg_py.cpp
+++ b/pybind/linalg_py.cpp
@@ -36,27 +36,57 @@ void linalg_binding(py::module &m) {
     },
     py::arg("Tin"), py::arg("keepdim"), py::arg("power_iteration") = 2, py::arg("seed") = -1);
 
+  // ---------------------------------------------------------------------------
+  // GIL guard discipline (applies to every py::call_guard<py::gil_scoped_release>
+  // in the pybind/ layer; network_py.cpp and unitensor_py.cpp refer here):
+  //
+  //  (a) A guarded lambda body must NEVER touch py::* / CPython API. The guard
+  //      releases the GIL for the duration of the call only: arguments are
+  //      converted to C++ types BEFORE the guard is constructed, and the return
+  //      value is converted back to Python AFTER the guard is destroyed
+  //      (pybind11/attr.h: "T scope_guard; return foo(args...)"). Keep the body
+  //      pure C++.
+  //  (b) call_guard<A, B> constructs guards left to right. Appending
+  //      py::scoped_ostream_redirect (whose default constructor imports
+  //      sys.stdout and therefore needs the GIL) AFTER gil_scoped_release will
+  //      crash. If a binding ever needs both, put the redirect FIRST, or scope
+  //      a py::gil_scoped_release manually inside the lambda body around the
+  //      compute call. (Redirected writes themselves are safe without the GIL:
+  //      pythonbuf::_sync() in pybind11/iostream.h reacquires it.)
+  //  (c) Releasing around LinOp-taking solvers (Lanczos/Arnoldi/...) is safe
+  //      even though they call back into Python matvec() overrides: the
+  //      PYBIND11_OVERRIDE machinery opens with gil_scoped_acquire
+  //      (pybind11/pybind11.h:3532, PYBIND11_OVERRIDE_IMPL) before invoking the
+  //      Python method.
+  //
+  // Scope: all O(n^3)-class linalg entry points carry the guard, EXCEPT
+  // ExpH/ExpM which are being rewritten in PR #915 (guards added there would
+  // conflict). The elementwise operator sweep (Add/Mul/... in tensor_py.cpp)
+  // is deliberately deferred.
+  // ---------------------------------------------------------------------------
   m_linalg.def(
     "Svd",
     [](const cytnx::Tensor &Tin, const bool &is_UvT) { return cytnx::linalg::Svd(Tin, is_UvT); },
-    py::arg("Tin"), py::arg("is_UvT") = true);
+    py::arg("Tin"), py::arg("is_UvT") = true, py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Svd",
     [](const cytnx::UniTensor &Tin, const bool &is_UvT) { return cytnx::linalg::Svd(Tin, is_UvT); },
-    py::arg("Tin"), py::arg("is_UvT") = true);
+    py::arg("Tin"), py::arg("is_UvT") = true, py::call_guard<py::gil_scoped_release>());
 
   m_linalg.def(
     "Gesvd",
     [](const cytnx::Tensor &Tin, const bool &is_U, const bool &is_vT) {
       return cytnx::linalg::Gesvd(Tin, is_U, is_vT);
     },
-    py::arg("Tin"), py::arg("is_U") = true, py::arg("is_vT") = true);
+    py::arg("Tin"), py::arg("is_U") = true, py::arg("is_vT") = true,
+    py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Gesvd",
     [](const cytnx::UniTensor &Tin, const bool &is_U, const bool &is_vT) {
       return cytnx::linalg::Gesvd(Tin, is_U, is_vT);
     },
-    py::arg("Tin"), py::arg("is_U") = true, py::arg("is_vT") = true);
+    py::arg("Tin"), py::arg("is_U") = true, py::arg("is_vT") = true,
+    py::call_guard<py::gil_scoped_release>());
 
   m_linalg.def(
     "Rsvd",  // for Tensor
@@ -73,7 +103,7 @@ void linalg_binding(py::module &m) {
     py::arg("Tin"), py::arg("keepdim"), py::arg("err") = double(0), py::arg("is_U") = true,
     py::arg("is_vT") = true, py::arg("return_err") = (unsigned int)(0), py::arg("mindim") = 1,
     py::arg("oversampling_summand") = 10, py::arg("oversampling_factor") = 1.,
-    py::arg("power_iteration") = 0, py::arg("seed") = -1);
+    py::arg("power_iteration") = 0, py::arg("seed") = -1, py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Rsvd",  // for UniTensor, without min_blockdim
     [](const cytnx::UniTensor &Tin, cytnx_uint64 keepdim, double err, bool is_U, bool is_vT,
@@ -89,7 +119,7 @@ void linalg_binding(py::module &m) {
     py::arg("Tin"), py::arg("keepdim"), py::arg("err") = double(0), py::arg("is_U") = true,
     py::arg("is_vT") = true, py::arg("return_err") = (unsigned int)(0), py::arg("mindim") = 1,
     py::arg("oversampling_summand") = 10, py::arg("oversampling_factor") = 1.,
-    py::arg("power_iteration") = 0, py::arg("seed") = -1);
+    py::arg("power_iteration") = 0, py::arg("seed") = -1, py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Rsvd",  // for UniTensor, with min_blockdim
     [](const cytnx::UniTensor &Tin, cytnx_uint64 keepdim,
@@ -106,7 +136,8 @@ void linalg_binding(py::module &m) {
     py::arg("Tin"), py::arg("keepdim"), py::arg("min_blockdim"), py::arg("err") = double(0),
     py::arg("is_U") = true, py::arg("is_vT") = true, py::arg("return_err") = (unsigned int)(0),
     py::arg("mindim") = 1, py::arg("oversampling_summand") = 10,
-    py::arg("oversampling_factor") = 1., py::arg("power_iteration") = 0, py::arg("seed") = -1);
+    py::arg("oversampling_factor") = 1., py::arg("power_iteration") = 0, py::arg("seed") = -1,
+    py::call_guard<py::gil_scoped_release>());
 
   m_linalg.def(
     "Gesvd_truncate",
@@ -115,7 +146,8 @@ void linalg_binding(py::module &m) {
       return cytnx::linalg::Gesvd_truncate(Tin, keepdim, err, is_U, is_vT, return_err, mindim);
     },
     py::arg("Tin"), py::arg("keepdim"), py::arg("err") = double(0), py::arg("is_U") = true,
-    py::arg("is_vT") = true, py::arg("return_err") = (unsigned int)(0), py::arg("mindim") = 1);
+    py::arg("is_vT") = true, py::arg("return_err") = (unsigned int)(0), py::arg("mindim") = 1,
+    py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Gesvd_truncate",
     [](const UniTensor &Tin, const cytnx_uint64 &keepdim, const cytnx_double &err, const bool &is_U,
@@ -123,7 +155,8 @@ void linalg_binding(py::module &m) {
       return cytnx::linalg::Gesvd_truncate(Tin, keepdim, err, is_U, is_vT, return_err, mindim);
     },
     py::arg("Tin"), py::arg("keepdim"), py::arg("err") = 0, py::arg("is_U") = true,
-    py::arg("is_vT") = true, py::arg("return_err") = (unsigned int)(0), py::arg("mindim") = 1);
+    py::arg("is_vT") = true, py::arg("return_err") = (unsigned int)(0), py::arg("mindim") = 1,
+    py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Gesvd_truncate",
     [](const UniTensor &Tin, const cytnx_uint64 &keepdim, std::vector<cytnx_uint64> min_blockdim,
@@ -134,7 +167,7 @@ void linalg_binding(py::module &m) {
     },
     py::arg("Tin"), py::arg("keepdim"), py::arg("min_blockdim"), py::arg("err") = 0,
     py::arg("is_U") = true, py::arg("is_vT") = true, py::arg("return_err") = (unsigned int)(0),
-    py::arg("mindim") = 1);
+    py::arg("mindim") = 1, py::call_guard<py::gil_scoped_release>());
 
   m_linalg.def(
     "Svd_truncate",
@@ -143,7 +176,8 @@ void linalg_binding(py::module &m) {
       return cytnx::linalg::Svd_truncate(Tin, keepdim, err, is_UvT, return_err, mindim);
     },
     py::arg("Tin"), py::arg("keepdim"), py::arg("err") = double(0), py::arg("is_UvT") = true,
-    py::arg("return_err") = (unsigned int)(0), py::arg("mindim") = 1);
+    py::arg("return_err") = (unsigned int)(0), py::arg("mindim") = 1,
+    py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Svd_truncate",
     [](const UniTensor &Tin, const cytnx_uint64 &keepdim, const double &err, const bool &is_UvT,
@@ -151,7 +185,8 @@ void linalg_binding(py::module &m) {
       return cytnx::linalg::Svd_truncate(Tin, keepdim, err, is_UvT, return_err, mindim);
     },
     py::arg("Tin"), py::arg("keepdim"), py::arg("err") = 0, py::arg("is_UvT") = true,
-    py::arg("return_err") = (unsigned int)(0), py::arg("mindim") = 1);
+    py::arg("return_err") = (unsigned int)(0), py::arg("mindim") = 1,
+    py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Svd_truncate",
     [](const UniTensor &Tin, const cytnx_uint64 &keepdim, std::vector<cytnx_uint64> min_blockdim,
@@ -161,7 +196,8 @@ void linalg_binding(py::module &m) {
                                          mindim);
     },
     py::arg("Tin"), py::arg("keepdim"), py::arg("min_blockdim"), py::arg("err") = 0,
-    py::arg("is_UvT") = true, py::arg("return_err") = (unsigned int)(0), py::arg("mindim") = 1);
+    py::arg("is_UvT") = true, py::arg("return_err") = (unsigned int)(0), py::arg("mindim") = 1,
+    py::call_guard<py::gil_scoped_release>());
 
   // m_linalg.def("Eigh", &cytnx::linalg::Eigh, py::arg("Tin"), py::arg("is_V") = true,
   //              py::arg("row_v") = false);
@@ -172,26 +208,30 @@ void linalg_binding(py::module &m) {
     [](const Tensor &Tin, const bool &is_V, const bool &row_v) {
       return cytnx::linalg::Eigh(Tin, is_V, row_v);
     },
-    py::arg("Tin"), py::arg("is_V") = true, py::arg("row_v") = false);
+    py::arg("Tin"), py::arg("is_V") = true, py::arg("row_v") = false,
+    py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Eigh",
     [](const UniTensor &Tin, const bool &is_V, const bool &row_v) {
       return cytnx::linalg::Eigh(Tin, is_V, row_v);
     },
-    py::arg("Tin"), py::arg("is_V") = true, py::arg("row_v") = false);
+    py::arg("Tin"), py::arg("is_V") = true, py::arg("row_v") = false,
+    py::call_guard<py::gil_scoped_release>());
 
   m_linalg.def(
     "Eig",
     [](const Tensor &Tin, const bool &is_V, const bool &row_v) {
       return cytnx::linalg::Eig(Tin, is_V, row_v);
     },
-    py::arg("Tin"), py::arg("is_V") = true, py::arg("row_v") = false);
+    py::arg("Tin"), py::arg("is_V") = true, py::arg("row_v") = false,
+    py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Eig",
     [](const UniTensor &Tin, const bool &is_V, const bool &row_v) {
       return cytnx::linalg::Eig(Tin, is_V, row_v);
     },
-    py::arg("Tin"), py::arg("is_V") = true, py::arg("row_v") = false);
+    py::arg("Tin"), py::arg("is_V") = true, py::arg("row_v") = false,
+    py::call_guard<py::gil_scoped_release>());
 
   m_linalg.def("Exp", &cytnx::linalg::Exp, py::arg("Tin"));
   m_linalg.def("Exp_", &cytnx::linalg::Exp_, py::arg("Tio"));
@@ -748,32 +788,36 @@ void linalg_binding(py::module &m) {
   m_linalg.def(
     "Qr",
     [](const cytnx::UniTensor &Tin, const bool &is_tau) { return cytnx::linalg::Qr(Tin, is_tau); },
-    py::arg("Tio"), py::arg("is_tau") = false);
+    py::arg("Tio"), py::arg("is_tau") = false, py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Qr",
     [](const cytnx::Tensor &Tin, const bool &is_tau) { return cytnx::linalg::Qr(Tin, is_tau); },
-    py::arg("Tio"), py::arg("is_tau") = false);
+    py::arg("Tio"), py::arg("is_tau") = false, py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Qdr",
     [](const cytnx::UniTensor &Tin, const bool &is_tau) { return cytnx::linalg::Qdr(Tin, is_tau); },
-    py::arg("Tio"), py::arg("is_tau") = false);
+    py::arg("Tio"), py::arg("is_tau") = false, py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Qdr",
     [](const cytnx::Tensor &Tin, const bool &is_tau) { return cytnx::linalg::Qdr(Tin, is_tau); },
-    py::arg("Tio"), py::arg("is_tau") = false);
+    py::arg("Tio"), py::arg("is_tau") = false, py::call_guard<py::gil_scoped_release>());
 
   // m_linalg.def("InvM", &cytnx::linalg::InvM, py::arg("Tin"));
 
   // m_linalg.def("InvM_", &cytnx::linalg::InvM_, py::arg("Tio"));
   m_linalg.def(
-    "InvM_", [](cytnx::UniTensor &Tio) { cytnx::linalg::InvM_(Tio); }, py::arg("Tio"));
+    "InvM_", [](cytnx::UniTensor &Tio) { cytnx::linalg::InvM_(Tio); }, py::arg("Tio"),
+    py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
-    "InvM_", [](cytnx::Tensor &Tio) { cytnx::linalg::InvM_(Tio); }, py::arg("Tio"));
+    "InvM_", [](cytnx::Tensor &Tio) { cytnx::linalg::InvM_(Tio); }, py::arg("Tio"),
+    py::call_guard<py::gil_scoped_release>());
 
   m_linalg.def(
-    "InvM", [](cytnx::UniTensor &Tin) { return cytnx::linalg::InvM(Tin); }, py::arg("Tin"));
+    "InvM", [](cytnx::UniTensor &Tin) { return cytnx::linalg::InvM(Tin); }, py::arg("Tin"),
+    py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
-    "InvM", [](cytnx::Tensor &Tin) { return cytnx::linalg::InvM(Tin); }, py::arg("Tin"));
+    "InvM", [](cytnx::Tensor &Tin) { return cytnx::linalg::InvM(Tin); }, py::arg("Tin"),
+    py::call_guard<py::gil_scoped_release>());
 
   m_linalg.def(
     "Inv", [](const UniTensor &Tin, double clip) { return cytnx::linalg::Inv(Tin, clip); },
@@ -801,18 +845,23 @@ void linalg_binding(py::module &m) {
   m_linalg.def(
     "Conj_", [](cytnx::UniTensor &Tin) { cytnx::linalg::Conj_(Tin); }, py::arg("Tin"));
 
-  m_linalg.def("Matmul", &cytnx::linalg::Matmul, py::arg("T1"), py::arg("T2"));
-  m_linalg.def("Matmul_dg", &cytnx::linalg::Matmul_dg, py::arg("T1"), py::arg("T2"));
+  m_linalg.def("Matmul", &cytnx::linalg::Matmul, py::arg("T1"), py::arg("T2"),
+               py::call_guard<py::gil_scoped_release>());
+  m_linalg.def("Matmul_dg", &cytnx::linalg::Matmul_dg, py::arg("T1"), py::arg("T2"),
+               py::call_guard<py::gil_scoped_release>());
   m_linalg.def("Diag", &cytnx::linalg::Diag, py::arg("Tin"));
-  m_linalg.def("Det", &cytnx::linalg::Det, py::arg("Tin"));
+  m_linalg.def("Det", &cytnx::linalg::Det, py::arg("Tin"),
+               py::call_guard<py::gil_scoped_release>());
   m_linalg.def("Tensordot", &cytnx::linalg::Tensordot, py::arg("T1"), py::arg("T2"),
                py::arg("indices_1"), py::arg("indices_2"), py::arg("cacheL") = false,
-               py::arg("cacheR") = false);
+               py::arg("cacheR") = false, py::call_guard<py::gil_scoped_release>());
   m_linalg.def("Tensordot_dg", &cytnx::linalg::Tensordot_dg, py::arg("T1"), py::arg("T2"),
-               py::arg("indices_1"), py::arg("indices_2"), py::arg("diag_L"));
+               py::arg("indices_1"), py::arg("indices_2"), py::arg("diag_L"),
+               py::call_guard<py::gil_scoped_release>());
   m_linalg.def("Outer", &cytnx::linalg::Outer, py::arg("T1"), py::arg("T2"));
   m_linalg.def("Kron", &cytnx::linalg::Kron, py::arg("T1"), py::arg("T2"),
-               py::arg("Tl_pad_left") = false, py::arg("Tr_pad_left") = false);
+               py::arg("Tl_pad_left") = false, py::arg("Tr_pad_left") = false,
+               py::call_guard<py::gil_scoped_release>());
   m_linalg.def("Vectordot", &cytnx::linalg::Vectordot, py::arg("T1"), py::arg("T2"),
                py::arg("is_conj") = false);
   m_linalg.def("Tridiag", &cytnx::linalg::Tridiag, py::arg("A"), py::arg("B"),
@@ -825,7 +874,8 @@ void linalg_binding(py::module &m) {
   m_linalg.def(
     "Norm", [](cytnx::Tensor &T1) { return cytnx::linalg::Norm(T1); }, py::arg("T1"));
 
-  m_linalg.def("Dot", &cytnx::linalg::Dot, py::arg("T1"), py::arg("T2"));
+  m_linalg.def("Dot", &cytnx::linalg::Dot, py::arg("T1"), py::arg("T2"),
+               py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Axpy", [](const Scalar &a, const Tensor &x) { return cytnx::linalg::Axpy(a, x); },
     py::arg("a"), py::arg("x"));
@@ -842,12 +892,12 @@ void linalg_binding(py::module &m) {
   m_linalg.def("Axpy_", &cytnx::linalg::Axpy_, py::arg("a"), py::arg("x"), py::arg("y"));
 
   m_linalg.def("Gemm_", &cytnx::linalg::Gemm_, py::arg("a"), py::arg("x"), py::arg("y"),
-               py::arg("b"), py::arg("c"));
+               py::arg("b"), py::arg("c"), py::call_guard<py::gil_scoped_release>());
 
   m_linalg.def(
     "Gemm",
     [](const Scalar &a, const Tensor &x, const Tensor &y) { return cytnx::linalg::Gemm(a, x, y); },
-    py::arg("a"), py::arg("x"), py::arg("y"));
+    py::arg("a"), py::arg("x"), py::arg("y"), py::call_guard<py::gil_scoped_release>());
 
   m_linalg.def(
     "Trace",
@@ -895,7 +945,7 @@ void linalg_binding(py::module &m) {
     [](const Tensor &T1, const Tensor &T2, const std::vector<cytnx_uint64> &shared_axes) {
       return linalg::Directsum(T1, T2, shared_axes);
     },
-    py::arg("T1"), py::arg("T2"), py::arg("shared_axes"));
+    py::arg("T1"), py::arg("T2"), py::arg("shared_axes"), py::call_guard<py::gil_scoped_release>());
 
   m_linalg.def(
     "Hosvd",
@@ -904,7 +954,7 @@ void linalg_binding(py::module &m) {
       return cytnx::linalg::Hosvd(Tin, mode, is_core, is_Ls, truncate_dim);
     },
     py::arg("Tn"), py::arg("mode"), py::arg("is_core") = true, py::arg("is_Ls") = false,
-    py::arg("truncate_dim") = std::vector<cytnx_int64>());
+    py::arg("truncate_dim") = std::vector<cytnx_int64>(), py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Hosvd",
     [](const cytnx::UniTensor &Tin, const std::vector<cytnx_uint64> &mode, const bool &is_core,
@@ -912,7 +962,7 @@ void linalg_binding(py::module &m) {
       return cytnx::linalg::Hosvd(Tin, mode, is_core, is_Ls, truncate_dim);
     },
     py::arg("Tn"), py::arg("mode"), py::arg("is_core") = true, py::arg("is_Ls") = false,
-    py::arg("truncate_dim") = std::vector<cytnx_int64>());
+    py::arg("truncate_dim") = std::vector<cytnx_int64>(), py::call_guard<py::gil_scoped_release>());
 
   m_linalg.def(
     "Arnoldi",
@@ -923,7 +973,7 @@ void linalg_binding(py::module &m) {
     },
     py::arg("Hop"), py::arg("Tin"), py::arg("which") = "LM", py::arg("Maxiter") = 10000,
     py::arg("CvgCrit") = 0, py::arg("k") = 1, py::arg("is_V") = true, py::arg("ncv") = 0,
-    py::arg("verbose") = false);
+    py::arg("verbose") = false, py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Arnoldi",
     [](LinOp *Hop, const UniTensor &Tin, const std::string which, const cytnx_uint64 &Maxiter,
@@ -933,7 +983,7 @@ void linalg_binding(py::module &m) {
     },
     py::arg("Hop"), py::arg("Tin"), py::arg("which") = "LM", py::arg("Maxiter") = 10000,
     py::arg("CvgCrit") = 0, py::arg("k") = 1, py::arg("is_V") = true, py::arg("ncv") = 0,
-    py::arg("verbose") = false);
+    py::arg("verbose") = false, py::call_guard<py::gil_scoped_release>());
 
   m_linalg.def(
     "Lanczos",
@@ -945,7 +995,8 @@ void linalg_binding(py::module &m) {
     },
     py::arg("Hop"), py::arg("Tin"), py::arg("method"), py::arg("CvgCrit") = 1.0e-14,
     py::arg("Maxiter") = 10000, py::arg("k") = 1, py::arg("is_V") = true, py::arg("is_row") = false,
-    py::arg("max_krydim") = 0, py::arg("verbose") = false);
+    py::arg("max_krydim") = 0, py::arg("verbose") = false,
+    py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Lanczos",
     [](LinOp *Hop, const UniTensor &Tin, const std::string method, const double &CvgCrit,
@@ -956,7 +1007,8 @@ void linalg_binding(py::module &m) {
     },
     py::arg("Hop"), py::arg("Tin"), py::arg("method"), py::arg("CvgCrit") = 1.0e-14,
     py::arg("Maxiter") = 10000, py::arg("k") = 1, py::arg("is_V") = true, py::arg("is_row") = false,
-    py::arg("max_krydim") = 0, py::arg("verbose") = false);
+    py::arg("max_krydim") = 0, py::arg("verbose") = false,
+    py::call_guard<py::gil_scoped_release>());
 
   m_linalg.def(
     "Lanczos",
@@ -967,7 +1019,7 @@ void linalg_binding(py::module &m) {
     },
     py::arg("Hop"), py::arg("Tin"), py::arg("which") = "SA", py::arg("Maxiter") = 10000,
     py::arg("CvgCrit") = 0, py::arg("k") = 1, py::arg("is_V") = true, py::arg("ncv") = 0,
-    py::arg("verbose") = false);
+    py::arg("verbose") = false, py::call_guard<py::gil_scoped_release>());
   m_linalg.def(
     "Lanczos",
     [](LinOp *Hop, const UniTensor &Tin, const std::string which, const cytnx_uint64 &Maxiter,
@@ -977,7 +1029,7 @@ void linalg_binding(py::module &m) {
     },
     py::arg("Hop"), py::arg("Tin"), py::arg("which") = "SA", py::arg("Maxiter") = 10000,
     py::arg("CvgCrit") = 0, py::arg("k") = 1, py::arg("is_V") = true, py::arg("ncv") = 0,
-    py::arg("verbose") = false);
+    py::arg("verbose") = false, py::call_guard<py::gil_scoped_release>());
 
   m_linalg.def(
     "Lanczos_Exp",
@@ -986,14 +1038,16 @@ void linalg_binding(py::module &m) {
       return cytnx::linalg::Lanczos_Exp(Hop, v, tau, CvgCrit, Maxiter, verbose);
     },
     py::arg("Hop"), py::arg("v"), py::arg("tau"), py::arg("CvgCrit") = 1.0e-14,
-    py::arg("Maxiter") = 10000, py::arg("verbose") = false);
+    py::arg("Maxiter") = 10000, py::arg("verbose") = false,
+    py::call_guard<py::gil_scoped_release>());
 
   m_linalg.def(
     "Lstsq",
     [](const Tensor &A, const Tensor &b, const float &rcond) {
       return cytnx::linalg::Lstsq(A, b, rcond);
     },
-    py::arg("A"), py::arg("b"), py::arg("rcond") = float(-1));
+    py::arg("A"), py::arg("b"), py::arg("rcond") = float(-1),
+    py::call_guard<py::gil_scoped_release>());
 
   /*
   m_linalg.def("c_Lanczos_ER",

--- a/pybind/network_py.cpp
+++ b/pybind/network_py.cpp
@@ -96,7 +96,9 @@ void network_binding(py::module &m) {
     .def("getOrder", [](Network &self) { return self.getOrder(); })
 
     // .def("getOrder", &Network::getOrder)
-    .def("Launch", &Network::Launch, py::arg("network_type") = (int)NtType.Regular)
+    // GIL: see the guard discipline note in linalg_py.cpp
+    .def("Launch", &Network::Launch, py::arg("network_type") = (int)NtType.Regular,
+         py::call_guard<py::gil_scoped_release>())
 
     .def("construct", &Network::construct, py::arg("alias"), py::arg("labels"),
          py::arg("outlabel") = std::vector<std::string>(), py::arg("outrk") = (cytnx_int64)0,

--- a/pybind/unitensor_py.cpp
+++ b/pybind/unitensor_py.cpp
@@ -986,7 +986,8 @@ void unitensor_binding(py::module &m) {
 
 
 
-    .def("contract", &UniTensor::contract, py::arg("inR"), py::arg("mv_elem_self")=false, py::arg("mv_elem_rhs")=false)
+    // GIL: see the guard discipline note in linalg_py.cpp
+    .def("contract", &UniTensor::contract, py::arg("inR"), py::arg("mv_elem_self")=false, py::arg("mv_elem_rhs")=false, py::call_guard<py::gil_scoped_release>())
 
     .def("getTotalQnums", &UniTensor::getTotalQnums, py::arg("physical")=false)
 
@@ -2095,20 +2096,24 @@ void unitensor_binding(py::module &m) {
 
   //   m.def("Contract", Contract, py::arg("Tl"), py::arg("Tr"), py::arg("cacheL") = false,
   //         py::arg("cacheR") = false);
+  // GIL: see the guard discipline note in linalg_py.cpp
   m.def(
     "Contract",
     [](const UniTensor &inL, const UniTensor &inR, const bool &cacheL,
        const bool &cacheR) -> UniTensor { return Contract(inL, inR, cacheL, cacheR); },
-    py::arg("Tl"), py::arg("Tr"), py::arg("cacheL") = false, py::arg("cacheR") = false);
+    py::arg("Tl"), py::arg("Tr"), py::arg("cacheL") = false, py::arg("cacheR") = false,
+    py::call_guard<py::gil_scoped_release>());
   m.def(
     "Contract",
     [](const std::vector<UniTensor> &TNs, const std::string &order,
        const bool &optimal) -> UniTensor { return Contract(TNs, order, optimal); },
-    py::arg("TNs"), py::arg("order") = "", py::arg("optimal") = true);
+    py::arg("TNs"), py::arg("order") = "", py::arg("optimal") = true,
+    py::call_guard<py::gil_scoped_release>());
   m.def(
     "Contracts",
     [](const std::vector<UniTensor> &TNs, const std::string &order,
        const bool &optimal) -> UniTensor { return Contracts(TNs, order, optimal); },
-    py::arg("TNs"), py::arg("order") = "", py::arg("optimal") = true);
+    py::arg("TNs"), py::arg("order") = "", py::arg("optimal") = true,
+    py::call_guard<py::gil_scoped_release>());
 }
 #endif

--- a/pytests/binding_gil_test.py
+++ b/pytests/binding_gil_test.py
@@ -16,6 +16,8 @@ this keeps the assertion meaningful across faster/slower CI machines.
 import threading
 import time
 
+import pytest
+
 import cytnx
 
 
@@ -25,21 +27,35 @@ def _time_one_svd(a):
     return time.monotonic() - t0
 
 
-def test_svd_releases_gil():
-    # 400x400 is too fast on Accelerate/LAPACK-backed builds (~0.08s per
-    # call) to reliably exceed the ticker-starvation threshold even when the
-    # GIL is held for the whole call; 900x900 gives a single-call duration
-    # of several hundred ms, which is comfortably observable.
-    a = cytnx.random.normal([900, 900], mean=0.0, std=1.0)
+# A single serial Svd must take at least this long for the ticker-starvation
+# signal to be discriminating; otherwise the test would pass vacuously even
+# with the GIL held. It is comfortably above the ~0.2s scheduling-jitter floor
+# used by the assertion below.
+_CALIBRATION_FLOOR_S = 0.3
 
-    # Measure a single serial Svd call to calibrate the "GIL held too long"
-    # threshold to this machine's speed instead of a brittle fixed constant.
+
+def test_svd_releases_gil():
+    # Scale the matrix up until a single serial Svd reliably exceeds the
+    # discrimination floor, so the test stays meaningful regardless of how fast
+    # this machine's LAPACK backend is (a fixed 900x900 clears ~0.3s on typical
+    # runners but can drop to ~0.2s on the fastest ones). Svd is O(n^3), so each
+    # 1.5x growth in dim is ~3.4x the work. If even the largest size stays under
+    # the floor, the machine is simply too fast to discriminate -- skip rather
+    # than fail flakily.
+    dim = 900
+    max_dim = 2000
+    a = cytnx.random.normal([dim, dim], mean=0.0, std=1.0)
     serial_duration = _time_one_svd(a)
-    # If a single call is not clearly above the 0.2s jitter floor, the test
-    # would pass vacuously even with the GIL held; force a resize instead.
-    assert serial_duration > 0.25, (
-        "matrix too small to discriminate GIL hold from floor"
-    )
+    while serial_duration < _CALIBRATION_FLOOR_S and dim < max_dim:
+        dim = min(int(dim * 1.5), max_dim)
+        a = cytnx.random.normal([dim, dim], mean=0.0, std=1.0)
+        serial_duration = _time_one_svd(a)
+    if serial_duration < _CALIBRATION_FLOOR_S:
+        pytest.skip(
+            f"machine too fast to discriminate GIL hold from the timing floor "
+            f"(Svd of {dim}x{dim} took {serial_duration:.3f}s "
+            f"< {_CALIBRATION_FLOOR_S}s)"
+        )
 
     ticks = []
     stop = threading.Event()

--- a/pytests/binding_gil_test.py
+++ b/pytests/binding_gil_test.py
@@ -1,0 +1,122 @@
+"""GIL-release tests for expensive pybind11 bindings (Phase 1 Task 5).
+
+These bindings (Svd, Lanczos/Arnoldi w/ LinOp, Contract, Network.Launch, ...)
+now carry py::call_guard<py::gil_scoped_release>() so a long-running C++
+computation does not block other Python threads. The threading test below
+starts a "ticker" thread that timestamps itself every ~1ms while the main
+thread repeatedly calls cytnx.linalg.Svd on a modestly large matrix; if the
+GIL were held throughout the Svd call, the ticker would starve and the max
+gap between consecutive ticks would balloon to roughly the Svd call
+duration. We compare the observed max gap against the measured duration of
+a single serial Svd call (scaled with margin) rather than a fixed wall-clock
+constant, since the fixed-threshold approach is sensitive to machine load;
+this keeps the assertion meaningful across faster/slower CI machines.
+"""
+
+import threading
+import time
+
+import cytnx
+
+
+def _time_one_svd(a):
+    t0 = time.monotonic()
+    cytnx.linalg.Svd(a)
+    return time.monotonic() - t0
+
+
+def test_svd_releases_gil():
+    # 400x400 is too fast on Accelerate/LAPACK-backed builds (~0.08s per
+    # call) to reliably exceed the ticker-starvation threshold even when the
+    # GIL is held for the whole call; 900x900 gives a single-call duration
+    # of several hundred ms, which is comfortably observable.
+    a = cytnx.random.normal([900, 900], mean=0.0, std=1.0)
+
+    # Measure a single serial Svd call to calibrate the "GIL held too long"
+    # threshold to this machine's speed instead of a brittle fixed constant.
+    serial_duration = _time_one_svd(a)
+    # If a single call is not clearly above the 0.2s jitter floor, the test
+    # would pass vacuously even with the GIL held; force a resize instead.
+    assert serial_duration > 0.25, (
+        "matrix too small to discriminate GIL hold from floor"
+    )
+
+    ticks = []
+    stop = threading.Event()
+
+    def ticker():
+        while not stop.is_set():
+            ticks.append(time.monotonic())
+            time.sleep(0.001)
+
+    # daemon=True as a backstop: even if the finally below is somehow
+    # skipped, a leaked ticker must not hang interpreter shutdown.
+    th = threading.Thread(target=ticker, daemon=True)
+    th.start()
+    try:
+        # Give the ticker a moment to start collecting before the heavy calls.
+        time.sleep(0.01)
+        for _ in range(3):
+            cytnx.linalg.Svd(a)
+    finally:
+        # Always stop the ticker, even if an Svd call raises - a leaked
+        # ticker would otherwise outlive the test and mask the real error.
+        stop.set()
+        th.join()
+
+    gaps = [t1 - t0 for t0, t1 in zip(ticks, ticks[1:])]
+    assert gaps, "ticker thread did not record any ticks"
+    max_gap = max(gaps)
+    # If the GIL were held for the whole call, max_gap would be roughly
+    # serial_duration. Require it to be well under that (half, with a floor
+    # of 0.2s to stay robust on loaded machines where scheduling jitter alone
+    # can cost tens of ms).
+    threshold = max(0.2, serial_duration * 0.5)
+    assert max_gap < threshold, (
+        f"GIL held too long: max_gap={max_gap:.3f}s, "
+        f"serial_svd_duration={serial_duration:.3f}s, threshold={threshold:.3f}s"
+    )
+
+
+def test_lanczos_with_python_linop_still_works():
+    # Precondition smoke test: subclassing LinOp from Python and overriding
+    # matvec() must still work at all (direct call, no solver involved).
+    # This does NOT exercise the GIL-released path - see
+    # test_lanczos_gnd_with_python_linop below for the trampoline-under-
+    # guarded-solver case.
+    class MyOp(cytnx.LinOp):
+        def __init__(self):
+            cytnx.LinOp.__init__(self, "mv", 4)
+
+        def matvec(self, v):
+            return v * 2.0
+
+    op = MyOp()
+    v = cytnx.ones([4])
+    out = op.matvec(v)
+    assert out.shape() == [4]
+
+
+def test_lanczos_gnd_with_python_linop():
+    # Cheap real Lanczos call (Gnd = ground state) through a python-defined
+    # LinOp, mirroring example/DMRG/dmrg_two_sites_dense.py's Hxx pattern.
+    # This exercises the full guarded Lanczos binding with the trampoline
+    # matvec callback while the GIL is released around the C++ solver body.
+    class Diag(cytnx.LinOp):
+        def __init__(self, nx):
+            cytnx.LinOp.__init__(self, "mv", nx, cytnx.Type.Double, cytnx.Device.cpu)
+
+        def matvec(self, v):
+            out = v.clone()
+            for i in range(out.shape()[0]):
+                out[i] = out[i].item() * (i + 1)
+            return out
+
+    nx = 4
+    op = Diag(nx)
+    v0 = cytnx.ones([nx])
+    energy, psivec = cytnx.linalg.Lanczos(
+        Hop=op, method="Gnd", Maxiter=200, CvgCrit=1e-10, Tin=v0
+    )
+    # smallest eigenvalue of diag(1,2,3,4) is 1
+    assert abs(energy[0].item() - 1.0) < 1e-6


### PR DESCRIPTION
## Problem

No binding released the GIL, so any long-running call (SVD, eigensolver, contraction, `Network.Launch`) blocked every other Python thread for its full duration.

## Fix

`py::call_guard<py::gil_scoped_release>()` on 50 binding sites: all O(n³)-class linalg entry points (Svd/Gesvd/±truncate, Rsvd, Eigh/Eig, Qr/Qdr, Hosvd, Lstsq, InvM/InvM_, Matmul(+_dg), Tensordot(+_dg), Kron, Dot, Gemm/Gemm_, Directsum, Det, Arnoldi, Lanczos, Lanczos_Exp), `Contract`/`Contracts`/`.contract`, and `Network.Launch`. **ExpH/ExpM are deliberately excluded** — open PR #915 rewrites those bindings; guarding them here would conflict.

Safety was verified against the fetched pybind11 3.0.1 source, and the rules are recorded in an in-code discipline note at the first guard site: guarded lambda bodies are pure C++ (argument conversion happens before the guard, return conversion after it); `py::scoped_ostream_redirect` needs the GIL so guard composition order matters; Python `LinOp.matvec` callbacks are safe because `PYBIND11_OVERRIDE` reacquires the GIL (verified at pybind11.h:3532) — pinned by an end-to-end test running a real Lanczos ground-state solve through a Python-subclassed `LinOp`.

## Testing

New `pytests/binding_gil_test.py`: a self-calibrating threading test (asserts a ticker thread keeps running during Svd; red on the unguarded build with gap ≈ full Svd duration), a LinOp smoke test, and the Lanczos-through-Python-LinOp integration test. Elementwise/Tensor-operator sweep deliberately deferred (documented in the in-code note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)