### PR TITLE
fix(symmetry): FermionParitySymmetry::check_qnums rejected all qnums

### DIFF
--- a/src/Symmetry.cpp
+++ b/src/Symmetry.cpp
@@ -165,8 +165,8 @@ namespace cytnx {
   }
 
   bool cytnx::FermionParitySymmetry::check_qnums(const std::vector<cytnx_int64> &qnums) {
-    for (cytnx_uint64 i = 0; i < qnums.size(); i++) {
-      if (!this->check_qnum(qnums[i])) return false;
+    for (const auto &qnum : qnums) {
+      if (!this->check_qnum(qnum)) return false;
     }
     return true;
   }

--- a/src/Symmetry.cpp
+++ b/src/Symmetry.cpp
@@ -165,12 +165,10 @@ namespace cytnx {
   }
 
   bool cytnx::FermionParitySymmetry::check_qnums(const std::vector<cytnx_int64> &qnums) {
-    bool out = true;
     for (cytnx_uint64 i = 0; i < qnums.size(); i++) {
-      out = ((qnums[i] >= 0) && (qnums[i] < this->n));
-      if (out == false) break;
+      if (!this->check_qnum(qnums[i])) return false;
     }
-    return out;
+    return true;
   }
 
   void cytnx::FermionParitySymmetry::combine_rule_(std::vector<cytnx_int64> &out,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(
   test_tools.cpp
   common_data_generator.cpp
   Bond_test.cpp
+  Symmetry_test.cpp
   Network_test.cpp
   UniTensor_base_test.cpp
   ncon_test.cpp

--- a/tests/Symmetry_test.cpp
+++ b/tests/Symmetry_test.cpp
@@ -1,0 +1,27 @@
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "Symmetry.hpp"
+
+namespace {
+
+  using cytnx::Symmetry;
+
+  TEST(Symmetry, FermionParityCheckQnum) {
+    Symmetry sym = Symmetry::FermionParity();
+    EXPECT_TRUE(sym.check_qnum(0));
+    EXPECT_TRUE(sym.check_qnum(1));
+    EXPECT_FALSE(sym.check_qnum(-1));
+    EXPECT_FALSE(sym.check_qnum(2));
+  }
+
+  TEST(Symmetry, FermionParityCheckQnums) {
+    Symmetry sym = Symmetry::FermionParity();
+    EXPECT_TRUE(sym.check_qnums({0, 1}));
+    EXPECT_FALSE(sym.check_qnums({2}));
+    EXPECT_FALSE(sym.check_qnums({-1}));
+    EXPECT_FALSE(sym.check_qnums({0, 1, 2}));
+  }
+
+}  // namespace


### PR DESCRIPTION
## Summary

`FermionParitySymmetry::check_qnums` compared each qnum against `this->n`, but `FermionParitySymmetry` sets `n = -2` — the `fPar` stype sentinel from `SymmetryType`, not a modulus. As a result the plural form returned `false` for every non-empty input, while the singular `check_qnum` correctly validated against `[0, 2)`.

**Impact:** no in-tree caller was affected — Bond validation (`src/Bond.cpp`) uses the singular `check_qnum`, which is why fPar bonds have always validated fine. The plural form is, however, exposed to users via the Python bindings (`Symmetry.check_qnums`), where it silently rejected valid parity qnum lists.

## Fix

Reimplement `check_qnums` as a loop over `check_qnum` so the two forms cannot diverge again.

## Tests

New `tests/Symmetry_test.cpp` (registered in `tests/CMakeLists.txt`) covering both forms for fPar:
- `check_qnums({0, 1}) == true`, `check_qnums({2}) == false`, plus `{-1}` and `{0, 1, 2}` rejection
- singular `check_qnum` for 0/1 accepted, -1/2 rejected

Verified red-green: the `check_qnums({0, 1})` assertion fails before the fix and passes after.

## Note for #842

The value-type Symmetry refactor branch (`refactor/symmetry-value-type`, #842) deliberately preserved this quirk byte-for-byte; it should pick up this fix when rebasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)