### PR TITLE
fix(arpack): pass Fortran hidden character-length arguments in ARPACK calls

### DIFF
--- a/include/backend/arpack_wrapper.hpp
+++ b/include/backend/arpack_wrapper.hpp
@@ -3,76 +3,89 @@
 
 #include "lapack_wrapper.hpp"
 #include <complex>
+#include <cstddef>
 
 namespace arpack {
+
+  // Fortran compilers pass a hidden length argument, appended after the declared
+  // arguments, for every CHARACTER dummy (gfortran >= 8 passes it as size_t; older
+  // gfortran and other Unix compilers as int -- passing size_t is compatible with
+  // both on LP64 little-endian targets, matching LAPACK's modern FORTRAN_STRLEN
+  // convention). Omitting them from the C prototypes is undefined behavior, so the
+  // declarations below carry one trailing length per CHARACTER argument and call
+  // sites must pass the actual lengths (bmat: 1, which: 2, howmny: 1).
 
   extern "C" {
 
   // === Real Symmetric (double precision) ===
   void dsaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol, double *resid,
                int *ncv, double *v, int *ldv, int *iparam, int *ipntr, double *workd, double *workl,
-               int *lworkl, int *info);
+               int *lworkl, int *info, std::size_t bmat_len, std::size_t which_len);
 
   void dseupd_(int *rvec, char *howmny, int *select, double *d, double *z, int *ldz, double *sigma,
                char *bmat, int *n, char *which, int *nev, double *tol, double *resid, int *ncv,
                double *v, int *ldv, int *iparam, int *ipntr, double *workd, double *workl,
-               int *lworkl, int *info);
+               int *lworkl, int *info, std::size_t howmny_len, std::size_t bmat_len,
+               std::size_t which_len);
 
   // === Real Symmetric (single precision) ===
   void ssaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol, float *resid,
                int *ncv, float *v, int *ldv, int *iparam, int *ipntr, float *workd, float *workl,
-               int *lworkl, int *info);
+               int *lworkl, int *info, std::size_t bmat_len, std::size_t which_len);
 
   void sseupd_(int *rvec, char *howmny, int *select, float *d, float *z, int *ldz, float *sigma,
                char *bmat, int *n, char *which, int *nev, float *tol, float *resid, int *ncv,
                float *v, int *ldv, int *iparam, int *ipntr, float *workd, float *workl, int *lworkl,
-               int *info);
+               int *info, std::size_t howmny_len, std::size_t bmat_len, std::size_t which_len);
 
   // === Real Non-Symmetric (double precision) ===
   void dnaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol, double *resid,
                int *ncv, double *v, int *ldv, int *iparam, int *ipntr, double *workd, double *workl,
-               int *lworkl, int *info);
+               int *lworkl, int *info, std::size_t bmat_len, std::size_t which_len);
 
   void dneupd_(int *rvec, char *howmny, int *select, double *dr, double *di, double *z, int *ldz,
                double *sigmar, double *sigmai, double *workev, char *bmat, int *n, char *which,
                int *nev, double *tol, double *resid, int *ncv, double *v, int *ldv, int *iparam,
-               int *ipntr, double *workd, double *workl, int *lworkl, int *info);
+               int *ipntr, double *workd, double *workl, int *lworkl, int *info,
+               std::size_t howmny_len, std::size_t bmat_len, std::size_t which_len);
 
   // === Real Non-Symmetric (single precision) ===
   void snaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol, float *resid,
                int *ncv, float *v, int *ldv, int *iparam, int *ipntr, float *workd, float *workl,
-               int *lworkl, int *info);
+               int *lworkl, int *info, std::size_t bmat_len, std::size_t which_len);
 
   void sneupd_(int *rvec, char *howmny, int *select, float *dr, float *di, float *z, int *ldz,
                float *sigmar, float *sigmai, float *workev, char *bmat, int *n, char *which,
                int *nev, float *tol, float *resid, int *ncv, float *v, int *ldv, int *iparam,
-               int *ipntr, float *workd, float *workl, int *lworkl, int *info);
+               int *ipntr, float *workd, float *workl, int *lworkl, int *info,
+               std::size_t howmny_len, std::size_t bmat_len, std::size_t which_len);
 
   // === Complex General (non-Hermitian, double precision) ===
   void znaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
                std::complex<double> *resid, int *ncv, std::complex<double> *v, int *ldv,
                int *iparam, int *ipntr, std::complex<double> *workd, std::complex<double> *workl,
