### PR TITLE
test(pybind): drop shadow-name guard, cover @= identity (follow-up to #986)

### DIFF
--- a/pytests/binding_inplace_test.py
+++ b/pytests/binding_inplace_test.py
@@ -67,32 +67,18 @@ def test_bond_redirect__chains():
     assert b.type() == cytnx.BD_BRA
 
 
-def test_shadow_bindings_are_gone():
-    """The c__*/c_* shadow names must no longer be reachable on any instance;
-    only the real dunder/method names remain."""
-    t = cytnx.zeros([2])
-    for name in (
-        "c__iadd__", "c__isub__", "c__imul__", "c__itruediv__", "c__ifloordiv__",
-        "c__ipow__", "c__imatmul__", "cConj_", "cExp_", "cInvM_", "cInv_", "cAbs_", "cPow_",
-    ):
-        assert not hasattr(t, name), f"Tensor.{name} shadow binding still present"
-
-    ut = cytnx.UniTensor(cytnx.ones([2, 2]))
-    for name in (
-        "cConj_", "cTrace_", "cTranspose_", "cnormalize_", "cDagger_", "ctag",
-        "c__ipow__", "cPow_", "cInv_", "ctruncate_", "c_set_name", "c_set_label",
-        "c_set_labels", "c_relabel_", "c_relabels_", "c_set_rowrank_", "cfrom",
-    ):
-        assert not hasattr(ut, name), f"UniTensor.{name} shadow binding still present"
-
-    s = cytnx.Storage(3, Type.Double)
-    for name in (
-        "c_pylist_double", "c_pylist_complex128", "c_pylist_float", "c_pylist_complex64",
-        "c_pylist_uint64", "c_pylist_int64", "c_pylist_uint32", "c_pylist_int32",
-        "c_pylist_uint16", "c_pylist_int16", "c_pylist_bool",
-    ):
-        assert not hasattr(s, name), f"Storage.{name} shadow binding still present"
-
-    b = cytnx.Bond(2, cytnx.BD_KET)
-    for name in ("c_redirect_", "c_getDegeneracy_refarg", "c_group_duplicates_refarg"):
-        assert not hasattr(b, name), f"Bond.{name} shadow binding still present"
+def test_imatmul_preserves_identity():
+    # `@=` is the one genuine behavioral change from the shadow-API removal:
+    # the old wrapper was misspelled `def __imatmul` (no trailing `__`), so
+    # `a @= b` fell back to `a = a @ b` and rebound `a` to a new object. With
+    # __imatmul__ bound correctly it now mutates in place and preserves identity.
+    a = cytnx.arange(4).reshape(2, 2)
+    b = cytnx.arange(4).reshape(2, 2)
+    expected = cytnx.linalg.Dot(a, b)
+    alias = a  # second reference to the same object
+    aid = id(a)
+    a @= b
+    assert a is alias  # in-place: no new object was created
+    assert id(a) == aid
+    # the mutation is visible through the alias and matches a @ b
+    assert (alias - expected).Norm().item() == 0.0


### PR DESCRIPTION
Follow-up to the merged #986, addressing the two review comments on `pytests/binding_inplace_test.py`.

## Changes

- **Remove `test_shadow_bindings_are_gone`** (per @IvanaGyro, [review comment](https://github.com/Cytnx-dev/Cytnx/pull/986#discussion_r3533995928): *"This test is useless for the future code. This should be clean up."*). It only asserts that the deleted `c__*`/`c_*` shadow names are absent — a one-time migration guard with no value for future code, and the last place in the tree that even referenced those dead names.

- **Add `test_imatmul_preserves_identity`** (per @pcchen's approval follow-up). `@=` is the one genuine behavioral change from #986: on master the wrapper was misspelled `def __imatmul` (missing the trailing `__`), so `a @= b` fell back to `a = a @ b` and rebound `a` to a **new** object. With `__imatmul__` bound correctly it now mutates in place and preserves identity. This path was previously untested.

## Verification

Built the Python module from the post-#986 tree and ran the file:

- New test **passes** on the post-#986 module (`__imatmul__` present, `a @= b` mutates in place, `a is alias`, and the alias observes the result of `a @ b`).
- The same test **fails** on the pre-#986 module (v1.0.0: `a @= b` rebinds `a`, `a is alias` is False) — confirming it genuinely pins the fixed behavior rather than passing vacuously.
- Full file: **7 passed**.

Net: −29/+15 (one dead test out, one meaningful test in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)