### PR TITLE
fix(UniTensor): rebuild block metadata instead of mutating shared blocks in-place

### DIFF
--- a/include/UniTensor.hpp
+++ b/include/UniTensor.hpp
@@ -608,7 +608,11 @@ namespace cytnx {
     }
 
     boost::intrusive_ptr<UniTensor_base> contiguous_() {
-      this->_block.contiguous_();
+      // Rebind _block to the non-mutating Tensor::contiguous() result instead of calling
+      // contiguous_() in place, so a block Tensor shared with another UniTensor (e.g. via
+      // relabel()) is not corrupted (#724). Tensor::contiguous() is cheap when the block is
+      // already contiguous (no data copy; same impl returned).
+      this->_block = this->_block.contiguous();
       return boost::intrusive_ptr<UniTensor_base>(this);
     }
     boost::intrusive_ptr<UniTensor_base> contiguous() {
@@ -1441,7 +1445,12 @@ namespace cytnx {
     }
 
     boost::intrusive_ptr<UniTensor_base> contiguous_() {
-      for (unsigned int b = 0; b < this->_blocks.size(); b++) this->_blocks[b].contiguous_();
+      // Rebind each block to the non-mutating Tensor::contiguous() result instead of calling
+      // contiguous_() in place, so a block Tensor shared with another UniTensor (e.g. via
+      // relabel()) is not corrupted (#724). Tensor::contiguous() is cheap when the block is
+      // already contiguous (no data copy; same impl returned).
+      for (unsigned int b = 0; b < this->_blocks.size(); b++)
+        this->_blocks[b] = this->_blocks[b].contiguous();
       return boost::intrusive_ptr<UniTensor_base>(this);
     }
     boost::intrusive_ptr<UniTensor_base> contiguous();
@@ -2213,7 +2222,11 @@ namespace cytnx {
 
     boost::intrusive_ptr<UniTensor_base> contiguous_() {
       //[21 Aug 2024] This is a copy from BlockUniTensor;
-      for (unsigned int b = 0; b < this->_blocks.size(); b++) this->_blocks[b].contiguous_();
+      // Rebind each block to the non-mutating Tensor::contiguous() result instead of calling
+      // contiguous_() in place, so a block Tensor shared with another UniTensor (e.g. via
+      // relabel()) is not corrupted (#724).
+      for (unsigned int b = 0; b < this->_blocks.size(); b++)
+        this->_blocks[b] = this->_blocks[b].contiguous();
       return boost::intrusive_ptr<UniTensor_base>(this);
     }
     boost::intrusive_ptr<UniTensor_base> contiguous();

--- a/src/BlockFermionicUniTensor.cpp
+++ b/src/BlockFermionicUniTensor.cpp
@@ -660,7 +660,10 @@ namespace cytnx {
       // inner_to_outer permute!
       for (cytnx_int64 b = 0; b < this->_inner_to_outer_idx.size(); b++) {
         this->_inner_to_outer_idx[b] = vec_map(this->_inner_to_outer_idx[b], mapper_u64);
-        this->_blocks[b].permute_(mapper_u64);
+        // Build new block metadata via the non-mutating Tensor::permute() and rebind _blocks[b]
+        // to it, rather than mutating the (possibly shared) block Tensor in place with
+        // permute_(), so other UniTensors sharing the same block are not corrupted (#724).
+        this->_blocks[b] = this->_blocks[b].permute(mapper_u64);
       }
 
       if (rowrank >= 0) {
@@ -790,7 +793,10 @@ namespace cytnx {
       // inner_to_outer permute!
       for (cytnx_int64 b = 0; b < this->_inner_to_outer_idx.size(); b++) {
         this->_inner_to_outer_idx[b] = vec_map(this->_inner_to_outer_idx[b], mapper_u64);
-        this->_blocks[b].permute_(mapper_u64);
+        // Build new block metadata via the non-mutating Tensor::permute() and rebind _blocks[b]
+        // to it, rather than mutating the (possibly shared) block Tensor in place with
+        // permute_(), so other UniTensors sharing the same block are not corrupted (#724).
+        this->_blocks[b] = this->_blocks[b].permute(mapper_u64);
       }
 
       if (rowrank >= 0) {
@@ -1540,6 +1546,12 @@ namespace cytnx {
             }
           }
         } else {
+          // KNOWN ISSUE (#724, not fixed by this change): same as the analogous branch in
+          // BlockUniTensor::contract() (src/BlockUniTensor.cpp) — the branches below temporarily
+          // mutate this->_blocks[a] / Rtn->_blocks[b] / tmp_Rtn->_blocks[b] in place via
+          // permute_()/reshape_(), then restore afterward. If those blocks are shared with
+          // another UniTensor, that other UniTensor is transiently (or, on an exception,
+          // permanently) corrupted. Left as a follow-up; see BlockUniTensor.cpp for details.
           BlockFermionicUniTensor *tmp_Rtn = Rtn;
           bool tmp_rtn_is_casted = false;
 
@@ -1715,6 +1727,8 @@ namespace cytnx {
           }  // end else (common_dtype <= 4)
         }
   #else
+          // NOTE: shared-block mutate/restore hazard — see KNOWN ISSUE (#724) at top of this
+          // else-block.
           // First select left block to do gemm
           for (cytnx_int64 a = 0; a < this->_blocks.size(); a++) {
             cytnx_int64 comm_dim = 1;
@@ -2694,7 +2708,9 @@ namespace cytnx {
           new_shape.push_back(this->_blocks[b].shape()[i]);
         }
       }
-      this->_blocks[b].reshape_(new_shape);
+      // Rebind to a freshly-reshaped block instead of mutating the (possibly shared) block
+      // Tensor in place, so other UniTensors sharing this block are not corrupted (#724).
+      this->_blocks[b] = this->_blocks[b].reshape(new_shape);
     }
 
     for (int b = 0; b < this->_blocks.size(); b++) {

--- a/src/BlockUniTensor.cpp
+++ b/src/BlockUniTensor.cpp
@@ -607,7 +607,11 @@ namespace cytnx {
       // inner_to_outer permute!
       for (cytnx_int64 b = 0; b < this->_inner_to_outer_idx.size(); b++) {
         this->_inner_to_outer_idx[b] = vec_map(this->_inner_to_outer_idx[b], mapper_u64);
-        this->_blocks[b].permute_(mapper_u64);
+        // Build new block metadata via the non-mutating Tensor::permute() and rebind _blocks[b]
+        // to it, rather than mutating the (possibly shared) block Tensor in place with
+        // permute_(). Storage stays shared (no data copy); only this UniTensor's block gets
+        // fresh metadata, so other UniTensors sharing the same block are not corrupted (#724).
+        this->_blocks[b] = this->_blocks[b].permute(mapper_u64);
       }
 
       if (rowrank >= 0) {
@@ -987,6 +991,18 @@ namespace cytnx {
             }
           }
         } else {
+          // KNOWN ISSUE (#724, not fixed by this change): the three branches below (the
+          // UNI_MKL integer-dtype Matmul fallback, the UNI_MKL Gemm_Batch path, and the
+          // non-MKL Matmul fallback further down) temporarily
+          // mutate this->_blocks[a] / Rtn->_blocks[b] / tmp_Rtn->_blocks[b] in place via
+          // permute_()/reshape_(), then restore the original shape/permutation afterward. If
+          // any of those blocks are shared with another UniTensor (e.g. via relabel()), that
+          // other UniTensor's block is transiently corrupted during the contraction, and would
+          // be corrupted permanently if an exception were thrown before the restore runs.
+          // Converting this to the non-mutating rebind pattern used elsewhere in this file would
+          // require threading local Tensor variables through the Gemm_Batch batching loop and
+          // the dtype-casting/early-cleanup logic across three near-duplicate branches; left as
+          // a follow-up rather than risking a rushed change to this hot contraction path.
           BlockUniTensor *tmp_Rtn = Rtn;
           bool tmp_rtn_is_casted = false;
 
@@ -1153,6 +1169,8 @@ namespace cytnx {
           }  // end else (common_dtype <= 4)
         }
   #else
+          // NOTE: shared-block mutate/restore hazard — see KNOWN ISSUE (#724) at top of this
+          // else-block.
           // First select left block to do gemm
           for (cytnx_int64 a = 0; a < this->_blocks.size(); a++) {
             cytnx_int64 comm_dim = 1;
@@ -1970,7 +1988,9 @@ namespace cytnx {
           new_shape.push_back(this->_blocks[b].shape()[i]);
         }
       }
-      this->_blocks[b].reshape_(new_shape);
+      // Rebind to a freshly-reshaped block instead of mutating the (possibly shared) block
+      // Tensor in place, so other UniTensors sharing this block are not corrupted (#724).
+      this->_blocks[b] = this->_blocks[b].reshape(new_shape);
     }
 
     for (int b = 0; b < this->_blocks.size(); b++) {

--- a/src/DenseUniTensor.cpp
+++ b/src/DenseUniTensor.cpp
@@ -368,7 +368,11 @@ namespace cytnx {
     } else {
       this->_bonds = vec_map(vec_clone(this->bonds()), mapper_u64);  // this will check validity
       this->_labels = vec_map(this->labels(), mapper_u64);
-      this->_block.permute_(mapper_u64);
+      // Build new block metadata via the non-mutating Tensor::permute() and rebind _block to it,
+      // rather than mutating the (possibly shared) block Tensor in place with permute_(). This
+      // keeps Storage shared (no data copy) while giving this UniTensor's block its own fresh
+      // metadata, so other UniTensors sharing the same block are not corrupted (#724).
+      this->_block = this->_block.permute(mapper_u64);
       if (rowrank >= 0) {
         cytnx_error_msg((rowrank > this->_bonds.size()) || (rowrank < 0),
                         "[ERROR] rowrank cannot exceed the rank of UniTensor, and should be >=0.%s",
@@ -404,7 +408,8 @@ namespace cytnx {
     } else {
       this->_bonds = vec_map(vec_clone(this->bonds()), mapper_u64);  // this will check validity
       this->_labels = vec_map(this->labels(), mapper_u64);
-      this->_block.permute_(mapper_u64);
+      // See the analogous comment in the cytnx_int64-mapper overload above (#724).
+      this->_block = this->_block.permute(mapper_u64);
       if (rowrank >= 0) {
         cytnx_error_msg((rowrank > this->_bonds.size()) || (rowrank < 0),
                         "[ERROR] rowrank cannot exceed the rank of UniTensor, and should be >=0.%s",
@@ -713,6 +718,8 @@ namespace cytnx {
                     "[ERROR] rowrank cannot larger than the rank of reshaped UniTensor.%s", "\n");
     if (this->is_diag()) {
       // if(new_shape.size()!=2){
+      // cytnx::linalg::Diag() always allocates a brand new Tensor (never shared with any other
+      // UniTensor), so mutating it in place here is safe.
       this->_block = cytnx::linalg::Diag(this->_block);
       this->_block.reshape_(new_shape);
       this->Init_by_Tensor(this->_block, false, rowrank, this->_name);
@@ -722,7 +729,9 @@ namespace cytnx {
       //    is_diag=True should have rowrank=1.%s","\n");
       //}
     } else {
-      this->_block.reshape_(new_shape);
+      // Build new block metadata via the non-mutating Tensor::reshape() and rebind _block to it,
+      // rather than mutating the (possibly shared) block Tensor in place with reshape_() (#724).
+      this->_block = this->_block.reshape(new_shape);
       this->Init_by_Tensor(this->_block, false, rowrank, this->_name);
     }
   }
@@ -841,7 +850,9 @@ namespace cytnx {
     }
     new_shape.resize(this->rank());  // rank follows this->_labels.size()!
 
-    this->_block.reshape_(new_shape);
+    // Rebind to a freshly-reshaped block instead of mutating the (possibly shared) block Tensor
+    // in place, so other UniTensors sharing this block are not corrupted (#724).
+    this->_block = this->_block.reshape(new_shape);
 
     // change rowrank:
     this->_rowrank = newrowrank;
@@ -1071,9 +1082,13 @@ namespace cytnx {
       std::vector<cytnx_int64> old_shape_L(tmpL.shape().begin(), tmpL.shape().end());
       std::vector<cytnx_int64> shape_L =
         vec_concatenate(old_shape_L, std::vector<cytnx_int64>(tmpR.shape().size(), 1));
-      tmpL.reshape_(shape_L);
+      // tmpL may still alias the same Tensor_impl as this->_block (see the "share view!!" copy
+      // above when already contiguous), which may itself be shared with other UniTensors.
+      // Rebind via the non-mutating reshape() instead of reshape_() so we don't transiently (or,
+      // if Kron() throws, permanently) corrupt that shared block's metadata (#724). tmpL is a
+      // local scratch variable not used after Kron(), so no "reshape back" is needed anymore.
+      tmpL = tmpL.reshape(shape_L);
       tmp->_block = linalg::Kron(tmpL, tmpR, false, true);
-      tmpL.reshape_(old_shape_L);
       tmp->_is_diag = false;
 
       //}

--- a/tests/BlockFermionicUniTensor_test.cpp
+++ b/tests/BlockFermionicUniTensor_test.cpp
@@ -163,7 +163,7 @@ TEST_F(BlockFermionicUniTensorTest, SaveLoad) {
   UniTensor BFUT1_loaded = BFUT1_loaded.Load(temp_file_path);
   EXPECT_TRUE(AreEqUniTensor(BFUT1, BFUT1_loaded));
   // for char*
-  const char *fname = temp_file_path.c_str();
+  const char* fname = temp_file_path.c_str();
   BFUT1.Save(fname);
   UniTensor BFUT1_loaded_char_save = BFUT1_loaded_char_save.Load(temp_file_path);
   EXPECT_TRUE(AreEqUniTensor(BFUT1, BFUT1_loaded_char_save));
@@ -217,6 +217,58 @@ TEST_F(BlockFermionicUniTensorTest, Transpose) {
   EXPECT_EQ(tmp2.bonds()[1].type(), BD_OUT);
   EXPECT_EQ(tmp2.bonds()[2].type(), BD_OUT);
   EXPECT_TRUE(AreEqUniTensor(tmp2, tmp));
+}
+
+/*=====test info=====
+describe:regression test for issue #724 on the BlockFermionicUniTensor path.
+         Two UniTensors sharing the same underlying block Tensors (via
+         relabel(), documented to share data with the original) must not
+         corrupt each other's metadata when one of them is permuted in
+         place with permute_(). BlockFermionicUniTensor::permute_ is a
+         distinct implementation from BlockUniTensor's (it additionally
+         updates the per-block sign-flip state), so it gets its own test.
+====================*/
+TEST_F(BlockFermionicUniTensorTest, PermuteInPlaceOnSharedBlockDoesNotCorruptOtherHolder) {
+  UniTensor uT = BFUT3.clone().set_name("uT");
+  UniTensor uT2 = uT.relabel({"p", "q", "r", "s", "t"}).set_name("uT2");
+
+  // Precondition: the two UniTensors really do share the same block storage.
+  ASSERT_TRUE(uT.same_data(uT2));
+  ASSERT_EQ(uT.Nblocks(), uT2.Nblocks());
+
+  const auto orig_shape = uT.shape();
+  const auto orig_labels = uT.labels();
+  const auto orig_signflip = uT.signflip();
+  // The 8 non-zero entries of BFUT3 as initialized in the fixture.
+  const std::vector<std::vector<cytnx_uint64>> nz_locs = {
+    {0, 0, 0, 0, 0}, {0, 0, 1, 0, 0}, {0, 1, 2, 0, 0}, {0, 1, 3, 0, 0},
+    {1, 0, 2, 0, 0}, {1, 0, 3, 0, 0}, {1, 1, 0, 0, 0}, {1, 1, 1, 0, 0}};
+  const std::vector<double> nz_vals = {1., 2., 3., 4., 5., 6., 7., 8.};
+
+  std::vector<cytnx_int64> a = {3, 1, 4, 2, 0};
+  uT2.permute_(a);
+
+  // uT2 changed as expected: after resolving the pending sign flips it must match the
+  // BFUT3PERM reference (same permutation as the pre-existing LinAlgElementwise test).
+  EXPECT_TRUE(AreEqUniTensor(BFUT3PERM, uT2.contiguous().apply()));
+
+  // uT must be completely unaffected: shape, labels, sign-flip state, and data all preserved.
+  ASSERT_EQ(uT.shape(), orig_shape);
+  EXPECT_EQ(uT.labels(), orig_labels);
+  EXPECT_EQ(uT.signflip(), orig_signflip);
+  EXPECT_TRUE(AreEqUniTensor(uT, BFUT3));
+  // Reading uT after uT2's in-place permute must not even throw (stale block/qnum mapping vs. a
+  // physically permuted shared block Tensor can manifest as an out-of-bound access).
+  for (size_t n = 0; n < nz_locs.size(); n++) {
+    try {
+      ASSERT_TRUE(uT.at(nz_locs[n]).exists());
+      EXPECT_DOUBLE_EQ(double(uT.at(nz_locs[n]).real()), nz_vals[n]);
+    } catch (const std::exception& e) {
+      ADD_FAILURE() << "uT.at(nz_locs[" << n
+                    << "]) threw after uT2.permute_() (shared-block metadata corrupted): "
+                    << e.what();
+    }
+  }
 }
 
 // ============ convert_from / from_ ============

--- a/tests/BlockUniTensor_test.cpp
+++ b/tests/BlockUniTensor_test.cpp
@@ -327,6 +327,104 @@ TEST_F(BlockUniTensorTest, permute_2) {
     }
 }
 
+/*=====test info=====
+describe:regression test for issue #724 on the BlockUniTensor path. Two
+         UniTensors sharing the same underlying block Tensors (via
+         relabel(), documented to share data with the original) must not
+         corrupt each other's metadata when one of them is permuted in
+         place with permute_().
+====================*/
+TEST_F(BlockUniTensorTest, PermuteInPlaceOnSharedBlockDoesNotCorruptOtherHolder) {
+  UniTensor uT = UT_permute_2.clone().set_name("uT");
+  UniTensor uT2 = uT.relabel({"a", "b"}).set_name("uT2");
+
+  // Precondition: the two UniTensors really do share the same block storage.
+  ASSERT_TRUE(uT.same_data(uT2));
+  ASSERT_EQ(uT.Nblocks(), uT2.Nblocks());
+
+  const auto orig_shape = uT.shape();
+  const auto orig_labels = uT.labels();
+  ASSERT_EQ(orig_shape, std::vector<cytnx_uint64>({10, 10}));
+  std::vector<std::vector<double>> orig_vals(10, std::vector<double>(10, 0.0));
+  std::vector<std::vector<bool>> orig_exists(10, std::vector<bool>(10, false));
+  for (cytnx_int64 j = 0; j < 10; j++)
+    for (cytnx_int64 k = 0; k < 10; k++) {
+      orig_exists[j][k] = uT.at({j, k}).exists();
+      if (orig_exists[j][k]) orig_vals[j][k] = double(uT.at({j, k}).real());
+    }
+
+  std::vector<cytnx_int64> a = {1, 0};
+  uT2.permute_(a, -1);
+
+  // uT2 changed as expected (matches the pre-existing permute_2 reference answer).
+  for (cytnx_int64 j = 0; j < 10; j++)
+    for (cytnx_int64 k = 0; k < 10; k++) {
+      EXPECT_EQ(uT2.at({j, k}).exists(), UT_permute_ans2.at({j, k}).exists());
+      if (uT2.at({j, k}).exists())
+        EXPECT_EQ(double(uT2.at({j, k}).real()), double(UT_permute_ans2.at({j, k}).real()));
+    }
+
+  // uT must be completely unaffected: shape, labels, and data all preserved. Reading uT after
+  // uT2's in-place permute must not even throw (a stale block/qnum mapping vs. a physically
+  // permuted shared block Tensor can manifest as an out-of-bound access), so guard each read.
+  ASSERT_EQ(uT.shape(), orig_shape);
+  EXPECT_EQ(uT.labels(), orig_labels);
+  for (cytnx_int64 j = 0; j < 10; j++)
+    for (cytnx_int64 k = 0; k < 10; k++) {
+      try {
+        EXPECT_EQ(uT.at({j, k}).exists(), orig_exists[j][k]);
+        if (orig_exists[j][k] && uT.at({j, k}).exists())
+          EXPECT_EQ(double(uT.at({j, k}).real()), orig_vals[j][k]);
+      } catch (const std::exception& e) {
+        ADD_FAILURE() << "uT.at({" << j << "," << k
+                      << "}) threw after uT2.permute_() (shared-block metadata corrupted): "
+                      << e.what();
+      }
+    }
+}
+
+/*=====test info=====
+describe:control test - when blocks are NOT shared (independent clone), an
+         in-place permute_() on one BlockUniTensor must not affect the
+         other. Guards against a fix that over-isolates or breaks normal
+         (non-shared) permute_ behavior.
+====================*/
+TEST_F(BlockUniTensorTest, PermuteInPlaceOnNonSharedBlockLeavesCloneUnaffected) {
+  UniTensor uT = UT_permute_2.clone().set_name("uT");
+  UniTensor uT_indep = uT.clone().set_name("uT_indep");
+
+  ASSERT_FALSE(uT.same_data(uT_indep));
+
+  const auto orig_shape = uT.shape();
+  std::vector<std::vector<bool>> orig_exists(10, std::vector<bool>(10, false));
+  std::vector<std::vector<double>> orig_vals(10, std::vector<double>(10, 0.0));
+  for (cytnx_int64 j = 0; j < 10; j++)
+    for (cytnx_int64 k = 0; k < 10; k++) {
+      orig_exists[j][k] = uT.at({j, k}).exists();
+      if (orig_exists[j][k]) orig_vals[j][k] = double(uT.at({j, k}).real());
+    }
+
+  std::vector<cytnx_int64> a = {1, 0};
+  uT_indep.permute_(a, -1);
+
+  // uT_indep must match the known permute_2 reference answer (proves the permute really ran).
+  for (cytnx_int64 j = 0; j < 10; j++)
+    for (cytnx_int64 k = 0; k < 10; k++) {
+      EXPECT_EQ(uT_indep.at({j, k}).exists(), UT_permute_ans2.at({j, k}).exists());
+      if (uT_indep.at({j, k}).exists())
+        EXPECT_EQ(double(uT_indep.at({j, k}).real()), double(UT_permute_ans2.at({j, k}).real()));
+    }
+
+  // uT (the clone source, independent storage) must be completely unaffected.
+  EXPECT_EQ(uT.shape(), orig_shape);
+  for (cytnx_int64 j = 0; j < 10; j++)
+    for (cytnx_int64 k = 0; k < 10; k++) {
+      EXPECT_EQ(uT.at({j, k}).exists(), orig_exists[j][k]);
+      if (orig_exists[j][k] && uT.at({j, k}).exists())
+        EXPECT_EQ(double(uT.at({j, k}).real()), orig_vals[j][k]);
+    }
+}
+
 TEST_F(BlockUniTensorTest, contiguous) {
   auto bks = UT_pB_ans.permute({1, 2, 0}).contiguous().get_blocks();
 

--- a/tests/DenseUniTensor_test.cpp
+++ b/tests/DenseUniTensor_test.cpp
@@ -2010,6 +2010,122 @@ TEST_F(DenseUniTensorTest, reshape_utuninit) {
 }
 
 /*=====test info=====
+describe:regression test for issue #724. Two UniTensors sharing the same
+         underlying block Tensor (via relabel(), which is documented to
+         return a new UniTensor whose data is still shared with the
+         original) must not corrupt each other's metadata when one of them
+         is permuted in place with permute_(). Reproduces the exact
+         scenario from the issue report.
+====================*/
+TEST_F(DenseUniTensorTest, PermuteInPlaceOnSharedBlockDoesNotCorruptOtherHolder) {
+  UniTensor uT = UniTensor::arange(6).reshape({2, 3}).set_name("uT").set_rowrank(1);
+  UniTensor uT2 = uT.relabel({"a", "b"}).set_name("uT2");
+
+  // Precondition: the two UniTensors really do share the same block storage.
+  ASSERT_TRUE(uT.same_data(uT2));
+
+  const auto orig_shape = uT.shape();
+  const auto orig_labels = uT.labels();
+  std::vector<std::vector<double>> orig_vals(2, std::vector<double>(3));
+  for (cytnx_uint64 i = 0; i < 2; i++)
+    for (cytnx_uint64 j = 0; j < 3; j++) orig_vals[i][j] = double(uT.at({i, j}).real());
+
+  uT2.permute_(std::vector<cytnx_int64>{1, 0});
+
+  // uT2 changed as expected.
+  EXPECT_EQ(uT2.shape(), std::vector<cytnx_uint64>({3, 2}));
+
+  // uT must be completely unaffected: shape, labels, and data all preserved. Reading uT after
+  // uT2's in-place permute must not even throw (metadata desynced from the physically permuted
+  // shared block Tensor can manifest as an out-of-bound access), so guard each read.
+  EXPECT_EQ(uT.shape(), orig_shape);
+  EXPECT_EQ(uT.labels(), orig_labels);
+  for (cytnx_uint64 i = 0; i < 2; i++)
+    for (cytnx_uint64 j = 0; j < 3; j++) {
+      try {
+        EXPECT_DOUBLE_EQ(double(uT.at({i, j}).real()), orig_vals[i][j]);
+      } catch (const std::exception &e) {
+        ADD_FAILURE() << "uT.at({" << i << "," << j
+                      << "}) threw after uT2.permute_() (shared-block metadata corrupted): "
+                      << e.what();
+      }
+    }
+
+  // uT2 must still read back the correct (permuted) data.
+  for (cytnx_uint64 i = 0; i < 2; i++)
+    for (cytnx_uint64 j = 0; j < 3; j++)
+      EXPECT_DOUBLE_EQ(double(uT2.at({j, i}).real()), orig_vals[i][j]);
+}
+
+/*=====test info=====
+describe:regression test for issue #724, reshape_() variant. Same sharing
+         setup as PermuteInPlaceOnSharedBlockDoesNotCorruptOtherHolder, but
+         calling reshape_() on the shared-block holder instead of
+         permute_(), per manuschneider's comment that reshape_() is
+         similarly affected.
+====================*/
+TEST_F(DenseUniTensorTest, ReshapeInPlaceOnSharedBlockDoesNotCorruptOtherHolder) {
+  UniTensor uT = UniTensor::arange(6).reshape({2, 3}).set_name("uT");
+  UniTensor uT2 = uT.relabel({"a", "b"}).set_name("uT2");
+
+  ASSERT_TRUE(uT.same_data(uT2));
+
+  const auto orig_shape = uT.shape();
+  std::vector<double> orig_vals(6);
+  for (cytnx_uint64 i = 0; i < 2; i++)
+    for (cytnx_uint64 j = 0; j < 3; j++) orig_vals[i * 3 + j] = double(uT.at({i, j}).real());
+
+  uT2.reshape_({3, 2});
+
+  EXPECT_EQ(uT2.shape(), std::vector<cytnx_uint64>({3, 2}));
+
+  // uT must be unaffected by uT2's in-place reshape. Guard reads since a metadata/storage
+  // mismatch from the bug can manifest as an out-of-bound access rather than just wrong data.
+  EXPECT_EQ(uT.shape(), orig_shape);
+  for (cytnx_uint64 i = 0; i < 2; i++)
+    for (cytnx_uint64 j = 0; j < 3; j++) {
+      try {
+        EXPECT_DOUBLE_EQ(double(uT.at({i, j}).real()), orig_vals[i * 3 + j]);
+      } catch (const std::exception &e) {
+        ADD_FAILURE() << "uT.at({" << i << "," << j
+                      << "}) threw after uT2.reshape_() (shared-block metadata corrupted): "
+                      << e.what();
+      }
+    }
+
+  // uT2 must read back the correctly reshaped data.
+  for (cytnx_uint64 i = 0; i < 3; i++)
+    for (cytnx_uint64 j = 0; j < 2; j++)
+      EXPECT_DOUBLE_EQ(double(uT2.at({i, j}).real()), orig_vals[i * 2 + j]);
+}
+
+/*=====test info=====
+describe:control test - when blocks are NOT shared (independent clone),
+         in-place permute_() on one UniTensor must obviously not affect the
+         other; this guards against a fix that accidentally over-isolates
+         or breaks normal (non-shared) permute_ behavior.
+====================*/
+TEST_F(DenseUniTensorTest, PermuteInPlaceOnNonSharedBlockLeavesCloneUnaffected) {
+  UniTensor uT = UniTensor::arange(6).reshape({2, 3}).set_name("uT");
+  UniTensor uT_indep = uT.clone().set_name("uT_indep");
+
+  ASSERT_FALSE(uT.same_data(uT_indep));
+
+  const auto orig_shape = uT.shape();
+  std::vector<double> orig_vals(6);
+  for (cytnx_uint64 i = 0; i < 2; i++)
+    for (cytnx_uint64 j = 0; j < 3; j++) orig_vals[i * 3 + j] = double(uT.at({i, j}).real());
+
+  uT_indep.permute_(std::vector<cytnx_int64>{1, 0});
+
+  EXPECT_EQ(uT_indep.shape(), std::vector<cytnx_uint64>({3, 2}));
+  EXPECT_EQ(uT.shape(), orig_shape);
+  for (cytnx_uint64 i = 0; i < 2; i++)
+    for (cytnx_uint64 j = 0; j < 3; j++)
+      EXPECT_DOUBLE_EQ(double(uT.at({i, j}).real()), orig_vals[i * 3 + j]);
+}
+
+/*=====test info=====
 describe:test to_dense
 ====================*/
 TEST_F(DenseUniTensorTest, to_dense) {


### PR DESCRIPTION
## Problem

Fixes the core of #724. UniTensors can share block Tensors (e.g. `relabel()` copies the block handles), but the in-place `permute_`/`reshape_`/`contiguous_`/`combineBonds` implementations mutated per-block metadata directly — corrupting every other holder of the same block (wrong shapes, out-of-bounds reads).

## Fix

Per the approach agreed in the issue thread (manuschneider's proposal, endorsed by ianmccul): 13 sites across `DenseUniTensor`/`BlockUniTensor`/`BlockFermionicUniTensor` now rebuild block metadata via the non-mutating `Tensor::permute()/reshape()/contiguous()` and rebind (`_blocks[i] = _blocks[i].permute(...)`) — storage stays shared, metadata detaches. The one deliberate remainder: `Block*UniTensor::contract`'s transient mutate-restore of blocks (three hot-path branches) is marked with in-code `KNOWN ISSUE (#724)` blocks and breadcrumbs and is being fixed separately (in-flight follow-up session).

## Testing

Six new gtests: shared-block `permute_` (Dense, Block, BlockFermionic — the latter also pins the signflip vector), shared-block `reshape_` (Dense), and two non-shared control tests. Red-proved by reverting fix sites. Full suite: 1073 passed / 11 skipped / only the 4 pre-existing failures addressed by #977.

🤖 Generated with [Claude Code](https://claude.com/claude-code)