### PR TITLE
fix(pybind): collapse operator overloads per Python type; add __ne__/__bool__; fix numpy dtype loss

### DIFF
--- a/cytnx/Bond_conti.py
+++ b/cytnx/Bond_conti.py
@@ -1,9 +1,8 @@
 from .utils import *
 from cytnx import *
-# from typing import List
-# Use beartype to check the type of arguments
-from beartype.typing import List
 
 # All of Bond's Python-side helpers (redirect_, getDegeneracy, group_duplicates)
 # have been folded directly into the C++ bindings in pybind/bond_py.cpp; this
-# module intentionally has no remaining delegation wrappers.
+# module intentionally has no remaining delegation wrappers. The `List` import
+# that used to support type-hinted wrapper signatures here is gone now that
+# there is nothing left to type-hint against.

--- a/pybind/pyint_dispatch.hpp
+++ b/pybind/pyint_dispatch.hpp
@@ -1,0 +1,87 @@
+#ifndef PYBIND_PYINT_DISPATCH_HPP_
+#define PYBIND_PYINT_DISPATCH_HPP_
+
+#include <pybind11/pybind11.h>
+
+#include "Type.hpp"
+#include "cytnx_error.hpp"
+
+// =========================================================================
+// KEEP-SET ORDERING (canonical rationale -- per-operator comment blocks in
+// tensor_py.cpp / unitensor_py.cpp point here)
+// =========================================================================
+//
+// Every scalar-accepting Tensor/UniTensor operator is bound once per
+// Python-DISTINGUISHABLE dtype (the "keep-set"), not once per C++ dtype,
+// and the overloads MUST be registered in this order:
+//
+//   1. Tensor / UniTensor (elementwise operand)
+//   2. py::numpy_scalar<float>, py::numpy_scalar<std::complex<float>>
+//   3. py::numpy_scalar<int64/uint64/int32/uint32/int16/uint16/bool>
+//   4. py::int_ (arbitrary precision; dispatch_pyint below picks the
+//      int64 or uint64 kernel by magnitude)
+//   5. cytnx_double  (absorbs Python float and np.float64, a float subclass)
+//   6. cytnx_complex128  (absorbs Python complex and np.complex128)
+//   7. cytnx::Scalar  (widest implicit-conversion net, always last)
+//
+// WHY THE ORDER IS LOAD-BEARING (not just stub cosmetics): pybind11
+// resolves an overloaded call in two passes -- every overload is tried
+// WITHOUT implicit conversion first, then every overload is retried WITH
+// conversion -- and within a pass the first-registered match wins. Two
+// traps follow:
+//
+//   * The __index__ no-convert trap: pybind11's plain arithmetic
+//     type_caster for integral C++ types accepts ANY object satisfying the
+//     __index__ protocol even in the no-convert pass (pybind11 3.x cast.h,
+//     arithmetic type_caster). Every numpy integer scalar implements
+//     __index__, so a cytnx_int64-style overload registered before
+//     numpy_scalar<int32_t> greedily consumes np.int32 in the FIRST pass
+//     and silently rewrites its dtype to Int64; the numpy_scalar overload
+//     becomes unreachable. numpy scalars must therefore precede any plain
+//     integral (or py::int_-absorbing) overload.
+//
+//   * The __float__-fallback trap: Python's complex() builtin falls back
+//     to __float__ when __complex__ is absent, so the cytnx_complex128
+//     caster's convert pass accepts any float-like object (np.float32
+//     included). A complex128 overload registered before the float/double
+//     ones therefore captures real-valued np.float32 -- either silently
+//     upcasting it or, for __setitem__ on a real-dtype container, raising
+//     "cannot assign complex element to real container". np.float32 /
+//     np.complex64 must precede cytnx_double / cytnx_complex128.
+//
+// WHEN ADDING A NEW SCALAR-ACCEPTING OPERATOR: copy the keep-set and this
+// exact registration order; do NOT add per-C++-dtype overloads (they
+// collapse to duplicate Python signatures and break stub generation, see
+// issue #928), and do NOT register any plain integral/double/complex
+// overload ahead of the numpy scalars.
+// =========================================================================
+
+namespace pybind_cytnx {
+
+  // Python int is arbitrary precision while cytnx's fixed-width kernels are
+  // not, so a single py::int_ overload dispatches on the operand's magnitude:
+  // the signed int64 kernel when it fits (covering all negatives), otherwise
+  // the unsigned uint64 kernel for non-negative values up to uint64 max.
+  //
+  // Single-argument variant of the dispatch_pyint helper introduced for
+  // ExpH/ExpM in PR #915 (branch claude/fix-stubtest-errors,
+  // pybind/linalg_py.cpp, two-argument form). Once #915 merges,
+  // linalg_py.cpp's local copy should be folded into this header (e.g. by
+  // adding the two-arg overload here) instead of keeping a third copy.
+  template <class Fn>
+  auto dispatch_pyint(const pybind11::int_ &a, Fn &&fn) {
+    int overflow = 0;
+    const long long ia = PyLong_AsLongLongAndOverflow(a.ptr(), &overflow);
+    if (overflow == 0) return fn(static_cast<cytnx::cytnx_int64>(ia));
+    const unsigned long long ua = PyLong_AsUnsignedLongLong(a.ptr());
+    if (PyErr_Occurred()) {
+      PyErr_Clear();
+      cytnx_error_msg(true, "[ERROR] integer scalar out of the supported int64/uint64 range.%s",
+                      "\n");
+    }
+    return fn(static_cast<cytnx::cytnx_uint64>(ua));
+  }
+
+}  // namespace pybind_cytnx
+
+#endif  // PYBIND_PYINT_DISPATCH_HPP_

--- a/pybind/tensor_py.cpp
+++ b/pybind/tensor_py.cpp
@@ -13,9 +13,11 @@
 #include "cytnx.hpp"
 // #include "../include/cytnx_error.hpp"
 #include "complex.h"
+#include "pyint_dispatch.hpp"
 
 namespace py = pybind11;
 using namespace pybind11::literals;
+using pybind_cytnx::dispatch_pyint;
 
 #ifdef BACKEND_TORCH
 #else
@@ -421,17 +423,58 @@ void tensor_binding(py::module &m) {
 
            self.set(accessors, rhs);
          })
-    .def("__setitem__", &f_Tensor_setitem_scal<cytnx::cytnx_complex128>)
-    .def("__setitem__", &f_Tensor_setitem_scal<cytnx::cytnx_complex64>)
+    // __setitem__ keep-set; registration ORDER matters -- see "KEEP-SET
+    // ORDERING" in pybind/pyint_dispatch.hpp. Group-specific note: before
+    // this rewrite, __setitem__ had zero numpy_scalar overloads AND
+    // cytnx_complex128 registered first, so `t[0] = np.float32(x)` on a
+    // real-dtype Tensor was captured by the complex128 overload (the
+    // __float__-fallback trap) and raised "cannot assign complex element to
+    // real container" instead of just mis-preserving dtype.
+    .def("__setitem__",
+         [](cytnx::Tensor &self, py::object locators, const py::numpy_scalar<float> &rc) {
+           f_Tensor_setitem_scal(self, locators, static_cast<cytnx::cytnx_float>(rc));
+         })
+    .def("__setitem__",
+         [](cytnx::Tensor &self, py::object locators,
+            const py::numpy_scalar<std::complex<float>> &rc) {
+           f_Tensor_setitem_scal(self, locators, static_cast<cytnx::cytnx_complex64>(rc));
+         })
+    .def("__setitem__",
+         [](cytnx::Tensor &self, py::object locators, const py::numpy_scalar<int64_t> &rc) {
+           f_Tensor_setitem_scal(self, locators, static_cast<cytnx::cytnx_int64>(rc));
+         })
+    .def("__setitem__",
+         [](cytnx::Tensor &self, py::object locators, const py::numpy_scalar<uint64_t> &rc) {
+           f_Tensor_setitem_scal(self, locators, static_cast<cytnx::cytnx_uint64>(rc));
+         })
+    .def("__setitem__",
+         [](cytnx::Tensor &self, py::object locators, const py::numpy_scalar<int32_t> &rc) {
+           f_Tensor_setitem_scal(self, locators, static_cast<cytnx::cytnx_int32>(rc));
+         })
+    .def("__setitem__",
+         [](cytnx::Tensor &self, py::object locators, const py::numpy_scalar<uint32_t> &rc) {
+           f_Tensor_setitem_scal(self, locators, static_cast<cytnx::cytnx_uint32>(rc));
+         })
+    .def("__setitem__",
+         [](cytnx::Tensor &self, py::object locators, const py::numpy_scalar<int16_t> &rc) {
+           f_Tensor_setitem_scal(self, locators, static_cast<cytnx::cytnx_int16>(rc));
+         })
+    .def("__setitem__",
+         [](cytnx::Tensor &self, py::object locators, const py::numpy_scalar<uint16_t> &rc) {
+           f_Tensor_setitem_scal(self, locators, static_cast<cytnx::cytnx_uint16>(rc));
+         })
+    .def("__setitem__",
+         [](cytnx::Tensor &self, py::object locators, const py::numpy_scalar<bool> &rc) {
+           f_Tensor_setitem_scal(self, locators, static_cast<cytnx::cytnx_bool>(rc));
+         })
+    .def("__setitem__",
+         [](cytnx::Tensor &self, py::object locators, const py::int_ &rc) {
+           dispatch_pyint(
+             rc, [&](auto v) { f_Tensor_setitem_scal(self, locators, v); });
+         })
     .def("__setitem__", &f_Tensor_setitem_scal<cytnx::cytnx_double>)