-               int *lworkl, double *rwork, int *info);
+               int *lworkl, double *rwork, int *info, std::size_t bmat_len, std::size_t which_len);
 
   void zneupd_(int *rvec, char *howmny, int *select, std::complex<double> *d,
                std::complex<double> *z, int *ldz, std::complex<double> *sigma,
                std::complex<double> *workev, char *bmat, int *n, char *which, int *nev, double *tol,
                std::complex<double> *resid, int *ncv, std::complex<double> *v, int *ldv,
                int *iparam, int *ipntr, std::complex<double> *workd, std::complex<double> *workl,
-               int *lworkl, double *rwork, int *info);
+               int *lworkl, double *rwork, int *info, std::size_t howmny_len, std::size_t bmat_len,
+               std::size_t which_len);
 
   // === Complex General (non-Hermitian, single precision) ===
   void cnaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
                std::complex<float> *resid, int *ncv, std::complex<float> *v, int *ldv, int *iparam,
                int *ipntr, std::complex<float> *workd, std::complex<float> *workl, int *lworkl,
-               float *rwork, int *info);
+               float *rwork, int *info, std::size_t bmat_len, std::size_t which_len);
 
   void cneupd_(int *rvec, char *howmny, int *select, std::complex<float> *d, std::complex<float> *z,
                int *ldz, std::complex<float> *sigma, std::complex<float> *workev, char *bmat,
                int *n, char *which, int *nev, float *tol, std::complex<float> *resid, int *ncv,
                std::complex<float> *v, int *ldv, int *iparam, int *ipntr,
                std::complex<float> *workd, std::complex<float> *workl, int *lworkl, float *rwork,
-               int *info);
+               int *info, std::size_t howmny_len, std::size_t bmat_len, std::size_t which_len);
 
   }  // extern "C"
 

