### PR TITLE
Use cuda::std::complex for typed GPU complex dispatch

### DIFF
--- a/include/Tensor.hpp
+++ b/include/Tensor.hpp
@@ -514,9 +514,10 @@ namespace cytnx {
 
     // Convert storage to the logical Cytnx element pointer type.
     //
-    // Use ptr_as<T>() for host code and raw memory copies, including cudaMemcpy. For complex
-    // tensors, T is std::complex<...>. Use gpu_ptr_as<T>() only for CUDA APIs that require CUDA
-    // ABI element types such as cuDoubleComplex or cuComplex.
+    // Use ptr_as<T>() for host code and raw memory copies. For complex tensors, T is
+    // std::complex<...>. Use gpu_ptr_as<T>() for CUDA kernel code; for complex tensors, T is
+    // cuda::std::complex<...>. CUDA library APIs that require cuComplex ABI pointers should cast
+    // explicitly at the library-call boundary.
     template <typename T>
     T *ptr_as() const {
       cytnx_error_msg(this->dtype() != Type_class::cy_typeid_v<std::remove_cv_t<T>>,
@@ -535,10 +536,11 @@ namespace cytnx {
     // convert this->_impl->_storage->Mem to a typed variant of pointers, excluding void*
     gpu_pointer_types gpu_ptr() const;
 
-    // Convert storage to the CUDA ABI element pointer type.
+    // Convert storage to the CUDA kernel element pointer type.
     //
-    // This is for CUDA/cuBLAS/cuSOLVER/kernel interfaces. Generic host code and cudaMemcpy byte
-    // copies should use ptr_as<T>() so the logical Cytnx dtype mapping is checked.
+    // This is for CUDA kernel interfaces. Generic host code should use ptr_as<T>() so the logical
+    // Cytnx dtype mapping is checked. CUDA library APIs that require cuComplex ABI pointers should
+    // cast explicitly at the library-call boundary.
     template <typename T>
     T *gpu_ptr_as() const {
       cytnx_error_msg(

--- a/include/Type.hpp
+++ b/include/Type.hpp
@@ -13,6 +13,10 @@
 
 #include "cytnx_error.hpp"  // also brings in cuComplex.h
 
+#ifdef UNI_GPU
+  #include <cuda/std/complex>
+#endif
+
 #define MKL_Complex8 std::complex<float>
 #define MKL_Complex16 std::complex<double>
 
@@ -51,6 +55,11 @@ namespace cytnx {
   typedef std::complex<double> cytnx_complex128;
   typedef bool cytnx_bool;
 
+#ifdef UNI_GPU
+  using cytnx_cuda_complex64 = cuda::std::complex<float>;
+  using cytnx_cuda_complex128 = cuda::std::complex<double>;
+#endif
+
   namespace internal {
     template <class>
     struct is_complex_impl : std::false_type {};
@@ -58,11 +67,21 @@ namespace cytnx {
     template <class T>
     struct is_complex_impl<std::complex<T>> : std::true_type {};
 
+#ifdef UNI_GPU
+    template <class T>
+    struct is_complex_impl<cuda::std::complex<T>> : std::true_type {};
+#endif
+
     template <typename>
     struct is_complex_floating_point_impl : std::false_type {};
 
     template <typename T>
     struct is_complex_floating_point_impl<std::complex<T>> : std::is_floating_point<T> {};
+
+#ifdef UNI_GPU
+    template <typename T>
+    struct is_complex_floating_point_impl<cuda::std::complex<T>> : std::is_floating_point<T> {};
+#endif
 
     template <std::size_t I, typename T, typename Tuple>
     constexpr std::size_t index_in_tuple_helper() {
@@ -157,11 +176,13 @@ namespace cytnx {
     std::variant<void, cytnx_complex128, cytnx_complex64, cytnx_double, cytnx_float, cytnx_int64,
                  cytnx_uint64, cytnx_int32, cytnx_uint32, cytnx_int16, cytnx_uint16, cytnx_bool>;
 
-  // For GPU storage, the types are slightly different because CUDA uses their own complex type
+  // For GPU kernels, use cuda::std::complex for complex arithmetic. Low-level CUDA library calls
+  // that require cuComplex ABI pointers should cast explicitly at those call boundaries.
 #ifdef UNI_GPU
   using Type_list_gpu =
-    std::variant<void, cuDoubleComplex, cuComplex, cytnx_double, cytnx_float, cytnx_int64,
-                 cytnx_uint64, cytnx_int32, cytnx_uint32, cytnx_int16, cytnx_uint16, cytnx_bool>;
+    std::variant<void, cytnx_cuda_complex128, cytnx_cuda_complex64, cytnx_double, cytnx_float,
+                 cytnx_int64, cytnx_uint64, cytnx_int32, cytnx_uint32, cytnx_int16, cytnx_uint16,
+                 cytnx_bool>;
 #endif
 
   // The number of supported types

--- a/src/backend/algo_internal_gpu/cuSort_internal.cuh
+++ b/src/backend/algo_internal_gpu/cuSort_internal.cuh
@@ -20,7 +20,7 @@ namespace cytnx {
     template <typename T>
     __host__ __device__ bool cuSortCompare(const T& a, const T& b) {
       if constexpr (is_complex_v<T>) {
-        return (real(a) == real(b)) ? (imag(a) < imag(b)) : (real(a) < real(b));
+        return (a.real() == b.real()) ? (a.imag() < b.imag()) : (a.real() < b.real());
       } else if constexpr (Vec2Like<T>) {
         return (a.x == b.x) ? (a.y < b.y) : (a.x < b.x);
       } else {

--- a/src/backend/linalg_internal_gpu/cuAdd_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuAdd_internal.cu
@@ -7,38 +7,9 @@ namespace cytnx {
 
     namespace {
 
-      template <typename T>
-      __device__ inline cuDoubleComplex CuToComplexDouble(const T &v) {
-        return make_cuDoubleComplex(static_cast<cytnx_double>(v), 0.0);
-      }
-
-      __device__ inline cuDoubleComplex CuToComplexDouble(const cuDoubleComplex &v) { return v; }
-
-      __device__ inline cuDoubleComplex CuToComplexDouble(const cuComplex &v) {
-        return cuComplexFloatToDouble(v);
-      }
-
-      template <typename T>
-      __device__ inline cuComplex CuToComplexFloat(const T &v) {
-        return make_cuFloatComplex(static_cast<cytnx_float>(v), 0.0f);
-      }
-
-      __device__ inline cuComplex CuToComplexFloat(const cuComplex &v) { return v; }
-
-      __device__ inline cuComplex CuToComplexFloat(const cuDoubleComplex &v) {
-        return make_cuFloatComplex(static_cast<cytnx_float>(cuCreal(v)),
-                                   static_cast<cytnx_float>(cuCimag(v)));
-      }
-
       template <typename TO, typename TL, typename TR>
       __device__ inline TO CuAddDispatchOp(const TL &lhs, const TR &rhs) {
-        if constexpr (std::is_same_v<TO, cuDoubleComplex>) {
-          return cuCadd(CuToComplexDouble(lhs), CuToComplexDouble(rhs));
-        } else if constexpr (std::is_same_v<TO, cuComplex>) {
-          return cuCaddf(CuToComplexFloat(lhs), CuToComplexFloat(rhs));
-        } else {
-          return static_cast<TO>(lhs) + static_cast<TO>(rhs);
-        }
+        return TO(lhs) + TO(rhs);
       }
 
       template <typename TO, typename TL, typename TR>
@@ -178,12 +149,12 @@ namespace cytnx {
                               const std::vector<cytnx_uint64> &invmapper_R) {
         switch (Rin->dtype()) {
           case Type.ComplexDouble:
-            cuAdd_dispatch_typed<TL, cuDoubleComplex>(out, Lin, Rin, len, shape, invmapper_L,
-                                                      invmapper_R);
+            cuAdd_dispatch_typed<TL, cytnx_cuda_complex128>(out, Lin, Rin, len, shape, invmapper_L,
+                                                            invmapper_R);
             break;
           case Type.ComplexFloat:
-            cuAdd_dispatch_typed<TL, cuComplex>(out, Lin, Rin, len, shape, invmapper_L,
-                                                invmapper_R);
+            cuAdd_dispatch_typed<TL, cytnx_cuda_complex64>(out, Lin, Rin, len, shape, invmapper_L,
+                                                           invmapper_R);
             break;
           case Type.Double:
             cuAdd_dispatch_typed<TL, cytnx_double>(out, Lin, Rin, len, shape, invmapper_L,
@@ -242,10 +213,12 @@ namespace cytnx {
 
       switch (Lin->dtype()) {
         case Type.ComplexDouble:
-          cuAdd_dispatch_rhs<cuDoubleComplex>(out, Lin, Rin, len, shape, invmapper_L, invmapper_R);
+          cuAdd_dispatch_rhs<cytnx_cuda_complex128>(out, Lin, Rin, len, shape, invmapper_L,
+                                                    invmapper_R);
           break;
         case Type.ComplexFloat:
-          cuAdd_dispatch_rhs<cuComplex>(out, Lin, Rin, len, shape, invmapper_L, invmapper_R);
+          cuAdd_dispatch_rhs<cytnx_cuda_complex64>(out, Lin, Rin, len, shape, invmapper_L,
+                                                   invmapper_R);
           break;
         case Type.Double:
           cuAdd_dispatch_rhs<cytnx_double>(out, Lin, Rin, len, shape, invmapper_L, invmapper_R);

--- a/src/backend/linalg_internal_gpu/cuDiv_dispatch.cu
+++ b/src/backend/linalg_internal_gpu/cuDiv_dispatch.cu
@@ -7,38 +7,9 @@ namespace cytnx {
 
     namespace {
 
-      template <typename T>
-      __device__ inline cuDoubleComplex CuToComplexDouble(const T &v) {
-        return make_cuDoubleComplex(static_cast<cytnx_double>(v), 0.0);
-      }
-
-      __device__ inline cuDoubleComplex CuToComplexDouble(const cuDoubleComplex &v) { return v; }
-
-      __device__ inline cuDoubleComplex CuToComplexDouble(const cuComplex &v) {
-        return cuComplexFloatToDouble(v);
-      }
-
-      template <typename T>
-      __device__ inline cuComplex CuToComplexFloat(const T &v) {
-        return make_cuFloatComplex(static_cast<cytnx_float>(v), 0.0f);
-      }
-
-      __device__ inline cuComplex CuToComplexFloat(const cuComplex &v) { return v; }
-
-      __device__ inline cuComplex CuToComplexFloat(const cuDoubleComplex &v) {
-        return make_cuFloatComplex(static_cast<cytnx_float>(cuCreal(v)),
-                                   static_cast<cytnx_float>(cuCimag(v)));
-      }
-
       template <typename TO, typename TL, typename TR>
       __device__ inline TO CuDivDispatchOp(const TL &lhs, const TR &rhs) {
-        if constexpr (std::is_same_v<TO, cuDoubleComplex>) {
-          return cuCdiv(CuToComplexDouble(lhs), CuToComplexDouble(rhs));
-        } else if constexpr (std::is_same_v<TO, cuComplex>) {
-          return cuCdivf(CuToComplexFloat(lhs), CuToComplexFloat(rhs));
-        } else {
-          return static_cast<TO>(lhs) / static_cast<TO>(rhs);
-        }
+        return TO(lhs) / TO(rhs);
       }
 
       template <typename TO, typename TL, typename TR>
@@ -178,12 +149,12 @@ namespace cytnx {
                               const std::vector<cytnx_uint64> &invmapper_R) {
         switch (Rin->dtype()) {
           case Type.ComplexDouble:
-            cuDiv_dispatch_typed<TL, cuDoubleComplex>(out, Lin, Rin, len, shape, invmapper_L,
-                                                      invmapper_R);
+            cuDiv_dispatch_typed<TL, cytnx_cuda_complex128>(out, Lin, Rin, len, shape, invmapper_L,
+                                                            invmapper_R);
             break;
           case Type.ComplexFloat:
-            cuDiv_dispatch_typed<TL, cuComplex>(out, Lin, Rin, len, shape, invmapper_L,
-                                                invmapper_R);
+            cuDiv_dispatch_typed<TL, cytnx_cuda_complex64>(out, Lin, Rin, len, shape, invmapper_L,
+                                                           invmapper_R);
             break;
           case Type.Double:
             cuDiv_dispatch_typed<TL, cytnx_double>(out, Lin, Rin, len, shape, invmapper_L,
@@ -242,10 +213,12 @@ namespace cytnx {
 
       switch (Lin->dtype()) {
         case Type.ComplexDouble:
-          cuDiv_dispatch_rhs<cuDoubleComplex>(out, Lin, Rin, len, shape, invmapper_L, invmapper_R);
+          cuDiv_dispatch_rhs<cytnx_cuda_complex128>(out, Lin, Rin, len, shape, invmapper_L,
+                                                    invmapper_R);
           break;
         case Type.ComplexFloat:
-          cuDiv_dispatch_rhs<cuComplex>(out, Lin, Rin, len, shape, invmapper_L, invmapper_R);
+          cuDiv_dispatch_rhs<cytnx_cuda_complex64>(out, Lin, Rin, len, shape, invmapper_L,
+                                                   invmapper_R);
           break;
         case Type.Double:
           cuDiv_dispatch_rhs<cytnx_double>(out, Lin, Rin, len, shape, invmapper_L, invmapper_R);

--- a/src/backend/linalg_internal_gpu/cuKron_internal.cuh
+++ b/src/backend/linalg_internal_gpu/cuKron_internal.cuh
@@ -46,7 +46,7 @@ namespace cytnx {
           x += cytnx_uint64(tmp2 / info[offset2 + j]) * info[len_nsa + j];
           y += cytnx_uint64(tmp2 % info[offset2 + j]) * info[offset1 + j];
         }
-        out[blockIdx.x * blockDim.x + threadIdx.x] = Lin[x] * Rin[y];
+        out[blockIdx.x * blockDim.x + threadIdx.x] = TO(Lin[x]) * TO(Rin[y]);
       }
     }
 

--- a/src/backend/linalg_internal_gpu/cuMul_dispatch.cu
+++ b/src/backend/linalg_internal_gpu/cuMul_dispatch.cu
@@ -7,38 +7,9 @@ namespace cytnx {
 
     namespace {
 
-      template <typename T>
-      __device__ inline cuDoubleComplex CuToComplexDouble(const T &v) {
-        return make_cuDoubleComplex(static_cast<cytnx_double>(v), 0.0);
-      }
-
-      __device__ inline cuDoubleComplex CuToComplexDouble(const cuDoubleComplex &v) { return v; }
-
-      __device__ inline cuDoubleComplex CuToComplexDouble(const cuComplex &v) {
-        return cuComplexFloatToDouble(v);
-      }
-
-      template <typename T>
-      __device__ inline cuComplex CuToComplexFloat(const T &v) {
-        return make_cuFloatComplex(static_cast<cytnx_float>(v), 0.0f);
-      }
-
-      __device__ inline cuComplex CuToComplexFloat(const cuComplex &v) { return v; }
-
-      __device__ inline cuComplex CuToComplexFloat(const cuDoubleComplex &v) {
-        return make_cuFloatComplex(static_cast<cytnx_float>(cuCreal(v)),
-                                   static_cast<cytnx_float>(cuCimag(v)));
-      }
-
       template <typename TO, typename TL, typename TR>
       __device__ inline TO CuMulDispatchOp(const TL &lhs, const TR &rhs) {
-        if constexpr (std::is_same_v<TO, cuDoubleComplex>) {
-          return cuCmul(CuToComplexDouble(lhs), CuToComplexDouble(rhs));
-        } else if constexpr (std::is_same_v<TO, cuComplex>) {
-          return cuCmulf(CuToComplexFloat(lhs), CuToComplexFloat(rhs));
-        } else {
-          return static_cast<TO>(lhs) * static_cast<TO>(rhs);
-        }
+        return TO(lhs) * TO(rhs);
       }
 
       template <typename TO, typename TL, typename TR>
@@ -178,12 +149,12 @@ namespace cytnx {
                               const std::vector<cytnx_uint64> &invmapper_R) {
         switch (Rin->dtype()) {
           case Type.ComplexDouble:
-            cuMul_dispatch_typed<TL, cuDoubleComplex>(out, Lin, Rin, len, shape, invmapper_L,
-                                                      invmapper_R);
+            cuMul_dispatch_typed<TL, cytnx_cuda_complex128>(out, Lin, Rin, len, shape, invmapper_L,
+                                                            invmapper_R);
             break;
           case Type.ComplexFloat:
-            cuMul_dispatch_typed<TL, cuComplex>(out, Lin, Rin, len, shape, invmapper_L,
-                                                invmapper_R);
+            cuMul_dispatch_typed<TL, cytnx_cuda_complex64>(out, Lin, Rin, len, shape, invmapper_L,
+                                                           invmapper_R);
             break;
           case Type.Double:
             cuMul_dispatch_typed<TL, cytnx_double>(out, Lin, Rin, len, shape, invmapper_L,
@@ -242,10 +213,12 @@ namespace cytnx {
 
       switch (Lin->dtype()) {
         case Type.ComplexDouble:
-          cuMul_dispatch_rhs<cuDoubleComplex>(out, Lin, Rin, len, shape, invmapper_L, invmapper_R);
+          cuMul_dispatch_rhs<cytnx_cuda_complex128>(out, Lin, Rin, len, shape, invmapper_L,
+                                                    invmapper_R);
           break;
         case Type.ComplexFloat:
-          cuMul_dispatch_rhs<cuComplex>(out, Lin, Rin, len, shape, invmapper_L, invmapper_R);
+          cuMul_dispatch_rhs<cytnx_cuda_complex64>(out, Lin, Rin, len, shape, invmapper_L,
+                                                   invmapper_R);
           break;
         case Type.Double:
           cuMul_dispatch_rhs<cytnx_double>(out, Lin, Rin, len, shape, invmapper_L, invmapper_R);

--- a/src/backend/linalg_internal_gpu/cuSub_dispatch.cu
+++ b/src/backend/linalg_internal_gpu/cuSub_dispatch.cu
@@ -7,38 +7,9 @@ namespace cytnx {
 
     namespace {
 
-      template <typename T>
-      __device__ inline cuDoubleComplex CuToComplexDouble(const T &v) {
-        return make_cuDoubleComplex(static_cast<cytnx_double>(v), 0.0);
-      }
-
-      __device__ inline cuDoubleComplex CuToComplexDouble(const cuDoubleComplex &v) { return v; }
-
-      __device__ inline cuDoubleComplex CuToComplexDouble(const cuComplex &v) {
-        return cuComplexFloatToDouble(v);
-      }
-
-      template <typename T>
-      __device__ inline cuComplex CuToComplexFloat(const T &v) {
-        return make_cuFloatComplex(static_cast<cytnx_float>(v), 0.0f);
-      }
-
-      __device__ inline cuComplex CuToComplexFloat(const cuComplex &v) { return v; }
-
-      __device__ inline cuComplex CuToComplexFloat(const cuDoubleComplex &v) {
-        return make_cuFloatComplex(static_cast<cytnx_float>(cuCreal(v)),
-                                   static_cast<cytnx_float>(cuCimag(v)));
-      }
-
       template <typename TO, typename TL, typename TR>
       __device__ inline TO CuSubDispatchOp(const TL &lhs, const TR &rhs) {
-        if constexpr (std::is_same_v<TO, cuDoubleComplex>) {
-          return cuCsub(CuToComplexDouble(lhs), CuToComplexDouble(rhs));
-        } else if constexpr (std::is_same_v<TO, cuComplex>) {
-          return cuCsubf(CuToComplexFloat(lhs), CuToComplexFloat(rhs));
-        } else {
-          return static_cast<TO>(lhs) - static_cast<TO>(rhs);
-        }
+        return TO(lhs) - TO(rhs);
       }
 
       template <typename TO, typename TL, typename TR>
@@ -178,12 +149,12 @@ namespace cytnx {
                               const std::vector<cytnx_uint64> &invmapper_R) {
         switch (Rin->dtype()) {
           case Type.ComplexDouble:
-            cuSub_dispatch_typed<TL, cuDoubleComplex>(out, Lin, Rin, len, shape, invmapper_L,
-                                                      invmapper_R);
+            cuSub_dispatch_typed<TL, cytnx_cuda_complex128>(out, Lin, Rin, len, shape, invmapper_L,
+                                                            invmapper_R);
             break;
           case Type.ComplexFloat:
-            cuSub_dispatch_typed<TL, cuComplex>(out, Lin, Rin, len, shape, invmapper_L,
-                                                invmapper_R);
+            cuSub_dispatch_typed<TL, cytnx_cuda_complex64>(out, Lin, Rin, len, shape, invmapper_L,
+                                                           invmapper_R);
             break;
           case Type.Double:
             cuSub_dispatch_typed<TL, cytnx_double>(out, Lin, Rin, len, shape, invmapper_L,
@@ -242,10 +213,12 @@ namespace cytnx {
 
       switch (Lin->dtype()) {
         case Type.ComplexDouble:
-          cuSub_dispatch_rhs<cuDoubleComplex>(out, Lin, Rin, len, shape, invmapper_L, invmapper_R);
+          cuSub_dispatch_rhs<cytnx_cuda_complex128>(out, Lin, Rin, len, shape, invmapper_L,
+                                                    invmapper_R);
           break;
         case Type.ComplexFloat:
-          cuSub_dispatch_rhs<cuComplex>(out, Lin, Rin, len, shape, invmapper_L, invmapper_R);
+          cuSub_dispatch_rhs<cytnx_cuda_complex64>(out, Lin, Rin, len, shape, invmapper_L,
+                                                   invmapper_R);
           break;
         case Type.Double:
           cuSub_dispatch_rhs<cytnx_double>(out, Lin, Rin, len, shape, invmapper_L, invmapper_R);

--- a/tests/Type_test.cpp
+++ b/tests/Type_test.cpp
@@ -14,6 +14,11 @@ namespace {
   using cytnx::cytnx_double;
   using cytnx::cytnx_int64;
   using cytnx::Type_list;
+#ifdef UNI_GPU
+  using cytnx::cytnx_cuda_complex128;
+  using cytnx::cytnx_cuda_complex64;
+  using cytnx::Type_list_gpu;
+#endif
   using cytnx::variant_contains_v;
   using cytnx::variant_index_v;
 
@@ -37,6 +42,21 @@ namespace {
   static_assert(cytnx::Type_class::Uint64 == cytnx::Type_class::Int64 + 1);
   static_assert(cytnx::Type_class::Uint32 == cytnx::Type_class::Int32 + 1);
   static_assert(cytnx::Type_class::Uint16 == cytnx::Type_class::Int16 + 1);
+
+#ifdef UNI_GPU
+  static_assert(variant_index_v<cytnx_cuda_complex128, Type_list_gpu> ==
+                cytnx::Type_class::ComplexDouble);
+  static_assert(variant_index_v<cytnx_cuda_complex64, Type_list_gpu> ==
+                cytnx::Type_class::ComplexFloat);
+  static_assert(cytnx::is_complex_v<cytnx_cuda_complex128>);
+  static_assert(cytnx::is_complex_v<cytnx_cuda_complex64>);
+  static_assert(
+    std::is_same_v<cytnx::Type_class::type_promote_gpu_t<cytnx_cuda_complex64, cytnx_double>,
+                   cytnx_cuda_complex128>);
+  static_assert(
+    std::is_same_v<cytnx::Type_class::type_promote_gpu_t<cytnx_double, cytnx_cuda_complex64>,
+                   cytnx_cuda_complex128>);
+#endif
 
 }  // namespace
 


### PR DESCRIPTION
This is an alternative fix to #995.


- use `cuda::std::complex<float/double>` as the typed GPU complex element type in `Type_list_gpu`
- keep `cuComplex` / `cuDoubleComplex` only at explicit CUDA library ABI boundaries
- teach Cytnx type traits about `cuda::std::complex`
- update templated GPU Add/Sub/Mul/Div/Kron/Sort paths to use normal C++ complex arithmetic in the promoted output type

Fixes #994
Fixes #999 
Supersedes #995

## Motivation

`cuComplex` is a C ABI type, not a C++ arithmetic type. Using it as the element type in typed C++/CUDA templates makes mixed real/complex dispatch fragile and forces local helper functions for operations that should just be ordinary arithmetic.

`cuda::std::complex` is available in the CUDA toolchain already used by Cytnx and is the better type for typed CUDA kernel code. CUDA library calls that require `cuComplex` pointers can still cast explicitly at the call boundary.

## Notes

This PR does not attempt to rewrite all older generated CUDA kernels or cuBLAS/cuSOLVER call sites. Those still use the existing `cuComplex` ABI where appropriate.

In particular, some large internal `.cu` kernel dispatch tables still cast `void*` buffers directly to `cuComplex` / `cuDoubleComplex`. This PR leaves those paths alone and only changes the typed GPU dispatch surface.

## Tests

- `clang-format-14 -i <touched files>`
- `git diff --check`
- `cmake --build build/openblas-cuda --target cytnx -j 8`
- `cmake --build build/openblas-cuda --target test_main -j 8`
- `ctest --test-dir build/openblas-cpu --output-on-failure -j 8`
  - `1086/1086` passed
- `cmake --build build/openblas-cuda --target gpu_test_main -j 8`
- `ctest --test-dir build/openblas-cuda -I 1087,1852 --output-on-failure -j 8`
  - `763/766` passed
  - failures appear unrelated to this PR:
    - `linalg_Test.gpu_BkFUt_Qr`: GPU QR not implemented without cuQuantum
    - `Gesvd_truncate.gpu_flag_combinations`: `cusolverDnDgesvdj` execution failure in
      the real-double cuSOLVER path
    - `Rsvd.gpu_flag_combinations`: same real-double cuSOLVER path