-    .def("__setitem__", &f_Tensor_setitem_scal<cytnx::cytnx_float>)
-    .def("__setitem__", &f_Tensor_setitem_scal<cytnx::cytnx_int64>)
-    .def("__setitem__", &f_Tensor_setitem_scal<cytnx::cytnx_uint64>)
-    .def("__setitem__", &f_Tensor_setitem_scal<cytnx::cytnx_int32>)
-    .def("__setitem__", &f_Tensor_setitem_scal<cytnx::cytnx_uint32>)
-    .def("__setitem__", &f_Tensor_setitem_scal<cytnx::cytnx_int16>)
-    .def("__setitem__", &f_Tensor_setitem_scal<cytnx::cytnx_uint16>)
-    .def("__setitem__", &f_Tensor_setitem_scal<cytnx::cytnx_bool>)
+    .def("__setitem__", &f_Tensor_setitem_scal<cytnx::cytnx_complex128>)
+    .def("__setitem__", &f_Tensor_setitem_scal<cytnx::Scalar>)
     // arithmetic >>
     .def("__neg__",
          [](cytnx::Tensor &self) {
@@ -448,44 +491,15 @@ void tensor_binding(py::module &m) {
            }
          })
     .def("__pos__", [](cytnx::Tensor &self) { return self; })
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__add__", [](cytnx::Tensor &self, const cytnx::Tensor &rhs) { return self.Add(rhs); })
     .def("__add__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Add(rhs); })
-    .def("__add__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex64 &rhs) { return self.Add(rhs); })
-    .def("__add__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_double &rhs) { return self.Add(rhs); })
-    .def("__add__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_float &rhs) { return self.Add(rhs); })
-    .def("__add__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int64 &rhs) { return self.Add(rhs); })
-    .def("__add__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint64 &rhs) { return self.Add(rhs); })
-    .def("__add__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int32 &rhs) { return self.Add(rhs); })
-    .def("__add__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint32 &rhs) { return self.Add(rhs); })
-    .def("__add__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int16 &rhs) { return self.Add(rhs); })
-    .def("__add__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint16 &rhs) { return self.Add(rhs); })
-    .def("__add__", [](cytnx::Tensor &self, const cytnx::cytnx_bool &rhs) { return self.Add(rhs); })
-    .def("__add__", [](cytnx::Tensor &self, const cytnx::Scalar &rhs) { return self.Add(rhs); })
-    .def("__add__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<double>> &rhs) {
-           return self.Add(static_cast<cytnx::cytnx_complex128>(rhs));
+         [](cytnx::Tensor &self, const py::numpy_scalar<float> &rhs) {
+           return self.Add(static_cast<cytnx::cytnx_float>(rhs));
          })
     .def("__add__",
          [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
            return self.Add(static_cast<cytnx::cytnx_complex64>(rhs));
-         })
-    .def("__add__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<double> &rhs) {
-           return self.Add(static_cast<cytnx::cytnx_double>(rhs));
-         })
-    .def("__add__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<float> &rhs) {
-           return self.Add(static_cast<cytnx::cytnx_float>(rhs));
          })
     .def("__add__",
          [](cytnx::Tensor &self, const py::numpy_scalar<int64_t> &rhs) {
@@ -515,52 +529,29 @@ void tensor_binding(py::module &m) {
          [](cytnx::Tensor &self, const py::numpy_scalar<bool> &rhs) {
            return self.Add(static_cast<cytnx::cytnx_bool>(rhs));
          })
+    .def("__add__",
+         [](cytnx::Tensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return self.Add(v); });
+         })
+    .def("__add__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_double &rhs) { return self.Add(rhs); })
+    .def("__add__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Add(rhs); })
+    .def("__add__", [](cytnx::Tensor &self, const cytnx::Scalar &rhs) { return self.Add(rhs); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
+    // NOTE (pre-existing, out of scope here): a numpy scalar on the LEFT
+    // (e.g. np.float32(1.0) + t) does not reach this __r*__ binding at all --
+    // Tensor defines __iter__, so numpy's ufunc machinery treats it as an
+    // array-like and tries to iterate it instead, raising
+    // "TypeError: 'TensorIterator' object is not iterable" (issue #692).
     .def("__radd__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &lhs) {
-           return cytnx::linalg::Add(lhs, self);
-         })
-    .def("__radd__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex64 &lhs) {
-           return cytnx::linalg::Add(lhs, self);
-         })
-    .def("__radd__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_double &lhs) { return cytnx::linalg::Add(lhs, self); })
-    .def("__radd__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_float &lhs) { return cytnx::linalg::Add(lhs, self); })
-    .def("__radd__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_int64 &lhs) { return cytnx::linalg::Add(lhs, self); })
-    .def("__radd__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_uint64 &lhs) { return cytnx::linalg::Add(lhs, self); })
-    .def("__radd__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_int32 &lhs) { return cytnx::linalg::Add(lhs, self); })
-    .def("__radd__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_uint32 &lhs) { return cytnx::linalg::Add(lhs, self); })
-    .def("__radd__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_int16 &lhs) { return cytnx::linalg::Add(lhs, self); })
-    .def("__radd__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_uint16 &lhs) { return cytnx::linalg::Add(lhs, self); })
-    .def("__radd__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_bool &lhs) { return cytnx::linalg::Add(lhs, self); })
-    .def("__radd__", [](cytnx::Tensor &self,
-                        const cytnx::Scalar &lhs) { return cytnx::linalg::Add(lhs, self); })
-    // does not work because an iterator for the Tensor is defined, and numpy + Tensor calls
-    // numpy.__add__(iterator)
-    .def("__radd__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<double>> &lhs) {
-           return cytnx::linalg::Add(static_cast<cytnx::cytnx_complex128>(lhs), self);
+         [](cytnx::Tensor &self, const py::numpy_scalar<float> &lhs) {
+           return cytnx::linalg::Add(static_cast<cytnx::cytnx_float>(lhs), self);
          })
     .def("__radd__",
          [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<float>> &lhs) {
            return cytnx::linalg::Add(static_cast<cytnx::cytnx_complex64>(lhs), self);
-         })
-    .def("__radd__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<double> &lhs) {
-           return cytnx::linalg::Add(static_cast<cytnx::cytnx_double>(lhs), self);
-         })
-    .def("__radd__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<float> &lhs) {
-           return cytnx::linalg::Add(static_cast<cytnx::cytnx_float>(lhs), self);
          })
     .def("__radd__",
          [](cytnx::Tensor &self, const py::numpy_scalar<int64_t> &lhs) {
@@ -590,93 +581,30 @@ void tensor_binding(py::module &m) {
          [](cytnx::Tensor &self, const py::numpy_scalar<bool> &lhs) {
            return cytnx::linalg::Add(static_cast<cytnx::cytnx_bool>(lhs), self);
          })
+    .def("__radd__",
+         [](cytnx::Tensor &self, const py::int_ &lhs) {
+           return dispatch_pyint(lhs, [&](auto v) { return cytnx::linalg::Add(v, self); });
+         })
+    .def("__radd__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_double &lhs) { return cytnx::linalg::Add(lhs, self); })
+    .def("__radd__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &lhs) { return cytnx::linalg::Add(lhs, self); })
+    .def("__radd__", [](cytnx::Tensor &self, const cytnx::Scalar &lhs) { return cytnx::linalg::Add(lhs, self); })
 
-    // __iadd__: bound directly under its real dunder name. Every overload takes
-    // py::object self so the lambda can return the SAME PyObject (identity-exact),
-    // instead of letting pybind wrap the returned Tensor& in a new Python object.
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__iadd__",
          [](py::object self, const cytnx::Tensor &rhs) {
            self.cast<cytnx::Tensor &>().Add_(rhs);
-           return self;
-         })  // these will return self!
-    .def("__iadd__",
-         [](py::object self, const cytnx::cytnx_complex128 &rhs) {
-           self.cast<cytnx::Tensor &>().Add_(rhs);
-           return self;
-         })
-    .def("__iadd__",
-         [](py::object self, const cytnx::cytnx_complex64 &rhs) {
-           self.cast<cytnx::Tensor &>().Add_(rhs);
-           return self;
-         })
-    .def("__iadd__",
-         [](py::object self, const cytnx::cytnx_double &rhs) {
-           self.cast<cytnx::Tensor &>().Add_(rhs);
-           return self;
-         })
-    .def("__iadd__",
-         [](py::object self, const cytnx::cytnx_float &rhs) {
-           self.cast<cytnx::Tensor &>().Add_(rhs);
-           return self;
-         })
-    .def("__iadd__",
-         [](py::object self, const cytnx::cytnx_int64 &rhs) {
-           self.cast<cytnx::Tensor &>().Add_(rhs);
-           return self;
-         })
-    .def("__iadd__",
-         [](py::object self, const cytnx::cytnx_uint64 &rhs) {
-           self.cast<cytnx::Tensor &>().Add_(rhs);
-           return self;
-         })
-    .def("__iadd__",
-         [](py::object self, const cytnx::cytnx_int32 &rhs) {
-           self.cast<cytnx::Tensor &>().Add_(rhs);
-           return self;
-         })
-    .def("__iadd__",
-         [](py::object self, const cytnx::cytnx_uint32 &rhs) {
-           self.cast<cytnx::Tensor &>().Add_(rhs);
-           return self;
-         })
-    .def("__iadd__",
-         [](py::object self, const cytnx::cytnx_int16 &rhs) {
-           self.cast<cytnx::Tensor &>().Add_(rhs);
-           return self;
-         })
-    .def("__iadd__",
-         [](py::object self, const cytnx::cytnx_uint16 &rhs) {
-           self.cast<cytnx::Tensor &>().Add_(rhs);
-           return self;
-         })
-    .def("__iadd__",
-         [](py::object self, const cytnx::cytnx_bool &rhs) {
-           self.cast<cytnx::Tensor &>().Add_(rhs);
-           return self;
-         })
-    .def("__iadd__",
-         [](py::object self, const cytnx::Scalar &rhs) {
-           self.cast<cytnx::Tensor &>().Add_(rhs);
-           return self;
-         })
-    .def("__iadd__",
-         [](py::object self, const py::numpy_scalar<std::complex<double>> &rhs) {
-           self.cast<cytnx::Tensor &>().Add_(static_cast<cytnx::cytnx_complex128>(rhs));
-           return self;
-         })
-    .def("__iadd__",
-         [](py::object self, const py::numpy_scalar<std::complex<float>> &rhs) {
-           self.cast<cytnx::Tensor &>().Add_(static_cast<cytnx::cytnx_complex64>(rhs));
-           return self;
-         })
-    .def("__iadd__",
-         [](py::object self, const py::numpy_scalar<double> &rhs) {
-           self.cast<cytnx::Tensor &>().Add_(static_cast<cytnx::cytnx_double>(rhs));
            return self;
          })
     .def("__iadd__",
          [](py::object self, const py::numpy_scalar<float> &rhs) {
            self.cast<cytnx::Tensor &>().Add_(static_cast<cytnx::cytnx_float>(rhs));
+           return self;
+         })
+    .def("__iadd__",
+         [](py::object self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           self.cast<cytnx::Tensor &>().Add_(static_cast<cytnx::cytnx_complex64>(rhs));
            return self;
          })
     .def("__iadd__",
@@ -714,45 +642,36 @@ void tensor_binding(py::module &m) {
            self.cast<cytnx::Tensor &>().Add_(static_cast<cytnx::cytnx_bool>(rhs));
            return self;
          })
+    .def("__iadd__",
+         [](py::object self, const py::int_ &rhs) {
+           dispatch_pyint(rhs, [&](auto v) { self.cast<cytnx::Tensor &>().Add_(v); });
+           return self;
+         })
+    .def("__iadd__",
+         [](py::object self, const cytnx::cytnx_double &rhs) {
+           self.cast<cytnx::Tensor &>().Add_(rhs);
+           return self;
+         })
+    .def("__iadd__",
+         [](py::object self, const cytnx::cytnx_complex128 &rhs) {
+           self.cast<cytnx::Tensor &>().Add_(rhs);
+           return self;
+         })
+    .def("__iadd__",
+         [](py::object self, const cytnx::Scalar &rhs) {
+           self.cast<cytnx::Tensor &>().Add_(rhs);
+           return self;
+         })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__sub__", [](cytnx::Tensor &self, const cytnx::Tensor &rhs) { return self.Sub(rhs); })
     .def("__sub__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Sub(rhs); })
-    .def("__sub__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex64 &rhs) { return self.Sub(rhs); })
-    .def("__sub__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_double &rhs) { return self.Sub(rhs); })
-    .def("__sub__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_float &rhs) { return self.Sub(rhs); })
-    .def("__sub__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int64 &rhs) { return self.Sub(rhs); })
-    .def("__sub__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint64 &rhs) { return self.Sub(rhs); })
-    .def("__sub__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int32 &rhs) { return self.Sub(rhs); })
-    .def("__sub__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint32 &rhs) { return self.Sub(rhs); })
-    .def("__sub__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int16 &rhs) { return self.Sub(rhs); })
-    .def("__sub__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint16 &rhs) { return self.Sub(rhs); })
-    .def("__sub__", [](cytnx::Tensor &self, const cytnx::cytnx_bool &rhs) { return self.Sub(rhs); })
-    .def("__sub__", [](cytnx::Tensor &self, const cytnx::Scalar &rhs) { return self.Sub(rhs); })
-    .def("__sub__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<double>> &rhs) {
-           return self.Sub(static_cast<cytnx::cytnx_complex128>(rhs));
+         [](cytnx::Tensor &self, const py::numpy_scalar<float> &rhs) {
+           return self.Sub(static_cast<cytnx::cytnx_float>(rhs));
          })
     .def("__sub__",
          [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
            return self.Sub(static_cast<cytnx::cytnx_complex64>(rhs));
-         })
-    .def("__sub__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<double> &rhs) {
-           return self.Sub(static_cast<cytnx::cytnx_double>(rhs));
-         })
-    .def("__sub__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<float> &rhs) {
-           return self.Sub(static_cast<cytnx::cytnx_float>(rhs));
          })
     .def("__sub__",
          [](cytnx::Tensor &self, const py::numpy_scalar<int64_t> &rhs) {
@@ -782,52 +701,29 @@ void tensor_binding(py::module &m) {
          [](cytnx::Tensor &self, const py::numpy_scalar<bool> &rhs) {
            return self.Sub(static_cast<cytnx::cytnx_bool>(rhs));
          })
+    .def("__sub__",
+         [](cytnx::Tensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return self.Sub(v); });
+         })
+    .def("__sub__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_double &rhs) { return self.Sub(rhs); })
+    .def("__sub__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Sub(rhs); })
+    .def("__sub__", [](cytnx::Tensor &self, const cytnx::Scalar &rhs) { return self.Sub(rhs); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
+    // NOTE (pre-existing, out of scope here): a numpy scalar on the LEFT
+    // (e.g. np.float32(1.0) + t) does not reach this __r*__ binding at all --
+    // Tensor defines __iter__, so numpy's ufunc machinery treats it as an
+    // array-like and tries to iterate it instead, raising
+    // "TypeError: 'TensorIterator' object is not iterable" (issue #692).
     .def("__rsub__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &lhs) {
-           return cytnx::linalg::Sub(lhs, self);
-         })
-    .def("__rsub__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex64 &lhs) {
-           return cytnx::linalg::Sub(lhs, self);
-         })
-    .def("__rsub__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_double &lhs) { return cytnx::linalg::Sub(lhs, self); })
-    .def("__rsub__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_float &lhs) { return cytnx::linalg::Sub(lhs, self); })
-    .def("__rsub__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_int64 &lhs) { return cytnx::linalg::Sub(lhs, self); })
-    .def("__rsub__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_uint64 &lhs) { return cytnx::linalg::Sub(lhs, self); })
-    .def("__rsub__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_int32 &lhs) { return cytnx::linalg::Sub(lhs, self); })
-    .def("__rsub__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_uint32 &lhs) { return cytnx::linalg::Sub(lhs, self); })
-    .def("__rsub__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_int16 &lhs) { return cytnx::linalg::Sub(lhs, self); })
-    .def("__rsub__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_uint16 &lhs) { return cytnx::linalg::Sub(lhs, self); })
-    .def("__rsub__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_bool &lhs) { return cytnx::linalg::Sub(lhs, self); })
-    .def("__rsub__", [](cytnx::Tensor &self,
-                        const cytnx::Scalar &lhs) { return cytnx::linalg::Sub(lhs, self); })
-    // does not work because an iterator for the Tensor is defined, and numpy - Tensor calls
-    // numpy.__sub__(iterator)
-    .def("__rsub__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<double>> &lhs) {
-           return cytnx::linalg::Sub(static_cast<cytnx::cytnx_complex128>(lhs), self);
+         [](cytnx::Tensor &self, const py::numpy_scalar<float> &lhs) {
+           return cytnx::linalg::Sub(static_cast<cytnx::cytnx_float>(lhs), self);
          })
     .def("__rsub__",
          [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<float>> &lhs) {
            return cytnx::linalg::Sub(static_cast<cytnx::cytnx_complex64>(lhs), self);
-         })
-    .def("__rsub__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<double> &lhs) {
-           return cytnx::linalg::Sub(static_cast<cytnx::cytnx_double>(lhs), self);
-         })
-    .def("__rsub__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<float> &lhs) {
-           return cytnx::linalg::Sub(static_cast<cytnx::cytnx_float>(lhs), self);
          })
     .def("__rsub__",
          [](cytnx::Tensor &self, const py::numpy_scalar<int64_t> &lhs) {
@@ -857,90 +753,30 @@ void tensor_binding(py::module &m) {
          [](cytnx::Tensor &self, const py::numpy_scalar<bool> &lhs) {
            return cytnx::linalg::Sub(static_cast<cytnx::cytnx_bool>(lhs), self);
          })
+    .def("__rsub__",
+         [](cytnx::Tensor &self, const py::int_ &lhs) {
+           return dispatch_pyint(lhs, [&](auto v) { return cytnx::linalg::Sub(v, self); });
+         })
+    .def("__rsub__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_double &lhs) { return cytnx::linalg::Sub(lhs, self); })
+    .def("__rsub__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &lhs) { return cytnx::linalg::Sub(lhs, self); })
+    .def("__rsub__", [](cytnx::Tensor &self, const cytnx::Scalar &lhs) { return cytnx::linalg::Sub(lhs, self); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__isub__",
          [](py::object self, const cytnx::Tensor &rhs) {
            self.cast<cytnx::Tensor &>().Sub_(rhs);
-           return self;
-         })  // these will return self!
-    .def("__isub__",
-         [](py::object self, const cytnx::cytnx_complex128 &rhs) {
-           self.cast<cytnx::Tensor &>().Sub_(rhs);
-           return self;
-         })
-    .def("__isub__",
-         [](py::object self, const cytnx::cytnx_complex64 &rhs) {
-           self.cast<cytnx::Tensor &>().Sub_(rhs);
-           return self;
-         })
-    .def("__isub__",
-         [](py::object self, const cytnx::cytnx_double &rhs) {
-           self.cast<cytnx::Tensor &>().Sub_(rhs);
-           return self;
-         })
-    .def("__isub__",
-         [](py::object self, const cytnx::cytnx_float &rhs) {
-           self.cast<cytnx::Tensor &>().Sub_(rhs);
-           return self;
-         })
-    .def("__isub__",
-         [](py::object self, const cytnx::cytnx_int64 &rhs) {
-           self.cast<cytnx::Tensor &>().Sub_(rhs);
-           return self;
-         })
-    .def("__isub__",
-         [](py::object self, const cytnx::cytnx_uint64 &rhs) {
-           self.cast<cytnx::Tensor &>().Sub_(rhs);
-           return self;
-         })
-    .def("__isub__",
-         [](py::object self, const cytnx::cytnx_int32 &rhs) {
-           self.cast<cytnx::Tensor &>().Sub_(rhs);
-           return self;
-         })
-    .def("__isub__",
-         [](py::object self, const cytnx::cytnx_uint32 &rhs) {
-           self.cast<cytnx::Tensor &>().Sub_(rhs);
-           return self;
-         })
-    .def("__isub__",
-         [](py::object self, const cytnx::cytnx_int16 &rhs) {
-           self.cast<cytnx::Tensor &>().Sub_(rhs);
-           return self;
-         })
-    .def("__isub__",
-         [](py::object self, const cytnx::cytnx_uint16 &rhs) {
-           self.cast<cytnx::Tensor &>().Sub_(rhs);
-           return self;
-         })
-    .def("__isub__",
-         [](py::object self, const cytnx::cytnx_bool &rhs) {
-           self.cast<cytnx::Tensor &>().Sub_(rhs);
-           return self;
-         })
-    .def("__isub__",
-         [](py::object self, const cytnx::Scalar &rhs) {
-           self.cast<cytnx::Tensor &>().Sub_(rhs);
-           return self;
-         })
-    .def("__isub__",
-         [](py::object self, const py::numpy_scalar<std::complex<double>> &rhs) {
-           self.cast<cytnx::Tensor &>().Sub_(static_cast<cytnx::cytnx_complex128>(rhs));
-           return self;
-         })
-    .def("__isub__",
-         [](py::object self, const py::numpy_scalar<std::complex<float>> &rhs) {
-           self.cast<cytnx::Tensor &>().Sub_(static_cast<cytnx::cytnx_complex64>(rhs));
-           return self;
-         })
-    .def("__isub__",
-         [](py::object self, const py::numpy_scalar<double> &rhs) {
-           self.cast<cytnx::Tensor &>().Sub_(static_cast<cytnx::cytnx_double>(rhs));
            return self;
          })
     .def("__isub__",
          [](py::object self, const py::numpy_scalar<float> &rhs) {
            self.cast<cytnx::Tensor &>().Sub_(static_cast<cytnx::cytnx_float>(rhs));
+           return self;
+         })
+    .def("__isub__",
+         [](py::object self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           self.cast<cytnx::Tensor &>().Sub_(static_cast<cytnx::cytnx_complex64>(rhs));
            return self;
          })
     .def("__isub__",
@@ -978,45 +814,36 @@ void tensor_binding(py::module &m) {
            self.cast<cytnx::Tensor &>().Sub_(static_cast<cytnx::cytnx_bool>(rhs));
            return self;
          })
+    .def("__isub__",
+         [](py::object self, const py::int_ &rhs) {
+           dispatch_pyint(rhs, [&](auto v) { self.cast<cytnx::Tensor &>().Sub_(v); });
+           return self;
+         })
+    .def("__isub__",
+         [](py::object self, const cytnx::cytnx_double &rhs) {
+           self.cast<cytnx::Tensor &>().Sub_(rhs);
+           return self;
+         })
+    .def("__isub__",
+         [](py::object self, const cytnx::cytnx_complex128 &rhs) {
+           self.cast<cytnx::Tensor &>().Sub_(rhs);
+           return self;
+         })
+    .def("__isub__",
+         [](py::object self, const cytnx::Scalar &rhs) {
+           self.cast<cytnx::Tensor &>().Sub_(rhs);
+           return self;
+         })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__mul__", [](cytnx::Tensor &self, const cytnx::Tensor &rhs) { return self.Mul(rhs); })
     .def("__mul__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Mul(rhs); })
-    .def("__mul__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex64 &rhs) { return self.Mul(rhs); })
-    .def("__mul__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_double &rhs) { return self.Mul(rhs); })
-    .def("__mul__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_float &rhs) { return self.Mul(rhs); })
-    .def("__mul__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int64 &rhs) { return self.Mul(rhs); })
-    .def("__mul__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint64 &rhs) { return self.Mul(rhs); })
-    .def("__mul__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int32 &rhs) { return self.Mul(rhs); })
-    .def("__mul__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint32 &rhs) { return self.Mul(rhs); })
-    .def("__mul__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int16 &rhs) { return self.Mul(rhs); })
-    .def("__mul__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint16 &rhs) { return self.Mul(rhs); })
-    .def("__mul__", [](cytnx::Tensor &self, const cytnx::cytnx_bool &rhs) { return self.Mul(rhs); })
-    .def("__mul__", [](cytnx::Tensor &self, const cytnx::Scalar &rhs) { return self.Mul(rhs); })
-    .def("__mul__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<double>> &rhs) {
-           return self.Mul(static_cast<cytnx::cytnx_complex128>(rhs));
+         [](cytnx::Tensor &self, const py::numpy_scalar<float> &rhs) {
+           return self.Mul(static_cast<cytnx::cytnx_float>(rhs));
          })
     .def("__mul__",
          [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
            return self.Mul(static_cast<cytnx::cytnx_complex64>(rhs));
-         })
-    .def("__mul__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<double> &rhs) {
-           return self.Mul(static_cast<cytnx::cytnx_double>(rhs));
-         })
-    .def("__mul__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<float> &rhs) {
-           return self.Mul(static_cast<cytnx::cytnx_float>(rhs));
          })
     .def("__mul__",
          [](cytnx::Tensor &self, const py::numpy_scalar<int64_t> &rhs) {
@@ -1046,52 +873,29 @@ void tensor_binding(py::module &m) {
          [](cytnx::Tensor &self, const py::numpy_scalar<bool> &rhs) {
            return self.Mul(static_cast<cytnx::cytnx_bool>(rhs));
          })
+    .def("__mul__",
+         [](cytnx::Tensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return self.Mul(v); });
+         })
+    .def("__mul__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_double &rhs) { return self.Mul(rhs); })
+    .def("__mul__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Mul(rhs); })
+    .def("__mul__", [](cytnx::Tensor &self, const cytnx::Scalar &rhs) { return self.Mul(rhs); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
+    // NOTE (pre-existing, out of scope here): a numpy scalar on the LEFT
+    // (e.g. np.float32(1.0) + t) does not reach this __r*__ binding at all --
+    // Tensor defines __iter__, so numpy's ufunc machinery treats it as an
+    // array-like and tries to iterate it instead, raising
+    // "TypeError: 'TensorIterator' object is not iterable" (issue #692).
     .def("__rmul__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &lhs) {
-           return cytnx::linalg::Mul(lhs, self);
-         })
-    .def("__rmul__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex64 &lhs) {
-           return cytnx::linalg::Mul(lhs, self);
-         })
-    .def("__rmul__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_double &lhs) { return cytnx::linalg::Mul(lhs, self); })
-    .def("__rmul__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_float &lhs) { return cytnx::linalg::Mul(lhs, self); })
-    .def("__rmul__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_int64 &lhs) { return cytnx::linalg::Mul(lhs, self); })
-    .def("__rmul__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_uint64 &lhs) { return cytnx::linalg::Mul(lhs, self); })
-    .def("__rmul__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_int32 &lhs) { return cytnx::linalg::Mul(lhs, self); })
-    .def("__rmul__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_uint32 &lhs) { return cytnx::linalg::Mul(lhs, self); })
-    .def("__rmul__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_int16 &lhs) { return cytnx::linalg::Mul(lhs, self); })
-    .def("__rmul__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_uint16 &lhs) { return cytnx::linalg::Mul(lhs, self); })
-    .def("__rmul__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_bool &lhs) { return cytnx::linalg::Mul(lhs, self); })
-    .def("__rmul__", [](cytnx::Tensor &self,
-                        const cytnx::Scalar &lhs) { return cytnx::linalg::Mul(lhs, self); })
-    // does not work because an iterator for the Tensor is defined, and numpy * Tensor calls
-    // numpy.__mul__(iterator)
-    .def("__rmul__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<double>> &lhs) {
-           return cytnx::linalg::Mul(static_cast<cytnx::cytnx_complex128>(lhs), self);
+         [](cytnx::Tensor &self, const py::numpy_scalar<float> &lhs) {
+           return cytnx::linalg::Mul(static_cast<cytnx::cytnx_float>(lhs), self);
          })
     .def("__rmul__",
          [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<float>> &lhs) {
            return cytnx::linalg::Mul(static_cast<cytnx::cytnx_complex64>(lhs), self);
-         })
-    .def("__rmul__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<double> &lhs) {
-           return cytnx::linalg::Mul(static_cast<cytnx::cytnx_double>(lhs), self);
-         })
-    .def("__rmul__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<float> &lhs) {
-           return cytnx::linalg::Mul(static_cast<cytnx::cytnx_float>(lhs), self);
          })
     .def("__rmul__",
          [](cytnx::Tensor &self, const py::numpy_scalar<int64_t> &lhs) {
@@ -1121,90 +925,30 @@ void tensor_binding(py::module &m) {
          [](cytnx::Tensor &self, const py::numpy_scalar<bool> &lhs) {
            return cytnx::linalg::Mul(static_cast<cytnx::cytnx_bool>(lhs), self);
          })
+    .def("__rmul__",
+         [](cytnx::Tensor &self, const py::int_ &lhs) {
+           return dispatch_pyint(lhs, [&](auto v) { return cytnx::linalg::Mul(v, self); });
+         })
+    .def("__rmul__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_double &lhs) { return cytnx::linalg::Mul(lhs, self); })
+    .def("__rmul__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &lhs) { return cytnx::linalg::Mul(lhs, self); })
+    .def("__rmul__", [](cytnx::Tensor &self, const cytnx::Scalar &lhs) { return cytnx::linalg::Mul(lhs, self); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__imul__",
          [](py::object self, const cytnx::Tensor &rhs) {
            self.cast<cytnx::Tensor &>().Mul_(rhs);
-           return self;
-         })  // these will return self!
-    .def("__imul__",
-         [](py::object self, const cytnx::cytnx_complex128 &rhs) {
-           self.cast<cytnx::Tensor &>().Mul_(rhs);
-           return self;
-         })
-    .def("__imul__",
-         [](py::object self, const cytnx::cytnx_complex64 &rhs) {
-           self.cast<cytnx::Tensor &>().Mul_(rhs);
-           return self;
-         })
-    .def("__imul__",
-         [](py::object self, const cytnx::cytnx_double &rhs) {
-           self.cast<cytnx::Tensor &>().Mul_(rhs);
-           return self;
-         })
-    .def("__imul__",
-         [](py::object self, const cytnx::cytnx_float &rhs) {
-           self.cast<cytnx::Tensor &>().Mul_(rhs);
-           return self;
-         })
-    .def("__imul__",
-         [](py::object self, const cytnx::cytnx_int64 &rhs) {
-           self.cast<cytnx::Tensor &>().Mul_(rhs);
-           return self;
-         })
-    .def("__imul__",
-         [](py::object self, const cytnx::cytnx_uint64 &rhs) {
-           self.cast<cytnx::Tensor &>().Mul_(rhs);
-           return self;
-         })
-    .def("__imul__",
-         [](py::object self, const cytnx::cytnx_int32 &rhs) {
-           self.cast<cytnx::Tensor &>().Mul_(rhs);
-           return self;
-         })
-    .def("__imul__",
-         [](py::object self, const cytnx::cytnx_uint32 &rhs) {
-           self.cast<cytnx::Tensor &>().Mul_(rhs);
-           return self;
-         })
-    .def("__imul__",
-         [](py::object self, const cytnx::cytnx_int16 &rhs) {
-           self.cast<cytnx::Tensor &>().Mul_(rhs);
-           return self;
-         })
-    .def("__imul__",
-         [](py::object self, const cytnx::cytnx_uint16 &rhs) {
-           self.cast<cytnx::Tensor &>().Mul_(rhs);
-           return self;
-         })
-    .def("__imul__",
-         [](py::object self, const cytnx::cytnx_bool &rhs) {
-           self.cast<cytnx::Tensor &>().Mul_(rhs);
-           return self;
-         })
-    .def("__imul__",
-         [](py::object self, const cytnx::Scalar &rhs) {
-           self.cast<cytnx::Tensor &>().Mul_(rhs);
-           return self;
-         })
-    .def("__imul__",
-         [](py::object self, const py::numpy_scalar<std::complex<double>> &rhs) {
-           self.cast<cytnx::Tensor &>().Mul_(static_cast<cytnx::cytnx_complex128>(rhs));
-           return self;
-         })
-    .def("__imul__",
-         [](py::object self, const py::numpy_scalar<std::complex<float>> &rhs) {
-           self.cast<cytnx::Tensor &>().Mul_(static_cast<cytnx::cytnx_complex64>(rhs));
-           return self;
-         })
-    .def("__imul__",
-         [](py::object self, const py::numpy_scalar<double> &rhs) {
-           self.cast<cytnx::Tensor &>().Mul_(static_cast<cytnx::cytnx_double>(rhs));
            return self;
          })
     .def("__imul__",
          [](py::object self, const py::numpy_scalar<float> &rhs) {
            self.cast<cytnx::Tensor &>().Mul_(static_cast<cytnx::cytnx_float>(rhs));
+           return self;
+         })
+    .def("__imul__",
+         [](py::object self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           self.cast<cytnx::Tensor &>().Mul_(static_cast<cytnx::cytnx_complex64>(rhs));
            return self;
          })
     .def("__imul__",
@@ -1242,137 +986,88 @@ void tensor_binding(py::module &m) {
            self.cast<cytnx::Tensor &>().Mul_(static_cast<cytnx::cytnx_bool>(rhs));
            return self;
          })
+    .def("__imul__",
+         [](py::object self, const py::int_ &rhs) {
+           dispatch_pyint(rhs, [&](auto v) { self.cast<cytnx::Tensor &>().Mul_(v); });
+           return self;
+         })
+    .def("__imul__",
+         [](py::object self, const cytnx::cytnx_double &rhs) {
+           self.cast<cytnx::Tensor &>().Mul_(rhs);
+           return self;
+         })
+    .def("__imul__",
+         [](py::object self, const cytnx::cytnx_complex128 &rhs) {
+           self.cast<cytnx::Tensor &>().Mul_(rhs);
+           return self;
+         })
+    .def("__imul__",
+         [](py::object self, const cytnx::Scalar &rhs) {
+           self.cast<cytnx::Tensor &>().Mul_(rhs);
+           return self;
+         })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__truediv__", [](cytnx::Tensor &self, const cytnx::Tensor &rhs) { return self.Div(rhs); })
     .def("__truediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Div(rhs); })
+         [](cytnx::Tensor &self, const py::numpy_scalar<float> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_float>(rhs));
+         })
     .def("__truediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex64 &rhs) { return self.Div(rhs); })
+         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_complex64>(rhs));
+         })
+    .def("__truediv__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<int64_t> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_int64>(rhs));
+         })
+    .def("__truediv__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<uint64_t> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_uint64>(rhs));
+         })
+    .def("__truediv__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<int32_t> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_int32>(rhs));
+         })
+    .def("__truediv__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<uint32_t> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_uint32>(rhs));
+         })
+    .def("__truediv__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<int16_t> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_int16>(rhs));
+         })
+    .def("__truediv__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<uint16_t> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_uint16>(rhs));
+         })
+    .def("__truediv__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<bool> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_bool>(rhs));
+         })
+    .def("__truediv__",
+         [](cytnx::Tensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return self.Div(v); });
+         })
     .def("__truediv__",
          [](cytnx::Tensor &self, const cytnx::cytnx_double &rhs) { return self.Div(rhs); })
     .def("__truediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_float &rhs) { return self.Div(rhs); })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int64 &rhs) { return self.Div(rhs); })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint64 &rhs) { return self.Div(rhs); })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int32 &rhs) { return self.Div(rhs); })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint32 &rhs) { return self.Div(rhs); })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int16 &rhs) { return self.Div(rhs); })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint16 &rhs) { return self.Div(rhs); })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_bool &rhs) { return self.Div(rhs); })
+         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Div(rhs); })
     .def("__truediv__", [](cytnx::Tensor &self, const cytnx::Scalar &rhs) { return self.Div(rhs); })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<double>> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_complex128>(rhs));
-         })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_complex64>(rhs));
-         })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<double> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_double>(rhs));
-         })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<float> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_float>(rhs));
-         })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<int64_t> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_int64>(rhs));
-         })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<uint64_t> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_uint64>(rhs));
-         })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<int32_t> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_int32>(rhs));
-         })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<uint32_t> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_uint32>(rhs));
-         })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<int16_t> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_int16>(rhs));
-         })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<uint16_t> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_uint16>(rhs));
-         })
-    .def("__truediv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<bool> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_bool>(rhs));
-         })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
+    // NOTE (pre-existing, out of scope here): a numpy scalar on the LEFT
+    // (e.g. np.float32(1.0) + t) does not reach this __r*__ binding at all --
+    // Tensor defines __iter__, so numpy's ufunc machinery treats it as an
+    // array-like and tries to iterate it instead, raising
+    // "TypeError: 'TensorIterator' object is not iterable" (issue #692).
     .def("__rtruediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rtruediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex64 &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rtruediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_double &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rtruediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_float &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rtruediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int64 &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rtruediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint64 &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rtruediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int32 &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rtruediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint32 &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rtruediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int16 &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rtruediv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint16 &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rtruediv__", [](cytnx::Tensor &self,
-                            const cytnx::cytnx_bool &lhs) { return cytnx::linalg::Div(lhs, self); })
-    .def("__rtruediv__", [](cytnx::Tensor &self,
-                            const cytnx::Scalar &lhs) { return cytnx::linalg::Div(lhs, self); })
-    // does not work because an iterator for the Tensor is defined, and numpy / Tensor calls
-    // numpy.__truediv__(iterator)
-    .def("__rtruediv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<double>> &lhs) {
-           return cytnx::linalg::Div(static_cast<cytnx::cytnx_complex128>(lhs), self);
+         [](cytnx::Tensor &self, const py::numpy_scalar<float> &lhs) {
+           return cytnx::linalg::Div(static_cast<cytnx::cytnx_float>(lhs), self);
          })
     .def("__rtruediv__",
          [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<float>> &lhs) {
            return cytnx::linalg::Div(static_cast<cytnx::cytnx_complex64>(lhs), self);
-         })
-    .def("__rtruediv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<double> &lhs) {
-           return cytnx::linalg::Div(static_cast<cytnx::cytnx_double>(lhs), self);
-         })
-    .def("__rtruediv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<float> &lhs) {
-           return cytnx::linalg::Div(static_cast<cytnx::cytnx_float>(lhs), self);
          })
     .def("__rtruediv__",
          [](cytnx::Tensor &self, const py::numpy_scalar<int64_t> &lhs) {
@@ -1402,90 +1097,30 @@ void tensor_binding(py::module &m) {
          [](cytnx::Tensor &self, const py::numpy_scalar<bool> &lhs) {
            return cytnx::linalg::Div(static_cast<cytnx::cytnx_bool>(lhs), self);
          })
+    .def("__rtruediv__",
+         [](cytnx::Tensor &self, const py::int_ &lhs) {
+           return dispatch_pyint(lhs, [&](auto v) { return cytnx::linalg::Div(v, self); });
+         })
+    .def("__rtruediv__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_double &lhs) { return cytnx::linalg::Div(lhs, self); })
+    .def("__rtruediv__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &lhs) { return cytnx::linalg::Div(lhs, self); })
+    .def("__rtruediv__", [](cytnx::Tensor &self, const cytnx::Scalar &lhs) { return cytnx::linalg::Div(lhs, self); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__itruediv__",
          [](py::object self, const cytnx::Tensor &rhs) {
            self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })  // these will return self!
-    .def("__itruediv__",
-         [](py::object self, const cytnx::cytnx_complex128 &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__itruediv__",
-         [](py::object self, const cytnx::cytnx_complex64 &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__itruediv__",
-         [](py::object self, const cytnx::cytnx_double &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__itruediv__",
-         [](py::object self, const cytnx::cytnx_float &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__itruediv__",
-         [](py::object self, const cytnx::cytnx_int64 &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__itruediv__",
-         [](py::object self, const cytnx::cytnx_uint64 &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__itruediv__",
-         [](py::object self, const cytnx::cytnx_int32 &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__itruediv__",
-         [](py::object self, const cytnx::cytnx_uint32 &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__itruediv__",
-         [](py::object self, const cytnx::cytnx_int16 &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__itruediv__",
-         [](py::object self, const cytnx::cytnx_uint16 &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__itruediv__",
-         [](py::object self, const cytnx::cytnx_bool &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__itruediv__",
-         [](py::object self, const cytnx::Scalar &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__itruediv__",
-         [](py::object self, const py::numpy_scalar<std::complex<double>> &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(static_cast<cytnx::cytnx_complex128>(rhs));
-           return self;
-         })
-    .def("__itruediv__",
-         [](py::object self, const py::numpy_scalar<std::complex<float>> &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(static_cast<cytnx::cytnx_complex64>(rhs));
-           return self;
-         })
-    .def("__itruediv__",
-         [](py::object self, const py::numpy_scalar<double> &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(static_cast<cytnx::cytnx_double>(rhs));
            return self;
          })
     .def("__itruediv__",
          [](py::object self, const py::numpy_scalar<float> &rhs) {
            self.cast<cytnx::Tensor &>().Div_(static_cast<cytnx::cytnx_float>(rhs));
+           return self;
+         })
+    .def("__itruediv__",
+         [](py::object self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           self.cast<cytnx::Tensor &>().Div_(static_cast<cytnx::cytnx_complex64>(rhs));
            return self;
          })
     .def("__itruediv__",
@@ -1523,141 +1158,88 @@ void tensor_binding(py::module &m) {
            self.cast<cytnx::Tensor &>().Div_(static_cast<cytnx::cytnx_bool>(rhs));
            return self;
          })
+    .def("__itruediv__",
+         [](py::object self, const py::int_ &rhs) {
+           dispatch_pyint(rhs, [&](auto v) { self.cast<cytnx::Tensor &>().Div_(v); });
+           return self;
+         })
+    .def("__itruediv__",
+         [](py::object self, const cytnx::cytnx_double &rhs) {
+           self.cast<cytnx::Tensor &>().Div_(rhs);
+           return self;
+         })
+    .def("__itruediv__",
+         [](py::object self, const cytnx::cytnx_complex128 &rhs) {
+           self.cast<cytnx::Tensor &>().Div_(rhs);
+           return self;
+         })
+    .def("__itruediv__",
+         [](py::object self, const cytnx::Scalar &rhs) {
+           self.cast<cytnx::Tensor &>().Div_(rhs);
+           return self;
+         })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
+    .def("__floordiv__", [](cytnx::Tensor &self, const cytnx::Tensor &rhs) { return self.Div(rhs); })
     .def("__floordiv__",
-         [](cytnx::Tensor &self, const cytnx::Tensor &rhs) { return self.Div(rhs); })
+         [](cytnx::Tensor &self, const py::numpy_scalar<float> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_float>(rhs));
+         })
     .def("__floordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Div(rhs); })
+         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_complex64>(rhs));
+         })
     .def("__floordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex64 &rhs) { return self.Div(rhs); })
+         [](cytnx::Tensor &self, const py::numpy_scalar<int64_t> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_int64>(rhs));
+         })
+    .def("__floordiv__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<uint64_t> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_uint64>(rhs));
+         })
+    .def("__floordiv__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<int32_t> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_int32>(rhs));
+         })
+    .def("__floordiv__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<uint32_t> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_uint32>(rhs));
+         })
+    .def("__floordiv__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<int16_t> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_int16>(rhs));
+         })
+    .def("__floordiv__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<uint16_t> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_uint16>(rhs));
+         })
+    .def("__floordiv__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<bool> &rhs) {
+           return self.Div(static_cast<cytnx::cytnx_bool>(rhs));
+         })
+    .def("__floordiv__",
+         [](cytnx::Tensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return self.Div(v); });
+         })
     .def("__floordiv__",
          [](cytnx::Tensor &self, const cytnx::cytnx_double &rhs) { return self.Div(rhs); })
     .def("__floordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_float &rhs) { return self.Div(rhs); })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int64 &rhs) { return self.Div(rhs); })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint64 &rhs) { return self.Div(rhs); })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int32 &rhs) { return self.Div(rhs); })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint32 &rhs) { return self.Div(rhs); })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int16 &rhs) { return self.Div(rhs); })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint16 &rhs) { return self.Div(rhs); })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_bool &rhs) { return self.Div(rhs); })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const cytnx::Scalar &rhs) { return self.Div(rhs); })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<double>> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_complex128>(rhs));
-         })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_complex64>(rhs));
-         })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<double> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_double>(rhs));
-         })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<float> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_float>(rhs));
-         })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<int64_t> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_int64>(rhs));
-         })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<uint64_t> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_uint64>(rhs));
-         })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<int32_t> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_int32>(rhs));
-         })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<uint32_t> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_uint32>(rhs));
-         })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<int16_t> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_int16>(rhs));
-         })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<uint16_t> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_uint16>(rhs));
-         })
-    .def("__floordiv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<bool> &rhs) {
-           return self.Div(static_cast<cytnx::cytnx_bool>(rhs));
-         })
+         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Div(rhs); })
+    .def("__floordiv__", [](cytnx::Tensor &self, const cytnx::Scalar &rhs) { return self.Div(rhs); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
+    // NOTE (pre-existing, out of scope here): a numpy scalar on the LEFT
+    // (e.g. np.float32(1.0) + t) does not reach this __r*__ binding at all --
+    // Tensor defines __iter__, so numpy's ufunc machinery treats it as an
+    // array-like and tries to iterate it instead, raising
+    // "TypeError: 'TensorIterator' object is not iterable" (issue #692).
     .def("__rfloordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rfloordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex64 &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rfloordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_double &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rfloordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_float &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rfloordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int64 &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rfloordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint64 &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rfloordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int32 &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rfloordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint32 &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rfloordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int16 &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rfloordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint16 &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rfloordiv__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_bool &lhs) {
-           return cytnx::linalg::Div(lhs, self);
-         })
-    .def("__rfloordiv__", [](cytnx::Tensor &self,
-                             const cytnx::Scalar &lhs) { return cytnx::linalg::Div(lhs, self); })
-    // does not give the right type because of type casting to python objects before handling to
-    // pybind
-    .def("__rfloordiv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<double>> &lhs) {
-           return cytnx::linalg::Div(static_cast<cytnx::cytnx_complex128>(lhs), self);
+         [](cytnx::Tensor &self, const py::numpy_scalar<float> &lhs) {
+           return cytnx::linalg::Div(static_cast<cytnx::cytnx_float>(lhs), self);
          })
     .def("__rfloordiv__",
          [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<float>> &lhs) {
            return cytnx::linalg::Div(static_cast<cytnx::cytnx_complex64>(lhs), self);
-         })
-    .def("__rfloordiv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<double> &lhs) {
-           return cytnx::linalg::Div(static_cast<cytnx::cytnx_double>(lhs), self);
-         })
-    .def("__rfloordiv__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<float> &lhs) {
-           return cytnx::linalg::Div(static_cast<cytnx::cytnx_float>(lhs), self);
          })
     .def("__rfloordiv__",
          [](cytnx::Tensor &self, const py::numpy_scalar<int64_t> &lhs) {
@@ -1687,90 +1269,30 @@ void tensor_binding(py::module &m) {
          [](cytnx::Tensor &self, const py::numpy_scalar<bool> &lhs) {
            return cytnx::linalg::Div(static_cast<cytnx::cytnx_bool>(lhs), self);
          })
+    .def("__rfloordiv__",
+         [](cytnx::Tensor &self, const py::int_ &lhs) {
+           return dispatch_pyint(lhs, [&](auto v) { return cytnx::linalg::Div(v, self); });
+         })
+    .def("__rfloordiv__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_double &lhs) { return cytnx::linalg::Div(lhs, self); })
+    .def("__rfloordiv__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &lhs) { return cytnx::linalg::Div(lhs, self); })
+    .def("__rfloordiv__", [](cytnx::Tensor &self, const cytnx::Scalar &lhs) { return cytnx::linalg::Div(lhs, self); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__ifloordiv__",
          [](py::object self, const cytnx::Tensor &rhs) {
            self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })  // these will return self!
-    .def("__ifloordiv__",
-         [](py::object self, const cytnx::cytnx_complex128 &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__ifloordiv__",
-         [](py::object self, const cytnx::cytnx_complex64 &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__ifloordiv__",
-         [](py::object self, const cytnx::cytnx_double &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__ifloordiv__",
-         [](py::object self, const cytnx::cytnx_float &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__ifloordiv__",
-         [](py::object self, const cytnx::cytnx_int64 &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__ifloordiv__",
-         [](py::object self, const cytnx::cytnx_uint64 &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__ifloordiv__",
-         [](py::object self, const cytnx::cytnx_int32 &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__ifloordiv__",
-         [](py::object self, const cytnx::cytnx_uint32 &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__ifloordiv__",
-         [](py::object self, const cytnx::cytnx_int16 &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__ifloordiv__",
-         [](py::object self, const cytnx::cytnx_uint16 &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__ifloordiv__",
-         [](py::object self, const cytnx::cytnx_bool &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__ifloordiv__",
-         [](py::object self, const cytnx::Scalar &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(rhs);
-           return self;
-         })
-    .def("__ifloordiv__",
-         [](py::object self, const py::numpy_scalar<std::complex<double>> &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(static_cast<cytnx::cytnx_complex128>(rhs));
-           return self;
-         })
-    .def("__ifloordiv__",
-         [](py::object self, const py::numpy_scalar<std::complex<float>> &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(static_cast<cytnx::cytnx_complex64>(rhs));
-           return self;
-         })
-    .def("__ifloordiv__",
-         [](py::object self, const py::numpy_scalar<double> &rhs) {
-           self.cast<cytnx::Tensor &>().Div_(static_cast<cytnx::cytnx_double>(rhs));
            return self;
          })
     .def("__ifloordiv__",
          [](py::object self, const py::numpy_scalar<float> &rhs) {
            self.cast<cytnx::Tensor &>().Div_(static_cast<cytnx::cytnx_float>(rhs));
+           return self;
+         })
+    .def("__ifloordiv__",
+         [](py::object self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           self.cast<cytnx::Tensor &>().Div_(static_cast<cytnx::cytnx_complex64>(rhs));
            return self;
          })
     .def("__ifloordiv__",
@@ -1808,45 +1330,36 @@ void tensor_binding(py::module &m) {
            self.cast<cytnx::Tensor &>().Div_(static_cast<cytnx::cytnx_bool>(rhs));
            return self;
          })
+    .def("__ifloordiv__",
+         [](py::object self, const py::int_ &rhs) {
+           dispatch_pyint(rhs, [&](auto v) { self.cast<cytnx::Tensor &>().Div_(v); });
+           return self;
+         })
+    .def("__ifloordiv__",
+         [](py::object self, const cytnx::cytnx_double &rhs) {
+           self.cast<cytnx::Tensor &>().Div_(rhs);
+           return self;
+         })
+    .def("__ifloordiv__",
+         [](py::object self, const cytnx::cytnx_complex128 &rhs) {
+           self.cast<cytnx::Tensor &>().Div_(rhs);
+           return self;
+         })
+    .def("__ifloordiv__",
+         [](py::object self, const cytnx::Scalar &rhs) {
+           self.cast<cytnx::Tensor &>().Div_(rhs);
+           return self;
+         })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__mod__", [](cytnx::Tensor &self, const cytnx::Tensor &rhs) { return self.Mod(rhs); })
     .def("__mod__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Mod(rhs); })
-    .def("__mod__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex64 &rhs) { return self.Mod(rhs); })
-    .def("__mod__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_double &rhs) { return self.Mod(rhs); })
-    .def("__mod__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_float &rhs) { return self.Mod(rhs); })
-    .def("__mod__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int64 &rhs) { return self.Mod(rhs); })
-    .def("__mod__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint64 &rhs) { return self.Mod(rhs); })
-    .def("__mod__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int32 &rhs) { return self.Mod(rhs); })
-    .def("__mod__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint32 &rhs) { return self.Mod(rhs); })
-    .def("__mod__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_int16 &rhs) { return self.Mod(rhs); })
-    .def("__mod__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_uint16 &rhs) { return self.Mod(rhs); })
-    .def("__mod__", [](cytnx::Tensor &self, const cytnx::cytnx_bool &rhs) { return self.Mod(rhs); })
-    .def("__mod__", [](cytnx::Tensor &self, const cytnx::Scalar &rhs) { return self.Mod(rhs); })
-    .def("__mod__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<double>> &rhs) {
-           return self.Mod(static_cast<cytnx::cytnx_complex128>(rhs));
+         [](cytnx::Tensor &self, const py::numpy_scalar<float> &rhs) {
+           return self.Mod(static_cast<cytnx::cytnx_float>(rhs));
          })
     .def("__mod__",
          [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
            return self.Mod(static_cast<cytnx::cytnx_complex64>(rhs));
-         })
-    .def("__mod__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<double> &rhs) {
-           return self.Mod(static_cast<cytnx::cytnx_double>(rhs));
-         })
-    .def("__mod__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<float> &rhs) {
-           return self.Mod(static_cast<cytnx::cytnx_float>(rhs));
          })
     .def("__mod__",
          [](cytnx::Tensor &self, const py::numpy_scalar<int64_t> &rhs) {
@@ -1876,52 +1389,29 @@ void tensor_binding(py::module &m) {
          [](cytnx::Tensor &self, const py::numpy_scalar<bool> &rhs) {
            return self.Mod(static_cast<cytnx::cytnx_bool>(rhs));
          })
+    .def("__mod__",
+         [](cytnx::Tensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return self.Mod(v); });
+         })
+    .def("__mod__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_double &rhs) { return self.Mod(rhs); })
+    .def("__mod__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Mod(rhs); })
+    .def("__mod__", [](cytnx::Tensor &self, const cytnx::Scalar &rhs) { return self.Mod(rhs); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
+    // NOTE (pre-existing, out of scope here): a numpy scalar on the LEFT
+    // (e.g. np.float32(1.0) + t) does not reach this __r*__ binding at all --
+    // Tensor defines __iter__, so numpy's ufunc machinery treats it as an
+    // array-like and tries to iterate it instead, raising
+    // "TypeError: 'TensorIterator' object is not iterable" (issue #692).
     .def("__rmod__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &lhs) {
-           return cytnx::linalg::Mod(lhs, self);
-         })
-    .def("__rmod__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex64 &lhs) {
-           return cytnx::linalg::Mod(lhs, self);
-         })
-    .def("__rmod__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_double &lhs) { return cytnx::linalg::Mod(lhs, self); })
-    .def("__rmod__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_float &lhs) { return cytnx::linalg::Mod(lhs, self); })
-    .def("__rmod__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_int64 &lhs) { return cytnx::linalg::Mod(lhs, self); })
-    .def("__rmod__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_uint64 &lhs) { return cytnx::linalg::Mod(lhs, self); })
-    .def("__rmod__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_int32 &lhs) { return cytnx::linalg::Mod(lhs, self); })
-    .def("__rmod__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_uint32 &lhs) { return cytnx::linalg::Mod(lhs, self); })
-    .def("__rmod__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_int16 &lhs) { return cytnx::linalg::Mod(lhs, self); })
-    .def("__rmod__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_uint16 &lhs) { return cytnx::linalg::Mod(lhs, self); })
-    .def("__rmod__", [](cytnx::Tensor &self,
-                        const cytnx::cytnx_bool &lhs) { return cytnx::linalg::Mod(lhs, self); })
-    .def("__rmod__", [](cytnx::Tensor &self,
-                        const cytnx::Scalar &lhs) { return cytnx::linalg::Mod(lhs, self); })
-    // does not work because an iterator for the Tensor is defined, and numpy % Tensor calls
-    // numpy.__mod__(iterator)
-    .def("__rmod__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<double>> &lhs) {
-           return cytnx::linalg::Mod(static_cast<cytnx::cytnx_complex128>(lhs), self);
+         [](cytnx::Tensor &self, const py::numpy_scalar<float> &lhs) {
+           return cytnx::linalg::Mod(static_cast<cytnx::cytnx_float>(lhs), self);
          })
     .def("__rmod__",
          [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<float>> &lhs) {
            return cytnx::linalg::Mod(static_cast<cytnx::cytnx_complex64>(lhs), self);
-         })
-    .def("__rmod__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<double> &lhs) {
-           return cytnx::linalg::Mod(static_cast<cytnx::cytnx_double>(lhs), self);
-         })
-    .def("__rmod__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<float> &lhs) {
-           return cytnx::linalg::Mod(static_cast<cytnx::cytnx_float>(lhs), self);
          })
     .def("__rmod__",
          [](cytnx::Tensor &self, const py::numpy_scalar<int64_t> &lhs) {
@@ -1951,37 +1441,25 @@ void tensor_binding(py::module &m) {
          [](cytnx::Tensor &self, const py::numpy_scalar<bool> &lhs) {
            return cytnx::linalg::Mod(static_cast<cytnx::cytnx_bool>(lhs), self);
          })
+    .def("__rmod__",
+         [](cytnx::Tensor &self, const py::int_ &lhs) {
+           return dispatch_pyint(lhs, [&](auto v) { return cytnx::linalg::Mod(v, self); });
+         })
+    .def("__rmod__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_double &lhs) { return cytnx::linalg::Mod(lhs, self); })
+    .def("__rmod__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &lhs) { return cytnx::linalg::Mod(lhs, self); })
+    .def("__rmod__", [](cytnx::Tensor &self, const cytnx::Scalar &lhs) { return cytnx::linalg::Mod(lhs, self); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__eq__", [](cytnx::Tensor &self, const cytnx::Tensor &rhs) { return self == rhs; })
     .def("__eq__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &rhs) { return self == rhs; })
-    .def("__eq__",
-         [](cytnx::Tensor &self, const cytnx::cytnx_complex64 &rhs) { return self == rhs; })
-    .def("__eq__", [](cytnx::Tensor &self, const cytnx::cytnx_double &rhs) { return self == rhs; })
-    .def("__eq__", [](cytnx::Tensor &self, const cytnx::cytnx_float &rhs) { return self == rhs; })
-    .def("__eq__", [](cytnx::Tensor &self, const cytnx::cytnx_int64 &rhs) { return self == rhs; })
-    .def("__eq__", [](cytnx::Tensor &self, const cytnx::cytnx_uint64 &rhs) { return self == rhs; })
-    .def("__eq__", [](cytnx::Tensor &self, const cytnx::cytnx_int32 &rhs) { return self == rhs; })
-    .def("__eq__", [](cytnx::Tensor &self, const cytnx::cytnx_uint32 &rhs) { return self == rhs; })
-    .def("__eq__", [](cytnx::Tensor &self, const cytnx::cytnx_int16 &rhs) { return self == rhs; })
-    .def("__eq__", [](cytnx::Tensor &self, const cytnx::cytnx_uint16 &rhs) { return self == rhs; })
-    .def("__eq__", [](cytnx::Tensor &self, const cytnx::cytnx_bool &rhs) { return self == rhs; })
-    //     .def("__eq__", [](cytnx::Tensor &self, const cytnx::Scalar &rhs) { return self == rhs; })
-    .def("__eq__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<double>> &rhs) {
-           return self == static_cast<cytnx::cytnx_complex128>(rhs);
+         [](cytnx::Tensor &self, const py::numpy_scalar<float> &rhs) {
+           return self == static_cast<cytnx::cytnx_float>(rhs);
          })
     .def("__eq__",
          [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
            return self == static_cast<cytnx::cytnx_complex64>(rhs);
-         })
-    .def("__eq__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<double> &rhs) {
-           return self == static_cast<cytnx::cytnx_double>(rhs);
-         })
-    .def("__eq__",
-         [](cytnx::Tensor &self, const py::numpy_scalar<float> &rhs) {
-           return self == static_cast<cytnx::cytnx_float>(rhs);
          })
     .def("__eq__",
          [](cytnx::Tensor &self, const py::numpy_scalar<int64_t> &rhs) {
@@ -2011,9 +1489,175 @@ void tensor_binding(py::module &m) {
          [](cytnx::Tensor &self, const py::numpy_scalar<bool> &rhs) {
            return self == static_cast<cytnx::cytnx_bool>(rhs);
          })
+    .def("__eq__",
+         [](cytnx::Tensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return self == v; });
+         })
+    .def("__eq__", [](cytnx::Tensor &self, const cytnx::cytnx_double &rhs) { return self == rhs; })
+    .def("__eq__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &rhs) { return self == rhs; })
+    .def("__eq__", [](cytnx::Tensor &self, const cytnx::Scalar &rhs) { return self == rhs; })
 
+    // __ne__ (#928/#916/#692 background): cytnx has no elementwise
+    // operator!= or Neq/logical-not kernel (checked: no `Neq`, no
+    // `logical_not`, no `operator!` anywhere in include/linalg.hpp or
+    // src/linalg/). Leaving __ne__ unbound is NOT safe: Python's default
+    // dunder-less `!=` falls back to `not (self == rhs)`, and __eq__ already
+    // returns an elementwise Bool Tensor here, so `not Tensor` collapses
+    // through __bool__/__len__ to a single bare `False` for any non-empty
+    // operand -- a silently wrong scalar instead of an elementwise
+    // comparison (exactly the bug #928/#916 describe). A cheap, correct
+    // elementwise implementation composes two EXISTING kernels instead of
+    // requiring a new C++ kernel: `self.Cpr(rhs)` (the same call __eq__
+    // uses) gives the elementwise equality as a Bool Tensor; arithmetic
+    // `1 - eq` on a Bool tensor promotes to Int64 (0/1) through the normal
+    // type-promotion path, and `.astype(Type.Bool)` casts it back to a
+    // proper elementwise Bool Tensor with the negated values. Verified
+    // empirically (both 1-D and 2-D, contiguous) to match numpy elementwise
+    // != semantics. Keep-set mirrors __eq__ (including the trailing Scalar
+    // overload); registration ORDER matters -- see "KEEP-SET ORDERING" in
+    // pybind/pyint_dispatch.hpp.
+    .def("__ne__",
+         [](cytnx::Tensor &self, const cytnx::Tensor &rhs) {
+           return (1 - self.Cpr(rhs)).astype(cytnx::Type.Bool);
+         })
+    .def("__ne__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<float> &rhs) {
+           return (1 - self.Cpr(static_cast<cytnx::cytnx_float>(rhs))).astype(cytnx::Type.Bool);
+         })
+    .def("__ne__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           return (1 - self.Cpr(static_cast<cytnx::cytnx_complex64>(rhs)))
+             .astype(cytnx::Type.Bool);
+         })
+    .def("__ne__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<int64_t> &rhs) {
+           return (1 - self.Cpr(static_cast<cytnx::cytnx_int64>(rhs))).astype(cytnx::Type.Bool);
+         })
+    .def("__ne__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<uint64_t> &rhs) {
+           return (1 - self.Cpr(static_cast<cytnx::cytnx_uint64>(rhs))).astype(cytnx::Type.Bool);
+         })
+    .def("__ne__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<int32_t> &rhs) {
+           return (1 - self.Cpr(static_cast<cytnx::cytnx_int32>(rhs))).astype(cytnx::Type.Bool);
+         })
+    .def("__ne__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<uint32_t> &rhs) {
+           return (1 - self.Cpr(static_cast<cytnx::cytnx_uint32>(rhs))).astype(cytnx::Type.Bool);
+         })
+    .def("__ne__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<int16_t> &rhs) {
+           return (1 - self.Cpr(static_cast<cytnx::cytnx_int16>(rhs))).astype(cytnx::Type.Bool);
+         })
+    .def("__ne__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<uint16_t> &rhs) {
+           return (1 - self.Cpr(static_cast<cytnx::cytnx_uint16>(rhs))).astype(cytnx::Type.Bool);
+         })
+    .def("__ne__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<bool> &rhs) {
+           return (1 - self.Cpr(static_cast<cytnx::cytnx_bool>(rhs))).astype(cytnx::Type.Bool);
+         })
+    .def("__ne__",
+         [](cytnx::Tensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) {
+             return (1 - self.Cpr(v)).astype(cytnx::Type.Bool);
+           });
+         })
+    .def("__ne__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_double &rhs) {
+           return (1 - self.Cpr(rhs)).astype(cytnx::Type.Bool);
+         })
+    .def("__ne__",
+         [](cytnx::Tensor &self, const cytnx::cytnx_complex128 &rhs) {
+           return (1 - self.Cpr(rhs)).astype(cytnx::Type.Bool);
+         })
+    .def("__ne__",
+         [](cytnx::Tensor &self, const cytnx::Scalar &rhs) {
+           return (1 - (self == rhs)).astype(cytnx::Type.Bool);
+         })
+
+    // __bool__ (numpy semantics, #928/#916/#692 background): previously
+    // unbound, so Python's truthiness fell through to __len__ (`if tensor:`
+    // just checked shape()[0] != 0), which never raises for a multi-element
+    // tensor and gives no meaningful truth value at all for an uninitialized
+    // (Void-dtype, shape []) Tensor beyond a low-level cytnx_error_msg
+    // RuntimeError. numpy raises ValueError for an array with more than one
+    // element ("truth value ... is ambiguous") and also for a size-0 array;
+    // cytnx never allows a genuinely empty (0-length) dimension, so the
+    // size-0 case that matters here is the uninitialized/Void Tensor.
+    // NOTE: this is a user-visible behavior change -- `if tensor:` used to
+    // be equivalent to `if len(tensor):` (shape()[0] truthiness) and now
+    // raises ValueError for any multi-element tensor instead.
+    .def("__bool__",
+         [](cytnx::Tensor &self) {
+           if (self.dtype() == cytnx::Type.Void) {
+             throw py::value_error("the truth value of an uninitialized Tensor is ambiguous.");
+           }
+           cytnx::cytnx_uint64 numel = 1;
+           for (auto &d : self.shape()) numel *= d;
+           if (numel != 1) {
+             throw py::value_error(
+               "the truth value of a Tensor with more than one element is ambiguous.");
+           }
+           if (self.dtype() == cytnx::Type.Double)
+             return bool(self.item<cytnx::cytnx_double>());
+           else if (self.dtype() == cytnx::Type.Float)
+             return bool(self.item<cytnx::cytnx_float>());
+           else if (self.dtype() == cytnx::Type.ComplexDouble)
+             return self.item<cytnx::cytnx_complex128>() != cytnx::cytnx_complex128(0, 0);
+           else if (self.dtype() == cytnx::Type.ComplexFloat)
+             return self.item<cytnx::cytnx_complex64>() != cytnx::cytnx_complex64(0, 0);
+           else if (self.dtype() == cytnx::Type.Uint64)
+             return bool(self.item<cytnx::cytnx_uint64>());
+           else if (self.dtype() == cytnx::Type.Int64)
+             return bool(self.item<cytnx::cytnx_int64>());
+           else if (self.dtype() == cytnx::Type.Uint32)
+             return bool(self.item<cytnx::cytnx_uint32>());
+           else if (self.dtype() == cytnx::Type.Int32)
+             return bool(self.item<cytnx::cytnx_int32>());
+           else if (self.dtype() == cytnx::Type.Uint16)
+             return bool(self.item<cytnx::cytnx_uint16>());
+           else if (self.dtype() == cytnx::Type.Int16)
+             return bool(self.item<cytnx::cytnx_int16>());
+           else  // Bool
+             return bool(self.item<cytnx::cytnx_bool>());
+         })
+
+    // __pow__/__ipow__: linalg::Pow/Tensor::Pow_ only take a plain double
+    // exponent, so the keep-set here is narrower than the arithmetic ops --
+    // there is no elementwise Tensor**Tensor kernel, and the output dtype
+    // follows the BASE tensor, not the exponent, so no numpy integer-dtype-
+    // preservation concern applies to the exponent itself. Still bind
+    // py::int_ and numpy_scalar<float> explicitly (rather than relying on
+    // pybind11's implicit double conversion) so #916-style stubs can show a
+    // precise signature once the stub pipeline (#915) lands, instead of only
+    // working by accident through the convert-pass fallback.
+    .def("__pow__",
+         [](cytnx::Tensor &self, const py::numpy_scalar<float> &p) {
+           return cytnx::linalg::Pow(self, static_cast<cytnx::cytnx_double>(
+                                             static_cast<cytnx::cytnx_float>(p)));
+         })
+    .def("__pow__",
+         [](cytnx::Tensor &self, const py::int_ &p) {
+           return dispatch_pyint(
+             p, [&](auto v) { return cytnx::linalg::Pow(self, static_cast<cytnx::cytnx_double>(v)); });
+         })
     .def("__pow__", [](cytnx::Tensor &self,
                        const cytnx::cytnx_double &p) { return cytnx::linalg::Pow(self, p); })
+    .def("__ipow__",
+         [](py::object self, const py::numpy_scalar<float> &p) {
+           self.cast<cytnx::Tensor &>().Pow_(
+             static_cast<cytnx::cytnx_double>(static_cast<cytnx::cytnx_float>(p)));
+           return self;
+         })
+    .def("__ipow__",
+         [](py::object self, const py::int_ &p) {
+           dispatch_pyint(p, [&](auto v) {
+             self.cast<cytnx::Tensor &>().Pow_(static_cast<cytnx::cytnx_double>(v));
+           });
+           return self;
+         })
     .def("__ipow__",
          [](py::object self, const cytnx::cytnx_double &p) {
            self.cast<cytnx::Tensor &>().Pow_(p);

--- a/pybind/unitensor_py.cpp
+++ b/pybind/unitensor_py.cpp
@@ -14,10 +14,12 @@
 #include <pybind11/warnings.h>
 
 #include "cytnx.hpp"
+#include "pyint_dispatch.hpp"
 
 namespace py = pybind11;
 using namespace pybind11::literals;
 using namespace cytnx;
+using pybind_cytnx::dispatch_pyint;
 
 #ifdef BACKEND_TORCH
 #else
@@ -454,53 +456,208 @@ void unitensor_binding(py::module &m) {
            return out;
          })
 
-    .def("set_elem", &f_UniTensor_setelem_scal<cytnx_complex128>)
-    .def("set_elem", &f_UniTensor_setelem_scal<cytnx_complex64>)
+    // set_elem/__setitem__ keep-set; registration ORDER matters -- see
+    // "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp. Group-specific note
+    // (scope extension beyond the plan's literal Tensor-only inventory):
+    // recon found UniTensor's set_elem/__setitem__ had the SAME
+    // registration-order bug as Tensor's __setitem__ -- np.float32 was
+    // accepted by the FIRST-registered cytnx_complex128 overload (the
+    // __float__-fallback trap), so `ut[0] = np.float32(2.5)` on a Float
+    // UniTensor did not merely mis-preserve dtype, it raised a hard
+    // RuntimeError ("Cannot set Complex Double to Float"). Fixed the same
+    // way for both the vector-locator (explicit index list) and
+    // single-int-locator (diagonal UniTensor) overload families.
+    .def("set_elem",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<float> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_float>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<std::complex<float>> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_complex64>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<int64_t> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_int64>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<uint64_t> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_uint64>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<int32_t> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_int32>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<uint32_t> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_uint32>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<int16_t> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_int16>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<uint16_t> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_uint16>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<bool> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_bool>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator, const py::int_ &rc) {
+           dispatch_pyint(rc, [&](auto v) { f_UniTensor_setelem_scal(self, locator, v); });
+         })
     .def("set_elem", &f_UniTensor_setelem_scal<cytnx_double>)
-    .def("set_elem", &f_UniTensor_setelem_scal<cytnx_float>)
-    .def("set_elem", &f_UniTensor_setelem_scal<cytnx_int64>)
-    .def("set_elem", &f_UniTensor_setelem_scal<cytnx_uint64>)
-    .def("set_elem", &f_UniTensor_setelem_scal<cytnx_int32>)
-    .def("set_elem", &f_UniTensor_setelem_scal<cytnx_uint32>)
-    .def("set_elem", &f_UniTensor_setelem_scal<cytnx_int16>)
-    .def("set_elem", &f_UniTensor_setelem_scal<cytnx_uint16>)
-    .def("set_elem", &f_UniTensor_setelem_scal<cytnx_bool>)
+    .def("set_elem", &f_UniTensor_setelem_scal<cytnx_complex128>)
 
-    .def("set_elem", &f_UniTensor_setelem_scal_int<cytnx_complex128>)
-    .def("set_elem", &f_UniTensor_setelem_scal_int<cytnx_complex64>)
+    .def("set_elem",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::numpy_scalar<float> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_float>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const cytnx_uint64 &locator,
+            const py::numpy_scalar<std::complex<float>> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_complex64>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::numpy_scalar<int64_t> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_int64>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::numpy_scalar<uint64_t> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_uint64>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::numpy_scalar<int32_t> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_int32>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::numpy_scalar<uint32_t> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_uint32>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::numpy_scalar<int16_t> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_int16>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::numpy_scalar<uint16_t> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_uint16>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::numpy_scalar<bool> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_bool>(rc));
+         })
+    .def("set_elem",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::int_ &rc) {
+           dispatch_pyint(rc, [&](auto v) { f_UniTensor_setelem_scal_int(self, locator, v); });
+         })
     .def("set_elem", &f_UniTensor_setelem_scal_int<cytnx_double>)
-    .def("set_elem", &f_UniTensor_setelem_scal_int<cytnx_float>)
-    .def("set_elem", &f_UniTensor_setelem_scal_int<cytnx_int64>)
-    .def("set_elem", &f_UniTensor_setelem_scal_int<cytnx_uint64>)
-    .def("set_elem", &f_UniTensor_setelem_scal_int<cytnx_int32>)
-    .def("set_elem", &f_UniTensor_setelem_scal_int<cytnx_uint32>)
-    .def("set_elem", &f_UniTensor_setelem_scal_int<cytnx_int16>)
-    .def("set_elem", &f_UniTensor_setelem_scal_int<cytnx_uint16>)
-    .def("set_elem", &f_UniTensor_setelem_scal_int<cytnx_bool>)
+    .def("set_elem", &f_UniTensor_setelem_scal_int<cytnx_complex128>)
 
-    .def("__setitem__", &f_UniTensor_setelem_scal<cytnx_complex128>)
-    .def("__setitem__", &f_UniTensor_setelem_scal<cytnx_complex64>)
+    .def("__setitem__",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<float> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_float>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<std::complex<float>> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_complex64>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<int64_t> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_int64>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<uint64_t> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_uint64>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<int32_t> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_int32>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<uint32_t> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_uint32>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<int16_t> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_int16>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<uint16_t> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_uint16>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator,
+            const py::numpy_scalar<bool> &rc) {
+           f_UniTensor_setelem_scal(self, locator, static_cast<cytnx_bool>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const std::vector<cytnx_uint64> &locator, const py::int_ &rc) {
+           dispatch_pyint(rc, [&](auto v) { f_UniTensor_setelem_scal(self, locator, v); });
+         })
     .def("__setitem__", &f_UniTensor_setelem_scal<cytnx_double>)
-    .def("__setitem__", &f_UniTensor_setelem_scal<cytnx_float>)
-    .def("__setitem__", &f_UniTensor_setelem_scal<cytnx_int64>)
-    .def("__setitem__", &f_UniTensor_setelem_scal<cytnx_uint64>)
-    .def("__setitem__", &f_UniTensor_setelem_scal<cytnx_int32>)
-    .def("__setitem__", &f_UniTensor_setelem_scal<cytnx_uint32>)
-    .def("__setitem__", &f_UniTensor_setelem_scal<cytnx_int16>)
-    .def("__setitem__", &f_UniTensor_setelem_scal<cytnx_uint16>)
-    .def("__setitem__", &f_UniTensor_setelem_scal<cytnx_bool>)
+    .def("__setitem__", &f_UniTensor_setelem_scal<cytnx_complex128>)
 
-    .def("__setitem__", &f_UniTensor_setelem_scal_int<cytnx_complex128>)
-    .def("__setitem__", &f_UniTensor_setelem_scal_int<cytnx_complex64>)
+    .def("__setitem__",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::numpy_scalar<float> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_float>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const cytnx_uint64 &locator,
+            const py::numpy_scalar<std::complex<float>> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_complex64>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::numpy_scalar<int64_t> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_int64>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::numpy_scalar<uint64_t> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_uint64>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::numpy_scalar<int32_t> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_int32>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::numpy_scalar<uint32_t> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_uint32>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::numpy_scalar<int16_t> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_int16>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::numpy_scalar<uint16_t> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_uint16>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::numpy_scalar<bool> &rc) {
+           f_UniTensor_setelem_scal_int(self, locator, static_cast<cytnx_bool>(rc));
+         })
+    .def("__setitem__",
+         [](UniTensor &self, const cytnx_uint64 &locator, const py::int_ &rc) {
+           dispatch_pyint(rc, [&](auto v) { f_UniTensor_setelem_scal_int(self, locator, v); });
+         })
     .def("__setitem__", &f_UniTensor_setelem_scal_int<cytnx_double>)
-    .def("__setitem__", &f_UniTensor_setelem_scal_int<cytnx_float>)
-    .def("__setitem__", &f_UniTensor_setelem_scal_int<cytnx_int64>)
-    .def("__setitem__", &f_UniTensor_setelem_scal_int<cytnx_uint64>)
-    .def("__setitem__", &f_UniTensor_setelem_scal_int<cytnx_int32>)
-    .def("__setitem__", &f_UniTensor_setelem_scal_int<cytnx_uint32>)
-    .def("__setitem__", &f_UniTensor_setelem_scal_int<cytnx_int16>)
-    .def("__setitem__", &f_UniTensor_setelem_scal_int<cytnx_uint16>)
-    .def("__setitem__", &f_UniTensor_setelem_scal_int<cytnx_bool>)
+    .def("__setitem__", &f_UniTensor_setelem_scal_int<cytnx_complex128>)
 
     .def("is_contiguous", &UniTensor::is_contiguous)
     .def("is_diag", &UniTensor::is_diag)
@@ -797,536 +954,728 @@ void unitensor_binding(py::module &m) {
            }
          })
     .def("__pos__", [](UniTensor &self) { return self; })
+    // NOTE: no __eq__/__ne__/__bool__ on UniTensor (intentional, Task 3 scope) -- Python falls
+    // back to identity semantics; see Tensor's __ne__/__bool__ notes in tensor_py.cpp.
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__add__", [](UniTensor &self, const UniTensor &rhs) { return linalg::Add(self, rhs); })
     .def("__add__",
-         [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return linalg::Add(self, rhs); })
+         [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
+           return linalg::Add(self, static_cast<cytnx::cytnx_float>(rhs));
+         })
     .def("__add__",
-         [](UniTensor &self, const cytnx::cytnx_complex64 &rhs) { return linalg::Add(self, rhs); })
+         [](UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           return linalg::Add(self, static_cast<cytnx::cytnx_complex64>(rhs));
+         })
+    .def("__add__",
+         [](UniTensor &self, const py::numpy_scalar<int64_t> &rhs) {
+           return linalg::Add(self, static_cast<cytnx::cytnx_int64>(rhs));
+         })
+    .def("__add__",
+         [](UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) {
+           return linalg::Add(self, static_cast<cytnx::cytnx_uint64>(rhs));
+         })
+    .def("__add__",
+         [](UniTensor &self, const py::numpy_scalar<int32_t> &rhs) {
+           return linalg::Add(self, static_cast<cytnx::cytnx_int32>(rhs));
+         })
+    .def("__add__",
+         [](UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) {
+           return linalg::Add(self, static_cast<cytnx::cytnx_uint32>(rhs));
+         })
+    .def("__add__",
+         [](UniTensor &self, const py::numpy_scalar<int16_t> &rhs) {
+           return linalg::Add(self, static_cast<cytnx::cytnx_int16>(rhs));
+         })
+    .def("__add__",
+         [](UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) {
+           return linalg::Add(self, static_cast<cytnx::cytnx_uint16>(rhs));
+         })
+    .def("__add__",
+         [](UniTensor &self, const py::numpy_scalar<bool> &rhs) {
+           return linalg::Add(self, static_cast<cytnx::cytnx_bool>(rhs));
+         })
+    .def("__add__",
+         [](UniTensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return linalg::Add(self, v); });
+         })
     .def("__add__",
          [](UniTensor &self, const cytnx::cytnx_double &rhs) { return linalg::Add(self, rhs); })
     .def("__add__",
-         [](UniTensor &self, const cytnx::cytnx_float &rhs) { return linalg::Add(self, rhs); })
-    .def("__add__",
-         [](UniTensor &self, const cytnx::cytnx_int64 &rhs) { return linalg::Add(self, rhs); })
-    .def("__add__",
-         [](UniTensor &self, const cytnx::cytnx_uint64 &rhs) { return linalg::Add(self, rhs); })
-    .def("__add__",
-         [](UniTensor &self, const cytnx::cytnx_int32 &rhs) { return linalg::Add(self, rhs); })
-    .def("__add__",
-         [](UniTensor &self, const cytnx::cytnx_uint32 &rhs) { return linalg::Add(self, rhs); })
-    .def("__add__",
-         [](UniTensor &self, const cytnx::cytnx_int16 &rhs) { return linalg::Add(self, rhs); })
-    .def("__add__",
-         [](UniTensor &self, const cytnx::cytnx_uint16 &rhs) { return linalg::Add(self, rhs); })
-    .def("__add__",
-         [](UniTensor &self, const cytnx::cytnx_bool &rhs) { return linalg::Add(self, rhs); })
-    .def("__add__", [](cytnx::UniTensor &self, const cytnx::Scalar &rhs) { return linalg::Add(self, rhs); })
-    .def("__add__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<double>> &rhs) { return linalg::Add(self, static_cast<cytnx::cytnx_complex128>(rhs)); })
-    .def("__add__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) { return linalg::Add(self, static_cast<cytnx::cytnx_complex64>(rhs)); })
-    .def("__add__", [](cytnx::UniTensor &self, const py::numpy_scalar<double> &rhs) { return linalg::Add(self, static_cast<cytnx::cytnx_double>(rhs)); })
-    .def("__add__", [](cytnx::UniTensor &self, const py::numpy_scalar<float> &rhs) { return linalg::Add(self, static_cast<cytnx::cytnx_float>(rhs)); })
-    .def("__add__", [](cytnx::UniTensor &self, const py::numpy_scalar<int64_t> &rhs) { return linalg::Add(self, static_cast<cytnx::cytnx_int64>(rhs)); })
-    .def("__add__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) { return linalg::Add(self, static_cast<cytnx::cytnx_uint64>(rhs)); })
-    .def("__add__", [](cytnx::UniTensor &self, const py::numpy_scalar<int32_t> &rhs) { return linalg::Add(self, static_cast<cytnx::cytnx_int32>(rhs)); })
-    .def("__add__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) { return linalg::Add(self, static_cast<cytnx::cytnx_uint32>(rhs)); })
-    .def("__add__", [](cytnx::UniTensor &self, const py::numpy_scalar<int16_t> &rhs) { return linalg::Add(self, static_cast<cytnx::cytnx_int16>(rhs)); })
-    .def("__add__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) { return linalg::Add(self, static_cast<cytnx::cytnx_uint16>(rhs)); })
-    .def("__add__", [](cytnx::UniTensor &self, const py::numpy_scalar<bool> &rhs) { return linalg::Add(self, static_cast<cytnx::cytnx_bool>(rhs)); })
+         [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return linalg::Add(self, rhs); })
+    .def("__add__", [](UniTensor &self, const cytnx::Scalar &rhs) { return linalg::Add(self, rhs); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__radd__",
-         [](UniTensor &self, const cytnx::cytnx_complex128 &lhs) { return linalg::Add(lhs, self); })
+         [](UniTensor &self, const py::numpy_scalar<float> &lhs) {
+           return linalg::Add(static_cast<cytnx::cytnx_float>(lhs), self);
+         })
     .def("__radd__",
-         [](UniTensor &self, const cytnx::cytnx_complex64 &lhs) { return linalg::Add(lhs, self); })
+         [](UniTensor &self, const py::numpy_scalar<std::complex<float>> &lhs) {
+           return linalg::Add(static_cast<cytnx::cytnx_complex64>(lhs), self);
+         })
+    .def("__radd__",
+         [](UniTensor &self, const py::numpy_scalar<int64_t> &lhs) {
+           return linalg::Add(static_cast<cytnx::cytnx_int64>(lhs), self);
+         })
+    .def("__radd__",
+         [](UniTensor &self, const py::numpy_scalar<uint64_t> &lhs) {
+           return linalg::Add(static_cast<cytnx::cytnx_uint64>(lhs), self);
+         })
+    .def("__radd__",
+         [](UniTensor &self, const py::numpy_scalar<int32_t> &lhs) {
+           return linalg::Add(static_cast<cytnx::cytnx_int32>(lhs), self);
+         })
+    .def("__radd__",
+         [](UniTensor &self, const py::numpy_scalar<uint32_t> &lhs) {
+           return linalg::Add(static_cast<cytnx::cytnx_uint32>(lhs), self);
+         })
+    .def("__radd__",
+         [](UniTensor &self, const py::numpy_scalar<int16_t> &lhs) {
+           return linalg::Add(static_cast<cytnx::cytnx_int16>(lhs), self);
+         })
+    .def("__radd__",
+         [](UniTensor &self, const py::numpy_scalar<uint16_t> &lhs) {
+           return linalg::Add(static_cast<cytnx::cytnx_uint16>(lhs), self);
+         })
+    .def("__radd__",
+         [](UniTensor &self, const py::numpy_scalar<bool> &lhs) {
+           return linalg::Add(static_cast<cytnx::cytnx_bool>(lhs), self);
+         })
+    .def("__radd__",
+         [](UniTensor &self, const py::int_ &lhs) {
+           return dispatch_pyint(lhs, [&](auto v) { return linalg::Add(v, self); });
+         })
     .def("__radd__",
          [](UniTensor &self, const cytnx::cytnx_double &lhs) { return linalg::Add(lhs, self); })
     .def("__radd__",
-         [](UniTensor &self, const cytnx::cytnx_float &lhs) { return linalg::Add(lhs, self); })
-    .def("__radd__",
-         [](UniTensor &self, const cytnx::cytnx_int64 &lhs) { return linalg::Add(lhs, self); })
-    .def("__radd__",
-         [](UniTensor &self, const cytnx::cytnx_uint64 &lhs) { return linalg::Add(lhs, self); })
-    .def("__radd__",
-         [](UniTensor &self, const cytnx::cytnx_int32 &lhs) { return linalg::Add(lhs, self); })
-    .def("__radd__",
-         [](UniTensor &self, const cytnx::cytnx_uint32 &lhs) { return linalg::Add(lhs, self); })
-    .def("__radd__",
-         [](UniTensor &self, const cytnx::cytnx_int16 &lhs) { return linalg::Add(lhs, self); })
-    .def("__radd__",
-         [](UniTensor &self, const cytnx::cytnx_uint16 &lhs) { return linalg::Add(lhs, self); })
-    .def("__radd__",
-         [](UniTensor &self, const cytnx::cytnx_bool &lhs) { return linalg::Add(lhs, self); })
-    .def("__radd__", [](cytnx::UniTensor &self, const cytnx::Scalar &lhs) { return cytnx::linalg::Add(lhs, self); })
-     // does not give the right type because of type casting to python objects before handling to pybind
-    .def("__radd__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<double>> &lhs) { return cytnx::linalg::Add(static_cast<cytnx::cytnx_complex128>(lhs), self); })
-    .def("__radd__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<float>> &lhs) { return cytnx::linalg::Add(static_cast<cytnx::cytnx_complex64>(lhs), self); })
-    .def("__radd__", [](cytnx::UniTensor &self, const py::numpy_scalar<double> &lhs) { return cytnx::linalg::Add(static_cast<cytnx::cytnx_double>(lhs), self); })
-    .def("__radd__", [](cytnx::UniTensor &self, const py::numpy_scalar<float> &lhs) { return cytnx::linalg::Add(static_cast<cytnx::cytnx_float>(lhs), self); })
-    .def("__radd__", [](cytnx::UniTensor &self, const py::numpy_scalar<int64_t> &lhs) { return cytnx::linalg::Add(static_cast<cytnx::cytnx_int64>(lhs), self); })
-    .def("__radd__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint64_t> &lhs) { return cytnx::linalg::Add(static_cast<cytnx::cytnx_uint64>(lhs), self); })
-    .def("__radd__", [](cytnx::UniTensor &self, const py::numpy_scalar<int32_t> &lhs) { return cytnx::linalg::Add(static_cast<cytnx::cytnx_int32>(lhs), self); })
-    .def("__radd__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint32_t> &lhs) { return cytnx::linalg::Add(static_cast<cytnx::cytnx_uint32>(lhs), self); })
-    .def("__radd__", [](cytnx::UniTensor &self, const py::numpy_scalar<int16_t> &lhs) { return cytnx::linalg::Add(static_cast<cytnx::cytnx_int16>(lhs), self); })
-    .def("__radd__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint16_t> &lhs) { return cytnx::linalg::Add(static_cast<cytnx::cytnx_uint16>(lhs), self); })
-    .def("__radd__", [](cytnx::UniTensor &self, const py::numpy_scalar<bool> &lhs) { return cytnx::linalg::Add(static_cast<cytnx::cytnx_bool>(lhs), self); })
+         [](UniTensor &self, const cytnx::cytnx_complex128 &lhs) { return linalg::Add(lhs, self); })
+    .def("__radd__", [](UniTensor &self, const cytnx::Scalar &lhs) { return linalg::Add(lhs, self); })
 
-
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__iadd__",
-         [](UniTensor &self, const UniTensor &rhs) {
-           return self.Add_(rhs);
-         })  // these will return self!
+         [](UniTensor &self, const UniTensor &rhs) { return self.Add_(rhs); })
+    .def("__iadd__",
+         [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
+           return self.Add_(static_cast<cytnx::cytnx_float>(rhs));
+         })
+    .def("__iadd__",
+         [](UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           return self.Add_(static_cast<cytnx::cytnx_complex64>(rhs));
+         })
+    .def("__iadd__",
+         [](UniTensor &self, const py::numpy_scalar<int64_t> &rhs) {
+           return self.Add_(static_cast<cytnx::cytnx_int64>(rhs));
+         })
+    .def("__iadd__",
+         [](UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) {
+           return self.Add_(static_cast<cytnx::cytnx_uint64>(rhs));
+         })
+    .def("__iadd__",
+         [](UniTensor &self, const py::numpy_scalar<int32_t> &rhs) {
+           return self.Add_(static_cast<cytnx::cytnx_int32>(rhs));
+         })
+    .def("__iadd__",
+         [](UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) {
+           return self.Add_(static_cast<cytnx::cytnx_uint32>(rhs));
+         })
+    .def("__iadd__",
+         [](UniTensor &self, const py::numpy_scalar<int16_t> &rhs) {
+           return self.Add_(static_cast<cytnx::cytnx_int16>(rhs));
+         })
+    .def("__iadd__",
+         [](UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) {
+           return self.Add_(static_cast<cytnx::cytnx_uint16>(rhs));
+         })
+    .def("__iadd__",
+         [](UniTensor &self, const py::numpy_scalar<bool> &rhs) {
+           return self.Add_(static_cast<cytnx::cytnx_bool>(rhs));
+         })
+    .def("__iadd__",
+         [](UniTensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return self.Add_(v); });
+         })
+    .def("__iadd__",
+         [](UniTensor &self, const cytnx::cytnx_double &rhs) { return self.Add_(rhs); })
     .def("__iadd__",
          [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Add_(rhs); })
-    .def("__iadd__",
-         [](UniTensor &self, const cytnx::cytnx_complex64 &rhs) { return self.Add_(rhs); })
-    .def("__iadd__", [](UniTensor &self, const cytnx::cytnx_double &rhs) { return self.Add_(rhs); })
-    .def("__iadd__", [](UniTensor &self, const cytnx::cytnx_float &rhs) { return self.Add_(rhs); })
-    .def("__iadd__", [](UniTensor &self, const cytnx::cytnx_int64 &rhs) { return self.Add_(rhs); })
-    .def("__iadd__", [](UniTensor &self, const cytnx::cytnx_uint64 &rhs) { return self.Add_(rhs); })
-    .def("__iadd__", [](UniTensor &self, const cytnx::cytnx_int32 &rhs) { return self.Add_(rhs); })
-    .def("__iadd__", [](UniTensor &self, const cytnx::cytnx_uint32 &rhs) { return self.Add_(rhs); })
-    .def("__iadd__", [](UniTensor &self, const cytnx::cytnx_int16 &rhs) { return self.Add_(rhs); })
-    .def("__iadd__", [](UniTensor &self, const cytnx::cytnx_uint16 &rhs) { return self.Add_(rhs); })
-    .def("__iadd__", [](UniTensor &self, const cytnx::cytnx_bool &rhs) { return self.Add_(rhs); })
-    .def("__iadd__", [](cytnx::UniTensor &self, const cytnx::Scalar &rhs) { return self.Add_(rhs); })
-    .def("__iadd__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<double>> &rhs) { return self.Add_(static_cast<cytnx::cytnx_complex128>(rhs)); })
-    .def("__iadd__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) { return self.Add_(static_cast<cytnx::cytnx_complex64>(rhs)); })
-    .def("__iadd__", [](cytnx::UniTensor &self, const py::numpy_scalar<double> &rhs) { return self.Add_(static_cast<cytnx::cytnx_double>(rhs)); })
-    .def("__iadd__", [](cytnx::UniTensor &self, const py::numpy_scalar<float> &rhs) { return self.Add_(static_cast<cytnx::cytnx_float>(rhs)); })
-    .def("__iadd__", [](cytnx::UniTensor &self, const py::numpy_scalar<int64_t> &rhs) { return self.Add_(static_cast<cytnx::cytnx_int64>(rhs)); })
-    .def("__iadd__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) { return self.Add_(static_cast<cytnx::cytnx_uint64>(rhs)); })
-    .def("__iadd__", [](cytnx::UniTensor &self, const py::numpy_scalar<int32_t> &rhs) { return self.Add_(static_cast<cytnx::cytnx_int32>(rhs)); })
-    .def("__iadd__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) { return self.Add_(static_cast<cytnx::cytnx_uint32>(rhs)); })
-    .def("__iadd__", [](cytnx::UniTensor &self, const py::numpy_scalar<int16_t> &rhs) { return self.Add_(static_cast<cytnx::cytnx_int16>(rhs)); })
-    .def("__iadd__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) { return self.Add_(static_cast<cytnx::cytnx_uint16>(rhs)); })
-    .def("__iadd__", [](cytnx::UniTensor &self, const py::numpy_scalar<bool> &rhs) { return self.Add_(static_cast<cytnx::cytnx_bool>(rhs)); })
+    .def("__iadd__", [](UniTensor &self, const cytnx::Scalar &rhs) { return self.Add_(rhs); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__sub__", [](UniTensor &self, const UniTensor &rhs) { return linalg::Sub(self, rhs); })
     .def("__sub__",
-         [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return linalg::Sub(self, rhs); })
+         [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
+           return linalg::Sub(self, static_cast<cytnx::cytnx_float>(rhs));
+         })
     .def("__sub__",
-         [](UniTensor &self, const cytnx::cytnx_complex64 &rhs) { return linalg::Sub(self, rhs); })
+         [](UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           return linalg::Sub(self, static_cast<cytnx::cytnx_complex64>(rhs));
+         })
+    .def("__sub__",
+         [](UniTensor &self, const py::numpy_scalar<int64_t> &rhs) {
+           return linalg::Sub(self, static_cast<cytnx::cytnx_int64>(rhs));
+         })
+    .def("__sub__",
+         [](UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) {
+           return linalg::Sub(self, static_cast<cytnx::cytnx_uint64>(rhs));
+         })
+    .def("__sub__",
+         [](UniTensor &self, const py::numpy_scalar<int32_t> &rhs) {
+           return linalg::Sub(self, static_cast<cytnx::cytnx_int32>(rhs));
+         })
+    .def("__sub__",
+         [](UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) {
+           return linalg::Sub(self, static_cast<cytnx::cytnx_uint32>(rhs));
+         })
+    .def("__sub__",
+         [](UniTensor &self, const py::numpy_scalar<int16_t> &rhs) {
+           return linalg::Sub(self, static_cast<cytnx::cytnx_int16>(rhs));
+         })
+    .def("__sub__",
+         [](UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) {
+           return linalg::Sub(self, static_cast<cytnx::cytnx_uint16>(rhs));
+         })
+    .def("__sub__",
+         [](UniTensor &self, const py::numpy_scalar<bool> &rhs) {
+           return linalg::Sub(self, static_cast<cytnx::cytnx_bool>(rhs));
+         })
+    .def("__sub__",
+         [](UniTensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return linalg::Sub(self, v); });
+         })
     .def("__sub__",
          [](UniTensor &self, const cytnx::cytnx_double &rhs) { return linalg::Sub(self, rhs); })
     .def("__sub__",
-         [](UniTensor &self, const cytnx::cytnx_float &rhs) { return linalg::Sub(self, rhs); })
-    .def("__sub__",
-         [](UniTensor &self, const cytnx::cytnx_int64 &rhs) { return linalg::Sub(self, rhs); })
-    .def("__sub__",
-         [](UniTensor &self, const cytnx::cytnx_uint64 &rhs) { return linalg::Sub(self, rhs); })
-    .def("__sub__",
-         [](UniTensor &self, const cytnx::cytnx_int32 &rhs) { return linalg::Sub(self, rhs); })
-    .def("__sub__",
-         [](UniTensor &self, const cytnx::cytnx_uint32 &rhs) { return linalg::Sub(self, rhs); })
-    .def("__sub__",
-         [](UniTensor &self, const cytnx::cytnx_int16 &rhs) { return linalg::Sub(self, rhs); })
-    .def("__sub__",
-         [](UniTensor &self, const cytnx::cytnx_uint16 &rhs) { return linalg::Sub(self, rhs); })
-    .def("__sub__",
-         [](UniTensor &self, const cytnx::cytnx_bool &rhs) { return linalg::Sub(self, rhs); })
-    .def("__sub__", [](cytnx::UniTensor &self, const cytnx::Scalar &rhs) { return self.Sub(rhs); })
-    .def("__sub__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<double>> &rhs) { return self.Sub(static_cast<cytnx::cytnx_complex128>(rhs)); })
-    .def("__sub__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) { return self.Sub(static_cast<cytnx::cytnx_complex64>(rhs)); })
-    .def("__sub__", [](cytnx::UniTensor &self, const py::numpy_scalar<double> &rhs) { return self.Sub(static_cast<cytnx::cytnx_double>(rhs)); })
-    .def("__sub__", [](cytnx::UniTensor &self, const py::numpy_scalar<float> &rhs) { return self.Sub(static_cast<cytnx::cytnx_float>(rhs)); })
-    .def("__sub__", [](cytnx::UniTensor &self, const py::numpy_scalar<int64_t> &rhs) { return self.Sub(static_cast<cytnx::cytnx_int64>(rhs)); })
-    .def("__sub__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) { return self.Sub(static_cast<cytnx::cytnx_uint64>(rhs)); })
-    .def("__sub__", [](cytnx::UniTensor &self, const py::numpy_scalar<int32_t> &rhs) { return self.Sub(static_cast<cytnx::cytnx_int32>(rhs)); })
-    .def("__sub__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) { return self.Sub(static_cast<cytnx::cytnx_uint32>(rhs)); })
-    .def("__sub__", [](cytnx::UniTensor &self, const py::numpy_scalar<int16_t> &rhs) { return self.Sub(static_cast<cytnx::cytnx_int16>(rhs)); })
-    .def("__sub__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) { return self.Sub(static_cast<cytnx::cytnx_uint16>(rhs)); })
-    .def("__sub__", [](cytnx::UniTensor &self, const py::numpy_scalar<bool> &rhs) { return self.Sub(static_cast<cytnx::cytnx_bool>(rhs)); })
+         [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return linalg::Sub(self, rhs); })
+    .def("__sub__", [](UniTensor &self, const cytnx::Scalar &rhs) { return linalg::Sub(self, rhs); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__rsub__",
-         [](UniTensor &self, const cytnx::cytnx_complex128 &lhs) { return linalg::Sub(lhs, self); })
+         [](UniTensor &self, const py::numpy_scalar<float> &lhs) {
+           return linalg::Sub(static_cast<cytnx::cytnx_float>(lhs), self);
+         })
     .def("__rsub__",
-         [](UniTensor &self, const cytnx::cytnx_complex64 &lhs) { return linalg::Sub(lhs, self); })
+         [](UniTensor &self, const py::numpy_scalar<std::complex<float>> &lhs) {
+           return linalg::Sub(static_cast<cytnx::cytnx_complex64>(lhs), self);
+         })
+    .def("__rsub__",
+         [](UniTensor &self, const py::numpy_scalar<int64_t> &lhs) {
+           return linalg::Sub(static_cast<cytnx::cytnx_int64>(lhs), self);
+         })
+    .def("__rsub__",
+         [](UniTensor &self, const py::numpy_scalar<uint64_t> &lhs) {
+           return linalg::Sub(static_cast<cytnx::cytnx_uint64>(lhs), self);
+         })
+    .def("__rsub__",
+         [](UniTensor &self, const py::numpy_scalar<int32_t> &lhs) {
+           return linalg::Sub(static_cast<cytnx::cytnx_int32>(lhs), self);
+         })
+    .def("__rsub__",
+         [](UniTensor &self, const py::numpy_scalar<uint32_t> &lhs) {
+           return linalg::Sub(static_cast<cytnx::cytnx_uint32>(lhs), self);
+         })
+    .def("__rsub__",
+         [](UniTensor &self, const py::numpy_scalar<int16_t> &lhs) {
+           return linalg::Sub(static_cast<cytnx::cytnx_int16>(lhs), self);
+         })
+    .def("__rsub__",
+         [](UniTensor &self, const py::numpy_scalar<uint16_t> &lhs) {
+           return linalg::Sub(static_cast<cytnx::cytnx_uint16>(lhs), self);
+         })
+    .def("__rsub__",
+         [](UniTensor &self, const py::numpy_scalar<bool> &lhs) {
+           return linalg::Sub(static_cast<cytnx::cytnx_bool>(lhs), self);
+         })
+    .def("__rsub__",
+         [](UniTensor &self, const py::int_ &lhs) {
+           return dispatch_pyint(lhs, [&](auto v) { return linalg::Sub(v, self); });
+         })
     .def("__rsub__",
          [](UniTensor &self, const cytnx::cytnx_double &lhs) { return linalg::Sub(lhs, self); })
     .def("__rsub__",
-         [](UniTensor &self, const cytnx::cytnx_float &lhs) { return linalg::Sub(lhs, self); })
-    .def("__rsub__",
-         [](UniTensor &self, const cytnx::cytnx_int64 &lhs) { return linalg::Sub(lhs, self); })
-    .def("__rsub__",
-         [](UniTensor &self, const cytnx::cytnx_uint64 &lhs) { return linalg::Sub(lhs, self); })
-    .def("__rsub__",
-         [](UniTensor &self, const cytnx::cytnx_int32 &lhs) { return linalg::Sub(lhs, self); })
-    .def("__rsub__",
-         [](UniTensor &self, const cytnx::cytnx_uint32 &lhs) { return linalg::Sub(lhs, self); })
-    .def("__rsub__",
-         [](UniTensor &self, const cytnx::cytnx_int16 &lhs) { return linalg::Sub(lhs, self); })
-    .def("__rsub__",
-         [](UniTensor &self, const cytnx::cytnx_uint16 &lhs) { return linalg::Sub(lhs, self); })
-    .def("__rsub__",
-         [](UniTensor &self, const cytnx::cytnx_bool &lhs) { return linalg::Sub(lhs, self); })
-    .def("__rsub__", [](cytnx::UniTensor &self, const cytnx::Scalar &lhs) { return cytnx::linalg::Sub(lhs, self); })
-     // does not give the right type because of type casting to python objects before handling to pybind
-    .def("__rsub__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<double>> &lhs) { return cytnx::linalg::Sub(static_cast<cytnx::cytnx_complex128>(lhs), self); })
-    .def("__rsub__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<float>> &lhs) { return cytnx::linalg::Sub(static_cast<cytnx::cytnx_complex64>(lhs), self); })
-    .def("__rsub__", [](cytnx::UniTensor &self, const py::numpy_scalar<double> &lhs) { return cytnx::linalg::Sub(static_cast<cytnx::cytnx_double>(lhs), self); })
-    .def("__rsub__", [](cytnx::UniTensor &self, const py::numpy_scalar<float> &lhs) { return cytnx::linalg::Sub(static_cast<cytnx::cytnx_float>(lhs), self); })
-    .def("__rsub__", [](cytnx::UniTensor &self, const py::numpy_scalar<int64_t> &lhs) { return cytnx::linalg::Sub(static_cast<cytnx::cytnx_int64>(lhs), self); })
-    .def("__rsub__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint64_t> &lhs) { return cytnx::linalg::Sub(static_cast<cytnx::cytnx_uint64>(lhs), self); })
-    .def("__rsub__", [](cytnx::UniTensor &self, const py::numpy_scalar<int32_t> &lhs) { return cytnx::linalg::Sub(static_cast<cytnx::cytnx_int32>(lhs), self); })
-    .def("__rsub__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint32_t> &lhs) { return cytnx::linalg::Sub(static_cast<cytnx::cytnx_uint32>(lhs), self); })
-    .def("__rsub__", [](cytnx::UniTensor &self, const py::numpy_scalar<int16_t> &lhs) { return cytnx::linalg::Sub(static_cast<cytnx::cytnx_int16>(lhs), self); })
-    .def("__rsub__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint16_t> &lhs) { return cytnx::linalg::Sub(static_cast<cytnx::cytnx_uint16>(lhs), self); })
-    .def("__rsub__", [](cytnx::UniTensor &self, const py::numpy_scalar<bool> &lhs) { return cytnx::linalg::Sub(static_cast<cytnx::cytnx_bool>(lhs), self); })
+         [](UniTensor &self, const cytnx::cytnx_complex128 &lhs) { return linalg::Sub(lhs, self); })
+    .def("__rsub__", [](UniTensor &self, const cytnx::Scalar &lhs) { return linalg::Sub(lhs, self); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__isub__",
-         [](UniTensor &self, const UniTensor &rhs) {
-           return self.Sub_(rhs);
-         })  // these will return self!
+         [](UniTensor &self, const UniTensor &rhs) { return self.Sub_(rhs); })
+    .def("__isub__",
+         [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
+           return self.Sub_(static_cast<cytnx::cytnx_float>(rhs));
+         })
+    .def("__isub__",
+         [](UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           return self.Sub_(static_cast<cytnx::cytnx_complex64>(rhs));
+         })
+    .def("__isub__",
+         [](UniTensor &self, const py::numpy_scalar<int64_t> &rhs) {
+           return self.Sub_(static_cast<cytnx::cytnx_int64>(rhs));
+         })
+    .def("__isub__",
+         [](UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) {
+           return self.Sub_(static_cast<cytnx::cytnx_uint64>(rhs));
+         })
+    .def("__isub__",
+         [](UniTensor &self, const py::numpy_scalar<int32_t> &rhs) {
+           return self.Sub_(static_cast<cytnx::cytnx_int32>(rhs));
+         })
+    .def("__isub__",
+         [](UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) {
+           return self.Sub_(static_cast<cytnx::cytnx_uint32>(rhs));
+         })
+    .def("__isub__",
+         [](UniTensor &self, const py::numpy_scalar<int16_t> &rhs) {
+           return self.Sub_(static_cast<cytnx::cytnx_int16>(rhs));
+         })
+    .def("__isub__",
+         [](UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) {
+           return self.Sub_(static_cast<cytnx::cytnx_uint16>(rhs));
+         })
+    .def("__isub__",
+         [](UniTensor &self, const py::numpy_scalar<bool> &rhs) {
+           return self.Sub_(static_cast<cytnx::cytnx_bool>(rhs));
+         })
+    .def("__isub__",
+         [](UniTensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return self.Sub_(v); });
+         })
+    .def("__isub__",
+         [](UniTensor &self, const cytnx::cytnx_double &rhs) { return self.Sub_(rhs); })
     .def("__isub__",
          [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Sub_(rhs); })
-    .def("__isub__",
-         [](UniTensor &self, const cytnx::cytnx_complex64 &rhs) { return self.Sub_(rhs); })
-    .def("__isub__", [](UniTensor &self, const cytnx::cytnx_double &rhs) { return self.Sub_(rhs); })
-    .def("__isub__", [](UniTensor &self, const cytnx::cytnx_float &rhs) { return self.Sub_(rhs); })
-    .def("__isub__", [](UniTensor &self, const cytnx::cytnx_int64 &rhs) { return self.Sub_(rhs); })
-    .def("__isub__", [](UniTensor &self, const cytnx::cytnx_uint64 &rhs) { return self.Sub_(rhs); })
-    .def("__isub__", [](UniTensor &self, const cytnx::cytnx_int32 &rhs) { return self.Sub_(rhs); })
-    .def("__isub__", [](UniTensor &self, const cytnx::cytnx_uint32 &rhs) { return self.Sub_(rhs); })
-    .def("__isub__", [](UniTensor &self, const cytnx::cytnx_int16 &rhs) { return self.Sub_(rhs); })
-    .def("__isub__", [](UniTensor &self, const cytnx::cytnx_uint16 &rhs) { return self.Sub_(rhs); })
-    .def("__isub__", [](UniTensor &self, const cytnx::cytnx_bool &rhs) { return self.Sub_(rhs); })
-    .def("__isub__", [](cytnx::UniTensor &self, const cytnx::Scalar &rhs) { return self.Sub_(rhs); })
-    .def("__isub__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<double>> &rhs) { return self.Sub_(static_cast<cytnx::cytnx_complex128>(rhs)); })
-    .def("__isub__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) { return self.Sub_(static_cast<cytnx::cytnx_complex64>(rhs)); })
-    .def("__isub__", [](cytnx::UniTensor &self, const py::numpy_scalar<double> &rhs) { return self.Sub_(static_cast<cytnx::cytnx_double>(rhs)); })
-    .def("__isub__", [](cytnx::UniTensor &self, const py::numpy_scalar<float> &rhs) { return self.Sub_(static_cast<cytnx::cytnx_float>(rhs)); })
-    .def("__isub__", [](cytnx::UniTensor &self, const py::numpy_scalar<int64_t> &rhs) { return self.Sub_(static_cast<cytnx::cytnx_int64>(rhs)); })
-    .def("__isub__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) { return self.Sub_(static_cast<cytnx::cytnx_uint64>(rhs)); })
-    .def("__isub__", [](cytnx::UniTensor &self, const py::numpy_scalar<int32_t> &rhs) { return self.Sub_(static_cast<cytnx::cytnx_int32>(rhs)); })
-    .def("__isub__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) { return self.Sub_(static_cast<cytnx::cytnx_uint32>(rhs)); })
-    .def("__isub__", [](cytnx::UniTensor &self, const py::numpy_scalar<int16_t> &rhs) { return self.Sub_(static_cast<cytnx::cytnx_int16>(rhs)); })
-    .def("__isub__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) { return self.Sub_(static_cast<cytnx::cytnx_uint16>(rhs)); })
-    .def("__isub__", [](cytnx::UniTensor &self, const py::numpy_scalar<bool> &rhs) { return self.Sub_(static_cast<cytnx::cytnx_bool>(rhs)); })
+    .def("__isub__", [](UniTensor &self, const cytnx::Scalar &rhs) { return self.Sub_(rhs); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__mul__", [](UniTensor &self, const UniTensor &rhs) { return linalg::Mul(self, rhs); })
     .def("__mul__",
-         [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return linalg::Mul(self, rhs); })
+         [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
+           return linalg::Mul(self, static_cast<cytnx::cytnx_float>(rhs));
+         })
     .def("__mul__",
-         [](UniTensor &self, const cytnx::cytnx_complex64 &rhs) { return linalg::Mul(self, rhs); })
+         [](UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           return linalg::Mul(self, static_cast<cytnx::cytnx_complex64>(rhs));
+         })
+    .def("__mul__",
+         [](UniTensor &self, const py::numpy_scalar<int64_t> &rhs) {
+           return linalg::Mul(self, static_cast<cytnx::cytnx_int64>(rhs));
+         })
+    .def("__mul__",
+         [](UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) {
+           return linalg::Mul(self, static_cast<cytnx::cytnx_uint64>(rhs));
+         })
+    .def("__mul__",
+         [](UniTensor &self, const py::numpy_scalar<int32_t> &rhs) {
+           return linalg::Mul(self, static_cast<cytnx::cytnx_int32>(rhs));
+         })
+    .def("__mul__",
+         [](UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) {
+           return linalg::Mul(self, static_cast<cytnx::cytnx_uint32>(rhs));
+         })
+    .def("__mul__",
+         [](UniTensor &self, const py::numpy_scalar<int16_t> &rhs) {
+           return linalg::Mul(self, static_cast<cytnx::cytnx_int16>(rhs));
+         })
+    .def("__mul__",
+         [](UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) {
+           return linalg::Mul(self, static_cast<cytnx::cytnx_uint16>(rhs));
+         })
+    .def("__mul__",
+         [](UniTensor &self, const py::numpy_scalar<bool> &rhs) {
+           return linalg::Mul(self, static_cast<cytnx::cytnx_bool>(rhs));
+         })
+    .def("__mul__",
+         [](UniTensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return linalg::Mul(self, v); });
+         })
     .def("__mul__",
          [](UniTensor &self, const cytnx::cytnx_double &rhs) { return linalg::Mul(self, rhs); })
     .def("__mul__",
-         [](UniTensor &self, const cytnx::cytnx_float &rhs) { return linalg::Mul(self, rhs); })
-    .def("__mul__",
-         [](UniTensor &self, const cytnx::cytnx_int64 &rhs) { return linalg::Mul(self, rhs); })
-    .def("__mul__",
-         [](UniTensor &self, const cytnx::cytnx_uint64 &rhs) { return linalg::Mul(self, rhs); })
-    .def("__mul__",
-         [](UniTensor &self, const cytnx::cytnx_int32 &rhs) { return linalg::Mul(self, rhs); })
-    .def("__mul__",
-         [](UniTensor &self, const cytnx::cytnx_uint32 &rhs) { return linalg::Mul(self, rhs); })
-    .def("__mul__",
-         [](UniTensor &self, const cytnx::cytnx_int16 &rhs) { return linalg::Mul(self, rhs); })
-    .def("__mul__",
-         [](UniTensor &self, const cytnx::cytnx_uint16 &rhs) { return linalg::Mul(self, rhs); })
-    .def("__mul__",
-         [](UniTensor &self, const cytnx::cytnx_bool &rhs) { return linalg::Mul(self, rhs); })
-    .def("__mul__", [](cytnx::UniTensor &self, const cytnx::Scalar &rhs) { return self.Mul(rhs); })
-    .def("__mul__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<double>> &rhs) { return self.Mul(static_cast<cytnx::cytnx_complex128>(rhs)); })
-    .def("__mul__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) { return self.Mul(static_cast<cytnx::cytnx_complex64>(rhs)); })
-    .def("__mul__", [](cytnx::UniTensor &self, const py::numpy_scalar<double> &rhs) { return self.Mul(static_cast<cytnx::cytnx_double>(rhs)); })
-    .def("__mul__", [](cytnx::UniTensor &self, const py::numpy_scalar<float> &rhs) { return self.Mul(static_cast<cytnx::cytnx_float>(rhs)); })
-    .def("__mul__", [](cytnx::UniTensor &self, const py::numpy_scalar<int64_t> &rhs) { return self.Mul(static_cast<cytnx::cytnx_int64>(rhs)); })
-    .def("__mul__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) { return self.Mul(static_cast<cytnx::cytnx_uint64>(rhs)); })
-    .def("__mul__", [](cytnx::UniTensor &self, const py::numpy_scalar<int32_t> &rhs) { return self.Mul(static_cast<cytnx::cytnx_int32>(rhs)); })
-    .def("__mul__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) { return self.Mul(static_cast<cytnx::cytnx_uint32>(rhs)); })
-    .def("__mul__", [](cytnx::UniTensor &self, const py::numpy_scalar<int16_t> &rhs) { return self.Mul(static_cast<cytnx::cytnx_int16>(rhs)); })
-    .def("__mul__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) { return self.Mul(static_cast<cytnx::cytnx_uint16>(rhs)); })
-    .def("__mul__", [](cytnx::UniTensor &self, const py::numpy_scalar<bool> &rhs) { return self.Mul(static_cast<cytnx::cytnx_bool>(rhs)); })
+         [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return linalg::Mul(self, rhs); })
+    .def("__mul__", [](UniTensor &self, const cytnx::Scalar &rhs) { return linalg::Mul(self, rhs); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__rmul__",
-         [](UniTensor &self, const cytnx::cytnx_complex128 &lhs) { return linalg::Mul(lhs, self); })
+         [](UniTensor &self, const py::numpy_scalar<float> &lhs) {
+           return linalg::Mul(static_cast<cytnx::cytnx_float>(lhs), self);
+         })
     .def("__rmul__",
-         [](UniTensor &self, const cytnx::cytnx_complex64 &lhs) { return linalg::Mul(lhs, self); })
+         [](UniTensor &self, const py::numpy_scalar<std::complex<float>> &lhs) {
+           return linalg::Mul(static_cast<cytnx::cytnx_complex64>(lhs), self);
+         })
+    .def("__rmul__",
+         [](UniTensor &self, const py::numpy_scalar<int64_t> &lhs) {
+           return linalg::Mul(static_cast<cytnx::cytnx_int64>(lhs), self);
+         })
+    .def("__rmul__",
+         [](UniTensor &self, const py::numpy_scalar<uint64_t> &lhs) {
+           return linalg::Mul(static_cast<cytnx::cytnx_uint64>(lhs), self);
+         })
+    .def("__rmul__",
+         [](UniTensor &self, const py::numpy_scalar<int32_t> &lhs) {
+           return linalg::Mul(static_cast<cytnx::cytnx_int32>(lhs), self);
+         })
+    .def("__rmul__",
+         [](UniTensor &self, const py::numpy_scalar<uint32_t> &lhs) {
+           return linalg::Mul(static_cast<cytnx::cytnx_uint32>(lhs), self);
+         })
+    .def("__rmul__",
+         [](UniTensor &self, const py::numpy_scalar<int16_t> &lhs) {
+           return linalg::Mul(static_cast<cytnx::cytnx_int16>(lhs), self);
+         })
+    .def("__rmul__",
+         [](UniTensor &self, const py::numpy_scalar<uint16_t> &lhs) {
+           return linalg::Mul(static_cast<cytnx::cytnx_uint16>(lhs), self);
+         })
+    .def("__rmul__",
+         [](UniTensor &self, const py::numpy_scalar<bool> &lhs) {
+           return linalg::Mul(static_cast<cytnx::cytnx_bool>(lhs), self);
+         })
+    .def("__rmul__",
+         [](UniTensor &self, const py::int_ &lhs) {
+           return dispatch_pyint(lhs, [&](auto v) { return linalg::Mul(v, self); });
+         })
     .def("__rmul__",
          [](UniTensor &self, const cytnx::cytnx_double &lhs) { return linalg::Mul(lhs, self); })
     .def("__rmul__",
-         [](UniTensor &self, const cytnx::cytnx_float &lhs) { return linalg::Mul(lhs, self); })
-    .def("__rmul__",
-         [](UniTensor &self, const cytnx::cytnx_int64 &lhs) { return linalg::Mul(lhs, self); })
-    .def("__rmul__",
-         [](UniTensor &self, const cytnx::cytnx_uint64 &lhs) { return linalg::Mul(lhs, self); })
-    .def("__rmul__",
-         [](UniTensor &self, const cytnx::cytnx_int32 &lhs) { return linalg::Mul(lhs, self); })
-    .def("__rmul__",
-         [](UniTensor &self, const cytnx::cytnx_uint32 &lhs) { return linalg::Mul(lhs, self); })
-    .def("__rmul__",
-         [](UniTensor &self, const cytnx::cytnx_int16 &lhs) { return linalg::Mul(lhs, self); })
-    .def("__rmul__",
-         [](UniTensor &self, const cytnx::cytnx_uint16 &lhs) { return linalg::Mul(lhs, self); })
-    .def("__rmul__",
-         [](UniTensor &self, const cytnx::cytnx_bool &lhs) { return linalg::Mul(lhs, self); })
-    .def("__rmul__", [](cytnx::UniTensor &self, const cytnx::Scalar &lhs) { return cytnx::linalg::Mul(lhs, self); })
-     // does not give the right type because of type casting to python objects before handling to pybind
-    .def("__rmul__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<double>> &lhs) { return cytnx::linalg::Mul(static_cast<cytnx::cytnx_complex128>(lhs), self); })
-    .def("__rmul__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<float>> &lhs) { return cytnx::linalg::Mul(static_cast<cytnx::cytnx_complex64>(lhs), self); })
-    .def("__rmul__", [](cytnx::UniTensor &self, const py::numpy_scalar<double> &lhs) { return cytnx::linalg::Mul(static_cast<cytnx::cytnx_double>(lhs), self); })
-    .def("__rmul__", [](cytnx::UniTensor &self, const py::numpy_scalar<float> &lhs) { return cytnx::linalg::Mul(static_cast<cytnx::cytnx_float>(lhs), self); })
-    .def("__rmul__", [](cytnx::UniTensor &self, const py::numpy_scalar<int64_t> &lhs) { return cytnx::linalg::Mul(static_cast<cytnx::cytnx_int64>(lhs), self); })
-    .def("__rmul__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint64_t> &lhs) { return cytnx::linalg::Mul(static_cast<cytnx::cytnx_uint64>(lhs), self); })
-    .def("__rmul__", [](cytnx::UniTensor &self, const py::numpy_scalar<int32_t> &lhs) { return cytnx::linalg::Mul(static_cast<cytnx::cytnx_int32>(lhs), self); })
-    .def("__rmul__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint32_t> &lhs) { return cytnx::linalg::Mul(static_cast<cytnx::cytnx_uint32>(lhs), self); })
-    .def("__rmul__", [](cytnx::UniTensor &self, const py::numpy_scalar<int16_t> &lhs) { return cytnx::linalg::Mul(static_cast<cytnx::cytnx_int16>(lhs), self); })
-    .def("__rmul__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint16_t> &lhs) { return cytnx::linalg::Mul(static_cast<cytnx::cytnx_uint16>(lhs), self); })
-    .def("__rmul__", [](cytnx::UniTensor &self, const py::numpy_scalar<bool> &lhs) { return cytnx::linalg::Mul(static_cast<cytnx::cytnx_bool>(lhs), self); })
+         [](UniTensor &self, const cytnx::cytnx_complex128 &lhs) { return linalg::Mul(lhs, self); })
+    .def("__rmul__", [](UniTensor &self, const cytnx::Scalar &lhs) { return linalg::Mul(lhs, self); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__imul__",
-         [](UniTensor &self, const UniTensor &rhs) {
-           return self.Mul_(rhs);
-         })  // these will return self!
+         [](UniTensor &self, const UniTensor &rhs) { return self.Mul_(rhs); })
+    .def("__imul__",
+         [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
+           return self.Mul_(static_cast<cytnx::cytnx_float>(rhs));
+         })
+    .def("__imul__",
+         [](UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           return self.Mul_(static_cast<cytnx::cytnx_complex64>(rhs));
+         })
+    .def("__imul__",
+         [](UniTensor &self, const py::numpy_scalar<int64_t> &rhs) {
+           return self.Mul_(static_cast<cytnx::cytnx_int64>(rhs));
+         })
+    .def("__imul__",
+         [](UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) {
+           return self.Mul_(static_cast<cytnx::cytnx_uint64>(rhs));
+         })
+    .def("__imul__",
+         [](UniTensor &self, const py::numpy_scalar<int32_t> &rhs) {
+           return self.Mul_(static_cast<cytnx::cytnx_int32>(rhs));
+         })
+    .def("__imul__",
+         [](UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) {
+           return self.Mul_(static_cast<cytnx::cytnx_uint32>(rhs));
+         })
+    .def("__imul__",
+         [](UniTensor &self, const py::numpy_scalar<int16_t> &rhs) {
+           return self.Mul_(static_cast<cytnx::cytnx_int16>(rhs));
+         })
+    .def("__imul__",
+         [](UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) {
+           return self.Mul_(static_cast<cytnx::cytnx_uint16>(rhs));
+         })
+    .def("__imul__",
+         [](UniTensor &self, const py::numpy_scalar<bool> &rhs) {
+           return self.Mul_(static_cast<cytnx::cytnx_bool>(rhs));
+         })
+    .def("__imul__",
+         [](UniTensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return self.Mul_(v); });
+         })
+    .def("__imul__",
+         [](UniTensor &self, const cytnx::cytnx_double &rhs) { return self.Mul_(rhs); })
     .def("__imul__",
          [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Mul_(rhs); })
-    .def("__imul__",
-         [](UniTensor &self, const cytnx::cytnx_complex64 &rhs) { return self.Mul_(rhs); })
-    .def("__imul__", [](UniTensor &self, const cytnx::cytnx_double &rhs) { return self.Mul_(rhs); })
-    .def("__imul__", [](UniTensor &self, const cytnx::cytnx_float &rhs) { return self.Mul_(rhs); })
-    .def("__imul__", [](UniTensor &self, const cytnx::cytnx_int64 &rhs) { return self.Mul_(rhs); })
-    .def("__imul__", [](UniTensor &self, const cytnx::cytnx_uint64 &rhs) { return self.Mul_(rhs); })
-    .def("__imul__", [](UniTensor &self, const cytnx::cytnx_int32 &rhs) { return self.Mul_(rhs); })
-    .def("__imul__", [](UniTensor &self, const cytnx::cytnx_uint32 &rhs) { return self.Mul_(rhs); })
-    .def("__imul__", [](UniTensor &self, const cytnx::cytnx_int16 &rhs) { return self.Mul_(rhs); })
-    .def("__imul__", [](UniTensor &self, const cytnx::cytnx_uint16 &rhs) { return self.Mul_(rhs); })
-    .def("__imul__", [](UniTensor &self, const cytnx::cytnx_bool &rhs) { return self.Mul_(rhs); })
-    .def("__imul__", [](cytnx::UniTensor &self, const cytnx::Scalar &rhs) { return self.Mul_(rhs); })
-    .def("__imul__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<double>> &rhs) { return self.Mul_(static_cast<cytnx::cytnx_complex128>(rhs)); })
-    .def("__imul__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) { return self.Mul_(static_cast<cytnx::cytnx_complex64>(rhs)); })
-    .def("__imul__", [](cytnx::UniTensor &self, const py::numpy_scalar<double> &rhs) { return self.Mul_(static_cast<cytnx::cytnx_double>(rhs)); })
-    .def("__imul__", [](cytnx::UniTensor &self, const py::numpy_scalar<float> &rhs) { return self.Mul_(static_cast<cytnx::cytnx_float>(rhs)); })
-    .def("__imul__", [](cytnx::UniTensor &self, const py::numpy_scalar<int64_t> &rhs) { return self.Mul_(static_cast<cytnx::cytnx_int64>(rhs)); })
-    .def("__imul__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) { return self.Mul_(static_cast<cytnx::cytnx_uint64>(rhs)); })
-    .def("__imul__", [](cytnx::UniTensor &self, const py::numpy_scalar<int32_t> &rhs) { return self.Mul_(static_cast<cytnx::cytnx_int32>(rhs)); })
-    .def("__imul__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) { return self.Mul_(static_cast<cytnx::cytnx_uint32>(rhs)); })
-    .def("__imul__", [](cytnx::UniTensor &self, const py::numpy_scalar<int16_t> &rhs) { return self.Mul_(static_cast<cytnx::cytnx_int16>(rhs)); })
-    .def("__imul__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) { return self.Mul_(static_cast<cytnx::cytnx_uint16>(rhs)); })
-    .def("__imul__", [](cytnx::UniTensor &self, const py::numpy_scalar<bool> &rhs) { return self.Mul_(static_cast<cytnx::cytnx_bool>(rhs)); })
+    .def("__imul__", [](UniTensor &self, const cytnx::Scalar &rhs) { return self.Mul_(rhs); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
+    .def("__truediv__", [](UniTensor &self, const UniTensor &rhs) { return linalg::Div(self, rhs); })
     .def("__truediv__",
-         [](UniTensor &self, const UniTensor &rhs) { return linalg::Div(self, rhs); })
+         [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_float>(rhs));
+         })
     .def("__truediv__",
-         [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return linalg::Div(self, rhs); })
+         [](UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_complex64>(rhs));
+         })
     .def("__truediv__",
-         [](UniTensor &self, const cytnx::cytnx_complex64 &rhs) { return linalg::Div(self, rhs); })
+         [](UniTensor &self, const py::numpy_scalar<int64_t> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_int64>(rhs));
+         })
+    .def("__truediv__",
+         [](UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_uint64>(rhs));
+         })
+    .def("__truediv__",
+         [](UniTensor &self, const py::numpy_scalar<int32_t> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_int32>(rhs));
+         })
+    .def("__truediv__",
+         [](UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_uint32>(rhs));
+         })
+    .def("__truediv__",
+         [](UniTensor &self, const py::numpy_scalar<int16_t> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_int16>(rhs));
+         })
+    .def("__truediv__",
+         [](UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_uint16>(rhs));
+         })
+    .def("__truediv__",
+         [](UniTensor &self, const py::numpy_scalar<bool> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_bool>(rhs));
+         })
+    .def("__truediv__",
+         [](UniTensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return linalg::Div(self, v); });
+         })
     .def("__truediv__",
          [](UniTensor &self, const cytnx::cytnx_double &rhs) { return linalg::Div(self, rhs); })
     .def("__truediv__",
-         [](UniTensor &self, const cytnx::cytnx_float &rhs) { return linalg::Div(self, rhs); })
-    .def("__truediv__",
-         [](UniTensor &self, const cytnx::cytnx_int64 &rhs) { return linalg::Div(self, rhs); })
-    .def("__truediv__",
-         [](UniTensor &self, const cytnx::cytnx_uint64 &rhs) { return linalg::Div(self, rhs); })
-    .def("__truediv__",
-         [](UniTensor &self, const cytnx::cytnx_int32 &rhs) { return linalg::Div(self, rhs); })
-    .def("__truediv__",
-         [](UniTensor &self, const cytnx::cytnx_uint32 &rhs) { return linalg::Div(self, rhs); })
-    .def("__truediv__",
-         [](UniTensor &self, const cytnx::cytnx_int16 &rhs) { return linalg::Div(self, rhs); })
-    .def("__truediv__",
-         [](UniTensor &self, const cytnx::cytnx_uint16 &rhs) { return linalg::Div(self, rhs); })
-    .def("__truediv__",
-         [](UniTensor &self, const cytnx::cytnx_bool &rhs) { return linalg::Div(self, rhs); })
-    .def("__truediv__", [](cytnx::UniTensor &self, const cytnx::Scalar &rhs) { return self.Div(rhs); })
-    .def("__truediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<double>> &rhs) { return self.Div(static_cast<cytnx::cytnx_complex128>(rhs)); })
-    .def("__truediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) { return self.Div(static_cast<cytnx::cytnx_complex64>(rhs)); })
-    .def("__truediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<double> &rhs) { return self.Div(static_cast<cytnx::cytnx_double>(rhs)); })
-    .def("__truediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<float> &rhs) { return self.Div(static_cast<cytnx::cytnx_float>(rhs)); })
-    .def("__truediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int64_t> &rhs) { return self.Div(static_cast<cytnx::cytnx_int64>(rhs)); })
-    .def("__truediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) { return self.Div(static_cast<cytnx::cytnx_uint64>(rhs)); })
-    .def("__truediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int32_t> &rhs) { return self.Div(static_cast<cytnx::cytnx_int32>(rhs)); })
-    .def("__truediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) { return self.Div(static_cast<cytnx::cytnx_uint32>(rhs)); })
-    .def("__truediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int16_t> &rhs) { return self.Div(static_cast<cytnx::cytnx_int16>(rhs)); })
-    .def("__truediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) { return self.Div(static_cast<cytnx::cytnx_uint16>(rhs)); })
-    .def("__truediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<bool> &rhs) { return self.Div(static_cast<cytnx::cytnx_bool>(rhs)); })
+         [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return linalg::Div(self, rhs); })
+    .def("__truediv__", [](UniTensor &self, const cytnx::Scalar &rhs) { return linalg::Div(self, rhs); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__rtruediv__",
-         [](UniTensor &self, const cytnx::cytnx_complex128 &lhs) { return linalg::Div(lhs, self); })
+         [](UniTensor &self, const py::numpy_scalar<float> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_float>(lhs), self);
+         })
     .def("__rtruediv__",
-         [](UniTensor &self, const cytnx::cytnx_complex64 &lhs) { return linalg::Div(lhs, self); })
+         [](UniTensor &self, const py::numpy_scalar<std::complex<float>> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_complex64>(lhs), self);
+         })
+    .def("__rtruediv__",
+         [](UniTensor &self, const py::numpy_scalar<int64_t> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_int64>(lhs), self);
+         })
+    .def("__rtruediv__",
+         [](UniTensor &self, const py::numpy_scalar<uint64_t> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_uint64>(lhs), self);
+         })
+    .def("__rtruediv__",
+         [](UniTensor &self, const py::numpy_scalar<int32_t> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_int32>(lhs), self);
+         })
+    .def("__rtruediv__",
+         [](UniTensor &self, const py::numpy_scalar<uint32_t> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_uint32>(lhs), self);
+         })
+    .def("__rtruediv__",
+         [](UniTensor &self, const py::numpy_scalar<int16_t> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_int16>(lhs), self);
+         })
+    .def("__rtruediv__",
+         [](UniTensor &self, const py::numpy_scalar<uint16_t> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_uint16>(lhs), self);
+         })
+    .def("__rtruediv__",
+         [](UniTensor &self, const py::numpy_scalar<bool> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_bool>(lhs), self);
+         })
+    .def("__rtruediv__",
+         [](UniTensor &self, const py::int_ &lhs) {
+           return dispatch_pyint(lhs, [&](auto v) { return linalg::Div(v, self); });
+         })
     .def("__rtruediv__",
          [](UniTensor &self, const cytnx::cytnx_double &lhs) { return linalg::Div(lhs, self); })
     .def("__rtruediv__",
-         [](UniTensor &self, const cytnx::cytnx_float &lhs) { return linalg::Div(lhs, self); })
-    .def("__rtruediv__",
-         [](UniTensor &self, const cytnx::cytnx_int64 &lhs) { return linalg::Div(lhs, self); })
-    .def("__rtruediv__",
-         [](UniTensor &self, const cytnx::cytnx_uint64 &lhs) { return linalg::Div(lhs, self); })
-    .def("__rtruediv__",
-         [](UniTensor &self, const cytnx::cytnx_int32 &lhs) { return linalg::Div(lhs, self); })
-    .def("__rtruediv__",
-         [](UniTensor &self, const cytnx::cytnx_uint32 &lhs) { return linalg::Div(lhs, self); })
-    .def("__rtruediv__",
-         [](UniTensor &self, const cytnx::cytnx_int16 &lhs) { return linalg::Div(lhs, self); })
-    .def("__rtruediv__",
-         [](UniTensor &self, const cytnx::cytnx_uint16 &lhs) { return linalg::Div(lhs, self); })
-    .def("__rtruediv__",
-         [](UniTensor &self, const cytnx::cytnx_bool &lhs) { return linalg::Div(lhs, self); })
-    .def("__rtruediv__", [](cytnx::UniTensor &self, const cytnx::Scalar &lhs) { return cytnx::linalg::Div(lhs, self); })
-     // does not give the right type because of type casting to python objects before handling to pybind
-    .def("__rtruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<double>> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_complex128>(lhs), self); })
-    .def("__rtruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<float>> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_complex64>(lhs), self); })
-    .def("__rtruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<double> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_double>(lhs), self); })
-    .def("__rtruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<float> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_float>(lhs), self); })
-    .def("__rtruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int64_t> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_int64>(lhs), self); })
-    .def("__rtruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint64_t> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_uint64>(lhs), self); })
-    .def("__rtruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int32_t> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_int32>(lhs), self); })
-    .def("__rtruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint32_t> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_uint32>(lhs), self); })
-    .def("__rtruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int16_t> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_int16>(lhs), self); })
-    .def("__rtruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint16_t> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_uint16>(lhs), self); })
-    .def("__rtruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<bool> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_bool>(lhs), self); })
+         [](UniTensor &self, const cytnx::cytnx_complex128 &lhs) { return linalg::Div(lhs, self); })
+    .def("__rtruediv__", [](UniTensor &self, const cytnx::Scalar &lhs) { return linalg::Div(lhs, self); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__itruediv__",
-         [](UniTensor &self, const UniTensor &rhs) {
-           return self.Div_(rhs);
-         })  // these will return self!
+         [](UniTensor &self, const UniTensor &rhs) { return self.Div_(rhs); })
     .def("__itruediv__",
-         [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Div_(rhs); })
+         [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_float>(rhs));
+         })
     .def("__itruediv__",
-         [](UniTensor &self, const cytnx::cytnx_complex64 &rhs) { return self.Div_(rhs); })
+         [](UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_complex64>(rhs));
+         })
+    .def("__itruediv__",
+         [](UniTensor &self, const py::numpy_scalar<int64_t> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_int64>(rhs));
+         })
+    .def("__itruediv__",
+         [](UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_uint64>(rhs));
+         })
+    .def("__itruediv__",
+         [](UniTensor &self, const py::numpy_scalar<int32_t> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_int32>(rhs));
+         })
+    .def("__itruediv__",
+         [](UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_uint32>(rhs));
+         })
+    .def("__itruediv__",
+         [](UniTensor &self, const py::numpy_scalar<int16_t> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_int16>(rhs));
+         })
+    .def("__itruediv__",
+         [](UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_uint16>(rhs));
+         })
+    .def("__itruediv__",
+         [](UniTensor &self, const py::numpy_scalar<bool> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_bool>(rhs));
+         })
+    .def("__itruediv__",
+         [](UniTensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return self.Div_(v); });
+         })
     .def("__itruediv__",
          [](UniTensor &self, const cytnx::cytnx_double &rhs) { return self.Div_(rhs); })
     .def("__itruediv__",
-         [](UniTensor &self, const cytnx::cytnx_float &rhs) { return self.Div_(rhs); })
-    .def("__itruediv__",
-         [](UniTensor &self, const cytnx::cytnx_int64 &rhs) { return self.Div_(rhs); })
-    .def("__itruediv__",
-         [](UniTensor &self, const cytnx::cytnx_uint64 &rhs) { return self.Div_(rhs); })
-    .def("__itruediv__",
-         [](UniTensor &self, const cytnx::cytnx_int32 &rhs) { return self.Div_(rhs); })
-    .def("__itruediv__",
-         [](UniTensor &self, const cytnx::cytnx_uint32 &rhs) { return self.Div_(rhs); })
-    .def("__itruediv__",
-         [](UniTensor &self, const cytnx::cytnx_int16 &rhs) { return self.Div_(rhs); })
-    .def("__itruediv__",
-         [](UniTensor &self, const cytnx::cytnx_uint16 &rhs) { return self.Div_(rhs); })
-    .def("__itruediv__",
-         [](UniTensor &self, const cytnx::cytnx_bool &rhs) { return self.Div_(rhs); })
-    .def("__itruediv__", [](cytnx::UniTensor &self, const cytnx::Scalar &rhs) { return self.Div_(rhs); })
-    .def("__itruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<double>> &rhs) { return self.Div_(static_cast<cytnx::cytnx_complex128>(rhs)); })
-    .def("__itruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) { return self.Div_(static_cast<cytnx::cytnx_complex64>(rhs)); })
-    .def("__itruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<double> &rhs) { return self.Div_(static_cast<cytnx::cytnx_double>(rhs)); })
-    .def("__itruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<float> &rhs) { return self.Div_(static_cast<cytnx::cytnx_float>(rhs)); })
-    .def("__itruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int64_t> &rhs) { return self.Div_(static_cast<cytnx::cytnx_int64>(rhs)); })
-    .def("__itruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) { return self.Div_(static_cast<cytnx::cytnx_uint64>(rhs)); })
-    .def("__itruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int32_t> &rhs) { return self.Div_(static_cast<cytnx::cytnx_int32>(rhs)); })
-    .def("__itruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) { return self.Div_(static_cast<cytnx::cytnx_uint32>(rhs)); })
-    .def("__itruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int16_t> &rhs) { return self.Div_(static_cast<cytnx::cytnx_int16>(rhs)); })
-    .def("__itruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) { return self.Div_(static_cast<cytnx::cytnx_uint16>(rhs)); })
-    .def("__itruediv__", [](cytnx::UniTensor &self, const py::numpy_scalar<bool> &rhs) { return self.Div_(static_cast<cytnx::cytnx_bool>(rhs)); })
+         [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Div_(rhs); })
+    .def("__itruediv__", [](UniTensor &self, const cytnx::Scalar &rhs) { return self.Div_(rhs); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
+    .def("__floordiv__", [](UniTensor &self, const UniTensor &rhs) { return linalg::Div(self, rhs); })
     .def("__floordiv__",
-         [](UniTensor &self, const UniTensor &rhs) { return linalg::Div(self, rhs); })
+         [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_float>(rhs));
+         })
     .def("__floordiv__",
-         [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return linalg::Div(self, rhs); })
+         [](UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_complex64>(rhs));
+         })
     .def("__floordiv__",
-         [](UniTensor &self, const cytnx::cytnx_complex64 &rhs) { return linalg::Div(self, rhs); })
+         [](UniTensor &self, const py::numpy_scalar<int64_t> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_int64>(rhs));
+         })
+    .def("__floordiv__",
+         [](UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_uint64>(rhs));
+         })
+    .def("__floordiv__",
+         [](UniTensor &self, const py::numpy_scalar<int32_t> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_int32>(rhs));
+         })
+    .def("__floordiv__",
+         [](UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_uint32>(rhs));
+         })
+    .def("__floordiv__",
+         [](UniTensor &self, const py::numpy_scalar<int16_t> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_int16>(rhs));
+         })
+    .def("__floordiv__",
+         [](UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_uint16>(rhs));
+         })
+    .def("__floordiv__",
+         [](UniTensor &self, const py::numpy_scalar<bool> &rhs) {
+           return linalg::Div(self, static_cast<cytnx::cytnx_bool>(rhs));
+         })
+    .def("__floordiv__",
+         [](UniTensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return linalg::Div(self, v); });
+         })
     .def("__floordiv__",
          [](UniTensor &self, const cytnx::cytnx_double &rhs) { return linalg::Div(self, rhs); })
     .def("__floordiv__",
-         [](UniTensor &self, const cytnx::cytnx_float &rhs) { return linalg::Div(self, rhs); })
-    .def("__floordiv__",
-         [](UniTensor &self, const cytnx::cytnx_int64 &rhs) { return linalg::Div(self, rhs); })
-    .def("__floordiv__",
-         [](UniTensor &self, const cytnx::cytnx_uint64 &rhs) { return linalg::Div(self, rhs); })
-    .def("__floordiv__",
-         [](UniTensor &self, const cytnx::cytnx_int32 &rhs) { return linalg::Div(self, rhs); })
-    .def("__floordiv__",
-         [](UniTensor &self, const cytnx::cytnx_uint32 &rhs) { return linalg::Div(self, rhs); })
-    .def("__floordiv__",
-         [](UniTensor &self, const cytnx::cytnx_int16 &rhs) { return linalg::Div(self, rhs); })
-    .def("__floordiv__",
-         [](UniTensor &self, const cytnx::cytnx_uint16 &rhs) { return linalg::Div(self, rhs); })
-    .def("__floordiv__",
-         [](UniTensor &self, const cytnx::cytnx_bool &rhs) { return linalg::Div(self, rhs); })
-    .def("__floordiv__", [](cytnx::UniTensor &self, const cytnx::Scalar &rhs) { return self.Div(rhs); })
-    .def("__floordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<double>> &rhs) { return self.Div(static_cast<cytnx::cytnx_complex128>(rhs)); })
-    .def("__floordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) { return self.Div(static_cast<cytnx::cytnx_complex64>(rhs)); })
-    .def("__floordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<double> &rhs) { return self.Div(static_cast<cytnx::cytnx_double>(rhs)); })
-    .def("__floordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<float> &rhs) { return self.Div(static_cast<cytnx::cytnx_float>(rhs)); })
-    .def("__floordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int64_t> &rhs) { return self.Div(static_cast<cytnx::cytnx_int64>(rhs)); })
-    .def("__floordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) { return self.Div(static_cast<cytnx::cytnx_uint64>(rhs)); })
-    .def("__floordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int32_t> &rhs) { return self.Div(static_cast<cytnx::cytnx_int32>(rhs)); })
-    .def("__floordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) { return self.Div(static_cast<cytnx::cytnx_uint32>(rhs)); })
-    .def("__floordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int16_t> &rhs) { return self.Div(static_cast<cytnx::cytnx_int16>(rhs)); })
-    .def("__floordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) { return self.Div(static_cast<cytnx::cytnx_uint16>(rhs)); })
-    .def("__floordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<bool> &rhs) { return self.Div(static_cast<cytnx::cytnx_bool>(rhs)); })
+         [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return linalg::Div(self, rhs); })
+    .def("__floordiv__", [](UniTensor &self, const cytnx::Scalar &rhs) { return linalg::Div(self, rhs); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__rfloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_complex128 &lhs) { return linalg::Div(lhs, self); })
+         [](UniTensor &self, const py::numpy_scalar<float> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_float>(lhs), self);
+         })
     .def("__rfloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_complex64 &lhs) { return linalg::Div(lhs, self); })
+         [](UniTensor &self, const py::numpy_scalar<std::complex<float>> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_complex64>(lhs), self);
+         })
+    .def("__rfloordiv__",
+         [](UniTensor &self, const py::numpy_scalar<int64_t> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_int64>(lhs), self);
+         })
+    .def("__rfloordiv__",
+         [](UniTensor &self, const py::numpy_scalar<uint64_t> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_uint64>(lhs), self);
+         })
+    .def("__rfloordiv__",
+         [](UniTensor &self, const py::numpy_scalar<int32_t> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_int32>(lhs), self);
+         })
+    .def("__rfloordiv__",
+         [](UniTensor &self, const py::numpy_scalar<uint32_t> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_uint32>(lhs), self);
+         })
+    .def("__rfloordiv__",
+         [](UniTensor &self, const py::numpy_scalar<int16_t> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_int16>(lhs), self);
+         })
+    .def("__rfloordiv__",
+         [](UniTensor &self, const py::numpy_scalar<uint16_t> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_uint16>(lhs), self);
+         })
+    .def("__rfloordiv__",
+         [](UniTensor &self, const py::numpy_scalar<bool> &lhs) {
+           return linalg::Div(static_cast<cytnx::cytnx_bool>(lhs), self);
+         })
+    .def("__rfloordiv__",
+         [](UniTensor &self, const py::int_ &lhs) {
+           return dispatch_pyint(lhs, [&](auto v) { return linalg::Div(v, self); });
+         })
     .def("__rfloordiv__",
          [](UniTensor &self, const cytnx::cytnx_double &lhs) { return linalg::Div(lhs, self); })
     .def("__rfloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_float &lhs) { return linalg::Div(lhs, self); })
-    .def("__rfloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_int64 &lhs) { return linalg::Div(lhs, self); })
-    .def("__rfloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_uint64 &lhs) { return linalg::Div(lhs, self); })
-    .def("__rfloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_int32 &lhs) { return linalg::Div(lhs, self); })
-    .def("__rfloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_uint32 &lhs) { return linalg::Div(lhs, self); })
-    .def("__rfloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_int16 &lhs) { return linalg::Div(lhs, self); })
-    .def("__rfloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_uint16 &lhs) { return linalg::Div(lhs, self); })
-    .def("__rfloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_bool &lhs) { return linalg::Div(lhs, self); })
-    .def("__rfloordiv__", [](cytnx::UniTensor &self, const cytnx::Scalar &lhs) { return cytnx::linalg::Div(lhs, self); })
-     // does not give the right type because of type casting to python objects before handling to pybind
-    .def("__rfloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<double>> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_complex128>(lhs), self); })
-    .def("__rfloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<float>> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_complex64>(lhs), self); })
-    .def("__rfloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<double> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_double>(lhs), self); })
-    .def("__rfloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<float> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_float>(lhs), self); })
-    .def("__rfloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int64_t> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_int64>(lhs), self); })
-    .def("__rfloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint64_t> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_uint64>(lhs), self); })
-    .def("__rfloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int32_t> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_int32>(lhs), self); })
-    .def("__rfloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint32_t> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_uint32>(lhs), self); })
-    .def("__rfloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int16_t> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_int16>(lhs), self); })
-    .def("__rfloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint16_t> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_uint16>(lhs), self); })
-    .def("__rfloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<bool> &lhs) { return cytnx::linalg::Div(static_cast<cytnx::cytnx_bool>(lhs), self); })
+         [](UniTensor &self, const cytnx::cytnx_complex128 &lhs) { return linalg::Div(lhs, self); })
+    .def("__rfloordiv__", [](UniTensor &self, const cytnx::Scalar &lhs) { return linalg::Div(lhs, self); })
 
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
     .def("__ifloordiv__",
-         [](UniTensor &self, const UniTensor &rhs) {
-           return self.Div_(rhs);
-         })  // these will return self!
+         [](UniTensor &self, const UniTensor &rhs) { return self.Div_(rhs); })
     .def("__ifloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Div_(rhs); })
+         [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_float>(rhs));
+         })
     .def("__ifloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_complex64 &rhs) { return self.Div_(rhs); })
+         [](UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_complex64>(rhs));
+         })
+    .def("__ifloordiv__",
+         [](UniTensor &self, const py::numpy_scalar<int64_t> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_int64>(rhs));
+         })
+    .def("__ifloordiv__",
+         [](UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_uint64>(rhs));
+         })
+    .def("__ifloordiv__",
+         [](UniTensor &self, const py::numpy_scalar<int32_t> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_int32>(rhs));
+         })
+    .def("__ifloordiv__",
+         [](UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_uint32>(rhs));
+         })
+    .def("__ifloordiv__",
+         [](UniTensor &self, const py::numpy_scalar<int16_t> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_int16>(rhs));
+         })
+    .def("__ifloordiv__",
+         [](UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_uint16>(rhs));
+         })
+    .def("__ifloordiv__",
+         [](UniTensor &self, const py::numpy_scalar<bool> &rhs) {
+           return self.Div_(static_cast<cytnx::cytnx_bool>(rhs));
+         })
+    .def("__ifloordiv__",
+         [](UniTensor &self, const py::int_ &rhs) {
+           return dispatch_pyint(rhs, [&](auto v) { return self.Div_(v); });
+         })
     .def("__ifloordiv__",
          [](UniTensor &self, const cytnx::cytnx_double &rhs) { return self.Div_(rhs); })
     .def("__ifloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_float &rhs) { return self.Div_(rhs); })
-    .def("__ifloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_int64 &rhs) { return self.Div_(rhs); })
-    .def("__ifloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_uint64 &rhs) { return self.Div_(rhs); })
-    .def("__ifloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_int32 &rhs) { return self.Div_(rhs); })
-    .def("__ifloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_uint32 &rhs) { return self.Div_(rhs); })
-    .def("__ifloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_int16 &rhs) { return self.Div_(rhs); })
-    .def("__ifloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_uint16 &rhs) { return self.Div_(rhs); })
-    .def("__ifloordiv__",
-         [](UniTensor &self, const cytnx::cytnx_bool &rhs) { return self.Div_(rhs); })
-    .def("__ifloordiv__", [](cytnx::UniTensor &self, const cytnx::Scalar &rhs) { return self.Div_(rhs); })
-    .def("__ifloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<double>> &rhs) { return self.Div_(static_cast<cytnx::cytnx_complex128>(rhs)); })
-    .def("__ifloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<std::complex<float>> &rhs) { return self.Div_(static_cast<cytnx::cytnx_complex64>(rhs)); })
-    .def("__ifloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<double> &rhs) { return self.Div_(static_cast<cytnx::cytnx_double>(rhs)); })
-    .def("__ifloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<float> &rhs) { return self.Div_(static_cast<cytnx::cytnx_float>(rhs)); })
-    .def("__ifloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int64_t> &rhs) { return self.Div_(static_cast<cytnx::cytnx_int64>(rhs)); })
-    .def("__ifloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint64_t> &rhs) { return self.Div_(static_cast<cytnx::cytnx_uint64>(rhs)); })
-    .def("__ifloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int32_t> &rhs) { return self.Div_(static_cast<cytnx::cytnx_int32>(rhs)); })
-    .def("__ifloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint32_t> &rhs) { return self.Div_(static_cast<cytnx::cytnx_uint32>(rhs)); })
-    .def("__ifloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<int16_t> &rhs) { return self.Div_(static_cast<cytnx::cytnx_int16>(rhs)); })
-    .def("__ifloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<uint16_t> &rhs) { return self.Div_(static_cast<cytnx::cytnx_uint16>(rhs)); })
-    .def("__ifloordiv__", [](cytnx::UniTensor &self, const py::numpy_scalar<bool> &rhs) { return self.Div_(static_cast<cytnx::cytnx_bool>(rhs)); })
+         [](UniTensor &self, const cytnx::cytnx_complex128 &rhs) { return self.Div_(rhs); })
+    .def("__ifloordiv__", [](UniTensor &self, const cytnx::Scalar &rhs) { return self.Div_(rhs); })
+
 
     /*
     .def("__mod__",[](UniTensor &self, const UniTensor &rhs){return self.Mod(rhs);})
@@ -1382,7 +1731,34 @@ void unitensor_binding(py::module &m) {
     .def("__rmod__", [](cytnx::UniTensor &self, const py::numpy_scalar<bool> &lhs) { return cytnx::linalg::Mod(static_cast<cytnx::cytnx_bool>(lhs), self); })
     */
 
+    // __pow__/__ipow__: UniTensor::Pow/Pow_ only take a plain double
+    // exponent (same shape as Tensor's, see tensor_py.cpp), so bind
+    // py::int_ and numpy_scalar<float> explicitly rather than relying on
+    // pybind11's implicit double conversion, for the same #916 stub-quality
+    // reason.
+    .def("__pow__",
+         [](UniTensor &self, const py::numpy_scalar<float> &p) {
+           return self.Pow(static_cast<cytnx::cytnx_double>(static_cast<cytnx::cytnx_float>(p)));
+         })
+    .def("__pow__",
+         [](UniTensor &self, const py::int_ &p) {
+           return dispatch_pyint(
+             p, [&](auto v) { return self.Pow(static_cast<cytnx::cytnx_double>(v)); });
+         })
     .def("__pow__", [](UniTensor &self, const cytnx::cytnx_double &p) { return self.Pow(p); })
+    .def("__ipow__",
+         [](py::object self, const py::numpy_scalar<float> &p) {
+           self.cast<UniTensor &>().Pow_(
+             static_cast<cytnx::cytnx_double>(static_cast<cytnx::cytnx_float>(p)));
+           return self;
+         })
+    .def("__ipow__",
+         [](py::object self, const py::int_ &p) {
+           dispatch_pyint(p, [&](auto v) {
+             self.cast<UniTensor &>().Pow_(static_cast<cytnx::cytnx_double>(v));
+           });
+           return self;
+         })
     .def("__ipow__",
          [](py::object self, const cytnx::cytnx_double &p) {
            self.cast<UniTensor &>().Pow_(p);

--- a/pytests/binding_dtype_test.py
+++ b/pytests/binding_dtype_test.py
@@ -1,0 +1,302 @@
+"""Tests for Task 3 of the binding-hygiene plan: collapse per-dtype operator
+overloads, fix `__ne__`/`__bool__`, close numpy gaps (issues #928/#916/#692).
+
+Background: every Tensor arithmetic dunder (`__add__`, `__iadd__`, ...) used
+to be bound once per C++ scalar type (12 native cytnx_* types) *and* once per
+numpy scalar type (11 more), even though many of those overloads collapse to
+the same Python-visible signature. This task collapses each operator down to
+the "keep-set" (Tensor/UniTensor, cytnx_double, cytnx_complex128, py::int_,
+numpy_scalar<float>/<complex64>, numpy_scalar<int64/uint64/int32/uint32/
+int16/uint16/bool>, Scalar) and adds the missing `__ne__`/`__bool__`
+semantics.
+
+Root cause found empirically for the numpy integer-dtype-preservation bug
+(recorded here because it explains several "unexpectedly red" baselines
+below): pybind11's plain arithmetic type_caster (used for cytnx_int64,
+cytnx_uint64, ... and, transitively, for anything that looks like a Python
+int) accepts ANY object satisfying the `__index__` protocol even in the
+*no-convert* resolution pass (pybind11 3.x cast.h, arithmetic type_caster's
+no-convert `__index__` acceptance via `PyIndex_Check`). Every numpy integer
+scalar
+(`np.int32`, `np.uint64`, `np.int16`, ...) implements `__index__`, so a
+`cytnx_int64`-typed overload registered *before* the corresponding
+`py::numpy_scalar<int32_t>` overload greedily wins the no-convert pass and
+the numpy_scalar overload is never reached -- silently downcasting/upcasting
+every numpy integer scalar to Int64 (or whatever fixed-width integral
+overload happens to be registered first), regardless of its actual numpy
+dtype. `numpy_scalar<float>`/`numpy_scalar<complex64>` do NOT suffer this
+because the floating-point branch of the same caster only accepts
+`PyFloat_Check` in the no-convert pass, and `np.float32`/`np.complex64`
+are not `PyFloat_Check`. This is exactly why the plan mandates registering
+numpy_scalar overloads BEFORE py::int_/cytnx_double/cytnx_complex128 in each
+operator group: it is not just a stub-quality nicety, it is required for the
+integer numpy_scalar overloads to be reachable at all.
+
+Red/green notes (recorded honestly against the branch-tip build, i.e. after
+T2's direct-binding in-place ops but before this task's overload-collapse
+changes):
+  - test_numpy_float32_preserves_dtype: `t + np.float32` and `t += np.float32`
+    PASS at baseline (numpy_scalar<float> already reachable because the plain
+    double/float casters reject non-PyFloat_Check objects in the no-convert
+    pass). `np.float32(1.0) + t` (numpy scalar on the LEFT) is a separate,
+    pre-existing, out-of-scope bug: Tensor defines `__iter__`, so numpy's
+    `__radd__` machinery tries to treat the Tensor as an array-like and
+    iterate it instead of calling `Tensor.__radd__`, raising
+    `TypeError: 'TensorIterator' object is not iterable`. This reproduces
+    identically before and after this task's changes (verified) and is
+    already called out in the existing source comments ("does not work
+    because an iterator for the Tensor is defined") and in issue #692's
+    thread ("an operation between a numpy object and a UniTensor object does
+    not work if the numpy object is on the left"). Fixing Tensor/numpy
+    __iter__ interop is out of scope for an operator-overload-collapse task
+    and is NOT attempted here; only the already-working forward direction is
+    asserted.
+  - test_numpy_complex64_preserves_dtype: same shape/reasoning as float32;
+    PASSES at baseline for the forward direction, reverse direction not
+    asserted for the same __iter__ reason.
+  - test_numpy_int32_preserves_dtype / *_uint32_* / *_int16_* / *_uint16_* /
+    *_uint64_preserves_dtype: FAIL at baseline -- see the __index__ root
+    cause above. `t + np.int32(1)` currently returns Int64, not Int32
+    (verified: dtype() == 5 (Int64) instead of 7 (Int32)); same for
+    uint32/int16/uint16, and np.uint64(1) also collapses to Int64 (5)
+    instead of staying Uint64 (6). This is genuine, in-scope red: fixed by
+    re-registering the numpy_scalar<T> overloads ahead of the plain integral
+    overloads per operator group.
+  - test_python_int_works_and_large_int: PASSES at baseline in full -- `t + 1`
+    dispatches through the existing cytnx_int64 overload, and the
+    `> int64 max` uint64 case also already works because pybind11's
+    convert-pass for the plain `cytnx_uint64` overload (registered directly,
+    not through a dispatch_pyint-style selector) correctly widens through
+    `PyLong_As*`/`as_unsigned` for a value beyond int64 range but within
+    uint64 range. Kept as a regression guard for the collapse (a naive
+    dispatch_pyint reimplementation could plausibly narrow this by mistake),
+    not because it was red.
+  - test_pow_accepts_int_and_numpy: PASSES at baseline -- __pow__ only accepts
+    a plain `cytnx_double` exponent, but pybind11's convert-pass already
+    accepts a Python `int` or `np.float32` there via `PyFloat_AsDouble`
+    (`convert=true` short-circuits the exact-`PyFloat_Check` gate quoted
+    above), and `linalg::Pow`'s output dtype follows the base tensor's dtype,
+    not the exponent's, so this was never actually broken for these two
+    inputs. Kept as a regression guard for the keep-set rewrite (the plan
+    still asks for explicit py::int_/numpy_scalar<float> overloads on
+    __pow__ so a numpy exponent that does NOT satisfy PyFloat_Check-or-
+    convert, e.g. a value pybind rejects some other way, is not silently
+    mishandled, and so the stub will show a precise signature once #915
+    lands rather than relying on the implicit-conversion fallback).
+  - test_setitem_numpy_scalar_preserves_dtype: FAILS at baseline, and worse
+    than expected -- Tensor's __setitem__ has zero numpy_scalar overloads
+    (only the 11 native cytnx_* ones, ordered complex128, complex64, double,
+    float, int64, ...), and `np.float32(2.5)` does not even reach the float
+    or double overload: it raises RuntimeError
+    ("cannot assign complex element to real container") because it is
+    accepted by the FIRST-registered `cytnx_complex128` overload. Python's
+    `complex()` builtin falls back to `__float__` when `__complex__` is
+    absent, so pybind11's complex type_caster's convert pass happily accepts
+    any float-like object, and registration order (complex128 first) lets it
+    win before double/float ever get a chance. This is a real, in-scope bug
+    (not just a missing-coverage gap) fixed by applying the same
+    keep-set-with-numpy-scalars-first ordering used for the arithmetic
+    operators to __setitem__.
+  - test_ne_is_not_silently_wrong / test_ne_elementwise_values: FAIL at
+    baseline -- __ne__ is unbound, so Python's default falls back to
+    `not (a == b)`; cytnx's __eq__ returns an elementwise Bool Tensor, and
+    `not Tensor` calls __bool__/__len__, collapsing to a single bare `False`
+    for any non-empty tensor -- a silently wrong scalar instead of an
+    elementwise comparison. (This is exactly the failure mode #928/#916
+    background describes; verified: `a != b` under Python's default returns
+    the Python constant `False`, not a Tensor, for two non-empty operands.)
+  - test_bool_multielement_raises / test_bool_uninitialized_raises: FAIL at
+    baseline -- __bool__ is unbound, so truthiness falls through to __len__
+    (`if tensor:` just checks shape()[0] != 0), never raising ValueError for
+    a multi-element tensor, and raises RuntimeError (not ValueError) for an
+    uninitialized (Void-dtype) tensor because __len__ itself cytnx_error_msg's
+    out.
+  - test_imatmul_preserves_identity: PASSES at baseline in this worktree
+    (T2's real, non-shadow `__imatmul__` binding already runs and does
+    `self.cast<Tensor&>() = Dot(...)` on the SAME py::object, so identity is
+    preserved here). Recorded per the plan's requirement to pin this down
+    explicitly: on unmodified master (before T2), `@=` only appeared to work
+    because the old python wrapper method was misspelled `__imatmul`
+    (missing trailing underscore) instead of `__imatmul__`, so the C++
+    `__imatmul__` binding was unreachable dead code and Python's `@=` silently
+    fell back to `t = t.__matmul__(x)` (rebinding the *name* in the caller's
+    scope, not mutating the object). This test guards against a future
+    regression (e.g. an accidental by-value self-cast) silently reintroducing
+    that non-in-place fallback behavior.
+
+Scope note: the plan's Task 3 inventory only lists Tensor's __setitem__ for
+the numpy-scalar-keep-set treatment ("mirror UniTensor's existing coverage").
+Recon here found UniTensor's own __setitem__/set_elem has the IDENTICAL
+registration-order bug (np.float32 hits the first-registered
+cytnx_complex128 overload) -- and worse than Tensor's, because setting a
+real scalar through the complex128 overload does not merely mis-preserve
+dtype, it raises a hard RuntimeError ("Cannot set Complex Double to
+Float") from the underlying storage. Since "UniTensor's existing coverage"
+was itself broken, mirroring it verbatim would have propagated the bug
+instead of fixing it, so UniTensor's __setitem__/set_elem (both the
+vector-locator and single-int-locator, i.e. diagonal-UniTensor, overload
+families) were given the same keep-set-with-numpy-scalars-first fix as
+Tensor's. This is a modest, consistency-motivated scope extension beyond
+the plan's literal inventory, called out explicitly in the commit body.
+"""
+
+import numpy as np
+import pytest
+
+import cytnx
+from cytnx import Type
+
+
+def test_numpy_float32_preserves_dtype():
+    t = cytnx.zeros([2], dtype=Type.Float)
+    assert (t + np.float32(1.0)).dtype() == Type.Float
+    t += np.float32(1.0)
+    assert t.dtype() == Type.Float
+
+
+def test_numpy_complex64_preserves_dtype():
+    t = cytnx.zeros([2], dtype=Type.ComplexFloat)
+    assert (t + np.complex64(1.0)).dtype() == Type.ComplexFloat
+    t += np.complex64(1.0)
+    assert t.dtype() == Type.ComplexFloat
+
+
+def test_numpy_int32_preserves_dtype():
+    t = cytnx.zeros([2], dtype=Type.Int32)
+    assert (t + np.int32(1)).dtype() == Type.Int32
+    t += np.int32(1)
+    assert t.dtype() == Type.Int32
+
+
+def test_numpy_uint32_preserves_dtype():
+    t = cytnx.zeros([2], dtype=Type.Uint32)
+    assert (t + np.uint32(1)).dtype() == Type.Uint32
+    t += np.uint32(1)
+    assert t.dtype() == Type.Uint32
+
+
+def test_numpy_int16_preserves_dtype():
+    t = cytnx.zeros([2], dtype=Type.Int16)
+    assert (t + np.int16(1)).dtype() == Type.Int16
+
+
+def test_numpy_uint16_preserves_dtype():
+    t = cytnx.zeros([2], dtype=Type.Uint16)
+    assert (t + np.uint16(1)).dtype() == Type.Uint16
+
+
+def test_numpy_uint64_preserves_dtype():
+    t = cytnx.zeros([2], dtype=Type.Uint64)
+    assert (t + np.uint64(1)).dtype() == Type.Uint64
+
+
+def test_python_int_works_and_large_int():
+    t = cytnx.zeros([2], dtype=Type.Int64)
+    assert (t + 1).dtype() == Type.Int64
+    t2 = cytnx.zeros([2], dtype=Type.Uint64)
+    _ = t2 + (2**63 + 1)  # > int64 max: must dispatch to uint64, not raise
+
+
+def test_pow_accepts_int_and_numpy():
+    t = cytnx.ones([2])
+    assert (t**2)[0].item() == 1.0
+    assert (t ** np.float32(2.0))[0].item() == 1.0
+
+
+def test_setitem_numpy_scalar_preserves_dtype():
+    t = cytnx.zeros([3], dtype=Type.Float)
+    t[0] = np.float32(2.5)
+    assert t.dtype() == Type.Float
+
+
+def test_ne_is_not_silently_wrong():
+    a = cytnx.ones([3])
+    b = cytnx.zeros([3])
+    r = a != b
+    # either elementwise Tensor of ones, or TypeError -- never a bare False
+    assert not (r is False)
+
+
+def test_ne_elementwise_values():
+    a = cytnx.ones([3])
+    b = cytnx.zeros([3])
+    r = a != b
+    assert isinstance(r, cytnx.Tensor)
+    assert r.dtype() == Type.Bool
+    assert bool(r[0].item()) is True
+
+    c = cytnx.ones([3])
+    r2 = a != c
+    assert bool(r2[0].item()) is False
+
+
+def test_ne_scalar_operand():
+    # cytnx.Scalar closes the keep-set for __ne__ exactly as it does for
+    # __eq__. Without the explicit overload, `t != Scalar(x)` only worked
+    # through pybind11's lossy implicit-conversion fallbacks
+    # (Scalar.__float__/__complex__ feeding the double/complex128 overloads),
+    # printing cytnx error noise to stderr mid-dispatch along the way and
+    # losing precision for integer Scalars beyond 2**53.
+    t = cytnx.ones([3])
+    r = t != cytnx.Scalar(2.0)
+    assert isinstance(r, cytnx.Tensor)
+    assert r.dtype() == Type.Bool
+    assert bool(r[0].item()) is True
+
+    r2 = t != cytnx.Scalar(1.0)
+    assert bool(r2[0].item()) is False
+
+
+def test_bool_multielement_raises():
+    t = cytnx.ones([3])
+    with pytest.raises(ValueError):
+        bool(t)
+    assert bool(cytnx.ones([1]))
+    assert not bool(cytnx.zeros([1]))
+
+
+def test_bool_uninitialized_raises():
+    t = cytnx.Tensor()
+    with pytest.raises(ValueError):
+        bool(t)
+
+
+def test_imatmul_preserves_identity():
+    a = cytnx.from_numpy(np.array([[1.0, 0.0], [0.0, 1.0]]))
+    ref = a
+    b = cytnx.from_numpy(np.array([[2.0, 0.0], [0.0, 2.0]]))
+    a @= b
+    assert a is ref
+    assert a[0, 0].item() == 2.0
+    assert a[1, 1].item() == 2.0
+    assert a[0, 1].item() == 0.0
+
+
+# UniTensor coverage for the same keep-set collapse (scope extension: recon
+# found UniTensor's __setitem__/set_elem shared Tensor's setitem bug, see the
+# module docstring's "Scope note").
+
+
+def test_unitensor_numpy_int32_preserves_dtype():
+    ut = cytnx.UniTensor(cytnx.zeros([2, 2], dtype=Type.Int32))
+    assert (ut + np.int32(1)).dtype() == Type.Int32
+    ut += np.int32(1)
+    assert ut.dtype() == Type.Int32
+
+
+def test_unitensor_pow_accepts_int_and_numpy():
+    ut = cytnx.UniTensor(cytnx.ones([1]))
+    assert (ut**2).item() == 1.0
+    assert (ut ** np.float32(2.0)).item() == 1.0
+
+
+def test_unitensor_set_elem_numpy_scalar_preserves_dtype():
+    ut = cytnx.UniTensor(cytnx.zeros([3], dtype=Type.Float))
+    ut.set_elem([0], np.float32(2.5))
+    assert ut.dtype() == Type.Float
+
+
+def test_unitensor_setitem_numpy_scalar_preserves_dtype():
+    ut = cytnx.UniTensor(cytnx.zeros([3], dtype=Type.Float))
+    ut[[0]] = np.float32(2.5)
+    assert ut.dtype() == Type.Float


### PR DESCRIPTION
## Problem

Addresses #928/#916 and finishes the core of #692. Every Tensor/UniTensor arithmetic operator was bound ~24× (one per C++ scalar type + numpy scalars). Beyond the stub blowup this caused **live dtype bugs**: pybind11's arithmetic caster accepts any `__index__`-bearing object even in the no-convert pass, so plain fixed-width int overloads registered ahead of the numpy-scalar ones silently ate `np.int32/uint64/…` and produced Int64 results; `t[0] = np.float32(x)` raised a hard RuntimeError (Tensor `__setitem__` had no numpy coverage and `complex128` registered first). Separately, `t1 != t2` returned a single always-`False` bool for non-empty tensors (Python's default `__ne__` negated the elementwise `__eq__` Tensor via `__len__`), and `bool(t)` fell through to `__len__`.

## Fix

- Every binary/reverse/in-place operator on Tensor and UniTensor collapsed to a per-Python-distinguishable-type keep-set (24→14 / 23→13): Tensor operand, numpy scalars (32-bit + integer dtypes preserved), arbitrary-precision `py::int_` with int64/uint64 runtime dispatch, `double`, `complex128`, `Scalar` — ordering is load-bearing and documented once in the new shared `pybind/pyint_dispatch.hpp` ("KEEP-SET ORDERING" note, cross-referencing PR #915 whose ExpH/ExpM work pioneered the pattern).
- `__setitem__`/`set_elem` numpy coverage + ordering fixed on both classes; `__pow__`/`__ipow__` accept ints and numpy scalars.
- New elementwise `__ne__` (composed from existing kernels, Bool result, mirrors `__eq__` including the `Scalar` operand) and numpy-semantics `__bool__` (ValueError for multi-element or Void; truthiness of the single element otherwise). **Behavior change:** `if tensor:` previously meant `len(tensor) > 0`.

## Testing

`pytests/binding_dtype_test.py` (20 tests) with per-test baseline red/green documented — 10 genuinely red pre-fix (dtype loss, setitem error, `__ne__`/`__bool__` traps). Full pytest 55 passed. Known pre-existing gap (numpy scalar on the LEFT of Tensor hits `__iter__`) documented, out of scope.

## Stacking

**Base branch is `fix/pybind-inplace-return-self` (PR #986).** Merge #986 first, then retarget to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)