### PR TITLE
chore(gitignore): ignore /.deps/ for local cuTENSOR/cuQuantum installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ GEMINI.local.md
 .antigravity/
 # Cursor
 .cursor/
+
+# Local CUDA math libs installed for testing (cuTENSOR / cuQuantum)
+/.deps/


### PR DESCRIPTION
Local, no-root installs of the CUDA math libs (e.g. NVIDIA pip wheels extracted under `.deps/cutensor` and `.deps/cuquantum`, pointed at via `CUTENSOR_ROOT`/`CUQUANTUM_ROOT`) drop hundreds of MB into the tree. Ignore `/.deps/` so they never show up in `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)