### PR TITLE
refactor(pybind)!: guard UniTensor +/- on matching metadata; drop * / (#934)

### DIFF
--- a/include/UniTensor.hpp
+++ b/include/UniTensor.hpp
@@ -349,6 +349,11 @@ namespace cytnx {
     virtual std::vector<Symmetry> syms() const;
 
     // arithmetic
+    // internal/advanced: the UniTensor-vs-UniTensor overloads below (Add_/Mul_/Sub_/Div_
+    // taking a boost::intrusive_ptr<UniTensor_base>) are not TN operations; python surface
+    // removed per #934. See operator+(const UniTensor&, const UniTensor&) in
+    // include/linalg.hpp for the full rationale. The Scalar overloads (scalar scaling)
+    // remain fully public, including from python.
     virtual void Add_(const boost::intrusive_ptr<UniTensor_base> &rhs);
     virtual void Add_(const Scalar &rhs);
 
@@ -4778,6 +4783,9 @@ namespace cytnx {
         @pre
         The two UniTensor need to have same structure.
         @note Compared to Add(const UniTensor&)const, this is an inplace function.
+        @note internal/advanced: not a TN operation; python surface removed per #934; see
+        operator+(const UniTensor&, const UniTensor&) in include/linalg.hpp for the
+        full rationale.
         @see Add_(const Scalar&), Add(const UniTensor&)const, Add(const Scalar&)const ,
         operator+=(const UniTensor&), operator+=(const Scalar&), \ref operator+
         */
@@ -4799,6 +4807,9 @@ namespace cytnx {
         @pre
         The two UniTensor need to have same structure.
         @note Compared to Mul(const UniTensor&)const, this is an inplace function.
+        @note internal/advanced: not a TN operation; python surface removed per #934; see
+        operator+(const UniTensor&, const UniTensor&) in include/linalg.hpp for the
+        full rationale.
         @see Mul_(const Scalar&), Mul(const UniTensor&)const, Mul(const Scalar&)const ,
         operator*=(const UniTensor&), operator*=(const Scalar&), \ref operator*
         */
@@ -4820,6 +4831,9 @@ namespace cytnx {
         @pre
         The two UniTensor need to have same structure.
         @note Compared to Sub(const UniTensor&)const, this is an inplace function.
+        @note internal/advanced: not a TN operation; python surface removed per #934; see
+        operator+(const UniTensor&, const UniTensor&) in include/linalg.hpp for the
+        full rationale.
         @see Sub_(const Scalar&), Sub(const UniTensor&)const, Sub(const Scalar&)const ,
         operator-=(const UniTensor&), operator-=(const Scalar&), \ref operator-
         */
@@ -4841,6 +4855,9 @@ namespace cytnx {
         @pre
         The two UniTensor need to have same structure.
         @note Compared to Div(const UniTensor&)const, this is an inplace function.
+        @note internal/advanced: not a TN operation; python surface removed per #934; see
+        operator+(const UniTensor&, const UniTensor&) in include/linalg.hpp for the
+        full rationale.
         @see Div_(const Scalar&), Div(const UniTensor&)const, Div(const Scalar&)const ,
         operator/=(const UniTensor&), operator/=(const Scalar&), \ref operator/
         */
@@ -4922,6 +4939,9 @@ namespace cytnx {
         @pre
         The two UniTensor need to have same structure.
         @note Compared to Add_(const UniTensor&), this function will create a new UniTensor.
+        @note internal/advanced: not a TN operation; python surface removed per #934; see
+        operator+(const UniTensor&, const UniTensor&) in include/linalg.hpp for the
+        full rationale.
         @see Add_(const UniTensor&), Add_(const Scalar&), Add(const Scalar&)const ,
         operator+=(const UniTensor&), operator+=(const Scalar&), \ref operator+
         */
@@ -4952,6 +4972,9 @@ namespace cytnx {
         @pre
         The two UniTensor need to have same structure.
         @note Compared to Mul_(const UniTensor&), this function will create a new UniTensor.
+        @note internal/advanced: not a TN operation; python surface removed per #934; see
+        operator+(const UniTensor&, const UniTensor&) in include/linalg.hpp for the
+        full rationale.
         @see Mul_(const UniTensor&), Mul_(const Scalar&), Mul(const Scalar&)const ,
         operator*=(const UniTensor&), operator*=(const Scalar&), \ref operator*
         */
@@ -4982,6 +5005,9 @@ namespace cytnx {
         @pre
         The two UniTensor need to have same structure.
         @note Compared to Div_(const UniTensor&), this function will create a new UniTensor.
+        @note internal/advanced: not a TN operation; python surface removed per #934; see
+        operator+(const UniTensor&, const UniTensor&) in include/linalg.hpp for the
+        full rationale.
         @see Div_(const UniTensor&), Div_(const Scalar&), Div(const Scalar&)const ,
         operator/=(const UniTensor&), operator/=(const Scalar&), \ref operator/
         */
@@ -5012,6 +5038,9 @@ namespace cytnx {
         @pre
         The two UniTensor need to have same structure.
         @note Compared to Sub_(const UniTensor&), this function will create a new UniTensor.
+        @note internal/advanced: not a TN operation; python surface removed per #934; see
+        operator+(const UniTensor&, const UniTensor&) in include/linalg.hpp for the
+        full rationale.
         @see Sub_(const UniTensor&), Sub_(const Scalar&), Sub(const Scalar&)const ,
         operator-=(const UniTensor&), operator-=(const Scalar&), \ref operator-
         */

--- a/include/linalg.hpp
+++ b/include/linalg.hpp
@@ -27,6 +27,20 @@ namespace cytnx {
    * @return [UniTensor] The result of the addition.
    * @pre \p Lt and \p Rt must have the same shape.
    * @see linalg::Add(const cytnx::UniTensor &Lt, const cytnx::UniTensor &Rt)
+   * @note internal/advanced: not a TN operation; python surface removed per #934
+   * (decision record 2026-07-06). This note is the canonical rationale for every
+   * UniTensor-vs-UniTensor elementwise arithmetic entry point: the free operators in
+   * this header ('+', '-', '*', '/') and the UniTensor::Add/Sub/Mul/Div member
+   * functions (in-place and out-of-place). The python UniTensor dunders raise
+   * TypeError for the UniTensor-vs-UniTensor case (see pybind/unitensor_py.cpp,
+   * raise_unitensor_elementwise_removed) while the C++ layer remains. operator+ and
+   * operator- are load-bearing: src/linalg/Lanczos_Gnd_Ut.cpp and
+   * src/linalg/Lanczos_Exp.cpp use them as genuine Krylov-subspace vector-space
+   * arithmetic (axpy) inside the solvers backing linalg::Lanczos(method="Gnd") and
+   * linalg::Lanczos_Exp(). operator* (elementwise/Hadamard product) and operator/
+   * (elementwise division) are basis-dependent, have no tensor-network meaning, and
+   * no in-tree C++ caller as of the audit; they are kept un-deprecated only because
+   * the removal task's scope was the python surface.
    */
   cytnx::UniTensor operator+(const cytnx::UniTensor &Lt, const cytnx::UniTensor &Rt);
 
@@ -63,6 +77,9 @@ namespace cytnx {
    * @return [UniTensor] The result of the subtraction.
    * @pre \p Lt and \p Rt must have the same shape.
    * @see linalg::Sub(const cytnx::UniTensor &Lt, const cytnx::UniTensor &Rt)
+   * @note internal/advanced: not a TN operation; python surface removed per #934;
+   * see operator+(const cytnx::UniTensor &Lt, const cytnx::UniTensor &Rt) for the
+   * full rationale.
    */
   cytnx::UniTensor operator-(const cytnx::UniTensor &Lt, const cytnx::UniTensor &Rt);
 
@@ -99,6 +116,9 @@ namespace cytnx {
    * @return [UniTensor] The result of the multiplication.
    * @pre \p Lt and \p Rt must have the same shape.
    * @see linalg::Mul(const cytnx::UniTensor &Lt, const cytnx::UniTensor &Rt)
+   * @note internal/advanced: not a TN operation; python surface removed per #934;
+   * see operator+(const cytnx::UniTensor &Lt, const cytnx::UniTensor &Rt) for the
+   * full rationale.
    */
   cytnx::UniTensor operator*(const cytnx::UniTensor &Lt, const cytnx::UniTensor &Rt);
 
@@ -135,6 +155,9 @@ namespace cytnx {
    * @return [UniTensor] The result of the division.
    * @pre \p Lt and \p Rt must have the same shape.
    * @see linalg::Div(const cytnx::UniTensor &Lt, const cytnx::UniTensor &Rt)
+   * @note internal/advanced: not a TN operation; python surface removed per #934;
+   * see operator+(const cytnx::UniTensor &Lt, const cytnx::UniTensor &Rt) for the
+   * full rationale.
    */
   cytnx::UniTensor operator/(const cytnx::UniTensor &Lt, const cytnx::UniTensor &Rt);
 

--- a/pybind/unitensor_py.cpp
+++ b/pybind/unitensor_py.cpp
@@ -95,24 +95,23 @@ inline bool parse_get_blocks_silent_arg(const py::args &args, const py::kwargs &
   return silent;
 }
 
-// Phase-2 Task 3 (issue #934, decision record 2026-07-06): elementwise
-// UniTensor(+)UniTensor arithmetic ('+', '-', '*', '/' and their in-place
-// forms) is not a well-defined tensor-network operation -- for
-// BlockUniTensor/BlockFermionicUniTensor it either destroys the block
-// structure or is basis-dependent (see #934); #753/#675 additionally
-// document it silently discarding labels. The python-facing dunders for the
-// UniTensor-vs-UniTensor overloads raise TypeError via the helper below
-// instead of performing the operation. Scalar<->UniTensor arithmetic (both
-// directions, out-of-place and in-place) is unaffected and keeps working.
+// Phase-2 Task 3 (issue #934, decision record 2026-07-06, amended): the four
+// elementwise UniTensor(+)UniTensor operator families split by whether the
+// operation is well defined:
 //
-// Three guidance bodies cover the eight call sites (+/+=/-/-= share the
-// vector-space text; the * and / pairs each share one). A future removal
-// (e.g. __mod__) should add its guidance constant here and reuse the helper.
-inline constexpr const char *kUniTensorAddSubRemovedGuidance =
-  "Use Contract() for tensor contraction, Kron() for tensor products, or scalar "
-  "arithmetic. If you need a Krylov-style vector-space linear combination (axpy), use "
-  "cytnx.linalg.Lanczos()/Lanczos_Exp()/Arnoldi(), which implement this internally in C++.";
-
+//   * '+' '-' '+=' '-=' are KEPT but guarded. They require the two operands to
+//     describe the same tensor slot -- matching type, rank, labels (in order),
+//     rowrank, diagonal-ness, and bonds. With matching metadata the sum /
+//     difference is unambiguous and label-preserving; with mismatched metadata
+//     the labels would be silently discarded (the #934/#753/#675 complaint), so
+//     they raise TypeError instead (see unitensor_addsub_metadata_mismatch).
+//   * '*' '/' '*=' '/=' are REMOVED: the elementwise (Hadamard) product /
+//     quotient of two UniTensors is basis-dependent and has no tensor-network
+//     meaning. Their dunders raise TypeError via raise_unitensor_elementwise_removed.
+//
+// Scalar<->UniTensor arithmetic (both directions, out-of-place and in-place) is
+// unaffected. The C++ operator+/operator- are unchanged -- the Krylov solvers
+// rely on them as vector-space operations.
 inline constexpr const char *kUniTensorMulRemovedGuidance =
   "Use Contract() for tensor contraction or Kron() for tensor (outer) products; for a "
   "genuinely elementwise (Hadamard) product, operate on the raw blocks instead -- "
@@ -130,6 +129,51 @@ inline constexpr const char *kUniTensorDivRemovedGuidance =
                                                              const std::string &alt) {
   throw py::type_error(std::format(
     "elementwise UniTensor{}UniTensor arithmetic was removed (issue #934): {}", op_name, alt));
+}
+
+// Render a label list for diagnostics, e.g. ['a', 'b'].
+inline std::string format_labels(const std::vector<std::string> &labels) {
+  std::string s = "[";
+  for (std::size_t i = 0; i < labels.size(); ++i) {
+    if (i) s += ", ";
+    s += "'" + labels[i] + "'";
+  }
+  s += "]";
+  return s;
+}
+
+// Returns "" when a and b have matching metadata for elementwise +/-, otherwise a
+// human-readable reason for the mismatch. +/- is only well-defined (and label-preserving)
+// when both operands describe the same tensor slot.
+inline std::string unitensor_addsub_metadata_mismatch(const UniTensor &a, const UniTensor &b) {
+  if (a.uten_type() != b.uten_type())
+    return std::format("different UniTensor types ({} vs {})", a.uten_type_str(),
+                       b.uten_type_str());
+  if (a.rank() != b.rank()) return std::format("different rank ({} vs {})", a.rank(), b.rank());
+  if (a.labels() != b.labels())
+    return std::format("different labels ({} vs {})", format_labels(a.labels()),
+                       format_labels(b.labels()));
+  if (a.rowrank() != b.rowrank())
+    return std::format("different rowrank ({} vs {})", a.rowrank(), b.rowrank());
+  if (a.is_diag() != b.is_diag())
+    return std::string("one is diagonal (is_diag=True) and the other is not");
+  const std::vector<Bond> &ba = a.bonds();
+  const std::vector<Bond> &bb = b.bonds();
+  for (std::size_t i = 0; i < ba.size(); ++i) {
+    if (ba[i] != bb[i])
+      return std::format("bond at leg {} (label '{}') does not match", i, a.labels()[i]);
+  }
+  return std::string();
+}
+
+[[noreturn]] inline void raise_unitensor_addsub_metadata_mismatch(const std::string &op_name,
+                                                                  const std::string &reason) {
+  throw py::type_error(std::format(
+    "UniTensor{}UniTensor requires the two operands to have matching metadata, but they have {}. "
+    "Elementwise +/- is only defined when both describe the same tensor slot (same labels, bonds, "
+    "rowrank, ...); align them first (e.g. permute()/relabel_()), or use Contract() / operate on "
+    "ut.get_block() for genuinely elementwise math. See issue #934.",
+    op_name, reason));
 }
 
 // Lambda used for _getitem__ and _setitem__
@@ -994,11 +1038,18 @@ void unitensor_binding(py::module &m) {
     // NOTE: no __eq__/__ne__/__bool__ on UniTensor (intentional, Task 3 scope) -- Python falls
     // back to identity semantics; see Tensor's __ne__/__bool__ notes in tensor_py.cpp.
     // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
-    // Phase-2 Task 3 (#934/2026-07-06 decision): UniTensor+UniTensor removed from the
-    // python surface; see raise_unitensor_elementwise_removed's doc comment above.
+    // Phase-2 Task 3 (#934/2026-07-06 decision, amended): UniTensor+UniTensor is kept but
+    // guarded on matching metadata; see unitensor_addsub_metadata_mismatch's doc comment above.
     .def("__add__",
          [](UniTensor &self, const UniTensor &rhs) -> UniTensor {
-           raise_unitensor_elementwise_removed(" + ", kUniTensorAddSubRemovedGuidance);
+           const std::string reason = unitensor_addsub_metadata_mismatch(self, rhs);
+           if (!reason.empty()) raise_unitensor_addsub_metadata_mismatch(" + ", reason);
+           // Add() dtype-promotes but resets labels to a plain range and clears the name;
+           // restore the shared metadata since the operands matched.
+           UniTensor out = self.Add(rhs);
+           out.relabel_(self.labels());
+           out.set_name(self.name());
+           return out;
          })
     .def("__add__",
          [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
@@ -1094,11 +1145,13 @@ void unitensor_binding(py::module &m) {
     .def("__radd__", [](UniTensor &self, const cytnx::Scalar &lhs) { return linalg::Add(lhs, self); })
 
     // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
-    // Phase-2 Task 3 (#934/2026-07-06 decision): UniTensor+=UniTensor removed from the
-    // python surface; see raise_unitensor_elementwise_removed's doc comment above.
+    // Phase-2 Task 3 (#934/2026-07-06 decision, amended): UniTensor+=UniTensor is kept but
+    // guarded on matching metadata; see unitensor_addsub_metadata_mismatch's doc comment above.
     .def("__iadd__",
          [](UniTensor &self, const UniTensor &rhs) -> UniTensor & {
-           raise_unitensor_elementwise_removed(" += ", kUniTensorAddSubRemovedGuidance);
+           const std::string reason = unitensor_addsub_metadata_mismatch(self, rhs);
+           if (!reason.empty()) raise_unitensor_addsub_metadata_mismatch(" += ", reason);
+           return self.Add_(rhs);  // in-place; preserves self's labels and name
          })
     .def("__iadd__",
          [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
@@ -1147,11 +1200,18 @@ void unitensor_binding(py::module &m) {
     .def("__iadd__", [](UniTensor &self, const cytnx::Scalar &rhs) { return self.Add_(rhs); })
 
     // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
-    // Phase-2 Task 3 (#934/2026-07-06 decision): UniTensor-UniTensor removed from the
-    // python surface; see raise_unitensor_elementwise_removed's doc comment above.
+    // Phase-2 Task 3 (#934/2026-07-06 decision, amended): UniTensor-UniTensor is kept but
+    // guarded on matching metadata; see unitensor_addsub_metadata_mismatch's doc comment above.
     .def("__sub__",
          [](UniTensor &self, const UniTensor &rhs) -> UniTensor {
-           raise_unitensor_elementwise_removed(" - ", kUniTensorAddSubRemovedGuidance);
+           const std::string reason = unitensor_addsub_metadata_mismatch(self, rhs);
+           if (!reason.empty()) raise_unitensor_addsub_metadata_mismatch(" - ", reason);
+           // Sub() dtype-promotes but resets labels to a plain range and clears the name;
+           // restore the shared metadata since the operands matched.
+           UniTensor out = self.Sub(rhs);
+           out.relabel_(self.labels());
+           out.set_name(self.name());
+           return out;
          })
     .def("__sub__",
          [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
@@ -1247,11 +1307,13 @@ void unitensor_binding(py::module &m) {
     .def("__rsub__", [](UniTensor &self, const cytnx::Scalar &lhs) { return linalg::Sub(lhs, self); })
 
     // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
-    // Phase-2 Task 3 (#934/2026-07-06 decision): UniTensor-=UniTensor removed from the
-    // python surface; see raise_unitensor_elementwise_removed's doc comment above.
+    // Phase-2 Task 3 (#934/2026-07-06 decision, amended): UniTensor-=UniTensor is kept but
+    // guarded on matching metadata; see unitensor_addsub_metadata_mismatch's doc comment above.
     .def("__isub__",
          [](UniTensor &self, const UniTensor &rhs) -> UniTensor & {
-           raise_unitensor_elementwise_removed(" -= ", kUniTensorAddSubRemovedGuidance);
+           const std::string reason = unitensor_addsub_metadata_mismatch(self, rhs);
+           if (!reason.empty()) raise_unitensor_addsub_metadata_mismatch(" -= ", reason);
+           return self.Sub_(rhs);  // in-place; preserves self's labels and name
          })
     .def("__isub__",
          [](UniTensor &self, const py::numpy_scalar<float> &rhs) {

--- a/pybind/unitensor_py.cpp
+++ b/pybind/unitensor_py.cpp
@@ -95,6 +95,43 @@ inline bool parse_get_blocks_silent_arg(const py::args &args, const py::kwargs &
   return silent;
 }
 
+// Phase-2 Task 3 (issue #934, decision record 2026-07-06): elementwise
+// UniTensor(+)UniTensor arithmetic ('+', '-', '*', '/' and their in-place
+// forms) is not a well-defined tensor-network operation -- for
+// BlockUniTensor/BlockFermionicUniTensor it either destroys the block
+// structure or is basis-dependent (see #934); #753/#675 additionally
+// document it silently discarding labels. The python-facing dunders for the
+// UniTensor-vs-UniTensor overloads raise TypeError via the helper below
+// instead of performing the operation. Scalar<->UniTensor arithmetic (both
+// directions, out-of-place and in-place) is unaffected and keeps working.
+//
+// Three guidance bodies cover the eight call sites (+/+=/-/-= share the
+// vector-space text; the * and / pairs each share one). A future removal
+// (e.g. __mod__) should add its guidance constant here and reuse the helper.
+inline constexpr const char *kUniTensorAddSubRemovedGuidance =
+  "Use Contract() for tensor contraction, Kron() for tensor products, or scalar "
+  "arithmetic. If you need a Krylov-style vector-space linear combination (axpy), use "
+  "cytnx.linalg.Lanczos()/Lanczos_Exp()/Arnoldi(), which implement this internally in C++.";
+
+inline constexpr const char *kUniTensorMulRemovedGuidance =
+  "Use Contract() for tensor contraction or Kron() for tensor (outer) products; for a "
+  "genuinely elementwise (Hadamard) product, operate on the raw blocks instead -- "
+  "Tensor-level elementwise arithmetic is fully supported via ut.get_block(). The Hadamard "
+  "product of two UniTensors is basis-dependent and not a tensor-network operation. Scalar "
+  "multiplication ('2.0 * ut', 'ut *= 2.0') is unaffected.";
+
+inline constexpr const char *kUniTensorDivRemovedGuidance =
+  "Use Contract() with an inverted operator, or scalar division ('ut / 2.0', 'ut /= 2.0') "
+  "if that is what you meant; for a genuinely elementwise division, operate on the raw "
+  "blocks instead -- Tensor-level elementwise arithmetic is fully supported via "
+  "ut.get_block(). Division of two UniTensors has no well-defined tensor-network meaning.";
+
+[[noreturn]] inline void raise_unitensor_elementwise_removed(const std::string &op_name,
+                                                             const std::string &alt) {
+  throw py::type_error(std::format(
+    "elementwise UniTensor{}UniTensor arithmetic was removed (issue #934): {}", op_name, alt));
+}
+
 // Lambda used for _getitem__ and _setitem__
 auto build_accessors = [](const UniTensor &self, py::object locators) {
   ssize_t start, stop, step, slicelength;
@@ -957,7 +994,12 @@ void unitensor_binding(py::module &m) {
     // NOTE: no __eq__/__ne__/__bool__ on UniTensor (intentional, Task 3 scope) -- Python falls
     // back to identity semantics; see Tensor's __ne__/__bool__ notes in tensor_py.cpp.
     // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
-    .def("__add__", [](UniTensor &self, const UniTensor &rhs) { return linalg::Add(self, rhs); })
+    // Phase-2 Task 3 (#934/2026-07-06 decision): UniTensor+UniTensor removed from the
+    // python surface; see raise_unitensor_elementwise_removed's doc comment above.
+    .def("__add__",
+         [](UniTensor &self, const UniTensor &rhs) -> UniTensor {
+           raise_unitensor_elementwise_removed(" + ", kUniTensorAddSubRemovedGuidance);
+         })
     .def("__add__",
          [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
            return linalg::Add(self, static_cast<cytnx::cytnx_float>(rhs));
@@ -1052,8 +1094,12 @@ void unitensor_binding(py::module &m) {
     .def("__radd__", [](UniTensor &self, const cytnx::Scalar &lhs) { return linalg::Add(lhs, self); })
 
     // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
+    // Phase-2 Task 3 (#934/2026-07-06 decision): UniTensor+=UniTensor removed from the
+    // python surface; see raise_unitensor_elementwise_removed's doc comment above.
     .def("__iadd__",
-         [](UniTensor &self, const UniTensor &rhs) { return self.Add_(rhs); })
+         [](UniTensor &self, const UniTensor &rhs) -> UniTensor & {
+           raise_unitensor_elementwise_removed(" += ", kUniTensorAddSubRemovedGuidance);
+         })
     .def("__iadd__",
          [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
            return self.Add_(static_cast<cytnx::cytnx_float>(rhs));
@@ -1101,7 +1147,12 @@ void unitensor_binding(py::module &m) {
     .def("__iadd__", [](UniTensor &self, const cytnx::Scalar &rhs) { return self.Add_(rhs); })
 
     // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
-    .def("__sub__", [](UniTensor &self, const UniTensor &rhs) { return linalg::Sub(self, rhs); })
+    // Phase-2 Task 3 (#934/2026-07-06 decision): UniTensor-UniTensor removed from the
+    // python surface; see raise_unitensor_elementwise_removed's doc comment above.
+    .def("__sub__",
+         [](UniTensor &self, const UniTensor &rhs) -> UniTensor {
+           raise_unitensor_elementwise_removed(" - ", kUniTensorAddSubRemovedGuidance);
+         })
     .def("__sub__",
          [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
            return linalg::Sub(self, static_cast<cytnx::cytnx_float>(rhs));
@@ -1196,8 +1247,12 @@ void unitensor_binding(py::module &m) {
     .def("__rsub__", [](UniTensor &self, const cytnx::Scalar &lhs) { return linalg::Sub(lhs, self); })
 
     // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
+    // Phase-2 Task 3 (#934/2026-07-06 decision): UniTensor-=UniTensor removed from the
+    // python surface; see raise_unitensor_elementwise_removed's doc comment above.
     .def("__isub__",
-         [](UniTensor &self, const UniTensor &rhs) { return self.Sub_(rhs); })
+         [](UniTensor &self, const UniTensor &rhs) -> UniTensor & {
+           raise_unitensor_elementwise_removed(" -= ", kUniTensorAddSubRemovedGuidance);
+         })
     .def("__isub__",
          [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
            return self.Sub_(static_cast<cytnx::cytnx_float>(rhs));
@@ -1245,7 +1300,13 @@ void unitensor_binding(py::module &m) {
     .def("__isub__", [](UniTensor &self, const cytnx::Scalar &rhs) { return self.Sub_(rhs); })
 
     // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
-    .def("__mul__", [](UniTensor &self, const UniTensor &rhs) { return linalg::Mul(self, rhs); })
+    // Phase-2 Task 3 (#934/2026-07-06 decision): UniTensor*UniTensor (Hadamard/elementwise
+    // product) removed from the python surface -- it is basis-dependent and not a
+    // tensor-network operation (#934); see raise_unitensor_elementwise_removed above.
+    .def("__mul__",
+         [](UniTensor &self, const UniTensor &rhs) -> UniTensor {
+           raise_unitensor_elementwise_removed(" * ", kUniTensorMulRemovedGuidance);
+         })
     .def("__mul__",
          [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
            return linalg::Mul(self, static_cast<cytnx::cytnx_float>(rhs));
@@ -1340,8 +1401,12 @@ void unitensor_binding(py::module &m) {
     .def("__rmul__", [](UniTensor &self, const cytnx::Scalar &lhs) { return linalg::Mul(lhs, self); })
 
     // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
+    // Phase-2 Task 3 (#934/2026-07-06 decision): UniTensor*=UniTensor (Hadamard/elementwise
+    // product) removed from the python surface; see __mul__'s comment above.
     .def("__imul__",
-         [](UniTensor &self, const UniTensor &rhs) { return self.Mul_(rhs); })
+         [](UniTensor &self, const UniTensor &rhs) -> UniTensor & {
+           raise_unitensor_elementwise_removed(" *= ", kUniTensorMulRemovedGuidance);
+         })
     .def("__imul__",
          [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
            return self.Mul_(static_cast<cytnx::cytnx_float>(rhs));
@@ -1389,7 +1454,14 @@ void unitensor_binding(py::module &m) {
     .def("__imul__", [](UniTensor &self, const cytnx::Scalar &rhs) { return self.Mul_(rhs); })
 
     // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
-    .def("__truediv__", [](UniTensor &self, const UniTensor &rhs) { return linalg::Div(self, rhs); })
+    // Phase-2 Task 3 (#934/2026-07-06 decision): UniTensor/UniTensor (elementwise division)
+    // removed from the python surface -- per #934 it has no well-defined tensor-network
+    // meaning (basis-dependent, and typically produces inf/nan); see
+    // raise_unitensor_elementwise_removed's doc comment above.
+    .def("__truediv__",
+         [](UniTensor &self, const UniTensor &rhs) -> UniTensor {
+           raise_unitensor_elementwise_removed(" / ", kUniTensorDivRemovedGuidance);
+         })
     .def("__truediv__",
          [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
            return linalg::Div(self, static_cast<cytnx::cytnx_float>(rhs));
@@ -1484,8 +1556,12 @@ void unitensor_binding(py::module &m) {
     .def("__rtruediv__", [](UniTensor &self, const cytnx::Scalar &lhs) { return linalg::Div(lhs, self); })
 
     // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
+    // Phase-2 Task 3 (#934/2026-07-06 decision): UniTensor/=UniTensor (elementwise
+    // division) removed from the python surface; see __truediv__'s comment above.
     .def("__itruediv__",
-         [](UniTensor &self, const UniTensor &rhs) { return self.Div_(rhs); })
+         [](UniTensor &self, const UniTensor &rhs) -> UniTensor & {
+           raise_unitensor_elementwise_removed(" /= ", kUniTensorDivRemovedGuidance);
+         })
     .def("__itruediv__",
          [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
            return self.Div_(static_cast<cytnx::cytnx_float>(rhs));

--- a/pytests/binding_unitensor_elementwise_test.py
+++ b/pytests/binding_unitensor_elementwise_test.py
@@ -1,0 +1,155 @@
+"""Tests for Phase-2 Task 3 of the API-semantics plan (issue #934, #753, #675).
+
+Maintainer ruling (yingjerkao, 2026-07-06): `UniTensor` is a tensor-network
+object, not a raw array. Element-wise `UniTensor (+) UniTensor` arithmetic
+(`+`, `-`, `*`, `/`, and their reflected/in-place forms) has no general
+tensor-network meaning -- for BlockUniTensor/BlockFermionicUniTensor it either
+destroys the block structure or is basis-dependent nonsense (see #934's
+enumeration; #753/#675 document the same operations losing labels). The
+python-facing dunders for the UniTensor-vs-UniTensor overloads are removed
+and now raise TypeError with guidance pointing at Contract()/Kron()/scalar
+arithmetic. This is INTENTIONALLY narrower than the C++ layer: the internal
+C++ `operator+`/`operator-` on UniTensor (declared in include/linalg.hpp) is
+kept, because src/linalg/Lanczos_Gnd_Ut.cpp and src/linalg/Lanczos_Exp.cpp
+use it as genuine Krylov-subspace vector-space arithmetic (axpy-style linear
+combinations) inside the Lanczos/BiCGSTAB solvers that back
+`cytnx.linalg.Lanczos(..., method="Gnd")` and `cytnx.linalg.Lanczos_Exp`
+(used by the DMRG and TDVP examples). Python users never call `+`/`-` on two
+UniTensors directly for that purpose; they call the solver entry points.
+
+Scalar (Python/numpy number, cytnx.Scalar) <-> UniTensor arithmetic is
+unaffected and stays public in both directions (`2.0 * ut`, `ut * 2.0`,
+`ut + 1.5`, `ut += 2.0`, etc.).
+"""
+
+import pytest
+import cytnx
+
+
+def _pair():
+    ut1 = cytnx.UniTensor(cytnx.ones([2, 2]))
+    ut2 = cytnx.UniTensor(cytnx.ones([2, 2]))
+    return ut1, ut2
+
+
+# ---------------------------------------------------------------------------
+# Removed: UniTensor (+) UniTensor elementwise arithmetic (out-of-place)
+# ---------------------------------------------------------------------------
+
+
+def test_add_unitensor_unitensor_raises():
+    ut1, ut2 = _pair()
+    with pytest.raises(TypeError, match=r"(?s)934.*Contract"):
+        ut1 + ut2
+
+
+def test_sub_unitensor_unitensor_raises():
+    ut1, ut2 = _pair()
+    with pytest.raises(TypeError, match=r"(?s)934.*Contract"):
+        ut1 - ut2
+
+
+def test_mul_unitensor_unitensor_raises():
+    ut1, ut2 = _pair()
+    with pytest.raises(TypeError, match=r"(?s)934.*Kron"):
+        ut1 * ut2
+
+
+def test_truediv_unitensor_unitensor_raises():
+    ut1, ut2 = _pair()
+    with pytest.raises(TypeError, match=r"(?s)934.*get_block"):
+        ut1 / ut2
+
+
+# ---------------------------------------------------------------------------
+# Removed: UniTensor (+)= UniTensor elementwise arithmetic (in-place)
+# ---------------------------------------------------------------------------
+
+
+def test_iadd_unitensor_unitensor_raises():
+    ut1, ut2 = _pair()
+    with pytest.raises(TypeError, match=r"(?s)934.*Contract"):
+        ut1 += ut2
+
+
+def test_isub_unitensor_unitensor_raises():
+    ut1, ut2 = _pair()
+    with pytest.raises(TypeError, match=r"(?s)934.*Contract"):
+        ut1 -= ut2
+
+
+def test_imul_unitensor_unitensor_raises():
+    ut1, ut2 = _pair()
+    with pytest.raises(TypeError, match=r"(?s)934.*Kron"):
+        ut1 *= ut2
+
+
+def test_itruediv_unitensor_unitensor_raises():
+    ut1, ut2 = _pair()
+    with pytest.raises(TypeError, match=r"(?s)934.*get_block"):
+        ut1 /= ut2
+
+
+# ---------------------------------------------------------------------------
+# Kept: scalar (+) UniTensor / UniTensor (+) scalar in both directions,
+# out-of-place and in-place.
+# ---------------------------------------------------------------------------
+
+
+def test_scalar_mul_unitensor_both_directions_still_works():
+    ut = cytnx.UniTensor(cytnx.ones([2, 2]))
+    r1 = 2.0 * ut
+    r2 = ut * 2.0
+    assert r1.get_block()[0, 0].item() == 2.0
+    assert r2.get_block()[0, 0].item() == 2.0
+
+
+def test_scalar_add_unitensor_still_works():
+    ut = cytnx.UniTensor(cytnx.ones([2, 2]))
+    r1 = ut + 1.5
+    r2 = 1.5 + ut
+    assert r1.get_block()[0, 0].item() == 2.5
+    assert r2.get_block()[0, 0].item() == 2.5
+
+
+def test_scalar_sub_unitensor_still_works():
+    ut = cytnx.UniTensor(cytnx.ones([2, 2]))
+    r1 = ut - 0.5
+    r2 = 3.0 - ut
+    assert r1.get_block()[0, 0].item() == 0.5
+    assert r2.get_block()[0, 0].item() == 2.0
+
+
+def test_scalar_truediv_unitensor_still_works():
+    ut = cytnx.UniTensor(cytnx.ones([2, 2]))
+    r1 = ut / 2.0
+    r2 = 4.0 / ut
+    assert r1.get_block()[0, 0].item() == 0.5
+    assert r2.get_block()[0, 0].item() == 4.0
+
+
+def test_iadd_scalar_still_works():
+    # NOTE: identity preservation for in-place dunders is Task 2's concern
+    # (binding_inplace_test.py); this test only pins down that the scalar
+    # in-place arithmetic still succeeds and produces the right value.
+    ut = cytnx.UniTensor(cytnx.ones([2, 2]))
+    ut += 2.0
+    assert ut.get_block()[0, 0].item() == 3.0
+
+
+def test_isub_scalar_still_works():
+    ut = cytnx.UniTensor(cytnx.ones([2, 2]))
+    ut -= 0.5
+    assert ut.get_block()[0, 0].item() == 0.5
+
+
+def test_imul_scalar_still_works():
+    ut = cytnx.UniTensor(cytnx.ones([2, 2]))
+    ut *= 3.0
+    assert ut.get_block()[0, 0].item() == 3.0
+
+
+def test_itruediv_scalar_still_works():
+    ut = cytnx.UniTensor(cytnx.ones([2, 2]))
+    ut /= 2.0
+    assert ut.get_block()[0, 0].item() == 0.5

--- a/pytests/binding_unitensor_elementwise_test.py
+++ b/pytests/binding_unitensor_elementwise_test.py
@@ -1,21 +1,25 @@
 """Tests for Phase-2 Task 3 of the API-semantics plan (issue #934, #753, #675).
 
-Maintainer ruling (yingjerkao, 2026-07-06): `UniTensor` is a tensor-network
-object, not a raw array. Element-wise `UniTensor (+) UniTensor` arithmetic
-(`+`, `-`, `*`, `/`, and their reflected/in-place forms) has no general
-tensor-network meaning -- for BlockUniTensor/BlockFermionicUniTensor it either
-destroys the block structure or is basis-dependent nonsense (see #934's
-enumeration; #753/#675 document the same operations losing labels). The
-python-facing dunders for the UniTensor-vs-UniTensor overloads are removed
-and now raise TypeError with guidance pointing at Contract()/Kron()/scalar
-arithmetic. This is INTENTIONALLY narrower than the C++ layer: the internal
-C++ `operator+`/`operator-` on UniTensor (declared in include/linalg.hpp) is
-kept, because src/linalg/Lanczos_Gnd_Ut.cpp and src/linalg/Lanczos_Exp.cpp
-use it as genuine Krylov-subspace vector-space arithmetic (axpy-style linear
-combinations) inside the Lanczos/BiCGSTAB solvers that back
-`cytnx.linalg.Lanczos(..., method="Gnd")` and `cytnx.linalg.Lanczos_Exp`
-(used by the DMRG and TDVP examples). Python users never call `+`/`-` on two
-UniTensors directly for that purpose; they call the solver entry points.
+Maintainer ruling (yingjerkao, 2026-07-06, amended): `UniTensor` is a
+tensor-network object, not a raw array. The four elementwise
+`UniTensor (+) UniTensor` operator families split by whether the operation is
+well defined:
+
+  * ``+`` ``-`` ``+=`` ``-=`` are KEPT, but guarded: they require the two
+    operands to describe the same tensor slot (matching type, rank, labels,
+    rowrank, is_diag, bonds). With matching metadata the sum/difference is
+    unambiguous and label-preserving; with mismatched metadata the labels would
+    be silently discarded (the #934/#753/#675 complaint), so they raise
+    TypeError instead.
+  * ``*`` ``/`` ``*=`` ``/=`` are REMOVED: the elementwise (Hadamard)
+    product/quotient of two UniTensors is basis-dependent and has no
+    tensor-network meaning. They raise TypeError with guidance.
+
+The C++ ``operator+``/``operator-`` on UniTensor (declared in
+include/linalg.hpp) is unchanged: src/linalg/Lanczos_Gnd_Ut.cpp and
+src/linalg/Lanczos_Exp.cpp use it as genuine Krylov-subspace vector-space
+arithmetic backing ``cytnx.linalg.Lanczos(..., method="Gnd")`` /
+``cytnx.linalg.Lanczos_Exp`` (used by the DMRG and TDVP examples).
 
 Scalar (Python/numpy number, cytnx.Scalar) <-> UniTensor arithmetic is
 unaffected and stays public in both directions (`2.0 * ut`, `ut * 2.0`,
@@ -27,26 +31,88 @@ import cytnx
 
 
 def _pair():
+    # two structurally-identical Dense UniTensors: same default labels, bonds,
+    # rowrank, is_diag -> matching metadata.
     ut1 = cytnx.UniTensor(cytnx.ones([2, 2]))
     ut2 = cytnx.UniTensor(cytnx.ones([2, 2]))
     return ut1, ut2
 
 
 # ---------------------------------------------------------------------------
-# Removed: UniTensor (+) UniTensor elementwise arithmetic (out-of-place)
+# Kept (guarded): UniTensor +/- UniTensor with matching metadata works and
+# preserves the shared labels (the #934 label-discarding is what we guard away).
 # ---------------------------------------------------------------------------
 
 
-def test_add_unitensor_unitensor_raises():
+def test_add_unitensor_matching_metadata_works():
     ut1, ut2 = _pair()
-    with pytest.raises(TypeError, match=r"(?s)934.*Contract"):
+    labels = ut1.labels()
+    out = ut1 + ut2
+    assert out.get_block()[0, 0].item() == 2.0
+    assert out.labels() == labels  # labels preserved, not reset to a plain range
+
+
+def test_sub_unitensor_matching_metadata_works():
+    ut1, ut2 = _pair()
+    labels = ut1.labels()
+    out = ut1 - ut2
+    assert out.get_block()[0, 0].item() == 0.0
+    assert out.labels() == labels
+
+
+def test_iadd_unitensor_matching_metadata_works():
+    ut1, ut2 = _pair()
+    labels = ut1.labels()
+    ut1 += ut2
+    assert ut1.get_block()[0, 0].item() == 2.0
+    assert ut1.labels() == labels
+
+
+def test_isub_unitensor_matching_metadata_works():
+    ut1, ut2 = _pair()
+    labels = ut1.labels()
+    ut1 -= ut2
+    assert ut1.get_block()[0, 0].item() == 0.0
+    assert ut1.labels() == labels
+
+
+# ---------------------------------------------------------------------------
+# Guarded: UniTensor +/- UniTensor with mismatched metadata raises TypeError.
+# ---------------------------------------------------------------------------
+
+
+def test_add_unitensor_mismatched_labels_raises():
+    ut1 = cytnx.UniTensor(cytnx.ones([2, 2])).relabel_(["a", "b"])
+    ut2 = cytnx.UniTensor(cytnx.ones([2, 2])).relabel_(["c", "d"])
+    with pytest.raises(TypeError, match=r"(?s)labels.*934"):
         ut1 + ut2
 
 
-def test_sub_unitensor_unitensor_raises():
-    ut1, ut2 = _pair()
-    with pytest.raises(TypeError, match=r"(?s)934.*Contract"):
+def test_sub_unitensor_mismatched_labels_raises():
+    ut1 = cytnx.UniTensor(cytnx.ones([2, 2])).relabel_(["a", "b"])
+    ut2 = cytnx.UniTensor(cytnx.ones([2, 2])).relabel_(["c", "d"])
+    with pytest.raises(TypeError, match=r"(?s)labels.*934"):
         ut1 - ut2
+
+
+def test_add_unitensor_mismatched_bonds_raises():
+    # same labels, different bond dimension on leg 'b' -> bond mismatch.
+    ut1 = cytnx.UniTensor(cytnx.ones([2, 2])).relabel_(["a", "b"])
+    ut2 = cytnx.UniTensor(cytnx.ones([2, 3])).relabel_(["a", "b"])
+    with pytest.raises(TypeError, match=r"(?s)934"):
+        ut1 + ut2
+
+
+def test_iadd_unitensor_mismatched_labels_raises():
+    ut1 = cytnx.UniTensor(cytnx.ones([2, 2])).relabel_(["a", "b"])
+    ut2 = cytnx.UniTensor(cytnx.ones([2, 2])).relabel_(["c", "d"])
+    with pytest.raises(TypeError, match=r"(?s)labels.*934"):
+        ut1 += ut2
+
+
+# ---------------------------------------------------------------------------
+# Removed: UniTensor * / UniTensor elementwise arithmetic (out-of-place & in-place)
+# ---------------------------------------------------------------------------
 
 
 def test_mul_unitensor_unitensor_raises():
@@ -59,23 +125,6 @@ def test_truediv_unitensor_unitensor_raises():
     ut1, ut2 = _pair()
     with pytest.raises(TypeError, match=r"(?s)934.*get_block"):
         ut1 / ut2
-
-
-# ---------------------------------------------------------------------------
-# Removed: UniTensor (+)= UniTensor elementwise arithmetic (in-place)
-# ---------------------------------------------------------------------------
-
-
-def test_iadd_unitensor_unitensor_raises():
-    ut1, ut2 = _pair()
-    with pytest.raises(TypeError, match=r"(?s)934.*Contract"):
-        ut1 += ut2
-
-
-def test_isub_unitensor_unitensor_raises():
-    ut1, ut2 = _pair()
-    with pytest.raises(TypeError, match=r"(?s)934.*Contract"):
-        ut1 -= ut2
 
 
 def test_imul_unitensor_unitensor_raises():


### PR DESCRIPTION
## Decision

Maintainer ruling (yingjerkao, 2026-07-06, **amended**) resolving #934, #753, and #675: elementwise `UniTensor ⊙ UniTensor` arithmetic splits by whether the operation is well defined.

- **`+` `-` `+=` `-=` are kept, but guarded.** Addition/subtraction of two UniTensors is a meaningful vector-space operation *when the operands describe the same tensor slot*. The Python dunders now require matching metadata and preserve the shared labels; on a mismatch they raise a guidance `TypeError` instead of silently discarding labels.
- **`*` `/` `*=` `/=` are removed.** The elementwise (Hadamard) product/quotient of two UniTensors is basis-dependent and has no tensor-network meaning. Their dunders raise `TypeError`.

(This amends the earlier ruling, which removed all eight operators from the Python surface.)

## What changed

- The four **add/sub** dunders check that the two operands match on `uten_type`, rank, labels (in order), rowrank, `is_diag`, and bonds (`unitensor_addsub_metadata_mismatch`). On a match they perform the op and **restore the shared labels/name** — `linalg::Add`/`Sub` reset labels to a plain range and clear the name, which is exactly the #934 label-discarding complaint. On a mismatch they raise a `TypeError` naming the specific difference and suggesting `permute()`/`relabel_()` to align.
- The four **mul/div** dunders raise `TypeError` with guidance pointing at `Contract()`/`Kron()`/`ut.get_block()`.
- **Scalar ↔ UniTensor arithmetic** (both directions, out-of-place and in-place) is fully retained and dtype-preserving.
- **C++ `operator+`/`operator-` are untouched** — the Krylov solvers (`Lanczos_Gnd_Ut.cpp`, `Lanczos_Exp.cpp`) depend on them as vector-space (axpy) operations, and they carry the canonical internal/advanced doxygen note added earlier in this PR.

## Semantics of "matching metadata"

Order-sensitive: same `uten_type`, rank, labels (same order), rowrank, `is_diag`, and bonds (via `Bond::operator==`). `a["i","j"] + a["j","i"]` raises rather than auto-permuting — align the operands first. This keeps the sum/difference unambiguous and label-preserving. (For symmetric `BlockUniTensor`, the C++ `Add_` already enforces matching bonds/`is_diag`; the Python guard adds the label check and a uniform `TypeError`.)

## BREAKING CHANGE (Python users)

- `ut1 * ut2` / `ut1 / ut2` (and `*=` / `/=`) now raise `TypeError`.
- `ut1 + ut2` / `ut1 - ut2` (and `+=` / `-=`) now raise `TypeError` **when the operands' metadata do not match** (previously they silently discarded labels). With matching metadata they work and preserve labels.

The error messages carry the full migration guidance.

## Testing

`pytests/binding_unitensor_elementwise_test.py` (20 tests): matching-metadata `+`/`-`/`+=`/`-=` work and preserve labels; mismatched labels/bonds raise `TypeError`; `*`/`/`/`*=`/`/=` raise; scalar paths retained. The non-example pytest suite (68 passed, 1 skipped) and the DMRG dense / TDVP1 / ED Ising examples (4 passed, exercising the surviving C++ solver arithmetic end-to-end) confirm no regression.

## Stacking

Base PR #991 is now merged; this branch is rebased onto `master` and merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
