### PR TITLE
docs: record 2026-07 API decisions and archive the phase execution plans

### DIFF
--- a/docs/dev/api-decisions.md
+++ b/docs/dev/api-decisions.md
@@ -1,0 +1,68 @@
+# API design decisions
+
+Recorded rulings on open API-semantics questions, with the issues they resolve
+and the PRs that implement them. Contributors should treat these as settled
+unless a maintainer reopens the discussion in the linked issue.
+
+## 2026-07-06 — rulings by @yingjerkao
+
+### 1. UniTensor elementwise arithmetic is removed from the Python surface
+
+Resolves the #753 / #675 / #934 discussion. Elementwise `UniTensor ⊙ UniTensor`
+(`+ - * /`, in-place and out-of-place) is not a meaningful tensor-network
+operation — it silently ignores labels and can break block structure — so the
+Python dunders now raise a guidance `TypeError` instead of being given label
+semantics. Alternatives named in the error: `Contract()`, `Kron()`, scalar
+arithmetic (fully retained), the Krylov solvers (`linalg.Lanczos`,
+`linalg.Lanczos_Exp`, `linalg.Arnoldi`), and `ut.get_block()` Tensor
+arithmetic for genuinely elementwise use. The C++ operators remain (the Krylov
+solvers use them as vector-space operations) and are documented internal-only.
+Implemented in PR #997.
+
+### 2. `norm()` returns `double`; `Norm()` is deprecated
+
+Resolves #676. New snake_case `Tensor::norm()`, `UniTensor::norm()`, and
+`linalg::norm()` return a plain `double`. The old `Norm()` spellings keep
+returning a rank-0 `Tensor` and are deprecated for one release (C++
+`[[deprecated]]`, Python `DeprecationWarning`). Implemented in PR #1000.
+
+### 3. Trailing underscore means in-place, everywhere
+
+Resolves #335 / #336 / #381 (with the #421 / #422 API merges). The convention:
+a trailing `_` marks an in-place method, which mutates `self` and returns it
+(C++ reference / same Python object) for chaining; the non-underscore spelling
+is always out-of-place. New canonical spellings added: `set_name_`,
+`set_label_`, `tag_`, `convert_from_`, `combineBond_`; the old spellings are
+deprecation shims for one release. **One breaking change:** bare
+`combineBond()` flipped from in-place to out-of-place at the same signature —
+use `combineBond_()` for the old behavior. Implemented in PR #1000.
+
+### 4. `permute`/`reshape` accept both call syntaxes on both classes
+
+Resolves #293. `Tensor` and `UniTensor` both accept the variadic form
+(`permute(1, 2, 0)`, and variadic string labels on UniTensor) and the list
+form (`permute([1, 2, 0])`). Additive, non-breaking. Implemented in PR #1000.
+
+## Consensus positions implemented from issue threads
+
+- **Bond is publicly immutable** (#846, position of @IvanaGyro; #841): in-place
+  mutators (`set_type`, `redirect_`, `combineBond_` on `Bond`, `clear_type`,
+  `group_duplicates_`, non-const `qnums()`/`syms()`) are removed in favor of
+  return-new forms (`retype`, `redirect`, `combineBond`, `group_duplicates`);
+  `BlockFermionicUniTensor::_signflip` is private behind a single documented
+  gateway for decomposition internals. Implemented in PR #1001.
+- **Shared-block safety** (#724, proposal of @manuschneider endorsed by
+  @ianmccul): in-place `permute_`/`reshape_`/`contiguous_`/`combineBonds` on
+  UniTensors rebuild per-block `Tensor` metadata via the non-mutating calls
+  (storage stays shared, metadata detaches) instead of mutating possibly
+  shared blocks. Implemented in PRs #998 and #1005.
+- **New code uses snake_case function names** in both C++ and Python (#836);
+  the existing API is not mass-renamed.
+
+## Where the detailed records live
+
+The full execution plans (task specs, verification gates, migration tables)
+for the three 2026-07 hardening phases are in [`docs/dev/plans/`](plans/).
+They were written by and for agent-assisted development sessions and contain
+machine-specific build paths; read them as historical decision records, not
+as current build instructions.

--- a/docs/dev/plans/2026-07-05-phase0-safety-fixes.md
+++ b/docs/dev/plans/2026-07-05-phase0-safety-fixes.md
@@ -1,0 +1,808 @@
+# Phase 0 Safety Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix six silent-corruption / memory-safety class defects in Cytnx (issues #906, #965, #951, #858, plus two newly found bugs) as six independent branches, one PR each.
+
+**Architecture:** Each task is a self-contained fix on its own branch cut from `master`, developed TDD-style in a single shared worktree with one test-enabled build directory (`build_t`). Tasks touch disjoint files. No task depends on another.
+
+**Tech Stack:** C++20, CMake (Unix Makefiles), GoogleTest (`tests/test_main` via `RUN_TESTS=ON`), pybind11 ≥ 3.0 (Task 4 only).
+
+---
+
+## Shared context for every task
+
+- Repo root (worktree): all paths below are relative to it.
+- **Branch naming:** each task creates its branch with `git checkout -b <branch> master` (we are in a linked worktree — `git checkout master` itself would fail because master is checked out in the main repo). Never commit to `master` or to `worktree-phase0-safety-fixes`.
+- **Build setup (once, on master, before Task 1):**
+
+```bash
+git submodule update --init --recursive   # fresh worktrees lack submodules (cmake_modules/morse_cmake)
+cmake -S . -B build_t -DRUN_TESTS=ON -DBUILD_PYTHON=OFF -DUSE_MKL=OFF -DUSE_HPTT=OFF -DUSE_CUDA=OFF \
+      -DCMAKE_CXX_FLAGS="-Wno-c++11-narrowing" \
+      -DCMAKE_EXE_LINKER_FLAGS="-L/Users/yjkao/miniconda3/lib"   # gtest/gmock dylibs live in the conda env
+cmake --build build_t -j10 --target test_main
+```
+
+  First build takes a while (fetches googletest, compiles whole library). Later builds are incremental. `build_t/` is untracked, so it survives branch switches; switching branches only rebuilds changed TUs.
+  (`-Wno-c++11-narrowing` is a local-dev workaround: pre-existing narrowing conversions in `tests/BlockUniTensor_test.cpp` are hard errors under AppleClang. Tracked separately — do NOT fix those test files in any Phase 0 branch.)
+- **Run tests:** `./build_t/tests/test_main --gtest_filter='<Filter>'` for fast iteration; `cmake --build build_t -j10 --target test_main && ./build_t/tests/test_main` for the full suite before each final commit.
+- **Error macro convention:** `cytnx_error_msg(cond, "fmt%s", "")` — the trailing `"%s", ""` is required by the existing macro (pre-`__VA_OPT__` style). Match it in any new call.
+- **Test naming:** GoogleTest names must not contain underscores (existing violations are issue #857 — do not add new ones). Use `TEST(SuiteName, CamelCaseName)`.
+- **Errors throw `std::logic_error`** (until Task 6 introduces `cytnx::error` deriving from it). `EXPECT_THROW(expr, std::logic_error)` works before and after.
+- **Known-failing baseline (pre-existing on unmodified master with this toolchain — do NOT try to fix, do NOT count as your regression):**
+  `linalg_Test.BkUt_Svd_truncate_return_err_returns_discarded_values`,
+  `linalg_Test.BkUt_Gesvd_truncate_return_err_returns_discarded_values`,
+  `linalg_Test.BkUt_Svd_truncate_return_err_one_returns_first_discarded_value`,
+  `linalg_Test.BkUt_Gesvd_truncate_return_err_one_returns_first_discarded_value`.
+  Full-suite gate for every task = 1063 passing / 11 skipped / exactly these 4 failing.
+- **Local uncommitted files:** `git status` shows modified `tests/BlockUniTensor_test.h`, `tests/utils/getNconParameter.h` (macOS build workarounds) and untracked `docs/superpowers/`, `build_t/`, logs. Leave them alone; `git add` ONLY the files your task lists.
+
+---
+
+### Task 1: Reject multiple `-1` dimensions in reshape
+
+**Bug:** In `Tensor_impl::reshape_`, the duplicate-`-1` guard tests `new_shape[i] != -1` (always false inside the `< 0` branch) instead of `has_undetermine`, so `t.reshape({-1, -1})` is silently accepted and leaves a `-1` in `_shape`.
+
+**Files:**
+- Modify: `include/backend/Tensor_impl.hpp:269-281` (inside `reshape_`)
+- Test: `tests/Tensor_test.cpp` (append)
+
+- [ ] **Step 1: Branch**
+
+```bash
+git checkout -b fix/reshape-reject-multiple-unknown-dims master
+```
+
+- [ ] **Step 2: Write the failing test** — append to `tests/Tensor_test.cpp`:
+
+```cpp
+TEST(Tensor, ReshapeRejectsMultipleUnknownDims) {
+  cytnx::Tensor t = cytnx::zeros({12}, cytnx::Type.Double);
+  EXPECT_THROW(t.reshape({-1, -1}), std::logic_error);
+  EXPECT_THROW(t.reshape_({-1, -1}), std::logic_error);
+  EXPECT_THROW(t.reshape({-2, 6}), std::logic_error);
+  // a single -1 must keep working
+  cytnx::Tensor r = t.reshape({3, -1});
+  EXPECT_EQ(r.shape(), (std::vector<cytnx::cytnx_uint64>{3, 4}));
+}
+```
+
+(Match the include/namespace style at the top of the existing file — if the file has `using namespace cytnx;`, drop the `cytnx::` prefixes.)
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+cmake --build build_t -j10 --target test_main && ./build_t/tests/test_main --gtest_filter='Tensor.ReshapeRejectsMultipleUnknownDims'
+```
+
+Expected: FAIL — `t.reshape({-1,-1})` does not throw.
+
+- [ ] **Step 4: Fix the guard** in `include/backend/Tensor_impl.hpp`. Replace:
+
+```cpp
+        if (new_shape[i] < 0) {
+          if (new_shape[i] != -1)
+            cytnx_error_msg(
+              new_shape[i] != -1, "%s",
+              "[ERROR] reshape can only have dimension > 0 and one undetermine rank specify as -1");
+          if (has_undetermine)
+            cytnx_error_msg(
+              new_shape[i] != -1, "%s",
+              "[ERROR] reshape can only have dimension > 0 and one undetermine rank specify as -1");
+          Udet_id = i;
+          has_undetermine = true;
+        } else {
+```
+
+with:
+
+```cpp
+        if (new_shape[i] < 0) {
+          cytnx_error_msg(
+            new_shape[i] != -1, "%s",
+            "[ERROR] reshape can only have dimension > 0 and one undetermine rank specify as -1");
+          cytnx_error_msg(
+            has_undetermine, "%s",
+            "[ERROR] reshape can only have dimension > 0 and one undetermine rank specify as -1");
+          Udet_id = i;
+          has_undetermine = true;
+        } else {
+```
+
+- [ ] **Step 5: Run test to verify it passes**, then run the full suite (`./build_t/tests/test_main`). Expected: all pass (this header is widely included — the rebuild is large; that's normal).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add include/backend/Tensor_impl.hpp tests/Tensor_test.cpp
+git commit -m "fix(Tensor): reject multiple -1 dimensions in reshape
+
+The duplicate-'-1' guard tested new_shape[i] != -1 (always false inside
+the negative branch) instead of has_undetermine, so reshape({-1,-1})
+was silently accepted and left a -1 in the shape.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Unconditional dtype check in `Storage::at<T>` / `Tensor::item<T>` (issue #965)
+
+**Bug:** Every `Storage_base::at<T>` specialization wraps its dtype check in `if (cytnx::User_debug)` (default `false`), so e.g. `Tensor({1}, Type.Float).item<double>()` reinterprets a float buffer as double and returns garbage. Note `data<T>()` specializations in the same file already check unconditionally — this makes `at<T>`/`back<T>` consistent with them.
+
+**Files:**
+- Modify: `src/backend/Storage_base.cpp` (all `at<T>` and `back<T>` specializations, ~line 650 onward)
+- Test: `tests/Storage_test.cpp`, `tests/Tensor_test.cpp` (append)
+
+- [ ] **Step 1: Branch**
+
+```bash
+git checkout -b fix/storage-at-unconditional-dtype-check master
+```
+
+- [ ] **Step 2: Audit internal callers first** (so the change doesn't break library code that abuses `at<T>`):
+
+```bash
+grep -rn "\.at<" src/ include/ | grep -v "//"
+grep -rn "\.back<" src/ include/ | grep -v "//"
+```
+
+Read each hit and confirm the requested `T` matches the storage dtype at that site (most internal code uses `data<T>()`, which already checks). If a mismatched internal call exists, fix it in the same commit and mention it in the report.
+
+- [ ] **Step 3: Write the failing tests** — append to `tests/Storage_test.cpp`:
+
+```cpp
+TEST(Storage, AtDtypeMismatchThrows) {
+  cytnx::Storage s(4, cytnx::Type.Float);
+  EXPECT_THROW(s.at<double>(0), std::logic_error);
+  EXPECT_THROW(s.at<cytnx::cytnx_int64>(0), std::logic_error);
+  EXPECT_NO_THROW(s.at<float>(0));
+}
+```
+
+and to `tests/Tensor_test.cpp`:
+
+```cpp
+TEST(Tensor, ItemDtypeMismatchThrows) {
+  cytnx::Tensor t = cytnx::zeros({1}, cytnx::Type.Float);
+  EXPECT_THROW(t.item<double>(), std::logic_error);
+  EXPECT_NO_THROW(t.item<float>());
+}
+```
+
+(Verify the `Storage(size, dtype)` constructor signature in `include/backend/Storage.hpp`; if it differs, use `Storage s; s.Init(4, cytnx::Type.Float);`.)
+
+- [ ] **Step 4: Run to verify they fail** (the mismatched `at<double>`/`item<double>` calls return garbage instead of throwing):
+
+```bash
+cmake --build build_t -j10 --target test_main && ./build_t/tests/test_main --gtest_filter='Storage.AtDtypeMismatchThrows:Tensor.ItemDtypeMismatchThrows'
+```
+
+- [ ] **Step 5: Remove the `User_debug` guard** in every `at<T>` and `back<T>` specialization in `src/backend/Storage_base.cpp`. Pattern — change:
+
+```cpp
+  template <>
+  double &Storage_base::at<double>(const cytnx_uint64 &idx) const {
+    if (cytnx::User_debug) {
+      cytnx_error_msg(this->dtype() != Type.Double,
+                      "[ERROR] type mismatch. try to get <double> type from raw data of type %s",
+                      Type.getname(this->dtype()).c_str());
+    }
+```
+
+to:
+
+```cpp
+  template <>
+  double &Storage_base::at<double>(const cytnx_uint64 &idx) const {
+    cytnx_error_msg(this->dtype() != Type.Double,
+                    "[ERROR] type mismatch. try to get <double> type from raw data of type %s",
+                    Type.getname(this->dtype()).c_str());
+```
+
+Apply to all specializations (float, double, complex<float>, complex<double>, all int widths, bool — both `at<T>` and `back<T>`; some guards are written without braces, e.g. the `std::complex` ones). Do NOT touch the bounds checks or other `User_debug` uses elsewhere in the file.
+
+- [ ] **Step 6: Run the new tests, then the full suite.** If any existing test fails, it was relying on a type-punned read — fix that test/call site and list it in your report.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/backend/Storage_base.cpp tests/Storage_test.cpp tests/Tensor_test.cpp
+git commit -m "fix(Storage): check dtype in at<T>/back<T> unconditionally (#965)
+
+The dtype-mismatch check was guarded by cytnx::User_debug (off by
+default), so Tensor::item<T>() and Storage::at<T>() silently
+reinterpreted storage as the wrong type in normal builds. data<T>()
+already checked unconditionally; at<T>/back<T> now match.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Scalar in-place Tensor arithmetic must mutate storage, not replace it (issue #906)
+
+**Bug:** `Tensor::operator+=<scalar>` (and `-=`, `*=`, `/=`; also the `Scalar` overloads) do `this->_impl->storage() = linalg::Add(*this, rc)._impl->storage();` (`src/Tensor.cpp:562-...`), replacing the storage pointer. Any view sharing the old storage silently detaches. The Tensor-RHS path (`iAdd`) mutates in place — the two paths disagree.
+
+**Fix:** route scalar RHS through the same `iAdd/iSub/iMul/iDiv` kernels by wrapping the scalar in a shape-`{1}` Tensor (the kernels already broadcast a length-1 RHS, preserve LHS dtype, and reject `real ⊙= complex` — see `src/linalg/iAdd.cpp:16` and `src/linalg/iArithmetic_visit.hpp::ApplyInplaceArithmeticOp`).
+
+**Deliberate behavior changes** (call out in commit message):
+1. Views sharing storage stay attached (the bug fix).
+2. dtype is preserved: `Float tensor += 1.0` stays `Float` (previously promoted to `Double`). This matches the existing `t += tensor_of_shape_{1}` behavior and numpy's scalar rules.
+3. `real_tensor += complex_scalar` now throws (previously silently promoted the tensor to complex).
+
+**Files:**
+- Modify: `src/Tensor.cpp` (the `+=`, `-=`, `*=`, `/=` scalar specializations block, starting ~line 561)
+- Test: `tests/Tensor_test.cpp` (append)
+
+- [ ] **Step 1: Branch**
+
+```bash
+git checkout -b fix/scalar-inplace-ops-preserve-storage master
+```
+
+- [ ] **Step 2: Write the failing tests** — append to `tests/Tensor_test.cpp`:
+
+```cpp
+TEST(Tensor, ScalarInplaceAddKeepsStorageSharing) {
+  cytnx::Tensor a = cytnx::zeros({4}, cytnx::Type.Double);
+  cytnx::Tensor b = a;  // shares storage (reference semantics)
+  a += 1.0;
+  EXPECT_TRUE(cytnx::is(a.storage(), b.storage()));
+  EXPECT_DOUBLE_EQ(b.storage().at<double>(0), 1.0);
+}
+
+TEST(Tensor, ScalarInplaceOpsPreserveDtype) {
+  cytnx::Tensor a = cytnx::ones({2}, cytnx::Type.Float);
+  a += 1.0;   // double scalar must not promote the tensor
+  a -= 0.5;
+  a *= 2.0;
+  a /= 3.0;
+  EXPECT_EQ(a.dtype(), cytnx::Type.Float);
+  EXPECT_FLOAT_EQ(a.storage().at<float>(0), 1.0f);
+}
+
+TEST(Tensor, ScalarInplaceRealPlusComplexThrows) {
+  cytnx::Tensor a = cytnx::zeros({2}, cytnx::Type.Double);
+  EXPECT_THROW(a += cytnx::cytnx_complex128(0, 1), std::logic_error);
+}
+
+TEST(Tensor, ScalarInplaceSubMulDivKeepStorageSharing) {
+  cytnx::Tensor a = cytnx::ones({3}, cytnx::Type.Double);
+  cytnx::Tensor b = a;
+  a -= 0.5;
+  a *= 4.0;
+  a /= 2.0;
+  EXPECT_TRUE(cytnx::is(a.storage(), b.storage()));
+  EXPECT_DOUBLE_EQ(b.storage().at<double>(2), 1.0);
+}
+
+TEST(Tensor, CytnxScalarInplaceAddKeepsStorageSharing) {
+  cytnx::Tensor a = cytnx::zeros({2}, cytnx::Type.Double);
+  cytnx::Tensor b = a;
+  a += cytnx::Scalar(2.5);
+  EXPECT_TRUE(cytnx::is(a.storage(), b.storage()));
+  EXPECT_DOUBLE_EQ(b.storage().at<double>(1), 2.5);
+}
+```
+
+`cytnx::is()` lives in `include/utils/is.hpp` (already included by Tensor.cpp; verify the test TU sees it — include `cytnx.hpp` covers it).
+
+- [ ] **Step 3: Run to verify the sharing/dtype tests fail** (throw-test may already pass or fail — record which):
+
+```bash
+cmake --build build_t -j10 --target test_main && ./build_t/tests/test_main --gtest_filter='Tensor.Scalar*:Tensor.CytnxScalar*'
+```
+
+- [ ] **Step 4: Implement.** In `src/Tensor.cpp`, add a file-local helper above the `+=` block (inside `namespace cytnx`):
+
+```cpp
+  namespace {
+    // Wrap a scalar as a shape-{1} Tensor on `device` so scalar in-place
+    // arithmetic can reuse the iAdd/iSub/iMul/iDiv kernels (which broadcast a
+    // length-1 RHS and mutate LHS storage in place). See #906.
+    template <class T>
+    Tensor _scalar_as_rank1_tensor(const T &rc, const int device) {
+      Tensor s({1}, Type.cy_typeid(rc), Device.cpu);
+      s.storage().at<T>(0) = rc;
+      if (device != Device.cpu) s = s.to(device);
+      return s;
+    }
+    Tensor _scalar_as_rank1_tensor(const Scalar &rc, const int device) {
+      Tensor s({1}, rc.dtype(), Device.cpu);
+      s.item() = rc;  // Sproxy assignment
+      if (device != Device.cpu) s = s.to(device);
+      return s;
+    }
+  }  // namespace
+```
+
+(If `s.item() = rc` does not compile, use `s.storage().at(0) = rc;` — both return a `Scalar::Sproxy`; check `include/backend/Scalar.hpp` for the supported assignment. Report which you used.)
+
+Then rewrite every scalar specialization — 11 builtin types + `Scalar`, for each of the four ops (the `Tensor`/`Tproxy`/`Sproxy` specializations stay as they are). Pattern:
+
+```cpp
+  template <>
+  Tensor &Tensor::operator+=<cytnx_double>(const cytnx_double &rc) {
+    cytnx::linalg::iAdd(*this, _scalar_as_rank1_tensor(rc, this->device()));
+    return *this;
+  }
+```
+
+Same for `cytnx_complex128`, `cytnx_complex64`, `cytnx_float`, `cytnx_int64`, `cytnx_uint64`, `cytnx_int32`, `cytnx_uint32`, `cytnx_int16`, `cytnx_uint16`, `cytnx_bool`, and `Scalar` — with `iSub` for `-=`, `iMul` for `*=`, `iDiv` for `/=`.
+
+- [ ] **Step 5: Run the new tests, then full suite.** Existing tests that assert dtype *promotion* after scalar in-place ops encode the old buggy behavior — update them to expect dtype preservation and list every such change in your report.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Tensor.cpp tests/Tensor_test.cpp
+git commit -m "fix(Tensor): scalar in-place arithmetic mutates storage in place (#906)
+
+t += 1.0 previously replaced t's Storage with a freshly computed one,
+silently detaching every view sharing that storage, while t += tensor
+mutated in place. Scalar RHS now routes through the same
+iAdd/iSub/iMul/iDiv kernels via a shape-{1} tensor.
+
+Behavior changes: dtype is preserved (Float += 1.0 stays Float, as the
+tensor-RHS path already behaved), and real ⊙= complex now throws
+instead of silently promoting the tensor.
+
+GPU note: the iAdd GPU path still rebinds on promotion; that remains
+tracked under #906.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Remove C `complex.h` from the pybind TU; rename macro-colliding template param (issue #951)
+
+**Bug:** `pybind/cytnx.cpp:15` does `#include "complex.h"` — the C header that defines `#define I _Complex_I`. It only compiles because it comes after `cytnx.hpp`; any reordering (or user TU including `<complex.h>` before cytnx headers) breaks `template <std::size_t I, ...>` in `include/Type.hpp`.
+
+**Files:**
+- Modify: `pybind/cytnx.cpp` (delete the include)
+- Modify: `include/Type.hpp` (rename template parameters named `I` to `Idx`)
+- No new test (compile-time fix); verification is building the python module.
+
+- [ ] **Step 1: Branch**
+
+```bash
+git checkout -b fix/remove-complex-h-macro-collision master
+```
+
+- [ ] **Step 2: Delete** the line `#include "complex.h"` from `pybind/cytnx.cpp`. Grep the pybind TUs to confirm nothing needs it:
+
+```bash
+grep -rn "_Complex_I\|creal\|cimag\| I(" pybind/ | head
+```
+
+- [ ] **Step 3: Rename template parameters named `I` in `include/Type.hpp`** to `Idx` (find with `grep -n "std::size_t I\b\|size_t I," include/Type.hpp`). This hardens the public header against any TU that includes `<complex.h>` first. Do NOT touch `src/backend/linalg_internal_cpu/Det_internal.cpp` (its `<complex.h>` use is TU-local and deliberately ordered).
+
+- [ ] **Step 4: Verify the C++ library still builds and tests pass:**
+
+```bash
+cmake --build build_t -j10 --target test_main && ./build_t/tests/test_main --gtest_filter='Type*'
+```
+
+- [ ] **Step 5: Verify the python module compiles without the include:**
+
+```bash
+cmake -S . -B build_py -DBUILD_PYTHON=ON -DRUN_TESTS=OFF -DUSE_MKL=OFF -DUSE_HPTT=OFF -DUSE_CUDA=OFF
+cmake --build build_py -j10
+```
+
+Expected: builds cleanly. (Import smoke-testing needs package assembly — compile success is the acceptance bar for this task.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pybind/cytnx.cpp include/Type.hpp
+git commit -m "fix: drop C complex.h from pybind TU and rename macro-colliding template param (#951)
+
+complex.h defines the macro I, which collides with template
+<std::size_t I> in Type.hpp and made the pybind TU compile only by
+include-order luck. The include was vestigial. Type.hpp's index
+parameters are renamed to Idx so user TUs that include <complex.h>
+before cytnx headers no longer break.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Type-promotion helpers + fix cross-kind promotion (issues #858, part of #692)
+
+**Bugs:**
+1. Nine-plus call sites use the magic expression `in.dtype() <= 2 ? in.dtype() + 2 : in.dtype()` to compute "the real counterpart" of a dtype (for singular-/eigen-value tensors), relying on enum ordering (`Void=0, ComplexDouble=1, ComplexFloat=2, Double=3, Float=4, ...`).
+2. `Type_class::type_promote` (`include/Type.hpp:342-359`) picks the *lower index*, so `ComplexFloat + Double → ComplexFloat`, silently discarding double precision (numpy/torch: `ComplexDouble`).
+
+**Files:**
+- Modify: `include/Type.hpp` (add `to_real`/`to_complex`, fix `type_promote`)
+- Modify: `src/linalg/Svd.cpp:27`, `src/linalg/Gesvd.cpp:29`, `src/linalg/Gesvd_truncate.cpp:56,71`, `src/linalg/Rsvd.cpp:83,503,518`, `src/linalg/Lstsq.cpp:53`, `src/linalg/Eigh.cpp:30`, `src/linalg/Tridiag.cpp:26` (and any further hits of the grep below)
+- Test: `tests/Type_test.cpp` (append)
+
+- [ ] **Step 1: Branch**
+
+```bash
+git checkout -b fix/type-promotion-cross-kind master
+```
+
+- [ ] **Step 2: Write the failing tests** — append to `tests/Type_test.cpp`:
+
+```cpp
+TEST(Type, ToRealMapsToRealCounterpart) {
+  EXPECT_EQ(cytnx::Type.to_real(cytnx::Type.ComplexDouble), cytnx::Type.Double);
+  EXPECT_EQ(cytnx::Type.to_real(cytnx::Type.ComplexFloat), cytnx::Type.Float);
+  EXPECT_EQ(cytnx::Type.to_real(cytnx::Type.Double), cytnx::Type.Double);
+  EXPECT_EQ(cytnx::Type.to_real(cytnx::Type.Int64), cytnx::Type.Int64);
+}
+
+TEST(Type, ToComplexMapsToComplexCounterpart) {
+  EXPECT_EQ(cytnx::Type.to_complex(cytnx::Type.Double), cytnx::Type.ComplexDouble);
+  EXPECT_EQ(cytnx::Type.to_complex(cytnx::Type.Float), cytnx::Type.ComplexFloat);
+  EXPECT_EQ(cytnx::Type.to_complex(cytnx::Type.ComplexFloat), cytnx::Type.ComplexFloat);
+  EXPECT_EQ(cytnx::Type.to_complex(cytnx::Type.Int64), cytnx::Type.ComplexDouble);
+}
+
+TEST(Type, PromoteMixedComplexRealUsesMaxPrecision) {
+  EXPECT_EQ(cytnx::Type.type_promote(cytnx::Type.ComplexFloat, cytnx::Type.Double),
+            cytnx::Type.ComplexDouble);
+  EXPECT_EQ(cytnx::Type.type_promote(cytnx::Type.Double, cytnx::Type.ComplexFloat),
+            cytnx::Type.ComplexDouble);
+  EXPECT_EQ(cytnx::Type.type_promote(cytnx::Type.ComplexFloat, cytnx::Type.Float),
+            cytnx::Type.ComplexFloat);
+  EXPECT_EQ(cytnx::Type.type_promote(cytnx::Type.ComplexDouble, cytnx::Type.Float),
+            cytnx::Type.ComplexDouble);
+  // unchanged same-kind rules
+  EXPECT_EQ(cytnx::Type.type_promote(cytnx::Type.Double, cytnx::Type.Float),
+            cytnx::Type.Double);
+  EXPECT_EQ(cytnx::Type.type_promote(cytnx::Type.ComplexFloat, cytnx::Type.Int64),
+            cytnx::Type.ComplexFloat);
+}
+
+TEST(Type, TensorAddMixedComplexRealPromotes) {
+  auto a = cytnx::zeros({2}, cytnx::Type.ComplexFloat);
+  auto b = cytnx::zeros({2}, cytnx::Type.Double);
+  EXPECT_EQ((a + b).dtype(), cytnx::Type.ComplexDouble);
+}
+```
+
+- [ ] **Step 3: Run to verify failure** (the `to_real`/`to_complex` tests fail to *compile* — that's the red step for new API; comment them out to watch the promote tests fail at runtime if you want a clean red, then restore):
+
+```bash
+cmake --build build_t -j10 --target test_main
+```
+
+- [ ] **Step 4: Implement in `include/Type.hpp`.** Next to `type_promote` (line ~342), add (inside `Type_class`, matching the style of `is_complex(unsigned int)` at line 323 — note the enum constants are accessible unqualified inside the class):
+
+```cpp
+    // Real counterpart of a dtype: ComplexDouble -> Double, ComplexFloat -> Float,
+    // anything else unchanged. Replaces the "dtype <= 2 ? dtype + 2 : dtype" idiom.
+    static constexpr unsigned int to_real(unsigned int type_id) {
+      check_type(type_id);
+      return is_complex(type_id) ? type_id + 2 : type_id;
+    }
+
+    // Complex counterpart of a dtype: Double -> ComplexDouble, Float -> ComplexFloat,
+    // complex types unchanged, integral/bool types -> ComplexDouble.
+    static constexpr unsigned int to_complex(unsigned int type_id) {
+      check_type(type_id);
+      if (is_complex(type_id)) return type_id;
+      if (type_id == Double) return ComplexDouble;
+      if (type_id == Float) return ComplexFloat;
+      if (type_id == Void) return Void;
+      return ComplexDouble;
+    }
+```
+
+(Adapt the constant spellings to how the enum is declared in this class — check how `type_promote` or `check_type` refer to them; if they use e.g. `Type_class::Double`, follow that.)
+
+Then fix `type_promote` by inserting the mixed-kind branch at the top:
+
+```cpp
+    // Find a common type for typeL and typeR
+    static constexpr unsigned int type_promote(unsigned int typeL, unsigned int typeR) {
+      if (typeL == Void || typeR == Void) return Void;
+      // Mixed complex/real: promote the real counterparts, then re-complexify.
+      // Fixes ComplexFloat + Double -> ComplexDouble (was ComplexFloat, dropping
+      // precision because the enum interleaves complexness and precision).
+      if (is_complex(typeL) != is_complex(typeR)) {
+        return to_complex(type_promote(to_real(typeL), to_real(typeR)));
+      }
+      if (typeL < typeR) {
+        if (!is_unsigned(typeR) && is_unsigned(typeL)) {
+          return typeL - 1;
+        } else {
+          return typeL;
+        }
+      } else {
+        if (typeR == 0) return 0;
+        if (!is_unsigned(typeL) && is_unsigned(typeR)) {
+          return typeR - 1;
+        } else {
+          return typeR;
+        }
+      }
+    }
+```
+
+(The old `if (typeL == 0) return 0;` early-outs are subsumed by the `Void` guard at the top; keep the body otherwise identical. `type_promote` is used at compile time via `type_promote_t` — it must stay `constexpr`.)
+
+- [ ] **Step 5: Replace the ordering hacks.** Find all sites:
+
+```bash
+grep -rn "dtype() <= 2" src/
+```
+
+At each `S.Init(..., in.dtype() <= 2 ? in.dtype() + 2 : in.dtype(), ...)` site, substitute `Type.to_real(in.dtype())`. At `src/linalg/Tridiag.cpp:26`, replace the `Diag.dtype() <= 2 || Sub_diag.dtype() <= 2` condition with `Type.is_complex(Diag.dtype()) || Type.is_complex(Sub_diag.dtype())`. If the grep finds sites beyond the list above, convert them too and list them in your report.
+
+- [ ] **Step 6: Run new tests, then the FULL suite** (`./build_t/tests/test_main`). The promote change alters result dtypes for mixed `ComplexFloat`⊙`Double` operations everywhere (Tensor ops, UniTensor contractions — `src/BlockUniTensor.cpp` uses `type_promote`). Any test asserting the old `ComplexFloat` result encodes the precision-loss bug — update it and list it in your report. If a *kernel dispatch* fails (missing instantiation for a promoted-type combination), STOP and report BLOCKED with the error — do not patch kernel tables ad hoc.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add include/Type.hpp tests/Type_test.cpp src/linalg/
+git commit -m "fix(Type): promote mixed complex/real dtypes by precision; add to_real/to_complex (#858)
+
+type_promote picked the lower enum index, so ComplexFloat + Double
+yielded ComplexFloat, silently discarding double precision. Mixed
+complex/real pairs now promote their real counterparts and
+re-complexify (ComplexFloat + Double -> ComplexDouble). Same-kind
+promotion is unchanged.
+
+Adds Type.to_real/Type.to_complex and replaces the enum-ordering hack
+'dtype <= 2 ? dtype + 2 : dtype' at all linalg call sites.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Rewrite `cytnx_error.hpp` (bounded formatting, namespaced, single-report)
+
+**Bugs (all in `include/cytnx_error.hpp:27-83`):** unbounded `vsprintf`/`sprintf` into 512/1024-byte stack buffers; `static inline` free functions `error_msg`/`warning_msg` at global namespace in a public header; macro bodies are bare `{...}` blocks (dangling-else hazard); the condition is evaluated twice; errors print to stderr *and* throw; `#define __PRETTY_FUNCTION__ __FUNCTION__` defines a reserved identifier on MSVC.
+
+**Constraints:**
+- Call sites stay source-compatible: `cytnx_error_msg(cond, "fmt", args...)` with at least one vararg (the `"%s",""` idiom). C++20 `__VA_OPT__` is available (CMAKE_CXX_STANDARD 20) — use it so zero-vararg calls also work, but do not rewrite call sites.
+- 225 test assertions expect `std::logic_error` — the new exception `cytnx::error` must derive from `std::logic_error`.
+- Keep the `#include`s the old header provided (`<cstdio> <cstdlib> <cstring> <stdarg.h> <iostream> <stdexcept>` + the execinfo block) — other TUs may depend on them transitively.
+- The `UNI_GPU` section (line 85 onward) is out of scope — do not modify it.
+- Backtrace printing: keep it, but only when `cytnx::User_debug` is true (declared in `include/Type.hpp:440` — but do NOT include Type.hpp from cytnx_error.hpp, that would create an include cycle; declare `namespace cytnx { extern bool User_debug; }` locally).
+
+**Files:**
+- Modify: `include/cytnx_error.hpp:1-83`
+- Test: create `tests/cytnx_error_test.cpp`, register in `tests/CMakeLists.txt`
+
+- [ ] **Step 1: Branch**
+
+```bash
+git checkout -b fix/error-macro-rewrite master
+```
+
+- [ ] **Step 2: Check for direct (non-macro) callers of `error_msg`/`warning_msg`:**
+
+```bash
+grep -rn "error_msg(" src/ include/ pybind/ tests/ | grep -v "cytnx_error_msg\|cytnx_warning_msg\|_error_msg_impl" | head -20
+```
+
+If any TU calls `error_msg(...)`/`warning_msg(...)` directly, adapt those call sites in this branch (they are few or none).
+
+- [ ] **Step 3: Write the failing test** — create `tests/cytnx_error_test.cpp`:
+
+```cpp
+#include <stdexcept>
+#include <string>
+
+#include "cytnx.hpp"
+#include "gtest/gtest.h"
+
+TEST(CytnxError, LongMessagesDoNotOverflow) {
+  std::string big(5000, 'x');
+  try {
+    cytnx_error_msg(true, "%s", big.c_str());
+    FAIL() << "expected throw";
+  } catch (const std::logic_error &e) {
+    EXPECT_NE(std::string(e.what()).find("xxxx"), std::string::npos);
+    EXPECT_GE(std::string(e.what()).size(), big.size());
+  }
+}
+
+TEST(CytnxError, ThrowsCytnxErrorType) {
+  EXPECT_THROW(cytnx_error_msg(true, "boom%s", ""), cytnx::error);
+  EXPECT_THROW(cytnx_error_msg(true, "boom%s", ""), std::logic_error);
+}
+
+TEST(CytnxError, FalseConditionDoesNotThrow) {
+  EXPECT_NO_THROW(cytnx_error_msg(false, "never%s", ""));
+}
+
+TEST(CytnxError, MacroIsSafeInIfElse) {
+  // dangling-else regression guard: must compile and take the else branch
+  bool flag = false;
+  if (flag)
+    cytnx_error_msg(true, "unreachable%s", "");
+  else
+    SUCCEED();
+}
+
+TEST(CytnxError, ConditionEvaluatedOnce) {
+  int n = 0;
+  cytnx_error_msg((++n, false), "never%s", "");
+  EXPECT_EQ(n, 1);
+}
+```
+
+Register it in `tests/CMakeLists.txt` inside the `add_executable(test_main ...)` list (alphabetical placement near `Type_test.cpp` is fine; the list is one file per line).
+
+- [ ] **Step 4: Run to verify failure.** `cytnx::error` doesn't exist yet → compile failure (red). The 5000-char test against the OLD header would smash the stack — do not bother running it under the old header; compile failure is the red step.
+
+- [ ] **Step 5: Rewrite `include/cytnx_error.hpp` lines 1-83** (everything before the `#if defined(UNI_GPU)` block) as:
+
+```cpp
+#ifndef CYTNX_CYTNX_ERROR_H_
+#define CYTNX_CYTNX_ERROR_H_
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <stdarg.h>
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#if defined(__has_include)
+  #if __has_include(<execinfo.h>)
+    #include <execinfo.h>
+    #define CYTNX_HAS_EXECINFO 1
+  #endif
+#endif
+
+#ifndef CYTNX_HAS_EXECINFO
+  #define CYTNX_HAS_EXECINFO 0
+#endif
+
+#ifdef _MSC_VER
+  #define CYTNX_FUNC_NAME __FUNCSIG__
+#else
+  #define CYTNX_FUNC_NAME __PRETTY_FUNCTION__
+#endif
+
+namespace cytnx {
+
+  extern bool User_debug;  // defined in src/Type.cpp
+
+  // Exception thrown by cytnx_error_msg. Derives std::logic_error for
+  // backward compatibility with existing catch/EXPECT_THROW sites.
+  class error : public std::logic_error {
+   public:
+    using std::logic_error::logic_error;
+  };
+
+  namespace internal {
+
+    inline std::string vformat_message(char const *format, va_list args) {
+      va_list args_copy;
+      va_copy(args_copy, args);
+      const int n = std::vsnprintf(nullptr, 0, format, args_copy);
+      va_end(args_copy);
+      if (n <= 0) return std::string(format);
+      std::string msg(static_cast<std::size_t>(n), '\0');
+      std::vsnprintf(msg.data(), msg.size() + 1, format, args);
+      return msg;
+    }
+
+    inline std::string compose_report(char const *kind, char const *func, char const *file,
+                                      int line, const std::string &msg) {
+      std::string out;
+      out.reserve(msg.size() + 256);
+      out += "\n# Cytnx ";
+      out += kind;
+      out += " occur at ";
+      out += func;
+      out += "\n# ";
+      out += kind;
+      out += ": ";
+      out += msg;
+      out += "\n# file : ";
+      out += file;
+      out += " (";
+      out += std::to_string(line);
+      out += ")";
+      return out;
+    }
+
+    inline void print_backtrace_if_debug() {
+      if (!cytnx::User_debug) return;
+#if CYTNX_HAS_EXECINFO
+      std::cerr << "Stack trace:" << std::endl;
+      void *array[10];
+      const int size = backtrace(array, 10);
+      char **strings = backtrace_symbols(array, size);
+      if (strings != nullptr) {
+        for (int i = 0; i < size; i++) std::cerr << strings[i] << std::endl;
+        free(strings);
+      }
+#else
+      std::cerr << "Stack trace is unavailable on this platform/compiler." << std::endl;
+#endif
+    }
+
+    [[noreturn]] inline void error_msg_impl(char const *func, char const *file, int line,
+                                            char const *format, ...) {
+      va_list args;
+      va_start(args, format);
+      const std::string msg = vformat_message(format, args);
+      va_end(args);
+      const std::string report = compose_report("error", func, file, line, msg);
+      print_backtrace_if_debug();
+      throw cytnx::error(report);
+    }
+
+    inline void warning_msg_impl(char const *func, char const *file, int line,
+                                 char const *format, ...) {
+      va_list args;
+      va_start(args, format);
+      const std::string msg = vformat_message(format, args);
+      va_end(args);
+      std::cerr << compose_report("warning", func, file, line, msg) << std::endl;
+    }
+
+  }  // namespace internal
+}  // namespace cytnx
+
+#define cytnx_error_msg(is_true, format, ...)                                        \
+  do {                                                                               \
+    if (is_true)                                                                     \
+      cytnx::internal::error_msg_impl(CYTNX_FUNC_NAME, __FILE__, __LINE__, (format) \
+                                        __VA_OPT__(, ) __VA_ARGS__);                 \
+  } while (0)
+
+#define cytnx_warning_msg(is_true, format, ...)                                        \
+  do {                                                                                 \
+    if (is_true)                                                                       \
+      cytnx::internal::warning_msg_impl(CYTNX_FUNC_NAME, __FILE__, __LINE__, (format) \
+                                          __VA_OPT__(, ) __VA_ARGS__);                 \
+  } while (0)
+```
+
+Keep everything from `#if defined(UNI_GPU)` onward unchanged, EXCEPT: if the GPU section references `__PRETTY_FUNCTION__` via the old `#ifdef _MSC_VER` redefine, leave the old `#define __PRETTY_FUNCTION__ __FUNCTION__` for MSVC in place *only if* something in the retained section still uses `__PRETTY_FUNCTION__` (grep the remainder of the file; if nothing does, delete the redefine).
+
+Behavior changes to note: errors no longer pre-print to stderr (the message is in `what()`; backtrace prints only under `User_debug`); exception type is now `cytnx::error` (still a `std::logic_error`).
+
+- [ ] **Step 6: Full rebuild and full test suite.** This header is included everywhere — expect a near-full rebuild. Two classes of fallout to watch:
+  - call sites written WITHOUT a trailing semicolon (`{...}` block tolerated it; `do{}while(0)` requires `;`) — fix any the compiler finds;
+  - tests asserting on stderr output of errors — update them.
+
+  List all fallout fixes in your report.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add include/cytnx_error.hpp tests/cytnx_error_test.cpp tests/CMakeLists.txt
+git commit -m "fix(error): bounded formatting, namespaced impl, single-report errors
+
+Replaces unbounded vsprintf into 512/1024-byte stack buffers with
+size-measured vsnprintf into std::string; moves error_msg/warning_msg
+out of the global namespace; wraps macros in do{}while(0) (dangling-
+else safety, single evaluation of the condition); introduces
+cytnx::error : std::logic_error; stops double-reporting (no stderr
+print before throw; backtrace only under User_debug); stops defining
+the reserved identifier __PRETTY_FUNCTION__ on MSVC.
+
+Call sites are source-compatible; __VA_OPT__ additionally allows
+zero-vararg calls going forward.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Plan self-review notes
+
+- Task 5 merges original items "to_real helper (#858)" and "type_promote fix" because the fix uses the helpers — shipping them separately would create a cross-branch dependency.
+- Task 3's helper uses `at<T>` writes on a freshly created CPU tensor — dtype always matches, so it composes safely with Task 2 (independent branches).
+- Task 6's test file must be registered in `tests/CMakeLists.txt`; all other tasks append to already-registered test files.
+- All tasks: full-suite run before final commit; report any existing-test updates explicitly.

--- a/docs/dev/plans/2026-07-06-phase1-binding-hygiene.md
+++ b/docs/dev/plans/2026-07-06-phase1-binding-hygiene.md
@@ -1,0 +1,347 @@
+# Phase 1 Binding Hygiene Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clean up the pybind11 layer: kill the `c__*` shadow API + monkey-patch delegation, collapse per-dtype operator overloads, fix `!=`/`bool()` semantics, register an exception translator, and release the GIL on expensive operations.
+
+**Architecture:** Five tasks. T2 and T3 touch the same operator regions of `tensor_py.cpp`/`unitensor_py.cpp`, so **T3's branch stacks on T2's**. T4 stacks on `fix/error-macro-rewrite` (needs `cytnx::error`, PR #983). T5 is independent from master but must NOT touch the `ExpH`/`ExpM` bindings (rewritten by open PR #915). Tests are pytest-based (these changes are Python-visible); the C++ suite is unaffected.
+
+**Tech Stack:** pybind11 ≥3.0 (FetchContent during build; `py::numpy_scalar<T>` available), scikit-build CMake build (`build_py`), pytest.
+
+---
+
+## Shared context for every task
+
+- **Tasks 3-6 work in the SECOND worktree `/Users/yjkao/Cytnx/.claude/worktrees/phase1-binding`** (created at T2's commit; has its own `build_py/`). The original worktree `phase0-safety-fixes` is occupied by a concurrent session (truncate_ fix on the T2 branch) — do not touch it. Use pypkg dir `$SCRATCH/pypkg2` (not `pypkg`) for the same reason. Branch with `git checkout -b <branch> <base>` (never `git checkout master`; never commit to `master`/`worktree-*` utility branches).
+- **T2-branch drift note:** `fix/pybind-inplace-return-self` may gain a truncate_-fix commit (+2 pytests → gate 37) from the concurrent session. T3 branches from whatever the branch TIP is at branch time; record the observed baseline tally in your report.
+- **Python build:** `build_py/` exists (configured `BUILD_PYTHON=ON, RUN_TESTS=OFF, USE_MKL=OFF, USE_HPTT=OFF, USE_CUDA=OFF`). Rebuild with `cmake --build build_py -j10`. The module lands at `build_py/cytnx.cpython-313-darwin.so`.
+- **Run pytests against the dev build** (never copy the .so into the repo's `cytnx/` dir):
+
+```bash
+SCRATCH=/private/tmp/claude-501/-Users-yjkao-Cytnx/ec89d9c5-55f7-474b-ad68-a79b3d8f7a37/scratchpad
+mkdir -p $SCRATCH/pypkg/cytnx
+cp cytnx/*.py cytnx/*.tmp $SCRATCH/pypkg/cytnx/   # glue + build-info files __init__.py reads at import
+cp build_py/cytnx.cpython-313-darwin.so $SCRATCH/pypkg/cytnx/
+# python3 -P is REQUIRED: without it, the repo's cytnx/ source dir (cwd) shadows the package
+PYTHONPATH=$SCRATCH/pypkg python3 -P -m pytest pytests/ -q      # full suite (~7 s)
+PYTHONPATH=$SCRATCH/pypkg python3 -P -m pytest pytests/<file> -q  # targeted
+```
+
+RE-COPY `cytnx/*.py` into `$SCRATCH/pypkg/cytnx/` after every edit to the python glue, and the `.so` after every rebuild — stale copies are the #1 confusing failure.
+
+- **Baseline (established 2026-07-06 on master-equivalent base): 28 passed, 0 failed, 0 skipped, ~7 s.** Every task's gate = 28 + its new tests, nothing else changed.
+- **Known landmines:** `numpy` is required by from_numpy paths; the DMRG/TDVP example tests are slow (minutes) — use `-x -q` and run the full suite only before commits.
+- **Do not touch:** `pybind/linalg_py.cpp` ExpH/ExpM bindings (open PR #915 rewrites them); `tests/BlockUniTensor_test.h`, `tests/utils/getNconParameter.h` (local uncommitted shims); anything in `docs/`, `build_t/`, `build_py/`, logs.
+- The stub pipeline (`tools/generate_stubs.py`, committed `.pyi`) is NOT on master (it's in PR #915) — do not attempt stub regeneration; instead ensure new bindings follow the one-overload-per-Python-type discipline so stubs come out clean once #915 lands.
+
+---
+
+### Task 1: Python test baseline (setup, no PR)
+
+- [ ] On `worktree-phase0-safety-fixes` (base state = master): `cmake --build build_py -j10` (should be a no-op or small rebuild).
+- [ ] Assemble `$SCRATCH/pypkg` per shared context; `PYTHONPATH=$SCRATCH/pypkg python3 -c "import cytnx; print(cytnx.__version__ if hasattr(cytnx,'__version__') else 'ok')"`.
+- [ ] Run `PYTHONPATH=$SCRATCH/pypkg python3 -m pytest pytests/ -q 2>&1 | tail -5`; record pass/fail/skip counts as THE BASELINE. If tests fail at baseline, record which (pre-existing) — do not fix them.
+
+---
+
+### Task 2: Kill the shadow API (branch `fix/pybind-inplace-return-self`, base `master`)
+
+**Problem (issues #779, #336):** In-place methods are bound as `c__iadd__`/`cConj_`/`c_relabel_`/… and re-exported by monkey-patching wrappers in `cytnx/*_conti.py` that call the shadow binding and `return self`. Three inconsistent return conventions exist; every in-place op pays a wasted Python-object copy; `help()`/stubs see the wrong API.
+
+**Canonical replacement pattern** — bind the real dunder/method name directly with a lambda that takes and returns the SAME `py::object`:
+
+```cpp
+// in-place arithmetic: python `t += x` keeps object identity
+.def("__iadd__", [](py::object self, const cytnx::Tensor &rhs) {
+  self.cast<cytnx::Tensor &>().Add_(rhs);
+  return self;
+})
+// in-place named method: `t.Conj_()` chains
+.def("Conj_", [](py::object self) {
+  self.cast<cytnx::Tensor &>().Conj_();
+  return self;
+})
+```
+
+This is identity-exact (returns the caller's own PyObject), needs no return_value_policy reasoning, and works for void- and ref-returning C++ methods alike.
+
+**Complete inventory to convert (from recon — implementer must cover every row):**
+
+- `tensor_py.cpp`: `c__iadd__`→`__iadd__` (Add_), `c__isub__`→`__isub__` (Sub_), `c__imul__`→`__imul__` (Mul_), `c__itruediv__`→`__itruediv__` (Div_), `c__ifloordiv__`→`__ifloordiv__` (FloorDiv_) — each currently ~24 overloads; keep the same overload set in this task (T3 collapses them). `c__ipow__`→`__ipow__` (linalg::Pow_), `c__imatmul__`→`__imatmul__` (self = Dot(self,rhs) — keep the rebind INSIDE C++ via `self.cast<Tensor&>() = Dot(...)`, return self). `cConj_/cExp_/cInvM_/cInv_/cAbs_/cPow_` → `Conj_/Exp_/InvM_/Inv_/Abs_/Pow_` returning self.
+- `unitensor_py.cpp`: `cConj_/cTrace_(×2)/cTranspose_/cnormalize_/cDagger_/ctag/c__ipow__/cPow_/ctruncate_(×2)/c_set_name/c_set_label(×2)/c_set_labels/c_relabel_(×4)/c_relabels_(×2)/c_set_rowrank_/cfrom` → direct names (`Conj_`, `Trace_`, `Transpose_`, `normalize_`, `Dagger_`, `tag`, `__ipow__`, `Pow_`, `truncate_`, `set_name`, `set_label`, `set_labels`, `relabel_`, `relabels_`, `set_rowrank_`, `convert_from`), all returning self via the py::object pattern. Keep the deprecation warnings where the conti layer or binding had them.
+- `bond_py.cpp`: `c_redirect_`→`redirect_` returning self. `c_getDegeneracy_refarg`(×2) and `c_group_duplicates_refarg` → bind `getDegeneracy(qnum, return_indices=False)` and `group_duplicates()` directly in C++ returning `py::tuple`/value (fold the Bond_conti.py logic into the lambda).
+- `storage_py.cpp`: 11 `c_pylist_<T>` → one `pylist()` binding that switches on `self.dtype()` in C++ (returns the right `std::vector<T>` via `py::cast`).
+- `Tensor_conti.py`/`UniTensor_conti.py`/`Storage_conti.py`: keep ONLY the genuinely-Python pieces: `__iter__` iterators, the `to/astype/contiguous` short-circuit wrappers (or move the short-circuit into the C++ lambda and delete — implementer's choice, but be consistent and report), `UniTensor.at` Hclass proxy wrapper, `Storage.pylist` (delete once C++ pylist exists). `Bond_conti.py`: delete the delegation parts. `Network_conti.py` (Diagram/graphviz) and `Symmetry_conti.py` (`Qs`) stay.
+- `cytnx/__init__.py`: keep imports for whatever conti files remain.
+
+**Steps:** (TDD; new pytest file first)
+
+- [ ] Branch: `git checkout -b fix/pybind-inplace-return-self master`
+- [ ] Write `pytests/binding_inplace_test.py` — identity + chaining + still-works assertions:
+
+```python
+import cytnx
+from cytnx import Tensor, Type
+
+
+def test_iadd_preserves_identity():
+    t = cytnx.zeros([4])
+    tid = id(t)
+    t += 1.0
+    assert id(t) == tid
+    assert t[0].item() == 1.0
+
+
+def test_inplace_named_methods_chain():
+    t = cytnx.ones([2, 2])
+    r = t.Conj_().Abs_()
+    assert r is t
+
+
+def test_unitensor_inplace_chain():
+    ut = cytnx.UniTensor(cytnx.ones([2, 2]))
+    r = ut.set_name("x").relabel_(["a", "b"])
+    assert r is ut
+    assert ut.name() == "x"
+    assert ut.labels() == ["a", "b"]
+
+
+def test_storage_pylist_roundtrip():
+    s = cytnx.Storage(3, Type.Double)
+    s.fill(1.5)
+    assert s.pylist() == [1.5, 1.5, 1.5]
+
+
+def test_bond_group_duplicates_tuple():
+    b = cytnx.Bond(cytnx.BD_KET, [[0], [0], [1]], [1, 1, 2], [cytnx.Symmetry.U1()])
+    nb, mapper = b.group_duplicates()
+    assert isinstance(mapper, list)
+```
+
+(Adapt constructor signatures to what pytests/bond_test.py actually uses — read it first. `r is t` for the named methods is the new guarantee this task introduces.)
+
+- [ ] Run against baseline build: identity/chaining tests FAIL today for `Conj_` etc. (`r is t` false — wrapper returns self but `t.Conj_()`... check: today's monkey-patch DOES return self, so those may PASS at baseline; the ones that fail are the direct-binding behaviors after conti deletion. Record which are red at baseline honestly; the real red is after deleting the conti layer with bindings not yet fixed — don't ship tests that were already green without noting it.)
+- [ ] Convert the inventory above file by file; delete the corresponding conti wrappers as each class completes; rebuild `cmake --build build_py -j10` (tensor_py.cpp/unitensor_py.cpp are slow TUs — batch edits before rebuilding); re-copy `cytnx/*.py` into `$SCRATCH/pypkg` after each conti edit.
+- [ ] Grep gates: `grep -rn '"c__\|"c_[a-z]' pybind/ | grep def` → zero shadow bindings left (careful of false positives: `clone`, `contiguous_`, `combineBond*`, `capacity`, `construct`); `grep -rn "c__\|cConj_\|cExp_\|cAbs_\|cPow_\|cInv\|cTrace_\|cTranspose_\|cnormalize_\|cDagger_\|ctag\|ctruncate_\|c_set_\|c_relabel\|c_redirect\|c_pylist\|cfrom" cytnx/ pytests/ example/` → zero references.
+- [ ] Full pytest suite = baseline + new tests. Commit:
+
+```bash
+git add pybind/tensor_py.cpp pybind/unitensor_py.cpp pybind/storage_py.cpp pybind/bond_py.cpp cytnx/ pytests/binding_inplace_test.py
+git commit -m "refactor(pybind): bind in-place methods directly, drop the c__* shadow API (#779)
+
+In-place dunders and _-suffixed methods are now bound under their real
+names with lambdas that take and return the same py::object, so python
+object identity is preserved and chaining works without the
+*_conti.py monkey-patch delegation layer. The c__iadd__/cConj_/...
+shadow bindings and their python wrappers are removed; genuinely
+python-side features (iterators, Network.Diagram, Qs, UniTensor.at
+proxy) remain.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Collapse per-dtype operator overloads; fix `__ne__`/`__bool__`; close numpy gaps (branch `fix/pybind-collapse-operator-overloads`, base `fix/pybind-inplace-return-self`)
+
+**Problem (#928/#916/#692):** every Tensor/UniTensor arithmetic op is bound ~24× (12 C++ scalar types + 12 numpy scalars); many collapse to identical Python signatures (→ ~5600 stub `overload-cannot-match` errors once stubs exist). `__pow__` takes only `cytnx_double`; Tensor `__setitem__` has no numpy-scalar overloads; `__ne__` is not bound (Python default negates the elementwise `__eq__` Tensor via `__len__` → `t1 != t2` is a single always-False bool for non-empty tensors — silent wrong answers); `__bool__` is not bound (truthiness falls through to `__len__`).
+
+**The keep-set per binary operator** (the #915 discipline, adapted; reference implementation: `git show origin/claude/fix-stubtest-errors -- pybind/linalg_py.cpp`, helper `dispatch_pyint`):
+
+1. `const Tensor &` (or UniTensor)
+2. `cytnx_double` — absorbs Python `float` and `numpy.float64` (a `float` subclass)
+3. `cytnx_complex128` — absorbs Python `complex` and `numpy.complex128`
+4. `py::int_` — arbitrary-precision Python int, runtime int64/uint64 dispatch (copy `dispatch_pyint`, single-arg variant)
+5. `py::numpy_scalar<float>`, `py::numpy_scalar<std::complex<float>>` — preserve 32-bit dtypes (#692)
+6. `py::numpy_scalar<T>` for int64/uint64/int32/uint32/int16/uint16/bool — preserve integer dtypes
+7. `const Scalar &` — cytnx Scalar objects
+
+Delete the now-unreachable `cytnx_float/int64/uint64/int32/uint32/int16/uint16/bool` direct overloads and `numpy_scalar<double>`/`numpy_scalar<complex<double>>` duplicates. Apply to: `__add__/__radd__/__sub__/__rsub__/__mul__/__rmul__/__truediv__/__rtruediv__/__eq__` and the T2-renamed `__iadd__/__isub__/__imul__/__itruediv__/__ifloordiv__` in BOTH `tensor_py.cpp` and `unitensor_py.cpp` (UniTensor has no `__eq__`/in-place ops bound — leave that gap; do NOT add new operators to UniTensor in this task beyond what exists).
+
+**Additional fixes in this task:**
+- `__pow__` (Tensor + UniTensor): accept the keep-set numerics (double path suffices computationally — `linalg::Pow` takes double — but bind `py::int_` and `numpy_scalar<float>` wrappers so dtypes/ints don't fail).
+- Tensor `__setitem__`: add the numpy-scalar keep-set (mirror UniTensor's existing coverage).
+- `__ne__` (Tensor): explicit elementwise binding — `[](const Tensor &self, rhs) { return self != rhs; }`? Cytnx C++ has no operator!=; implement as `cytnx::linalg::Cpr(self, rhs)`-based inversion — check how `__eq__` is implemented (`self == rhs` → linalg::Cpr) and whether a `Neq`/logical-not kernel exists; if there is no cheap elementwise !=, bind `__ne__` to raise `TypeError` with a clear message ("elementwise != not implemented; use ==") — NEVER leave the silent default. Report which option the codebase supports.
+- `__bool__` (Tensor): raise `ValueError` for size>1 ("truth value of a multi-element Tensor is ambiguous"), return `bool(item)` for exactly one element, raise for empty — numpy semantics. NOTE: this changes `if tensor:` behavior (previously used `__len__`); document in commit message.
+- Verify pybind11 overload ORDER (first-registered wins in the no-convert pass): Tensor first, then exact numpy scalars, then py::int_, then double/complex, then Scalar last. Write the order down in a comment block above each operator group.
+
+**Tests** — `pytests/binding_dtype_test.py`:
+
+```python
+import numpy as np
+import cytnx
+from cytnx import Type
+
+
+def test_numpy_float32_preserves_dtype():
+    t = cytnx.zeros([2], dtype=Type.Float)
+    assert (t + np.float32(1.0)).dtype() == Type.Float
+    assert (np.float32(1.0) + t).dtype() == Type.Float
+    t += np.float32(1.0)
+    assert t.dtype() == Type.Float
+
+
+def test_python_int_works_and_large_int():
+    t = cytnx.zeros([2], dtype=Type.Int64)
+    assert (t + 1).dtype() == Type.Int64
+    t2 = cytnx.zeros([2], dtype=Type.Uint64)
+    _ = t2 + (2**63 + 1)  # > int64 max: must dispatch to uint64, not raise
+
+
+def test_pow_accepts_int_and_numpy():
+    t = cytnx.ones([2])
+    assert (t**2)[0].item() == 1.0
+    assert (t ** np.float32(2.0))[0].item() == 1.0
+
+
+def test_setitem_numpy_scalar_preserves_dtype():
+    t = cytnx.zeros([3], dtype=Type.Float)
+    t[0] = np.float32(2.5)
+    assert t.dtype() == Type.Float
+
+
+def test_ne_is_not_silently_wrong():
+    a = cytnx.ones([3])
+    b = cytnx.zeros([3])
+    r = a != b
+    # either elementwise Tensor of ones, or TypeError — never a bare False
+    assert not (r is False)
+
+
+def test_bool_multielement_raises():
+    import pytest
+    t = cytnx.ones([3])
+    with pytest.raises(ValueError):
+        bool(t)
+    assert bool(cytnx.ones([1]))
+```
+
+- [ ] Branch: `git checkout -b fix/pybind-collapse-operator-overloads fix/pybind-inplace-return-self`
+- [ ] Write tests; run: dtype tests largely pass (numpy coverage exists), `test_ne_is_not_silently_wrong` and `test_bool_multielement_raises` FAIL (the red).
+- [ ] Implement per operator group; rebuild; targeted pytest; count final overloads per op (report before/after, expect 24→~13).
+- [ ] Full pytest = baseline + T2 + these. Commit with a body listing the keep-set, the `__ne__` decision, and the `__bool__` behavior change.
+
+---
+
+### Task 4: Exception translator (branch `fix/pybind-exception-translator`, base `fix/error-macro-rewrite`)
+
+**Problem:** every cytnx error surfaces as bare `RuntimeError` (pybind's fallback for `std::logic_error`), indistinguishable from other failures.
+
+- [ ] Branch: `git checkout -b fix/pybind-exception-translator fix/error-macro-rewrite`
+- [ ] In `pybind/cytnx.cpp` inside `PYBIND11_MODULE` (top, before submodule bindings):
+
+```cpp
+  // cytnx::error (cytnx_error_msg) -> cytnx.CytnxError (subclass of RuntimeError,
+  // so existing `except RuntimeError` code keeps working).
+  static py::exception<cytnx::error> cytnx_error_exc(m, "CytnxError", PyExc_RuntimeError);
+  py::register_exception_translator([](std::exception_ptr p) {
+    try {
+      if (p) std::rethrow_exception(p);
+    } catch (const cytnx::error &e) {
+      py::set_error(cytnx_error_exc, e.what());
+    }
+  });
+```
+
+(If `py::set_error` is unavailable in the fetched pybind11, use `cytnx_error_exc(e.what())` — check pybind11 3.x API; report which.)
+
+- [ ] Tests — `pytests/binding_exception_test.py`:
+
+```python
+import pytest
+import cytnx
+
+
+def test_cytnx_error_type_exists_and_raises():
+    with pytest.raises(cytnx.CytnxError):
+        cytnx.zeros([2]).reshape(3, 3)  # shape mismatch -> cytnx_error_msg
+    with pytest.raises(RuntimeError):   # subclass relationship preserved
+        cytnx.zeros([2]).reshape(3, 3)
+
+
+def test_message_content():
+    with pytest.raises(cytnx.CytnxError, match="reshape"):
+        cytnx.zeros([2]).reshape(3, 3)
+```
+
+- [ ] Build `build_py` on this branch (first build after branch switch rebuilds the error-header dependents — expected), assemble pypkg, run tests red→green (red = `cytnx.CytnxError` doesn't exist), full pytest = baseline + these.
+- [ ] Commit; note in the PR body that this stacks on #983 and must merge after it.
+
+---
+
+### Task 5: GIL release on expensive operations (branch `fix/pybind-gil-release`, base `master`)
+
+**Problem:** no binding releases the GIL; any long linalg call blocks all Python threads.
+
+**Safe by recon:** the `PyLinOp` trampoline uses `PYBIND11_OVERLOAD`, which reacquires the GIL internally, so releasing around LinOp-taking solvers is safe.
+
+- [ ] Branch: `git checkout -b fix/pybind-gil-release master`
+- [ ] Add `py::call_guard<py::gil_scoped_release>()` to these bindings ONLY (do not touch ExpH/ExpM — PR #915 rewrites them):
+  - `linalg_py.cpp`: Svd, Gesvd, Svd_truncate, Gesvd_truncate, Eigh, Eig, Qr, Qdr(if present), Lanczos (all variants), Lanczos_Exp, Lanczos_Gnd(if separate), Arnoldi (all), Tensordot, Gemm, Gemm_Batch(if present), Kron, Directsum, Det, Matmul, Dot (verify each exists; add to every overload of each).
+  - `unitensor_py.cpp`: `Contract`/`Contracts` free functions + `.contract` method.
+  - `network_py.cpp`: `Launch`.
+  - NOTE where a binding already has `py::call_guard<py::scoped_ostream_redirect,...>` — combine: `py::call_guard<py::gil_scoped_release, py::scoped_ostream_redirect, py::scoped_estream_redirect>()`? CAUTION: ostream redirect must hold the GIL (it touches python sys.stdout)! For any binding with an ostream redirect guard, put gil_scoped_release INSIDE the lambda body around the compute call instead, or skip that binding and report. Investigate which applies; do not blindly combine.
+- [ ] Tests — `pytests/binding_gil_test.py`:
+
+```python
+import threading
+import time
+import cytnx
+
+
+def test_svd_releases_gil():
+    a = cytnx.random.normal([400, 400], mean=0.0, std=1.0)
+    ticks = []
+    stop = threading.Event()
+
+    def ticker():
+        while not stop.is_set():
+            ticks.append(time.monotonic())
+            time.sleep(0.001)
+
+    th = threading.Thread(target=ticker)
+    th.start()
+    for _ in range(3):
+        cytnx.linalg.Svd(a)
+    stop.set()
+    th.join()
+    gaps = [b - a for a, b in zip(ticks, ticks[1:])]
+    assert max(gaps) < 0.2, f"GIL held too long: {max(gaps):.3f}s"
+
+
+def test_lanczos_with_python_linop_still_works():
+    # python-subclassed LinOp matvec must be callable while the solver
+    # holds a released GIL (trampoline reacquires)
+    class MyOp(cytnx.LinOp):
+        def __init__(self):
+            cytnx.LinOp.__init__(self, "mv", 4)
+
+        def matvec(self, v):
+            return v * 2.0
+
+    op = MyOp()
+    v = cytnx.ones([4])
+    out = op.matvec(v)
+    assert out.shape() == [4]
+```
+
+(Adapt LinOp constructor/random signatures to actual API from pytests/examples — read `example/` DMRG code for the LinOp subclass pattern, and use the real Lanczos entry point if cheap enough; otherwise the matvec smoke test plus Svd threading test suffice. The ticker-gap assertion can be flaky on loaded machines — use a generous 0.2 s threshold and mark `@pytest.mark.flaky`-free but rerun-once logic if needed; report your choice.)
+
+- [ ] Red: `test_svd_releases_gil` fails on baseline (max gap ≈ full Svd duration). Green after. Full pytest = baseline + these.
+- [ ] Commit; body lists every binding that got the guard and the ostream-redirect decision.
+
+---
+
+### Task 6 (optional, last): One-line docstrings for undocumented linalg bindings
+
+Only if time permits after T2–T5 review cycles; scope = `linalg_py.cpp` functions with zero docstrings EXCEPT ExpH/ExpM (#915), one line each, format `"Svd(Tin, is_UvT=True) -> [S, U, Vt]: singular value decomposition of a rank-2 Tensor."`. No tests; build + import suffices. Separate branch `docs/pybind-linalg-docstrings` from master.
+
+---
+
+## Plan self-review notes
+
+- T2 before T3 so the collapse applies to the final (direct) binding names; T3 stacks on T2's branch — its PR must say "merge after T2's PR".
+- T4 stacks on #983's branch — PR notes the dependency.
+- T5 from master avoids #915 (ExpH/ExpM) and #983 (error header) collisions; the only overlap risk is trivial adjacent-line conflicts in linalg_py.cpp.
+- The `__bool__`/`__ne__` changes and Storage `pylist` C++-ification are user-visible; each commit message documents them.
+- Stub regeneration deliberately out of scope until PR #915 lands its pipeline.

--- a/docs/dev/plans/2026-07-06-phase2-api-semantics.md
+++ b/docs/dev/plans/2026-07-06-phase2-api-semantics.md
@@ -1,0 +1,60 @@
+# Phase 2 API Semantics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Land the API-semantic decisions: shared-block permute corruption fix (#724), Bond immutability + signflip encapsulation (#846/#841), UniTensor elementwise removal (#934/#753/#675), `norm()->double` with `Norm()` deprecation (#676), underscore convention (#335/#336/#381 + #421/#422 merges), permute-syntax unification (#293).
+
+**Decision record (maintainer = yingjerkao, 2026-07-06, via this session):**
+1. UniTensor elementwise `+`/`-` (and other non-TN-meaningful elementwise UniTensor⊙UniTensor ops per #934's enumeration): **REMOVED from the public surface**; scalar⊙UniTensor stays. Python dunders raise TypeError with guidance (Contract/Kron/scalar ops).
+2. Norm: **add `norm()` returning double** (snake_case per #836); `Norm()` deprecated for one release, still returns Tensor.
+3. Underscore rule: **`_` suffix = in-place returning self, everywhere**; non-underscore = out-of-place. `set_name`/`set_label(s)`/`combineBonds` gain `_` variants as the in-place form; duplicate spellings collapse with `[[deprecated]]`/warning shims for one release.
+4. permute/reshape syntax: **both variadic and list forms accepted on both Tensor and UniTensor** (additive).
+
+**Consensus items from issue threads:** #724 fix = per-block non-mutating `Tensor.permute()/reshape()` (manuschneider + ianmccul); #846 = full public immutability of Bond, in-place mutators removed, SVD-truncate call sites build new Bonds (IvanaGyro's position prevailed); #841 = `_signflip` private, no public mutable accessor.
+
+## Task/branch map (bases matter — 10 PRs are open)
+
+| Task | Branch | Base | Scope |
+|---|---|---|---|
+| T1 | `fix/blockut-permute-shared-blocks` | origin/master (d02cb299) | #724, C++ + gtests |
+| T2 | `refactor/bond-immutable` | `fix/pybind-inplace-return-self` (#986 tip a3367f99 — bond_py.cpp conflicts otherwise) | #846 + #841, C++ + gtests + pybind mutator removal |
+| T3 | `refactor/unitensor-drop-elementwise` | `fix/pybind-collapse-operator-overloads` (ecb1fbd1, #991) | #934/#753/#675 removal, C++ + pybind + pytests |
+| T4 | `feat/api-conventions` | stacked on T3's branch | norm() (#676) + underscore audit (#335/#336/#381/#421/#422) + permute syntax (#293); 3 commits, one PR |
+
+Worktrees: `phase1-gil` (free; gets a `build_t` for C++ tests) for T1/T2; `phase1-binding` (free after #991) for T3/T4. `phase0-safety-fixes` may still be held by a chip session — avoid.
+
+## Shared context
+
+- C++ test build (create once in phase1-gil): `cmake -S . -B build_t -DRUN_TESTS=ON -DBUILD_PYTHON=OFF -DUSE_MKL=OFF -DUSE_HPTT=OFF -DUSE_CUDA=OFF -DCMAKE_CXX_FLAGS="-Wno-c++11-narrowing" -DCMAKE_EXE_LINKER_FLAGS="-L/Users/yjkao/miniconda3/lib" -DCMAKE_BUILD_RPATH=/Users/yjkao/miniconda3/lib` (the BUILD_RPATH is required — without it `gtest_discover_tests` can't run the binary post-link, "Error running test executable", and make deletes it). Baseline on new master (post-#982): establish before T1 and record (expect old 1063-baseline + #982's tests, same 4 known BkUt failures unless PR #977 merged — CHECK and record).
+- Local shims may be needed again in fresh worktree state (see [[macos-test-build-environment]] memory / Phase-0 plan): tests/BlockUniTensor_test.h fill cast + tests/utils/getNconParameter.h headers — apply as uncommitted, never stage. (Skip if PR #972 merged.)
+- pytest recipe: as Phase-1 plan (pypkg dirs, `python3 -P`). Gates per branch = that branch's base tally + new tests.
+- Deprecation shim pattern (C++): `[[deprecated("use X_ instead")]]` on the old spelling delegating to the new one; python: `warnings.warn(..., DeprecationWarning)` where a python-level shim exists. One release cycle, per decision record.
+- Every task: TDD, two-stage review, single commit per topic, never stage build dirs/logs/shims, verify branch attached.
+
+## T1: #724 — permute_/reshape_ on shared blocks (consensus fix)
+
+Bug: `BlockUniTensor::permute_` (and `reshape_` path on Dense) mutate per-block `Tensor`s in place; when blocks are shared between UniTensors (get_block_ views, cheap copies), the other holder's meta corrupts. Fix per issue consensus: build NEW per-block Tensor meta via the non-mutating `Tensor.permute()/reshape()` and assign into `_blocks[i]` (storage stays shared, meta detaches). Audit ALL Block*/Dense UniTensor in-place reshapers/permuters (`permute_`, `permute_nosignflip_`, `reshape_`, `combineBonds` path if it permutes in place) for the same pattern.
+
+Tests (gtest, tests/BlockUniTensor_test.cpp or new file + register): construct two UniTensors sharing blocks (via get_block_ / the reproduction in issue #724 — read it), permute_ one, assert the other's shape/meta unchanged and data still correct; same for reshape_ on Dense; regression for normal non-shared behavior.
+
+## T2: #846 + #841 — Bond immutability, signflip encapsulation
+
+Per issue #846's enumeration: remove/privatize `Bond::set_type`, `redirect_`, `combineBond_`, `clear_type`, non-const `qnums()`, `syms()`, mutable `getDegeneracies()`; keep const accessors + return-new variants (`redirect()`, `combineBond()`, `retype()` if needed). UniTensor: `bonds()` non-const overload removed (const-only) — internal code migrates to `_bonds` directly or explicit internal setter. #841: remove public `signflip_()` (UniTensor_base virtual + BlockFermionicUniTensor), make `_signflip` private, friend-grant the Svd_truncate internals that legitimately rebuild it (read the issue's proposal). Migrate ALL internal call sites (grep `\.set_type\|\.redirect_\|combineBond_\|clear_type\|\.qnums()\|\.syms()\|signflip_` across src/ include/ pybind/) to the immutable forms — expect Svd/Gesvd truncate + BlockFermionicUniTensor to need new-Bond construction. Keep deprecated shims ONLY where a removal would break the python API silently (pybind: drop `redirect_`/mutators bound by #986 — that is why this branch bases on #986's tip). Behavior: gtest that Bond handed to a UniTensor cannot be mutated through any public path; existing suite must stay green (fixes to tests that used mutators are expected — list each).
+
+## T3: drop UniTensor elementwise (+ decision 1)
+
+Read #934's enumeration first. Remove from public C++ surface (UniTensor.hpp operators + Add/Sub member forms taking UniTensor where elementwise-only) and from pybind (unitensor_py.cpp operator groups just collapsed by #991 — hence stacking). Scalar⊙UniTensor and UniTensor⊙scalar remain. Python `ut1 + ut2` must raise TypeError with message naming Contract()/Kron()/scalar alternatives. C++ callers inside the library (if any legitimately used elementwise UniTensor addition — e.g. linalg Lanczos_Ut adds UniTensors!) — AUDIT: `grep -rn "operator+\|Add(" src/linalg/*Ut*`; if solvers rely on elementwise UniTensor addition as a *vector-space* operation (they do — Krylov needs axpy), the C++ INTERNAL capability must remain (move to a documented internal/explicit function e.g. `linalg::VectorAdd(UniTensor,...)` or keep C++ operators but remove ONLY python exposure — decide based on audit, report; the ruling targets the user-facing python surface first). This nuance MUST be resolved by the implementer with evidence and reported; if removal breaks solvers, implement as: python surface removed + C++ operators kept but documented internal-only — and say so in the PR.
+
+Tests: pytest asserting `ut+ut` raises TypeError with the guidance message; scalar ops still work; solvers (Lanczos_Ut pytest path if exists) still green; full C++ suite green.
+
+## T4: api-conventions (3 commits, one PR)
+
+Commit A — `norm()`: C++ `Tensor::norm()`/`UniTensor::norm()` returning `double` (impl: existing Norm().item<double>() equivalent); `Norm()` marked `[[deprecated]]` (still Tensor). pybind binds `norm` (+ DeprecationWarning shim for `Norm` python-side if feasible via a wrapper binding that warns). linalg::Norm free function: add `linalg::norm` returning double, deprecate the old. Tests both layers.
+Commit B — underscore audit: enumerate every mutating method lacking `_` and every `_`-less/`_` duplicate pair across UniTensor/Tensor/Bond/Storage public APIs (`set_name`→`set_name_`, `set_label(s)`→`set_label_`/relabel_ merge per #421 semantics, `combineBonds`→`combineBonds_` in-place + `combineBond`(s) out-of-place merge per #422, `set_rowrank` vs `set_rowrank_` collapse, `tag`→`tag_`? — build the table FIRST, present it in the report, implement with deprecated shims; python shims warn). All `_` methods return self (C++ ref / py object) — #986 already did python; C++ side: fix `void` returns to `Type&` where the table says.
+Commit C — permute/reshape syntax: python bindings accept variadic ints on UniTensor (`permute(1,2,0)` and `permute("a","b")`? — variadic strings too for label form) and list form already exists on Tensor? (Tensor python takes *args today; add list acceptance) — make both classes accept both int-list and variadic (+ UniTensor string variadic), tests for each form on each class.
+
+## Sequencing
+
+T1 ∥ T2 forbidden in one worktree (both C++/gtest in phase1-gil) → T1 then T2 sequentially there. T3 then T4 sequentially in phase1-binding (pybind chain). T1/T2 may run parallel to T3/T4 (disjoint worktrees/files — CAUTION: T2 touches pybind/bond_py.cpp and T3/T4 touch unitensor/tensor_py — disjoint files, OK; T2 and T3 both touch UniTensor.hpp (bonds() removal vs operator removal — different regions, and DIFFERENT BRANCHES that will conflict at merge time; acceptable, resolve at merge; note in PRs).
+
+Gates: C++ suite at its base's tally + new (T1/T2); pytest at base tally + new (T3/T4); no regressions beyond recorded known-failing sets.

--- a/docs/dev/plans/README.md
+++ b/docs/dev/plans/README.md
@@ -1,0 +1,14 @@
+# Development plans (historical records)
+
+Execution plans for the 2026-07 hardening campaign (Phase 0: safety fixes,
+Phase 1: pybind binding hygiene, Phase 2: API semantics), written by and for
+agent-assisted development sessions.
+
+These are **historical decision records**: they capture the task
+specifications, the maintainer rulings and issue-thread consensus each task
+implemented, the verification gates used, and the deviations discovered during
+implementation. They are kept verbatim, including machine-specific build
+paths and worktree layouts that only applied to the machine the sessions ran
+on — do not follow them as build instructions. For current build guidance see
+the top-level documentation; for the distilled API rulings see
+[`../api-decisions.md`](../api-decisions.md).


### PR DESCRIPTION
Adds `docs/dev/api-decisions.md` — a contributor-facing record of the API rulings made on 2026-07-06 (resolving #934/#753/#675, #676, #335/#336/#381 + #421/#422, #293) and the issue-thread consensus positions implemented this cycle (#846/#841, #724, #836), each linked to the implementing PRs (#997, #998, #1000, #1001, #1005).

Also archives the three phase execution plans under `docs/dev/plans/` as historical records, clearly marked as such (they contain machine-specific paths from the agent sessions that executed them and are not build instructions).

Docs-only; no code changes. Independent of all open chains — merge anytime. If any linked PR's scope changes materially before merging, this file should be updated in that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)