### PR TITLE
fix(linalg): compute GPU Kron product in the promoted output dtype

### DIFF
--- a/src/backend/linalg_internal_gpu/cuKron_internal.cuh
+++ b/src/backend/linalg_internal_gpu/cuKron_internal.cuh
@@ -9,7 +9,9 @@
 #include "cytnx_error.hpp"
 #include "Type.hpp"
 #include "backend/lapack_wrapper.hpp"
+#include <cuComplex.h>
 #include <iostream>
+#include <type_traits>
 
 #ifndef __CUDACC__
   #error This file requires a CUDA compiler
@@ -18,6 +20,42 @@
 namespace cytnx {
 
   namespace linalg_internal {
+
+    // Promote an operand to the Kron output type before multiplying. The raw
+    // `operator*` overloads follow the left operand's precision (e.g.
+    // cuFloatComplex * double -> cuFloatComplex), which no longer matches the
+    // promoted output dtype after mixed complex/real pairs promote by precision
+    // (ComplexFloat + Double -> ComplexDouble, see #858). Computing the product
+    // in TO keeps the result assignable to `out`, mirroring cuDiv_dispatch.
+    template <typename T>
+    __device__ inline cuDoubleComplex cuKron_to_cd(const T &v) {
+      return make_cuDoubleComplex(static_cast<cytnx_double>(v), 0.0);
+    }
+    __device__ inline cuDoubleComplex cuKron_to_cd(const cuDoubleComplex &v) { return v; }
+    __device__ inline cuDoubleComplex cuKron_to_cd(const cuComplex &v) {
+      return cuComplexFloatToDouble(v);
+    }
+
+    template <typename T>
+    __device__ inline cuComplex cuKron_to_cf(const T &v) {
+      return make_cuFloatComplex(static_cast<cytnx_float>(v), 0.0f);
+    }
+    __device__ inline cuComplex cuKron_to_cf(const cuComplex &v) { return v; }
+    __device__ inline cuComplex cuKron_to_cf(const cuDoubleComplex &v) {
+      return make_cuFloatComplex(static_cast<cytnx_float>(cuCreal(v)),
+                                 static_cast<cytnx_float>(cuCimag(v)));
+    }
+
+    template <typename TO, typename TL, typename TR>
+    __device__ inline TO cuKron_mul(const TL &lhs, const TR &rhs) {
+      if constexpr (std::is_same_v<TO, cuDoubleComplex>) {
+        return cuCmul(cuKron_to_cd(lhs), cuKron_to_cd(rhs));
+      } else if constexpr (std::is_same_v<TO, cuComplex>) {
+        return cuCmulf(cuKron_to_cf(lhs), cuKron_to_cf(rhs));
+      } else {
+        return static_cast<TO>(lhs) * static_cast<TO>(rhs);
+      }
+    }
 
     template <class TO, class TL, class TR>
     __global__ void cuKron_kernel(TO *out, const TL *Lin, const TR *Rin, cytnx_uint64 *meta_infos,
@@ -46,7 +84,7 @@ namespace cytnx {
           x += cytnx_uint64(tmp2 / info[offset2 + j]) * info[len_nsa + j];
           y += cytnx_uint64(tmp2 % info[offset2 + j]) * info[offset1 + j];
         }
-        out[blockIdx.x * blockDim.x + threadIdx.x] = Lin[x] * Rin[y];
+        out[blockIdx.x * blockDim.x + threadIdx.x] = cuKron_mul<TO>(Lin[x], Rin[y]);
       }
     }
 


### PR DESCRIPTION
## What

Fix a GPU build break in `cuKron_kernel`: compute the Kron product in the **promoted output dtype** instead of relying on the raw `operator*` result type.

## Why

`cuKron_kernel` did `out[i] = Lin[x] * Rin[y]`. The cucomplex `operator*` overloads follow the left operand's precision, so `cuFloatComplex * double -> cuFloatComplex`. After #858 made mixed complex/real pairs promote by precision (`ComplexFloat + Double -> ComplexDouble`), the output type is `cuDoubleComplex`, and assigning the `cuFloatComplex` product to it fails to compile:

```
src/backend/linalg_internal_gpu/cuKron_internal.cuh:49: error: no operator "=" matches these operands
  operand types are: cuDoubleComplex = cuFloatComplex
```

This broke the CUDA build for the `(cuFloatComplex, cytnx_double)` instantiation (and its mirror). CI didn't catch it because it does not build the GPU path; the CPU `Kron_general` handles the conversion and compiled fine.

## How

Introduce a `cuKron_mul<TO>` helper that promotes both operands to `TO` before multiplying (`cuCmul`/`cuCmulf` for complex `TO`, `static_cast<TO>` otherwise), mirroring the existing `cuDiv_dispatch.cu` pattern. This makes the result assignable for every promoted `(TO, TL, TR)` triple.

## Testing

Built the full `cytnx` target with CUDA + cuTENSOR + cuQuantum (CUDA 12.9, sm_70 / V100) — compiles and links. Ran `Kron(ComplexFloat, Double)` on the GPU: output dtype is `ComplexDouble` and the values match the CPU reference and hand-computed expected results.

Note: this class of regression would be caught by a minimal GPU **compile** job in CI (no GPU hardware needed to compile the templates). Worth considering as a follow-up.

Fixes #994

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Posted by Claude Code on behalf of @pcchen