### PR TITLE
fix(UniTensor): thread non-mutating block views through contract()

### DIFF
--- a/src/BlockFermionicUniTensor.cpp
+++ b/src/BlockFermionicUniTensor.cpp
@@ -1495,26 +1495,23 @@ namespace cytnx {
 
         std::vector<cytnx_uint64> Lgbuffer;
         std::vector<cytnx_uint64> itoiR_idx;
-        std::vector<cytnx_uint64> oldshapeL;
-        std::vector<std::vector<cytnx_uint64>> oldshapeR(Rtn->_blocks.size(),
-                                                         std::vector<cytnx_uint64>());
+        // The operands' blocks may be shared with other UniTensors (#724), so they must not
+        // be permute_()/reshape_()'d in place. Matrix views are built with the non-mutating
+        // permute()/reshape() instead; right-block views are cached here since the same
+        // right block can pair with several left blocks.
+        std::vector<Tensor> Rmat(Rtn->_blocks.size());
+        std::vector<bool> Rmat_ready(Rtn->_blocks.size(), false);
         std::vector<std::vector<cytnx_uint64>> oldshapeC;
         std::vector<bool> reshaped(tmp->_blocks.size(), false);
         for (cytnx_int64 a = 0; a < tmp->_blocks.size(); a++) {
           oldshapeC.push_back(tmp->_blocks[a].shape());
         }
-        std::vector<cytnx_uint64> mapperL, mapperL_reversed, inv_mapperL(this->rank());
-        std::vector<cytnx_uint64> mapperR, inv_mapperR(rhs->rank());
+        std::vector<cytnx_uint64> mapperL, mapperL_reversed;
+        std::vector<cytnx_uint64> mapperR;
         vec_concatenate_(mapperL, non_comm_idx1, comm_idx1);
         std::reverse(comm_idx1.begin(), comm_idx1.end());
         vec_concatenate_(mapperL_reversed, non_comm_idx1, comm_idx1);
         vec_concatenate_(mapperR, comm_idx2, non_comm_idx2);
-        for (int aa = 0; aa < mapperL.size(); aa++) {
-          inv_mapperL[mapperL[aa]] = aa;
-        }
-        for (int aa = 0; aa < mapperR.size(); aa++) {
-          inv_mapperR[mapperR[aa]] = aa;
-        }
 
         // fermion signs
         std::vector<bool> signfliplhs = this->_lhssigns_(mapperL_reversed, comm_idx1.size());
@@ -1546,15 +1543,6 @@ namespace cytnx {
             }
           }
         } else {
-          // KNOWN ISSUE (#724, not fixed by this change): same as the analogous branch in
-          // BlockUniTensor::contract() (src/BlockUniTensor.cpp) — the branches below temporarily
-          // mutate this->_blocks[a] / Rtn->_blocks[b] / tmp_Rtn->_blocks[b] in place via
-          // permute_()/reshape_(), then restore afterward. If those blocks are shared with
-          // another UniTensor, that other UniTensor is transiently (or, on an exception,
-          // permanently) corrupted. Left as a follow-up; see BlockUniTensor.cpp for details.
-          BlockFermionicUniTensor *tmp_Rtn = Rtn;
-          bool tmp_rtn_is_casted = false;
-
           // check if all sub-tensor are same dtype and device
           if (User_debug) {
             bool all_sub_tensor_same_dtype = true;
@@ -1598,14 +1586,14 @@ namespace cytnx {
               itoiR_idx = mp[itoiL_common[a]];
               for (cytnx_uint64 aa = 0; aa < comm_idx1.size(); aa++)
                 comm_dim *= this->_blocks[a].shape()[comm_idx1[aa]];
-              this->_blocks[a].permute_(mapperL);
-              oldshapeL = this->_blocks[a].shape();
-              this->_blocks[a].reshape_({-1, comm_dim});
+              // matrix view of this->_blocks[a]; non-mutating (the block may be shared, #724)
+              const Tensor Lmat = this->_blocks[a].permute(mapperL).reshape({-1, comm_dim});
               for (cytnx_uint64 binx = 0; binx < itoiR_idx.size(); binx++) {
                 cytnx_uint64 b = itoiR_idx[binx];
-                Rtn->_blocks[b].permute_(mapperR);
-                oldshapeR[b] = Rtn->_blocks[b].shape();
-                Rtn->_blocks[b].reshape_({comm_dim, -1});
+                if (!Rmat_ready[b]) {
+                  Rmat[b] = Rtn->_blocks[b].permute(mapperR).reshape({comm_dim, -1});
+                  Rmat_ready[b] = true;
+                }
                 Lgbuffer.resize(non_comm_idx1.size() + non_comm_idx2.size());
                 for (cytnx_uint64 cc = 0; cc < non_comm_idx1.size(); cc++)
                   Lgbuffer[cc] = this->_inner_to_outer_idx[a][non_comm_idx1[cc]];
@@ -1616,30 +1604,18 @@ namespace cytnx {
                 cytnx_int64 targ_b = mpC[Lgbuffer];
                 // fermionic sign: negate when parities differ
                 if (signfliplhs[a] != signfliprhs[b]) {
-                  tmp->_blocks[targ_b] -= linalg::Matmul(this->_blocks[a], Rtn->_blocks[b])
-                                            .reshape(tmp->_blocks[targ_b].shape());
+                  tmp->_blocks[targ_b] -=
+                    linalg::Matmul(Lmat, Rmat[b]).reshape(tmp->_blocks[targ_b].shape());
                 } else {
-                  tmp->_blocks[targ_b] += linalg::Matmul(this->_blocks[a], Rtn->_blocks[b])
-                                            .reshape(tmp->_blocks[targ_b].shape());
+                  tmp->_blocks[targ_b] +=
+                    linalg::Matmul(Lmat, Rmat[b]).reshape(tmp->_blocks[targ_b].shape());
                 }
-                Rtn->_blocks[b].reshape_(oldshapeR[b]);
-                Rtn->_blocks[b].permute_(inv_mapperR);
               }
-              this->_blocks[a].reshape_(oldshapeL);
-              this->_blocks[a].permute_(inv_mapperL);
             }
           } else {
             // fp/complex: use Gemm_Batch
-            // If the dtype of this and Rtn are different, we need to cast to the common dtype
-            if (Rtn->dtype() != common_dtype) {
-              BlockFermionicUniTensor *tmpp = Rtn->clone_meta(true, true);
-              tmpp->_blocks.resize(Rtn->_blocks.size());
-              for (cytnx_int64 blk = 0; blk < Rtn->_blocks.size(); blk++) {
-                tmpp->_blocks[blk] = Rtn->_blocks[blk].astype(common_dtype);
-              }
-              tmp_Rtn = tmpp;
-              tmp_rtn_is_casted = true;
-            }
+            // (right blocks whose dtype differs from the common dtype are cast lazily when
+            // their matrix view is built below)
             // First select left block to do gemm
             for (cytnx_int64 a = 0; a < this->_blocks.size(); a++) {
               cytnx_int64 comm_dim = 1;
@@ -1648,10 +1624,8 @@ namespace cytnx {
               for (cytnx_uint64 aa = 0; aa < comm_idx1.size(); aa++) {
                 comm_dim *= this->_blocks[a].shape()[comm_idx1[aa]];
               }
-              // permute&reshape this->_blocks[a]
-              this->_blocks[a].permute_(mapperL);
-              oldshapeL = this->_blocks[a].shape();
-              this->_blocks[a].reshape_({-1, comm_dim});
+              // matrix view of this->_blocks[a]; non-mutating (the block may be shared, #724)
+              const Tensor Lmat = this->_blocks[a].permute(mapperL).reshape({-1, comm_dim});
               // Collect block pairs for this left block then call Gemm_Batch once.
               // Fermionic sign flips are encoded in alpha (+1 or -1 per group).
               std::vector<Tensor> batch_a, batch_b, batch_c;
@@ -1662,10 +1636,11 @@ namespace cytnx {
               for (cytnx_uint64 binx = 0; binx < itoiR_idx.size(); binx++) {
                 // get the index of the right block
                 cytnx_uint64 b = itoiR_idx[binx];
-                // permute&reshape Rtn->_blocks[b]
-                tmp_Rtn->_blocks[b].permute_(mapperR);
-                oldshapeR[b] = tmp_Rtn->_blocks[b].shape();
-                tmp_Rtn->_blocks[b].reshape_({comm_dim, -1});
+                if (!Rmat_ready[b]) {
+                  Rmat[b] =
+                    Rtn->_blocks[b].astype(common_dtype).permute(mapperR).reshape({comm_dim, -1});
+                  Rmat_ready[b] = true;
+                }
                 // prepare to find the target block
                 Lgbuffer.resize(non_comm_idx1.size() + non_comm_idx2.size());
                 for (cytnx_uint64 cc = 0; cc < non_comm_idx1.size(); cc++) {
@@ -1674,24 +1649,24 @@ namespace cytnx {
                 for (cytnx_uint64 cc = non_comm_idx1.size();
                      cc < non_comm_idx1.size() + non_comm_idx2.size(); cc++) {
                   Lgbuffer[cc] =
-                    tmp_Rtn->_inner_to_outer_idx[b][non_comm_idx2[cc - non_comm_idx1.size()]];
+                    Rtn->_inner_to_outer_idx[b][non_comm_idx2[cc - non_comm_idx1.size()]];
                 }
                 // target block index
                 cytnx_int64 targ_b = mpC[Lgbuffer];
                 double beta = 1.0;
                 if (!reshaped[targ_b]) {
-                  tmp->_blocks[targ_b].reshape_({(cytnx_int64)this->_blocks[a].shape()[0],
-                                                 (cytnx_int64)tmp_Rtn->_blocks[b].shape()[1]});
+                  tmp->_blocks[targ_b].reshape_(
+                    {(cytnx_int64)Lmat.shape()[0], (cytnx_int64)Rmat[b].shape()[1]});
                   reshaped[targ_b] = true;
                   beta = 0.0;
                 }
                 // fermionic sign goes into alpha (+1 or -1 per group)
                 double alpha = (signfliplhs[a] != signfliprhs[b]) ? -1.0 : 1.0;
-                batch_a.push_back(this->_blocks[a]);
-                batch_b.push_back(tmp_Rtn->_blocks[b]);
+                batch_a.push_back(Lmat);
+                batch_b.push_back(Rmat[b]);
                 batch_c.push_back(tmp->_blocks[targ_b]);
-                batch_alpha.push_back(Scalar(alpha).astype(this->_blocks[a].dtype()));
-                batch_beta.push_back(Scalar(beta).astype(this->_blocks[a].dtype()));
+                batch_alpha.push_back(Scalar(alpha).astype(Lmat.dtype()));
+                batch_beta.push_back(Scalar(beta).astype(Lmat.dtype()));
                 batch_targ_b.push_back(targ_b);
               }
               if (!batch_a.empty()) {
@@ -1700,18 +1675,8 @@ namespace cytnx {
                 for (std::size_t i = 0; i < batch_c.size(); i++)
                   tmp->_blocks[batch_targ_b[i]] = batch_c[i];
               }
-              // restore the shape&permutation of this->_blocks[a]
-              for (cytnx_uint64 binx = 0; binx < itoiR_idx.size(); binx++) {
-                cytnx_uint64 b = itoiR_idx[binx];
-
-                tmp_Rtn->_blocks[b].reshape_(oldshapeR[b]);
-                tmp_Rtn->_blocks[b].permute_(inv_mapperR);
-              }
-
-              this->_blocks[a].reshape_(oldshapeL);
-              this->_blocks[a].permute_(inv_mapperL);
             }
-            // restore the shape of tmp->_blocks
+            // restore the shape of tmp->_blocks (tmp is freshly built above and not shared)
             for (cytnx_int64 a = 0; a < tmp->_blocks.size(); a++) {
               tmp->_blocks[a].reshape_(oldshapeC[a]);
               if (!reshaped[a]) {
@@ -1719,16 +1684,9 @@ namespace cytnx {
                 tmp->_blocks[a].storage().set_zeros();
               }
             }
-
-            // if Rtn dtype is casted, delete the tmp_Rtn
-            if (tmp_rtn_is_casted) {
-              delete tmp_Rtn;
-            }
           }  // end else (common_dtype <= 4)
         }
   #else
-          // NOTE: shared-block mutate/restore hazard — see KNOWN ISSUE (#724) at top of this
-          // else-block.
           // First select left block to do gemm
           for (cytnx_int64 a = 0; a < this->_blocks.size(); a++) {
             cytnx_int64 comm_dim = 1;
@@ -1737,18 +1695,16 @@ namespace cytnx {
             for (cytnx_uint64 aa = 0; aa < comm_idx1.size(); aa++) {
               comm_dim *= this->_blocks[a].shape()[comm_idx1[aa]];
             }
-            // permute&reshape this->_blocks[a]
-            this->_blocks[a].permute_(mapperL);
-            oldshapeL = this->_blocks[a].shape();
-            this->_blocks[a].reshape_({-1, comm_dim});
+            // matrix view of this->_blocks[a]; non-mutating (the block may be shared, #724)
+            const Tensor Lmat = this->_blocks[a].permute(mapperL).reshape({-1, comm_dim});
             // loop over all right blocks that can contract with this->_blocks[a]
             for (cytnx_uint64 binx = 0; binx < itoiR_idx.size(); binx++) {
               // get the index of the right block
               cytnx_uint64 b = itoiR_idx[binx];
-              // permute&reshape Rtn->_blocks[b]
-              Rtn->_blocks[b].permute_(mapperR);
-              oldshapeR[b] = Rtn->_blocks[b].shape();
-              Rtn->_blocks[b].reshape_({comm_dim, -1});
+              if (!Rmat_ready[b]) {
+                Rmat[b] = Rtn->_blocks[b].permute(mapperR).reshape({comm_dim, -1});
+                Rmat_ready[b] = true;
+              }
               // prepare to find the target block
               Lgbuffer.resize(non_comm_idx1.size() + non_comm_idx2.size());
               for (cytnx_uint64 cc = 0; cc < non_comm_idx1.size(); cc++) {
@@ -1763,23 +1719,13 @@ namespace cytnx {
               cytnx_int64 targ_b = mpC[Lgbuffer];
               // fermionic signs included here
               if (signfliplhs[a] != signfliprhs[b]) {
-                tmp->_blocks[targ_b] -= linalg::Matmul(this->_blocks[a], Rtn->_blocks[b])
-                                          .reshape(tmp->_blocks[targ_b].shape());
+                tmp->_blocks[targ_b] -=
+                  linalg::Matmul(Lmat, Rmat[b]).reshape(tmp->_blocks[targ_b].shape());
               } else {
-                tmp->_blocks[targ_b] += linalg::Matmul(this->_blocks[a], Rtn->_blocks[b])
-                                          .reshape(tmp->_blocks[targ_b].shape());
+                tmp->_blocks[targ_b] +=
+                  linalg::Matmul(Lmat, Rmat[b]).reshape(tmp->_blocks[targ_b].shape());
               }
             }
-            // restore the shape&permutation of this->_blocks[a]
-            for (cytnx_uint64 binx = 0; binx < itoiR_idx.size(); binx++) {
-              cytnx_uint64 b = itoiR_idx[binx];
-
-              Rtn->_blocks[b].reshape_(oldshapeR[b]);
-              Rtn->_blocks[b].permute_(inv_mapperR);
-            }
-
-            this->_blocks[a].reshape_(oldshapeL);
-            this->_blocks[a].permute_(inv_mapperL);
           }
           // // restore the shape of tmp->_blocks
           // for(cytnx_int64 a=0;a<tmp->_blocks.size();a++){

--- a/src/BlockUniTensor.cpp
+++ b/src/BlockUniTensor.cpp
@@ -952,24 +952,21 @@ namespace cytnx {
 
         std::vector<cytnx_uint64> Lgbuffer;
         std::vector<cytnx_uint64> itoiR_idx;
-        std::vector<cytnx_uint64> oldshapeL;
-        std::vector<std::vector<cytnx_uint64>> oldshapeR(Rtn->_blocks.size(),
-                                                         std::vector<cytnx_uint64>());
+        // The operands' blocks may be shared with other UniTensors (#724), so they must not
+        // be permute_()/reshape_()'d in place. Matrix views are built with the non-mutating
+        // permute()/reshape() instead; right-block views are cached here since the same
+        // right block can pair with several left blocks.
+        std::vector<Tensor> Rmat(Rtn->_blocks.size());
+        std::vector<bool> Rmat_ready(Rtn->_blocks.size(), false);
         std::vector<std::vector<cytnx_uint64>> oldshapeC;
         std::vector<bool> reshaped(tmp->_blocks.size(), false);
         for (cytnx_int64 a = 0; a < tmp->_blocks.size(); a++) {
           oldshapeC.push_back(tmp->_blocks[a].shape());
         }
-        std::vector<cytnx_uint64> mapperL, inv_mapperL(this->rank());
-        std::vector<cytnx_uint64> mapperR, inv_mapperR(rhs->rank());
+        std::vector<cytnx_uint64> mapperL;
+        std::vector<cytnx_uint64> mapperR;
         vec_concatenate_(mapperL, non_comm_idx1, comm_idx1);
         vec_concatenate_(mapperR, comm_idx2, non_comm_idx2);
-        for (int aa = 0; aa < mapperL.size(); aa++) {
-          inv_mapperL[mapperL[aa]] = aa;
-        }
-        for (int aa = 0; aa < mapperR.size(); aa++) {
-          inv_mapperR[mapperR[aa]] = aa;
-        }
 
         if (this->is_diag() != Rtn->is_diag()) {
           for (cytnx_int64 a = 0; a < this->_blocks.size(); a++) {
@@ -991,21 +988,6 @@ namespace cytnx {
             }
           }
         } else {
-          // KNOWN ISSUE (#724, not fixed by this change): the three branches below (the
-          // UNI_MKL integer-dtype Matmul fallback, the UNI_MKL Gemm_Batch path, and the
-          // non-MKL Matmul fallback further down) temporarily
-          // mutate this->_blocks[a] / Rtn->_blocks[b] / tmp_Rtn->_blocks[b] in place via
-          // permute_()/reshape_(), then restore the original shape/permutation afterward. If
-          // any of those blocks are shared with another UniTensor (e.g. via relabel()), that
-          // other UniTensor's block is transiently corrupted during the contraction, and would
-          // be corrupted permanently if an exception were thrown before the restore runs.
-          // Converting this to the non-mutating rebind pattern used elsewhere in this file would
-          // require threading local Tensor variables through the Gemm_Batch batching loop and
-          // the dtype-casting/early-cleanup logic across three near-duplicate branches; left as
-          // a follow-up rather than risking a rushed change to this hot contraction path.
-          BlockUniTensor *tmp_Rtn = Rtn;
-          bool tmp_rtn_is_casted = false;
-
           // check if all sub-tensor are same dtype and device
           if (User_debug) {
             bool all_sub_tensor_same_dtype = true;
@@ -1049,14 +1031,14 @@ namespace cytnx {
               itoiR_idx = mp[itoiL_common[a]];
               for (cytnx_uint64 aa = 0; aa < comm_idx1.size(); aa++)
                 comm_dim *= this->_blocks[a].shape()[comm_idx1[aa]];
-              this->_blocks[a].permute_(mapperL);
-              oldshapeL = this->_blocks[a].shape();
-              this->_blocks[a].reshape_({-1, comm_dim});
+              // matrix view of this->_blocks[a]; non-mutating (the block may be shared, #724)
+              const Tensor Lmat = this->_blocks[a].permute(mapperL).reshape({-1, comm_dim});
               for (cytnx_uint64 binx = 0; binx < itoiR_idx.size(); binx++) {
                 cytnx_uint64 b = itoiR_idx[binx];
-                Rtn->_blocks[b].permute_(mapperR);
-                oldshapeR[b] = Rtn->_blocks[b].shape();
-                Rtn->_blocks[b].reshape_({comm_dim, -1});
+                if (!Rmat_ready[b]) {
+                  Rmat[b] = Rtn->_blocks[b].permute(mapperR).reshape({comm_dim, -1});
+                  Rmat_ready[b] = true;
+                }
                 Lgbuffer.resize(non_comm_idx1.size() + non_comm_idx2.size());
                 for (cytnx_uint64 cc = 0; cc < non_comm_idx1.size(); cc++)
                   Lgbuffer[cc] = this->_inner_to_outer_idx[a][non_comm_idx1[cc]];
@@ -1065,26 +1047,14 @@ namespace cytnx {
                   Lgbuffer[cc] =
                     Rtn->_inner_to_outer_idx[b][non_comm_idx2[cc - non_comm_idx1.size()]];
                 cytnx_int64 targ_b = mpC[Lgbuffer];
-                tmp->_blocks[targ_b] += linalg::Matmul(this->_blocks[a], Rtn->_blocks[b])
-                                          .reshape(tmp->_blocks[targ_b].shape());
-                Rtn->_blocks[b].reshape_(oldshapeR[b]);
-                Rtn->_blocks[b].permute_(inv_mapperR);
+                tmp->_blocks[targ_b] +=
+                  linalg::Matmul(Lmat, Rmat[b]).reshape(tmp->_blocks[targ_b].shape());
               }
-              this->_blocks[a].reshape_(oldshapeL);
-              this->_blocks[a].permute_(inv_mapperL);
             }
           } else {
             // fp/complex: use Gemm_Batch
-            // If the dtype of this and Rtn are different, we need to cast to the common dtype
-            if (Rtn->dtype() != common_dtype) {
-              BlockUniTensor *tmpp = Rtn->clone_meta(true, true);
-              tmpp->_blocks.resize(Rtn->_blocks.size());
-              for (cytnx_int64 blk = 0; blk < Rtn->_blocks.size(); blk++) {
-                tmpp->_blocks[blk] = Rtn->_blocks[blk].astype(common_dtype);
-              }
-              tmp_Rtn = tmpp;
-              tmp_rtn_is_casted = true;
-            }
+            // (right blocks whose dtype differs from the common dtype are cast lazily when
+            // their matrix view is built below)
             // First select left block to do gemm
             for (cytnx_int64 a = 0; a < this->_blocks.size(); a++) {
               cytnx_int64 comm_dim = 1;
@@ -1093,10 +1063,8 @@ namespace cytnx {
               for (cytnx_uint64 aa = 0; aa < comm_idx1.size(); aa++) {
                 comm_dim *= this->_blocks[a].shape()[comm_idx1[aa]];
               }
-              // permute&reshape this->_blocks[a]
-              this->_blocks[a].permute_(mapperL);
-              oldshapeL = this->_blocks[a].shape();
-              this->_blocks[a].reshape_({-1, comm_dim});
+              // matrix view of this->_blocks[a]; non-mutating (the block may be shared, #724)
+              const Tensor Lmat = this->_blocks[a].permute(mapperL).reshape({-1, comm_dim});
               // Collect block pairs for this left block then call Gemm_Batch once.
               std::vector<Tensor> batch_a, batch_b, batch_c;
               std::vector<Scalar> batch_alpha, batch_beta;
@@ -1106,10 +1074,11 @@ namespace cytnx {
               for (cytnx_uint64 binx = 0; binx < itoiR_idx.size(); binx++) {
                 // get the index of the right block
                 cytnx_uint64 b = itoiR_idx[binx];
-                // permute&reshape Rtn->_blocks[b]
-                tmp_Rtn->_blocks[b].permute_(mapperR);
-                oldshapeR[b] = tmp_Rtn->_blocks[b].shape();
-                tmp_Rtn->_blocks[b].reshape_({comm_dim, -1});
+                if (!Rmat_ready[b]) {
+                  Rmat[b] =
+                    Rtn->_blocks[b].astype(common_dtype).permute(mapperR).reshape({comm_dim, -1});
+                  Rmat_ready[b] = true;
+                }
                 // prepare to find the target block
                 Lgbuffer.resize(non_comm_idx1.size() + non_comm_idx2.size());
                 for (cytnx_uint64 cc = 0; cc < non_comm_idx1.size(); cc++) {
@@ -1118,22 +1087,22 @@ namespace cytnx {
                 for (cytnx_uint64 cc = non_comm_idx1.size();
                      cc < non_comm_idx1.size() + non_comm_idx2.size(); cc++) {
                   Lgbuffer[cc] =
-                    tmp_Rtn->_inner_to_outer_idx[b][non_comm_idx2[cc - non_comm_idx1.size()]];
+                    Rtn->_inner_to_outer_idx[b][non_comm_idx2[cc - non_comm_idx1.size()]];
                 }
                 // target block index
                 cytnx_int64 targ_b = mpC[Lgbuffer];
                 double beta = 1.0;
                 if (!reshaped[targ_b]) {
-                  tmp->_blocks[targ_b].reshape_({(cytnx_int64)this->_blocks[a].shape()[0],
-                                                 (cytnx_int64)tmp_Rtn->_blocks[b].shape()[1]});
+                  tmp->_blocks[targ_b].reshape_(
+                    {(cytnx_int64)Lmat.shape()[0], (cytnx_int64)Rmat[b].shape()[1]});
                   reshaped[targ_b] = true;
                   beta = 0.0;
                 }
-                batch_a.push_back(this->_blocks[a]);
-                batch_b.push_back(tmp_Rtn->_blocks[b]);
+                batch_a.push_back(Lmat);
+                batch_b.push_back(Rmat[b]);
                 batch_c.push_back(tmp->_blocks[targ_b]);
-                batch_alpha.push_back(Scalar(1.0).astype(this->_blocks[a].dtype()));
-                batch_beta.push_back(Scalar(beta).astype(this->_blocks[a].dtype()));
+                batch_alpha.push_back(Scalar(1.0).astype(Lmat.dtype()));
+                batch_beta.push_back(Scalar(beta).astype(Lmat.dtype()));
                 batch_targ_b.push_back(targ_b);
               }
               if (!batch_a.empty()) {
@@ -1142,18 +1111,8 @@ namespace cytnx {
                 for (std::size_t i = 0; i < batch_c.size(); i++)
                   tmp->_blocks[batch_targ_b[i]] = batch_c[i];
               }
-              // restore the shape&permutation of this->_blocks[a]
-              for (cytnx_uint64 binx = 0; binx < itoiR_idx.size(); binx++) {
-                cytnx_uint64 b = itoiR_idx[binx];
-
-                tmp_Rtn->_blocks[b].reshape_(oldshapeR[b]);
-                tmp_Rtn->_blocks[b].permute_(inv_mapperR);
-              }
-
-              this->_blocks[a].reshape_(oldshapeL);
-              this->_blocks[a].permute_(inv_mapperL);
             }
-            // restore the shape of tmp->_blocks
+            // restore the shape of tmp->_blocks (tmp is freshly built above and not shared)
             for (cytnx_int64 a = 0; a < tmp->_blocks.size(); a++) {
               tmp->_blocks[a].reshape_(oldshapeC[a]);
               if (!reshaped[a]) {
@@ -1161,16 +1120,9 @@ namespace cytnx {
                 tmp->_blocks[a].storage().set_zeros();
               }
             }
-
-            // if Rtn dtype is casted, delete the tmp_Rtn
-            if (tmp_rtn_is_casted) {
-              delete tmp_Rtn;
-            }
           }  // end else (common_dtype <= 4)
         }
   #else
-          // NOTE: shared-block mutate/restore hazard — see KNOWN ISSUE (#724) at top of this
-          // else-block.
           // First select left block to do gemm
           for (cytnx_int64 a = 0; a < this->_blocks.size(); a++) {
             cytnx_int64 comm_dim = 1;
@@ -1179,18 +1131,16 @@ namespace cytnx {
             for (cytnx_uint64 aa = 0; aa < comm_idx1.size(); aa++) {
               comm_dim *= this->_blocks[a].shape()[comm_idx1[aa]];
             }
-            // permute&reshape this->_blocks[a]
-            this->_blocks[a].permute_(mapperL);
-            oldshapeL = this->_blocks[a].shape();
-            this->_blocks[a].reshape_({-1, comm_dim});
+            // matrix view of this->_blocks[a]; non-mutating (the block may be shared, #724)
+            const Tensor Lmat = this->_blocks[a].permute(mapperL).reshape({-1, comm_dim});
             // loop over all right blocks that can contract with this->_blocks[a]
             for (cytnx_uint64 binx = 0; binx < itoiR_idx.size(); binx++) {
               // get the index of the right block
               cytnx_uint64 b = itoiR_idx[binx];
-              // permute&reshape Rtn->_blocks[b]
-              Rtn->_blocks[b].permute_(mapperR);
-              oldshapeR[b] = Rtn->_blocks[b].shape();
-              Rtn->_blocks[b].reshape_({comm_dim, -1});
+              if (!Rmat_ready[b]) {
+                Rmat[b] = Rtn->_blocks[b].permute(mapperR).reshape({comm_dim, -1});
+                Rmat_ready[b] = true;
+              }
               // prepare to find the target block
               Lgbuffer.resize(non_comm_idx1.size() + non_comm_idx2.size());
               for (cytnx_uint64 cc = 0; cc < non_comm_idx1.size(); cc++) {
@@ -1203,19 +1153,9 @@ namespace cytnx {
               }
               // target block index
               cytnx_int64 targ_b = mpC[Lgbuffer];
-              tmp->_blocks[targ_b] += linalg::Matmul(this->_blocks[a], Rtn->_blocks[b])
-                                        .reshape(tmp->_blocks[targ_b].shape());
+              tmp->_blocks[targ_b] +=
+                linalg::Matmul(Lmat, Rmat[b]).reshape(tmp->_blocks[targ_b].shape());
             }
-            // restore the shape&permutation of this->_blocks[a]
-            for (cytnx_uint64 binx = 0; binx < itoiR_idx.size(); binx++) {
-              cytnx_uint64 b = itoiR_idx[binx];
-
-              Rtn->_blocks[b].reshape_(oldshapeR[b]);
-              Rtn->_blocks[b].permute_(inv_mapperR);
-            }
-
-            this->_blocks[a].reshape_(oldshapeL);
-            this->_blocks[a].permute_(inv_mapperL);
           }
           // // restore the shape of tmp->_blocks
           // for(cytnx_int64 a=0;a<tmp->_blocks.size();a++){

--- a/tests/BlockFermionicUniTensor_test.cpp
+++ b/tests/BlockFermionicUniTensor_test.cpp
@@ -407,3 +407,82 @@ TEST_F(BlockFermionicUniTensorTest, ContractIntegerDtype) {
   EXPECT_EQ(int64_t(out.at({0, 0}).real()), 3);
   EXPECT_EQ(int64_t(out.at({2, 2}).real()), 8);
 }
+
+/*=====test info=====
+describe:regression test for issue #724 on the fermionic contract() path.
+         contract() used to permute_/reshape_ the operands' blocks in place
+         and restore them afterward. When the two operands alias each
+         other's blocks (relabel() shares block storage), the in-place
+         mutation of the left operand corrupts the right operand mid-
+         contraction: the contraction throws or produces wrong values.
+         contract() must treat both operands' blocks as read-only.
+====================*/
+TEST_F(BlockFermionicUniTensorTest, ContractAliasedSharedBlocksOperandsIntact) {
+  Bond ba = Bond(BD_IN, {Qs(0) >> 1, Qs(1) >> 2}, {Symmetry::FermionParity()});
+  Bond bb = Bond(BD_IN, {Qs(0) >> 2, Qs(1) >> 3}, {Symmetry::FermionParity()});
+  Bond bc = Bond(BD_OUT, {Qs(0) >> 1, Qs(1) >> 2}, {Symmetry::FermionParity()});
+  UniTensor A = UniTensor({ba, bb, bc}, {"a", "b", "c"});
+  random::uniform_(A, -1.0, 1.0, 42);
+  // B shares A's blocks; contracting over "a" and "c" makes the two operands
+  // of contract() alias each other's blocks (including block-with-itself pairs).
+  UniTensor B = A.relabel({"c", "d", "a"});
+  ASSERT_TRUE(A.same_data(B));
+
+  UniTensor Asnap = A.clone();  // pristine copy of the shared data
+  // reference result from fully independent operands
+  UniTensor expected = Contract(Asnap.clone(), Asnap.clone().relabel({"c", "d", "a"}));
+
+  UniTensor got;
+  try {
+    got = Contract(A, B);
+  } catch (const std::exception& e) {
+    FAIL() << "Contract() on operands sharing blocks threw: " << e.what();
+  }
+
+  ASSERT_EQ(got.Nblocks(), expected.Nblocks());
+  EXPECT_EQ(got.signflip(), expected.signflip());
+  for (cytnx_uint64 i = 0; i < got.Nblocks(); i++) {
+    EXPECT_TRUE(AreNearlyEqTensor(got.get_blocks_()[i], expected.get_blocks_()[i], 1e-12));
+  }
+
+  // both operands must be intact: values, shapes, signflip, and contiguity
+  ASSERT_EQ(A.Nblocks(), Asnap.Nblocks());
+  EXPECT_EQ(A.signflip(), Asnap.signflip());
+  for (cytnx_uint64 i = 0; i < A.Nblocks(); i++) {
+    EXPECT_EQ(A.get_blocks_()[i].shape(), Asnap.get_blocks_()[i].shape());
+    EXPECT_TRUE(AreNearlyEqTensor(A.get_blocks_()[i], Asnap.get_blocks_()[i], 0.0));
+  }
+  EXPECT_TRUE(A.is_contiguous());
+  EXPECT_TRUE(B.is_contiguous());
+}
+
+/*=====test info=====
+describe:regression test for issue #724 on the fermionic contract() path. A
+         third UniTensor sharing blocks with an operand (via relabel()) must
+         not observe any change from the contraction. The pre-fix mutate-
+         and-restore left the shared blocks with replaced, permuted storage
+         (non-contiguous), even though the values were restored.
+====================*/
+TEST_F(BlockFermionicUniTensorTest, ContractLeavesSharedBlockObserverUntouched) {
+  Bond ba = Bond(BD_IN, {Qs(0) >> 1, Qs(1) >> 2}, {Symmetry::FermionParity()});
+  Bond bb = Bond(BD_IN, {Qs(0) >> 2, Qs(1) >> 3}, {Symmetry::FermionParity()});
+  Bond bc = Bond(BD_OUT, {Qs(0) >> 1, Qs(1) >> 2}, {Symmetry::FermionParity()});
+  UniTensor A = UniTensor({ba, bb, bc}, {"a", "b", "c"});
+  random::uniform_(A, -1.0, 1.0, 7);
+  UniTensor observer = A.relabel({"x", "y", "z"});  // shares A's blocks; not an operand
+  ASSERT_TRUE(A.same_data(observer));
+  UniTensor snap = A.clone();
+
+  UniTensor R = A.clone().relabel({"c", "d", "a"});  // independent right operand
+  UniTensor got = Contract(A, R);
+  (void)got;
+
+  ASSERT_EQ(observer.Nblocks(), snap.Nblocks());
+  EXPECT_EQ(observer.signflip(), snap.signflip());
+  for (cytnx_uint64 i = 0; i < observer.Nblocks(); i++) {
+    EXPECT_EQ(observer.get_blocks_()[i].shape(), snap.get_blocks_()[i].shape());
+    EXPECT_TRUE(AreNearlyEqTensor(observer.get_blocks_()[i], snap.get_blocks_()[i], 0.0));
+  }
+  EXPECT_TRUE(observer.is_contiguous());
+  EXPECT_TRUE(R.is_contiguous());
+}

--- a/tests/BlockUniTensor_test.cpp
+++ b/tests/BlockUniTensor_test.cpp
@@ -1400,3 +1400,80 @@ TEST_F(BlockUniTensorTest, ContractIntegerDtype) {
   EXPECT_EQ(int64_t(out.at({0, 0}).real()), 3);
   EXPECT_EQ(int64_t(out.at({2, 2}).real()), 8);
 }
+
+/*=====test info=====
+describe:regression test for issue #724 on the contract() path. contract()
+         used to permute_/reshape_ the operands' blocks in place and restore
+         them afterward. When the two operands alias each other's blocks
+         (relabel() is documented to share block storage), the in-place
+         mutation of the left operand corrupts the right operand mid-
+         contraction: the contraction throws (rank-mismatched permute_ on an
+         already-reshaped shared block) or produces wrong values. contract()
+         must treat both operands' blocks as read-only.
+====================*/
+TEST_F(BlockUniTensorTest, ContractAliasedSharedBlocksOperandsIntact) {
+  Bond ba = Bond(BD_IN, {Qs(0) >> 1, Qs(1) >> 2});
+  Bond bb = Bond(BD_IN, {Qs(0) >> 2, Qs(1) >> 3});
+  Bond bc = Bond(BD_OUT, {Qs(0) >> 1, Qs(1) >> 2});
+  UniTensor A = UniTensor({ba, bb, bc}, {"a", "b", "c"});
+  random::uniform_(A, -1.0, 1.0, 42);
+  // B shares A's blocks; contracting over "a" and "c" makes the two operands
+  // of contract() alias each other's blocks (including block-with-itself pairs).
+  UniTensor B = A.relabel({"c", "d", "a"});
+  ASSERT_TRUE(A.same_data(B));
+
+  UniTensor Asnap = A.clone();  // pristine copy of the shared data
+  // reference result from fully independent operands
+  UniTensor expected = Contract(Asnap.clone(), Asnap.clone().relabel({"c", "d", "a"}));
+
+  UniTensor got;
+  try {
+    got = Contract(A, B);
+  } catch (const std::exception& e) {
+    FAIL() << "Contract() on operands sharing blocks threw: " << e.what();
+  }
+
+  ASSERT_EQ(got.Nblocks(), expected.Nblocks());
+  for (cytnx_uint64 i = 0; i < got.Nblocks(); i++) {
+    EXPECT_TRUE(AreNearlyEqTensor(got.get_blocks_()[i], expected.get_blocks_()[i], 1e-12));
+  }
+
+  // both operands must be intact: values, shapes, and contiguity
+  ASSERT_EQ(A.Nblocks(), Asnap.Nblocks());
+  for (cytnx_uint64 i = 0; i < A.Nblocks(); i++) {
+    EXPECT_EQ(A.get_blocks_()[i].shape(), Asnap.get_blocks_()[i].shape());
+    EXPECT_TRUE(AreNearlyEqTensor(A.get_blocks_()[i], Asnap.get_blocks_()[i], 0.0));
+  }
+  EXPECT_TRUE(A.is_contiguous());
+  EXPECT_TRUE(B.is_contiguous());
+}
+
+/*=====test info=====
+describe:regression test for issue #724 on the contract() path. A third
+         UniTensor sharing blocks with an operand (via relabel()) must not
+         observe any change from the contraction. The pre-fix mutate-and-
+         restore left the shared blocks with replaced, permuted storage
+         (non-contiguous), even though the values were restored.
+====================*/
+TEST_F(BlockUniTensorTest, ContractLeavesSharedBlockObserverUntouched) {
+  Bond ba = Bond(BD_IN, {Qs(0) >> 1, Qs(1) >> 2});
+  Bond bb = Bond(BD_IN, {Qs(0) >> 2, Qs(1) >> 3});
+  Bond bc = Bond(BD_OUT, {Qs(0) >> 1, Qs(1) >> 2});
+  UniTensor A = UniTensor({ba, bb, bc}, {"a", "b", "c"});
+  random::uniform_(A, -1.0, 1.0, 7);
+  UniTensor observer = A.relabel({"x", "y", "z"});  // shares A's blocks; not an operand
+  ASSERT_TRUE(A.same_data(observer));
+  UniTensor snap = A.clone();
+
+  UniTensor R = A.clone().relabel({"c", "d", "a"});  // independent right operand
+  UniTensor got = Contract(A, R);
+  (void)got;
+
+  ASSERT_EQ(observer.Nblocks(), snap.Nblocks());
+  for (cytnx_uint64 i = 0; i < observer.Nblocks(); i++) {
+    EXPECT_EQ(observer.get_blocks_()[i].shape(), snap.get_blocks_()[i].shape());
+    EXPECT_TRUE(AreNearlyEqTensor(observer.get_blocks_()[i], snap.get_blocks_()[i], 0.0));
+  }
+  EXPECT_TRUE(observer.is_contiguous());
+  EXPECT_TRUE(R.is_contiguous());
+}


### PR DESCRIPTION
Completes the #724 fix by converting the last remaining shared-block mutation site — the KNOWN-ISSUE remnant documented in-code by the parent PR #998. **Stacked on #998** (base = `fix/blockut-permute-shared-blocks`); the diff here is a single commit.

## Problem

`BlockUniTensor::contract` and `BlockFermionicUniTensor::contract` `permute_()`/`reshape_()`'d the operands' blocks in place before each Matmul/Gemm_Batch call and restored the metadata afterward. Any UniTensor sharing those blocks (e.g. via `relabel()`, which is documented to share block storage):

- observed transiently corrupted blocks during the contraction,
- was left with replaced, permuted (non-contiguous) block storage afterward even though values were restored, and
- was corrupted permanently if an exception fired before the restore ran.

In particular, contracting a UniTensor with a `relabel()` of itself threw a rank-mismatch error from `permute_` on an already-reshaped shared block.

## Fix

In all three branches of both files (UNI_MKL integer-dtype Matmul fallback, UNI_MKL fp/complex Gemm_Batch, non-MKL Matmul fallback), the rank-2 matrix views of the blocks are now built with the non-mutating `Tensor::permute()`/`reshape()` into local variables instead of mutating and restoring the blocks. Right-block views are cached per block index (the same right block can pair with several left blocks), preserving the old code's one-copy-per-participating-block cost. The Gemm_Batch eager cast-clone of the right operand (`clone_meta`/`astype`/manual `delete`) is replaced by a lazy `astype(common_dtype)` when each right block's view is built, which also removes the manually-deleted heap clone from the exception path.

## Tests (TDD red/green)

For both `BlockUniTensor` and `BlockFermionicUniTensor`:

- `ContractAliasedSharedBlocksOperandsIntact` — contracts a UniTensor with a `relabel()` of itself, so the operands alias each other's blocks (including block-with-itself pairs); pre-fix this threw mid-contraction. Asserts the result matches contracting independent clones and that both operands keep their values, shapes, and contiguity.
- `ContractLeavesSharedBlockObserverUntouched` — a third UniTensor sharing an operand's blocks must observe no change; pre-fix it ended up with replaced, non-contiguous block storage.

No dedicated exception-path test: on non-MKL builds no reachable error fires inside the (now removed) mutation window on valid inputs, and post-fix there is no mutation to leak in the first place.

The UNI_MKL branches are not compiled by the local `USE_MKL=OFF` build; they were additionally syntax/type-checked with `-DUNI_MKL -fsyntax-only`.

Full C++ suite on top of #998: 1092 ran / 1077 passed / 11 skipped / 4 known-failing (pre-existing `linalg_Test.BkUt_*Svd_truncate_return_err*` failures, unrelated to this change).

**Merge order:** merge this PR into `fix/blockut-permute-shared-blocks` before #998 merges, or merge #998 first and let GitHub retarget this PR to `master`. Fixes #724 once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
