### PR TITLE
fix(ci): set git identity before re-merging target branch in PR workflows

### DIFF
--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -32,7 +32,11 @@ jobs:
       # This step ensures we always test against the most recent target branch.
       - name: Merge with latest target branch (pull_request only)
         if: github.event_name == 'pull_request'
+        # A committer identity is required because a non-fast-forward merge
+        # creates a merge commit.
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin ${{ github.event.pull_request.base.ref }}
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
           # Refresh submodules in case the merge moved any gitlinks (e.g. cmake_modules/morse_cmake).

--- a/.github/workflows/ci-downstream-find-package.yml
+++ b/.github/workflows/ci-downstream-find-package.yml
@@ -63,7 +63,11 @@ jobs:
       # commit, so merge the latest target branch to test against current tip.
       - name: Merge with latest target branch (pull_request only)
         if: github.event_name == 'pull_request'
+        # A committer identity is required because a non-fast-forward merge
+        # creates a merge commit.
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin ${{ github.event.pull_request.base.ref }}
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
           # Refresh submodules in case the merge moved any gitlinks.

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -16,7 +16,11 @@ jobs:
     # This step ensures we always test against the most recent target branch.
     - name: Merge with latest target branch (pull_request only)
       if: github.event_name == 'pull_request'
+      # A committer identity is required because a non-fast-forward merge
+      # creates a merge commit.
       run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
         git fetch origin ${{ github.event.pull_request.base.ref }}
         git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 

--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -32,7 +32,11 @@ jobs:
     # This step ensures we always test against the most recent target branch.
     - name: Merge with latest target branch (pull_request only)
       if: github.event_name == 'pull_request'
+      # A committer identity is required because a non-fast-forward merge
+      # creates a merge commit.
       run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
         git fetch origin ${{ github.event.pull_request.base.ref }}
         git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
         # Refresh submodules in case the merge moved any gitlinks (e.g. cmake_modules/morse_cmake).


### PR DESCRIPTION
## Summary

Several PR workflows re-merge the base branch at job start so CI tests against the latest target branch, rather than a stale merge-preview commit:

```yaml
git fetch origin ${{ github.event.pull_request.base.ref }}
git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
```

When the base branch has advanced since GitHub computed the PR's merge-preview commit, this is a non-fast-forward merge, so git needs to create a real merge commit — which requires a committer identity. Ubuntu-hosted runners don't have one configured, while macOS-hosted runners do (a `~/.gitconfig` is baked into that image), so this fails intermittently and only on Ubuntu with:

```
Committer identity unknown
fatal: empty ident name (for <runner@...>) not allowed
```

This was observed on PR #987, where `BuildAndTest-ubuntu-latest`, `DownstreamFindPackage`, and `Formatting Check` all failed this way after `master` advanced mid-run, while the macOS legs of the same run succeeded.

`release_pypi.yml` already sets a bot git identity before this same merge step. This PR applies the identical fix to the other four workflows that have the same unguarded pattern:
- `ci-cmake_tests.yml`
- `ci-downstream-find-package.yml`
- `clang-format-check.yml`
- `conda_build.yml`

## Test plan

- [ ] CI passes on this PR (Ubuntu legs in particular)

---
_Generated by [Claude Code](https://claude.ai/code/session_019tRCuXPzR1xjMrGVTYDFNC)_