### PR TITLE
ci: set git committer identity before merging the target branch

### DIFF
--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -30,9 +30,13 @@ jobs:
       # When re-running a PR job, GitHub Actions uses the merge commit created at
       # the time of the original run, not a fresh merge with the latest target branch.
       # This step ensures we always test against the most recent target branch.
+      # A committer identity is required because a non-fast-forward merge creates
+      # a merge commit.
       - name: Merge with latest target branch (pull_request only)
         if: github.event_name == 'pull_request'
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin ${{ github.event.pull_request.base.ref }}
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
           # Refresh submodules in case the merge moved any gitlinks (e.g. cmake_modules/morse_cmake).

--- a/.github/workflows/ci-downstream-find-package.yml
+++ b/.github/workflows/ci-downstream-find-package.yml
@@ -61,9 +61,13 @@ jobs:
 
       # Match ci-cmake_tests.yml: re-runs of a PR job use the original merge
       # commit, so merge the latest target branch to test against current tip.
+      # A committer identity is required because a non-fast-forward merge creates
+      # a merge commit.
       - name: Merge with latest target branch (pull_request only)
         if: github.event_name == 'pull_request'
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin ${{ github.event.pull_request.base.ref }}
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
           # Refresh submodules in case the merge moved any gitlinks.

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -14,9 +14,13 @@ jobs:
     # When re-running a PR job, GitHub Actions uses the merge commit created at
     # the time of the original run, not a fresh merge with the latest target branch.
     # This step ensures we always test against the most recent target branch.
+    # A committer identity is required because a non-fast-forward merge creates
+    # a merge commit.
     - name: Merge with latest target branch (pull_request only)
       if: github.event_name == 'pull_request'
       run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
         git fetch origin ${{ github.event.pull_request.base.ref }}
         git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 

--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -30,9 +30,13 @@ jobs:
     # When re-running a PR job, GitHub Actions uses the merge commit created at
     # the time of the original run, not a fresh merge with the latest target branch.
     # This step ensures we always test against the most recent target branch.
+    # A committer identity is required because a non-fast-forward merge creates
+    # a merge commit.
     - name: Merge with latest target branch (pull_request only)
       if: github.event_name == 'pull_request'
       run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
         git fetch origin ${{ github.event.pull_request.base.ref }}
         git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
         # Refresh submodules in case the merge moved any gitlinks (e.g. cmake_modules/morse_cmake).


### PR DESCRIPTION
## Summary

The shared **"Merge with latest target branch (pull_request only)"** step runs

```
git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
```

without a configured git committer identity. Whenever a PR head is **behind its base branch**, the merge is not a fast-forward no-op, so git must create a merge commit — and fails with:

```
fatal: empty ident name (for <runner@...>) not allowed
```

killing the job with exit code 128 before any real work runs (observed 2026-07-06 on PR #984, run [28790515780](https://github.com/Cytnx-dev/Cytnx/actions/runs/28790515780)). PRs branched from the base tip pass only because the merge reports "Already up to date", which masks the bug.

## Fix

Configure the `github-actions[bot]` identity before the merge, exactly as `release_pypi.yml` already does:

```yaml
git config user.name "github-actions[bot]"
git config user.email "github-actions[bot]@users.noreply.github.com"
```

Applied to the four remaining workflows that carry the step:

- `.github/workflows/ci-cmake_tests.yml`
- `.github/workflows/ci-downstream-find-package.yml`
- `.github/workflows/clang-format-check.yml`
- `.github/workflows/conda_build.yml`

The step is otherwise unchanged. (`release_pypi.yml` already had the fix, so it needs no change.)

## Test plan

- [x] `yaml.safe_load` passes on all five workflow files
- [x] Verified every `git merge` in `.github/workflows/` is now preceded by the identity config
- [ ] CI on this PR exercises the merge step itself (this branch is at the master tip, so the merge will be a no-op here; the real proof is the next behind-base PR no longer failing with exit 128)

🤖 Generated with [Claude Code](https://claude.com/claude-code)