--- a/src/linalg/Arnoldi.cpp
+++ b/src/linalg/Arnoldi.cpp
@@ -220,13 +220,15 @@ namespace cytnx {
       std::function<void(cytnx_int32 * ido, char* bmat, cytnx_int32* n, char* which,
                          cytnx_int32* nev, T2* tol, T* resid, cytnx_int32* ncv, T* v,
                          cytnx_int32* ldv, cytnx_int32* iparam, cytnx_int32* ipntr, T* workd,
-                         T* workl, cytnx_int32* lworkl, T2* rwork, cytnx_int32* info)>
+                         T* workl, cytnx_int32* lworkl, T2* rwork, cytnx_int32* info,
+                         std::size_t bmat_len, std::size_t which_len)>
         func_xnaupd;
       std::function<void(cytnx_int32 * rvec, char* howmny, cytnx_int32* select, T* d, T* z,
                          cytnx_int32* ldz, T* sigma, T* workev, char* bmat, cytnx_int32* n,
                          char* which, cytnx_int32* nev, T2* tol, T* resid, cytnx_int32* ncv, T* v,
                          cytnx_int32* ldv, cytnx_int32* iparam, cytnx_int32* ipntr, T* workd,
-                         T* workl, cytnx_int32* lworkl, T2* rwork, cytnx_int32* info)>
+                         T* workl, cytnx_int32* lworkl, T2* rwork, cytnx_int32* info,
+                         std::size_t howmny_len, std::size_t bmat_len, std::size_t which_len)>
         func_xneupd;
       auto dtype = Hop->dtype();
       if constexpr (std::is_same_v<T, cytnx_complex128>) {
@@ -289,7 +291,7 @@ namespace cytnx {
       /// start iteration
       while (true) {
         func_xnaupd(&ido, &bmat, &dim, which, &nev, &tol, resid, &ncv, v, &ldv, iparam, ipntr,
-                    workd, workl, &lworkl, rwork, &info);
+                    workd, workl, &lworkl, rwork, &info, 1, 2);
         if (ido == -1 || ido == 1) {
           matvec(Hop, buffer_UT, &workd[ipntr[0] - 1], &workd[ipntr[1] - 1]);
         } else if (ido == 99) {
@@ -325,7 +327,8 @@ namespace cytnx {
         'A';  /// how many eigenvectors to calculate: 'A' => nev eigenvectors
               ///  when howmny == 'A', this is used as workspace to reorder the eigenvectors
       func_xneupd(&rvec, &howmny, select, d, z, &ldv, &sigma, workev, &bmat, &dim, which, &nev,
-                  &tol, resid, &ncv, v, &ldv, iparam, ipntr, workd, workl, &lworkl, rwork, &info);
+                  &tol, resid, &ncv, v, &ldv, iparam, ipntr, workd, workl, &lworkl, rwork, &info, 1,
+                  1, 2);
       if (info != 0) {
         clean_arpack_complex_buffer(resid, v, workd, workl, rwork, select, d, z, workev);
         cytnx_error_msg(true, "[ERROR][Arnoldi], Error: (zc)neupd_ INFO = %d\n", info);
@@ -397,13 +400,15 @@ namespace cytnx {
       std::function<void(cytnx_int32 * ido, char* bmat, cytnx_int32* n, char* which,
                          cytnx_int32* nev, T* tol, T* resid, cytnx_int32* ncv, T* v,
                          cytnx_int32* ldv, cytnx_int32* iparam, cytnx_int32* ipntr, T* workd,
-                         T* workl, cytnx_int32* lworkl, cytnx_int32* info)>
+                         T* workl, cytnx_int32* lworkl, cytnx_int32* info, std::size_t bmat_len,
+                         std::size_t which_len)>
         func_xnaupd;
       std::function<void(
         cytnx_int32 * rvec, char* howmny, cytnx_int32* select, T* dr, T* di, T* z, cytnx_int32* ldz,
         T* sigmar, T* sigmai, T* workev, char* bmat, cytnx_int32* n, char* which, cytnx_int32* nev,
         T* tol, T* resid, cytnx_int32* ncv, T* v, cytnx_int32* ldv, cytnx_int32* iparam,
-        cytnx_int32* ipntr, T* workd, T* workl, cytnx_int32* lworkl, cytnx_int32* info)>
+        cytnx_int32* ipntr, T* workd, T* workl, cytnx_int32* lworkl, cytnx_int32* info,
+        std::size_t howmny_len, std::size_t bmat_len, std::size_t which_len)>
         func_xneupd;
       auto dtype = Hop->dtype();
       if constexpr (std::is_same_v<T, cytnx_double>) {
@@ -465,7 +470,7 @@ namespace cytnx {
       /// start iteration
       while (true) {
         func_xnaupd(&ido, &bmat, &dim, which, &nev, &tol, resid, &ncv, v, &ldv, iparam, ipntr,
-                    workd, workl, &lworkl, &info);
+                    workd, workl, &lworkl, &info, 1, 2);
         if (ido == -1 || ido == 1) {
           matvec(Hop, buffer_UT, &workd[ipntr[0] - 1], &workd[ipntr[1] - 1]);
         } else if (ido == 99) {
@@ -502,7 +507,7 @@ namespace cytnx {
               ///  when howmny == 'A', this is used as workspace to reorder the eigenvectors
       func_xneupd(&rvec, &howmny, select, dr, di, z, &ldv, &sigmar, &sigmai, workev, &bmat, &dim,
                   which, &nev, &tol, resid, &ncv, v, &ldv, iparam, ipntr, workd, workl, &lworkl,
-                  &info);
+                  &info, 1, 1, 2);
       if (info != 0) {
         clean_arpack_real_buffer(resid, v, workd, workl, dr, di, select, z, workev);
         cytnx_error_msg(true, "[ERROR][Arnoldi], Error: (zc)neupd_ INFO = %d\n", info);

--- a/src/linalg/Lanczos.cpp
+++ b/src/linalg/Lanczos.cpp
@@ -259,13 +259,15 @@ namespace cytnx {
       std::function<void(cytnx_int32 * ido, char *bmat, cytnx_int32 *n, char *which,
                          cytnx_int32 *nev, T *tol, T *resid, cytnx_int32 *ncv, T *v,
                          cytnx_int32 *ldv, cytnx_int32 *iparam, cytnx_int32 *ipntr, T *workd,
-                         T *workl, cytnx_int32 *lworkl, cytnx_int32 *info)>
+                         T *workl, cytnx_int32 *lworkl, cytnx_int32 *info, std::size_t bmat_len,
+                         std::size_t which_len)>
         func_xsaupd;
       std::function<void(cytnx_int32 * rvec, char *howmny, cytnx_int32 *select, T *d, T *z,
                          cytnx_int32 *ldz, T *sigma, char *bmat, cytnx_int32 *n, char *which,
                          cytnx_int32 *nev, T *tol, T *resid, cytnx_int32 *ncv, T *v,
                          cytnx_int32 *ldv, cytnx_int32 *iparam, cytnx_int32 *ipntr, T *workd,
-                         T *workl, cytnx_int32 *lworkl, cytnx_int32 *info)>
+                         T *workl, cytnx_int32 *lworkl, cytnx_int32 *info, std::size_t howmny_len,
+                         std::size_t bmat_len, std::size_t which_len)>
         func_xseupd;
       auto dtype = Hop->dtype();
       if constexpr (std::is_same_v<T, cytnx_double>) {
@@ -328,7 +330,7 @@ namespace cytnx {
       while (true) {
         iter++;
         func_xsaupd(&ido, &bmat, &dim, which, &nev, &tol, resid, &ncv, v, &ldv, iparam, ipntr,
-                    workd, workl, &lworkl, &info);
+                    workd, workl, &lworkl, &info, 1, 2);
         if (ido == -1 || ido == 1) {
           matvec(Hop, buffer_UT, &workd[ipntr[0] - 1], &workd[ipntr[1] - 1]);
         } else if (ido == 99) {
@@ -364,7 +366,7 @@ namespace cytnx {
         'A';  /// how many eigenvectors to calculate: 'A' => nev eigenvectors
               ///  when howmny == 'A', this is used as workspace to reorder the eigenvectors
       func_xseupd(&rvec, &howmny, select, d, z, &ldv, &sigma, &bmat, &dim, which, &nev, &tol, resid,
-                  &ncv, v, &ldv, iparam, ipntr, workd, workl, &lworkl, &info);
+                  &ncv, v, &ldv, iparam, ipntr, workd, workl, &lworkl, &info, 1, 1, 2);
       if (info != 0) {
         clean_arpack_buffer(resid, v, workd, workl, select, d, z);
         cytnx_error_msg(true, "[ERROR][Lanczos], Error: d(s)seupd_ INFO = %d\n", info);


### PR DESCRIPTION
## Summary

The `extern "C"` prototypes in `include/backend/arpack_wrapper.hpp` omitted the hidden length argument that Fortran compilers append for every `CHARACTER` dummy (`bmat`, `which`, `howmny`). Calling through such prototypes is undefined behavior. It happens to be benign for ARPACK's fixed-length dummies under today's gfortran ABI — and it was explicitly **not** the cause of the macOS segfaults investigated in #974 (those were environment-induced; see that issue) — but it is exactly the class of ABI mismatch that surfaces as platform-specific corruption, and was flagged as a cleanup follow-up when closing #974.

## Changes

- **include/backend/arpack_wrapper.hpp** — all twelve `x{s,n}aupd_` / `x{s,n}eupd_` prototypes gain trailing `std::size_t` length parameters, one per `CHARACTER` argument, with a comment documenting the convention. `std::size_t` matches gfortran ≥ 8 and LAPACK's modern `FORTRAN_STRLEN` convention; on LP64 little-endian targets it is also register/stack-slot compatible with the `int` lengths used by older compilers.
- **src/linalg/Lanczos.cpp, src/linalg/Arnoldi.cpp** — the `std::function` dispatch signatures extended to match, and every call site now passes the actual lengths (`bmat`: 1, `which`: 2, `howmny`: 1).

No functional change is expected on any platform where the code currently works: the callee already expected these arguments; we now actually pass them.

## Verification

On macOS arm64 (AppleClang, conda-forge arpack-ng 2.1.0 + OpenBLAS), with the #972 test compile fixes applied locally (not part of this branch):

- full `test_main` build succeeds;
- all **81 tests in `*Lanczos*` + `Arnoldi*` pass** (run without `DYLD_LIBRARY_PATH`, per the pitfall documented in #974/#972) — covering the d/s symmetric, d/s non-symmetric, and z/c complex driver pairs.

Linux/GCC CI exercises the same call paths and should show no change.

Related: #974 (root-cause investigation that flagged this), #626 (original ARPACK integration), #893 (previous wrapper cleanup, exonerated in #974).

🤖 Generated with [Claude Code](https://claude.com/claude-code)