### PR TITLE
fix(pybind): keep-set ordering for Scalar constructors, add __bool__

### DIFF
--- a/include/Type.hpp
+++ b/include/Type.hpp
@@ -380,6 +380,18 @@ namespace cytnx {
       return ComplexDouble;
     }
 
+    // The dtype linalg::Norm() produces for an input of the given dtype: the
+    // real counterpart for floating/complex dtypes, Double for integer/bool
+    // inputs (which Norm computes in double precision). This is the single
+    // home of that policy -- src/linalg/Norm.cpp and callers pre-sizing
+    // norm accumulators (e.g. UniTensor::normalize_) both use it, so they
+    // cannot drift apart.
+    static constexpr unsigned int norm_result_dtype(unsigned int type_id) {
+      check_type(type_id);
+      if (is_float(type_id)) return to_real(type_id);
+      return Double;
+    }
+
     // Find a common type for typeL and typeR
     static constexpr unsigned int type_promote(unsigned int typeL, unsigned int typeR) {
       if (typeL == Void || typeR == Void) return Void;

--- a/include/backend/Scalar.hpp
+++ b/include/backend/Scalar.hpp
@@ -5,2516 +5,69 @@
   #include "Type.hpp"
   #include "cytnx_error.hpp"
   #include "intrusive_ptr_base.hpp"
-  #include <vector>
-  #include <initializer_list>
-  #include <string>
-  #include <iostream>
-  #include <cmath>
+  #include <ostream>
   #include <type_traits>
-  #include <limits>
+  #include <variant>
 namespace cytnx {
 
   ///@cond
   class Storage_base;
-  class Tensor_base;
 
   // The following two declarations are necessary for ADL.
   void intrusive_ptr_add_ref(Storage_base *);
   void intrusive_ptr_release(Storage_base *);
-
-  // real implementation
-  class Scalar_base {
-   private:
-   public:
-    int _dtype;
-
-    // Scalar_base(const Scalar_base &rhs);
-    // Scalar_base& operator=(const Scalar_base &rhs);
-    Scalar_base() : _dtype(Type.Void){};
-
-    virtual cytnx_float to_cytnx_float() const {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot cast to anytype!!%s", "\n");
-      return 0;
-    };
-    virtual cytnx_double to_cytnx_double() const {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot cast to anytype!!%s", "\n");
-      return 0;
-    };
-    virtual cytnx_complex64 to_cytnx_complex64() const {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot cast to anytype!!%s", "\n");
-      return cytnx_complex64(0, 0);
-    };
-    virtual cytnx_complex128 to_cytnx_complex128() const {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot cast to anytype!!%s", "\n");
-      return cytnx_complex128(0, 0);
-    };
-    virtual cytnx_int64 to_cytnx_int64() const {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot cast to anytype!!%s", "\n");
-      return 0;
-    };
-    virtual cytnx_uint64 to_cytnx_uint64() const {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot cast to anytype!!%s", "\n");
-      return 0;
-    };
-    virtual cytnx_int32 to_cytnx_int32() const {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot cast to anytype!!%s", "\n");
-      return 0;
-    };
-    virtual cytnx_uint32 to_cytnx_uint32() const {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot cast to anytype!!%s", "\n");
-      return 0;
-    };
-    virtual cytnx_int16 to_cytnx_int16() const {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot cast to anytype!!%s", "\n");
-      return 0;
-    };
-    virtual cytnx_uint16 to_cytnx_uint16() const {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot cast to anytype!!%s", "\n");
-      return 0;
-    };
-    virtual cytnx_bool to_cytnx_bool() const {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot cast to anytype!!%s", "\n");
-      return 0;
-    }
-
-    virtual void iadd(const Scalar_base *c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void iadd(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void iadd(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void iadd(const cytnx_double &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void iadd(const cytnx_float &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void iadd(const cytnx_uint64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void iadd(const cytnx_int64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void iadd(const cytnx_uint32 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void iadd(const cytnx_int32 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void iadd(const cytnx_uint16 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void iadd(const cytnx_int16 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void iadd(const cytnx_bool &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-
-    virtual void isub(const Scalar_base *c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void isub(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void isub(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void isub(const cytnx_double &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void isub(const cytnx_float &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void isub(const cytnx_uint64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void isub(const cytnx_int64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void isub(const cytnx_uint32 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void isub(const cytnx_int32 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void isub(const cytnx_uint16 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void isub(const cytnx_int16 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void isub(const cytnx_bool &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-
-    virtual void imul(const Scalar_base *c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void imul(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void imul(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void imul(const cytnx_double &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void imul(const cytnx_float &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void imul(const cytnx_uint64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void imul(const cytnx_int64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void imul(const cytnx_uint32 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void imul(const cytnx_int32 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void imul(const cytnx_uint16 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void imul(const cytnx_int16 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void imul(const cytnx_bool &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-
-    virtual void idiv(const Scalar_base *c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void idiv(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void idiv(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void idiv(const cytnx_double &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void idiv(const cytnx_float &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void idiv(const cytnx_uint64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void idiv(const cytnx_int64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void idiv(const cytnx_uint32 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void idiv(const cytnx_int32 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void idiv(const cytnx_uint16 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void idiv(const cytnx_int16 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void idiv(const cytnx_bool &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-
-    virtual bool less(const Scalar_base *c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool less(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool less(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool less(const cytnx_double &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool less(const cytnx_float &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool less(const cytnx_uint64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool less(const cytnx_int64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool less(const cytnx_uint32 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool less(const cytnx_int32 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool less(const cytnx_uint16 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool less(const cytnx_int16 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool less(const cytnx_bool &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-
-    virtual bool greater(const Scalar_base *c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool greater(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool greater(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool greater(const cytnx_double &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool greater(const cytnx_float &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool greater(const cytnx_uint64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool greater(const cytnx_int64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool greater(const cytnx_uint32 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool greater(const cytnx_int32 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool greater(const cytnx_uint16 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool greater(const cytnx_int16 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    virtual bool greater(const cytnx_bool &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-
-    virtual bool eq(const Scalar_base *c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return 0;
-    }
-    // virtual bool approx_eq(const Scalar_base *c, const double &tol = 1e-8) {
-    //   cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    //   return 0;
-    // }
-
-    virtual void set_maxval() {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    };
-    virtual void set_minval() {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    };
-
-    virtual void conj_() {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual Scalar_base *get_real() {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return nullptr;
-    }
-    virtual Scalar_base *get_imag() {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return nullptr;
-    }
-
-    virtual void iabs() {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void isqrt() {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-
-    virtual void assign_selftype(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void assign_selftype(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void assign_selftype(const cytnx_double &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void assign_selftype(const cytnx_float &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void assign_selftype(const cytnx_uint64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void assign_selftype(const cytnx_int64 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void assign_selftype(const cytnx_uint32 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void assign_selftype(const cytnx_int32 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void assign_selftype(const cytnx_uint16 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void assign_selftype(const cytnx_int16 &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-    virtual void assign_selftype(const cytnx_bool &c) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-    }
-
-    virtual Scalar_base *astype(const unsigned int &dtype) {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return nullptr;
-    }
-
-    /**
-     * @deprecated This method is not in use anymore.
-     */
-    [[deprecated("This method is not in use anymore.")]] virtual void *get_raw_address() const {
-      cytnx_error_msg(true, "[ERROR] Void Type Scalar cannot have operation!!%s", "\n");
-      return nullptr;
-    }
-
-    virtual void print(std::ostream &os) const {};
-    virtual Scalar_base *copy() const {
-      Scalar_base *tmp = new Scalar_base();
-      return tmp;
-    };
-
-    virtual ~Scalar_base(){};
-  };
-
-  typedef Scalar_base *(*pScalar_init)();
-  ///@endcond
-
-  ///@cond
-  class Scalar_init_interface : public Type_class {
-   public:
-    // std::vector<pScalar_init> UScIInit;
-    inline static pScalar_init UScIInit[N_Type];
-    inline static bool inited = false;
-    Scalar_init_interface();
-  };
-  extern Scalar_init_interface __ScII;
-  ///@endcond
-
-  ///@cond
-  class ComplexDoubleScalar : public Scalar_base {
-   public:
-    cytnx_complex128 _elem;
-
-    ComplexDoubleScalar() : _elem(0) { this->_dtype = Type.ComplexDouble; };
-    ComplexDoubleScalar(const cytnx_complex128 &in) : _elem(0) {
-      this->_dtype = Type.ComplexDouble;
-      this->_elem = in;
-    }
-
-    cytnx_float to_cytnx_float() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex128 to real%s", "\n");
-      return 0;
-    };
-    cytnx_double to_cytnx_double() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex128 to real%s", "\n");
-      return 0;
-    };
-    cytnx_complex64 to_cytnx_complex64() const { return cytnx_complex64(this->_elem); };
-    cytnx_complex128 to_cytnx_complex128() const { return this->_elem; };
-    cytnx_int64 to_cytnx_int64() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex128 to real%s", "\n");
-      return 0;
-    };
-    cytnx_uint64 to_cytnx_uint64() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex128 to real%s", "\n");
-      return 0;
-    };
-    cytnx_int32 to_cytnx_int32() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex128 to real%s", "\n");
-      return 0;
-    };
-    cytnx_uint32 to_cytnx_uint32() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex128 to real%s", "\n");
-      return 0;
-    };
-    cytnx_int16 to_cytnx_int16() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex128 to real%s", "\n");
-      return 0;
-    };
-    cytnx_uint16 to_cytnx_uint16() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex128 to real%s", "\n");
-      return 0;
-    };
-    cytnx_bool to_cytnx_bool() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex128 to real%s", "\n");
-      return 0;
-    };
-
-    void assign_selftype(const cytnx_complex128 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_complex64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_double &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_float &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_bool &c) { this->_elem = c; }
-
-    void iadd(const Scalar_base *c) { this->_elem += c->to_cytnx_complex128(); }
-    void iadd(const cytnx_complex128 &c) { this->_elem += c; }
-    void iadd(const cytnx_complex64 &c) { this->_elem += c; }
-    void iadd(const cytnx_double &c) { this->_elem += c; }
-    void iadd(const cytnx_float &c) { this->_elem += c; }
-    void iadd(const cytnx_uint64 &c) { this->_elem += c; }
-    void iadd(const cytnx_int64 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint32 &c) { this->_elem += c; }
-    void iadd(const cytnx_int32 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint16 &c) { this->_elem += c; }
-    void iadd(const cytnx_int16 &c) { this->_elem += c; }
-    void iadd(const cytnx_bool &c) { this->_elem += c; }
-
-    void isub(const Scalar_base *c) { this->_elem -= c->to_cytnx_complex128(); }
-    void isub(const cytnx_complex128 &c) { this->_elem -= c; }
-    void isub(const cytnx_complex64 &c) { this->_elem -= c; }
-    void isub(const cytnx_double &c) { this->_elem -= c; }
-    void isub(const cytnx_float &c) { this->_elem -= c; }
-    void isub(const cytnx_uint64 &c) { this->_elem -= c; }
-    void isub(const cytnx_int64 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint32 &c) { this->_elem -= c; }
-    void isub(const cytnx_int32 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint16 &c) { this->_elem -= c; }
-    void isub(const cytnx_int16 &c) { this->_elem -= c; }
-    void isub(const cytnx_bool &c) { this->_elem -= c; }
-
-    void imul(const Scalar_base *c) { this->_elem *= c->to_cytnx_complex128(); }
-    void imul(const cytnx_complex128 &c) { this->_elem *= c; }
-    void imul(const cytnx_complex64 &c) { this->_elem *= c; }
-    void imul(const cytnx_double &c) { this->_elem *= c; }
-    void imul(const cytnx_float &c) { this->_elem *= c; }
-    void imul(const cytnx_uint64 &c) { this->_elem *= c; }
-    void imul(const cytnx_int64 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint32 &c) { this->_elem *= c; }
-    void imul(const cytnx_int32 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint16 &c) { this->_elem *= c; }
-    void imul(const cytnx_int16 &c) { this->_elem *= c; }
-    void imul(const cytnx_bool &c) { this->_elem *= c; }
-
-    void idiv(const Scalar_base *c) { this->_elem /= c->to_cytnx_complex128(); }
-    void idiv(const cytnx_complex128 &c) { this->_elem /= c; }
-    void idiv(const cytnx_complex64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_double &c) { this->_elem /= c; }
-    void idiv(const cytnx_float &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_bool &c) { this->_elem /= c; }
-
-    void iabs() { this->_elem = std::abs(cytnx_complex128(this->_elem)); }
-    void isqrt() { this->_elem = std::sqrt(this->_elem); }
-
-    bool less(const Scalar_base *c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_double &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_float &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_uint64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_int64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_uint32 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_int32 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_uint16 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_int16 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_bool &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-
-    bool greater(const Scalar_base *c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_double &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_float &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_uint64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_int64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_uint32 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_int32 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_uint16 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_int16 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_bool &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-
-    bool eq(const Scalar_base *c) { return this->_elem == c->to_cytnx_complex128(); }
-    // bool approx_eq(const Scalar_base *c, const cytnx_double &tol = 1e-8) {
-    //   return std::abs(this->_elem - c->to_cytnx_complex128()) <= tol;
-    // }
-
-    void set_maxval() {
-      cytnx_error_msg(true, "[ERROR] maxval not supported for complex type%s", "\n");
-    }
-    void set_minval() {
-      cytnx_error_msg(true, "[ERROR] minval not supported for complex type%s", "\n");
-    }
-
-    void conj_() { this->_elem = std::conj(this->_elem); }
-    Scalar_base *get_real() {
-      Scalar_base *tmp = __ScII.UScIInit[Type.Double]();
-      tmp->assign_selftype(this->_elem.real());
-      return tmp;
-    }
-    Scalar_base *get_imag() {
-      Scalar_base *tmp = __ScII.UScIInit[Type.Double]();
-      tmp->assign_selftype(this->_elem.imag());
-      return tmp;
-    }
-
-    void *get_raw_address() const { return (void *)(&this->_elem); }
-
-    Scalar_base *astype(const unsigned int &dtype) {
-      Scalar_base *tmp = __ScII.UScIInit[dtype]();
-      tmp->assign_selftype(this->_elem);
-      return tmp;
-    }
-
-    Scalar_base *copy() const {
-      ComplexDoubleScalar *tmp = new ComplexDoubleScalar(this->_elem);
-      return tmp;
-    };
-    void print(std::ostream &os) const { os << "< " << this->_elem << " >"; };
-  };
-
-  class ComplexFloatScalar : public Scalar_base {
-   public:
-    cytnx_complex64 _elem;
-
-    ComplexFloatScalar() : _elem(0) { this->_dtype = Type.ComplexFloat; };
-    ComplexFloatScalar(const cytnx_complex64 &in) : _elem(0) {
-      this->_dtype = Type.ComplexFloat;
-      this->_elem = in;
-    }
-
-    cytnx_float to_cytnx_float() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex64 to real%s", "\n");
-      return 0;
-    };
-    cytnx_double to_cytnx_double() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex64 to real%s", "\n");
-      return 0;
-    };
-    cytnx_complex64 to_cytnx_complex64() const { return this->_elem; };
-    cytnx_complex128 to_cytnx_complex128() const { return cytnx_complex128(this->_elem); };
-    cytnx_int64 to_cytnx_int64() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex64 to real%s", "\n");
-      return 0;
-    };
-    cytnx_uint64 to_cytnx_uint64() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex64 to real%s", "\n");
-      return 0;
-    };
-    cytnx_int32 to_cytnx_int32() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex64 to real%s", "\n");
-      return 0;
-    };
-    cytnx_uint32 to_cytnx_uint32() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex64 to real%s", "\n");
-      return 0;
-    };
-    cytnx_int16 to_cytnx_int16() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex64 to real%s", "\n");
-      return 0;
-    };
-    cytnx_uint16 to_cytnx_uint16() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex64 to real%s", "\n");
-      return 0;
-    };
-    cytnx_bool to_cytnx_bool() const {
-      cytnx_error_msg(true, "[ERROR] Cannot cast complex64 to real%s", "\n");
-      return 0;
-    };
-
-    void assign_selftype(const cytnx_complex128 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_complex64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_double &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_float &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_bool &c) { this->_elem = c; }
-
-    void iadd(const Scalar_base *c) { this->_elem += c->to_cytnx_complex64(); }
-    void iadd(const cytnx_complex128 &c) { this->_elem += c; }
-    void iadd(const cytnx_complex64 &c) { this->_elem += c; }
-    void iadd(const cytnx_double &c) { this->_elem += c; }
-    void iadd(const cytnx_float &c) { this->_elem += c; }
-    void iadd(const cytnx_uint64 &c) { this->_elem += c; }
-    void iadd(const cytnx_int64 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint32 &c) { this->_elem += c; }
-    void iadd(const cytnx_int32 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint16 &c) { this->_elem += c; }
-    void iadd(const cytnx_int16 &c) { this->_elem += c; }
-    void iadd(const cytnx_bool &c) { this->_elem += c; }
-
-    void isub(const Scalar_base *c) { this->_elem -= c->to_cytnx_complex64(); }
-    void isub(const cytnx_complex128 &c) { this->_elem -= c; }
-    void isub(const cytnx_complex64 &c) { this->_elem -= c; }
-    void isub(const cytnx_double &c) { this->_elem -= c; }
-    void isub(const cytnx_float &c) { this->_elem -= c; }
-    void isub(const cytnx_uint64 &c) { this->_elem -= c; }
-    void isub(const cytnx_int64 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint32 &c) { this->_elem -= c; }
-    void isub(const cytnx_int32 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint16 &c) { this->_elem -= c; }
-    void isub(const cytnx_int16 &c) { this->_elem -= c; }
-    void isub(const cytnx_bool &c) { this->_elem -= c; }
-
-    void imul(const Scalar_base *c) { this->_elem *= c->to_cytnx_complex64(); }
-    void imul(const cytnx_complex128 &c) { this->_elem *= c; }
-    void imul(const cytnx_complex64 &c) { this->_elem *= c; }
-    void imul(const cytnx_double &c) { this->_elem *= c; }
-    void imul(const cytnx_float &c) { this->_elem *= c; }
-    void imul(const cytnx_uint64 &c) { this->_elem *= c; }
-    void imul(const cytnx_int64 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint32 &c) { this->_elem *= c; }
-    void imul(const cytnx_int32 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint16 &c) { this->_elem *= c; }
-    void imul(const cytnx_int16 &c) { this->_elem *= c; }
-    void imul(const cytnx_bool &c) { this->_elem *= c; }
-
-    void idiv(const Scalar_base *c) { this->_elem /= c->to_cytnx_complex64(); }
-    void idiv(const cytnx_complex128 &c) { this->_elem /= c; }
-    void idiv(const cytnx_complex64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_double &c) { this->_elem /= c; }
-    void idiv(const cytnx_float &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_bool &c) { this->_elem /= c; }
-
-    bool less(const Scalar_base *c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_double &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_float &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_uint64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_int64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_uint32 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_int32 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_uint16 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_int16 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_bool &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-
-    bool greater(const Scalar_base *c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_double &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_float &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_uint64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_int64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_uint32 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_int32 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_uint16 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_int16 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_bool &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-
-    bool eq(const Scalar_base *c) { return this->_elem == c->to_cytnx_complex64(); }
-    // bool approx_eq(const Scalar_base *c, const cytnx_double &tol = 1e-8) {
-    //   return std::abs(this->_elem - c->to_cytnx_complex64()) <= tol;
-    // }
-
-    void set_maxval() {
-      cytnx_error_msg(true, "[ERROR] maxval not supported for complex type%s", "\n");
-    }
-    void set_minval() {
-      cytnx_error_msg(true, "[ERROR] minval not supported for complex type%s", "\n");
-    }
-
-    void conj_() { this->_elem = std::conj(this->_elem); }
-    Scalar_base *get_real() {
-      Scalar_base *tmp = __ScII.UScIInit[Type.Float]();
-      tmp->assign_selftype(this->_elem.real());
-      return tmp;
-    }
-    Scalar_base *get_imag() {
-      Scalar_base *tmp = __ScII.UScIInit[Type.Float]();
-      tmp->assign_selftype(this->_elem.imag());
-      return tmp;
-    }
-
-    void iabs() { this->_elem = std::abs(this->_elem); }
-    void isqrt() { this->_elem = std::sqrt(this->_elem); }
-
-    void *get_raw_address() const { return (void *)(&this->_elem); }
-    Scalar_base *astype(const unsigned int &dtype) {
-      Scalar_base *tmp = __ScII.UScIInit[dtype]();
-      tmp->assign_selftype(this->_elem);
-      return tmp;
-    }
-
-    Scalar_base *copy() const {
-      ComplexFloatScalar *tmp = new ComplexFloatScalar(this->_elem);
-      return tmp;
-    };
-    void print(std::ostream &os) const { os << "< " << this->_elem << " >"; };
-  };
-
-  class DoubleScalar : public Scalar_base {
-   public:
-    cytnx_double _elem;
-
-    DoubleScalar() : _elem(0) { this->_dtype = Type.Double; };
-    DoubleScalar(const cytnx_double &in) : _elem(0) {
-      this->_dtype = Type.Double;
-      this->_elem = in;
-    }
-
-    cytnx_float to_cytnx_float() const { return this->_elem; };
-    cytnx_double to_cytnx_double() const { return this->_elem; };
-    cytnx_complex64 to_cytnx_complex64() const { return this->_elem; };
-    cytnx_complex128 to_cytnx_complex128() const { return this->_elem; };
-    cytnx_int64 to_cytnx_int64() const { return this->_elem; };
-    cytnx_uint64 to_cytnx_uint64() const { return this->_elem; };
-    cytnx_int32 to_cytnx_int32() const { return this->_elem; };
-    cytnx_uint32 to_cytnx_uint32() const { return this->_elem; };
-    cytnx_int16 to_cytnx_int16() const { return this->_elem; };
-    cytnx_uint16 to_cytnx_uint16() const { return this->_elem; };
-    cytnx_bool to_cytnx_bool() const { return this->_elem; };
-
-    void assign_selftype(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_double &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_float &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_bool &c) { this->_elem = c; }
-
-    void iadd(const Scalar_base *c) { this->_elem += c->to_cytnx_double(); }
-    void iadd(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_double &c) { this->_elem += c; }
-    void iadd(const cytnx_float &c) { this->_elem += c; }
-    void iadd(const cytnx_uint64 &c) { this->_elem += c; }
-    void iadd(const cytnx_int64 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint32 &c) { this->_elem += c; }
-    void iadd(const cytnx_int32 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint16 &c) { this->_elem += c; }
-    void iadd(const cytnx_int16 &c) { this->_elem += c; }
-    void iadd(const cytnx_bool &c) { this->_elem += c; }
-
-    void isub(const Scalar_base *c) { this->_elem -= c->to_cytnx_double(); }
-    void isub(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_double &c) { this->_elem -= c; }
-    void isub(const cytnx_float &c) { this->_elem -= c; }
-    void isub(const cytnx_uint64 &c) { this->_elem -= c; }
-    void isub(const cytnx_int64 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint32 &c) { this->_elem -= c; }
-    void isub(const cytnx_int32 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint16 &c) { this->_elem -= c; }
-    void isub(const cytnx_int16 &c) { this->_elem -= c; }
-    void isub(const cytnx_bool &c) { this->_elem -= c; }
-
-    void imul(const Scalar_base *c) { this->_elem *= c->to_cytnx_double(); }
-    void imul(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_double &c) { this->_elem *= c; }
-    void imul(const cytnx_float &c) { this->_elem *= c; }
-    void imul(const cytnx_uint64 &c) { this->_elem *= c; }
-    void imul(const cytnx_int64 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint32 &c) { this->_elem *= c; }
-    void imul(const cytnx_int32 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint16 &c) { this->_elem *= c; }
-    void imul(const cytnx_int16 &c) { this->_elem *= c; }
-    void imul(const cytnx_bool &c) { this->_elem *= c; }
-
-    void idiv(const Scalar_base *c) { this->_elem /= c->to_cytnx_double(); }
-    void idiv(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_double &c) { this->_elem /= c; }
-    void idiv(const cytnx_float &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_bool &c) { this->_elem /= c; }
-
-    void iabs() { this->_elem = std::abs(this->_elem); }
-    void isqrt() { this->_elem = std::sqrt(this->_elem); }
-
-    bool less(const Scalar_base *c) { return this->_elem < c->to_cytnx_double(); }
-    bool less(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_double &c) { return this->_elem < c; }
-    bool less(const cytnx_float &c) { return this->_elem < c; }
-    bool less(const cytnx_uint64 &c) { return this->_elem < c; }
-    bool less(const cytnx_int64 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint32 &c) { return this->_elem < c; }
-    bool less(const cytnx_int32 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint16 &c) { return this->_elem < c; }
-    bool less(const cytnx_int16 &c) { return this->_elem < c; }
-    bool less(const cytnx_bool &c) { return this->_elem < c; }
-
-    bool greater(const Scalar_base *c) { return this->_elem > c->to_cytnx_double(); }
-    bool greater(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_double &c) { return this->_elem > c; }
-    bool greater(const cytnx_float &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_bool &c) { return this->_elem > c; }
-
-    bool eq(const Scalar_base *c) { return this->_elem == c->to_cytnx_double(); }
-    // bool approx_eq(const Scalar_base *c, const cytnx_double &tol = 1e-8) {
-    //   return std::abs(this->_elem - c->to_cytnx_double()) <= tol;
-    // }
-
-    void set_maxval() { this->_elem = std::numeric_limits<double>::max(); }
-    void set_minval() { this->_elem = std::numeric_limits<double>::min(); }
-
-    void conj_() { return; }
-    Scalar_base *get_real() { return this->copy(); }
-    Scalar_base *get_imag() {
-      cytnx_error_msg(true, "[ERROR] real type Scalar does not have imag part!%s", "\n");
-      return nullptr;
-    }
-
-    void *get_raw_address() const { return (void *)(&this->_elem); }
-    Scalar_base *astype(const unsigned int &dtype) {
-      Scalar_base *tmp = __ScII.UScIInit[dtype]();
-      tmp->assign_selftype(this->_elem);
-      return tmp;
-    }
-    Scalar_base *copy() const {
-      DoubleScalar *tmp = new DoubleScalar(this->_elem);
-      return tmp;
-    };
-    void print(std::ostream &os) const { os << "< " << this->_elem << " >"; };
-  };
-
-  class FloatScalar : public Scalar_base {
-   public:
-    cytnx_float _elem;
-
-    FloatScalar() : _elem(0) { this->_dtype = Type.Float; };
-    FloatScalar(const cytnx_float &in) : _elem(0) {
-      this->_dtype = Type.Float;
-      this->_elem = in;
-    }
-
-    cytnx_float to_cytnx_float() const { return this->_elem; };
-    cytnx_double to_cytnx_double() const { return this->_elem; };
-    cytnx_complex64 to_cytnx_complex64() const { return this->_elem; };
-    cytnx_complex128 to_cytnx_complex128() const { return this->_elem; };
-    cytnx_int64 to_cytnx_int64() const { return this->_elem; };
-    cytnx_uint64 to_cytnx_uint64() const { return this->_elem; };
-    cytnx_int32 to_cytnx_int32() const { return this->_elem; };
-    cytnx_uint32 to_cytnx_uint32() const { return this->_elem; };
-    cytnx_int16 to_cytnx_int16() const { return this->_elem; };
-    cytnx_uint16 to_cytnx_uint16() const { return this->_elem; };
-    cytnx_bool to_cytnx_bool() const { return this->_elem; };
-
-    void assign_selftype(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_double &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_float &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_bool &c) { this->_elem = c; }
-
-    void iadd(const Scalar_base *c) { this->_elem += c->to_cytnx_float(); }
-    void iadd(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_double &c) { this->_elem += c; }
-    void iadd(const cytnx_float &c) { this->_elem += c; }
-    void iadd(const cytnx_uint64 &c) { this->_elem += c; }
-    void iadd(const cytnx_int64 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint32 &c) { this->_elem += c; }
-    void iadd(const cytnx_int32 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint16 &c) { this->_elem += c; }
-    void iadd(const cytnx_int16 &c) { this->_elem += c; }
-    void iadd(const cytnx_bool &c) { this->_elem += c; }
-
-    void isub(const Scalar_base *c) { this->_elem -= c->to_cytnx_float(); }
-    void isub(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_double &c) { this->_elem -= c; }
-    void isub(const cytnx_float &c) { this->_elem -= c; }
-    void isub(const cytnx_uint64 &c) { this->_elem -= c; }
-    void isub(const cytnx_int64 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint32 &c) { this->_elem -= c; }
-    void isub(const cytnx_int32 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint16 &c) { this->_elem -= c; }
-    void isub(const cytnx_int16 &c) { this->_elem -= c; }
-    void isub(const cytnx_bool &c) { this->_elem -= c; }
-
-    void imul(const Scalar_base *c) { this->_elem *= c->to_cytnx_float(); }
-    void imul(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_double &c) { this->_elem *= c; }
-    void imul(const cytnx_float &c) { this->_elem *= c; }
-    void imul(const cytnx_uint64 &c) { this->_elem *= c; }
-    void imul(const cytnx_int64 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint32 &c) { this->_elem *= c; }
-    void imul(const cytnx_int32 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint16 &c) { this->_elem *= c; }
-    void imul(const cytnx_int16 &c) { this->_elem *= c; }
-    void imul(const cytnx_bool &c) { this->_elem *= c; }
-
-    void idiv(const Scalar_base *c) { this->_elem /= c->to_cytnx_float(); }
-    void idiv(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_double &c) { this->_elem /= c; }
-    void idiv(const cytnx_float &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_bool &c) { this->_elem /= c; }
-
-    bool less(const Scalar_base *c) { return this->_elem < c->to_cytnx_float(); }
-    bool less(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_double &c) { return this->_elem < c; }
-    bool less(const cytnx_float &c) { return this->_elem < c; }
-    bool less(const cytnx_uint64 &c) { return this->_elem < c; }
-    bool less(const cytnx_int64 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint32 &c) { return this->_elem < c; }
-    bool less(const cytnx_int32 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint16 &c) { return this->_elem < c; }
-    bool less(const cytnx_int16 &c) { return this->_elem < c; }
-    bool less(const cytnx_bool &c) { return this->_elem < c; }
-
-    bool greater(const Scalar_base *c) { return this->_elem > c->to_cytnx_float(); }
-    bool greater(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_double &c) { return this->_elem > c; }
-    bool greater(const cytnx_float &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_bool &c) { return this->_elem > c; }
-
-    bool eq(const Scalar_base *c) { return this->_elem == c->to_cytnx_float(); }
-    // bool approx_eq(const Scalar_base *c, const cytnx_double &tol = 1e-8) {
-    //   return std::abs(this->_elem - c->to_cytnx_float()) <= tol;
-    // }
-
-    void isqrt() { this->_elem = std::sqrt(this->_elem); }
-
-    void conj_() { return; }
-    Scalar_base *get_real() { return this->copy(); }
-    Scalar_base *get_imag() {
-      cytnx_error_msg(true, "[ERROR] real type Scalar does not have imag part!%s", "\n");
-      return nullptr;
-    }
-
-    void set_maxval() { this->_elem = std::numeric_limits<float>::max(); }
-    void set_minval() { this->_elem = std::numeric_limits<float>::min(); }
-
-    void iabs() { this->_elem = std::abs(this->_elem); }
-
-    void *get_raw_address() const { return (void *)(&this->_elem); }
-    Scalar_base *astype(const unsigned int &dtype) {
-      Scalar_base *tmp = __ScII.UScIInit[dtype]();
-      tmp->assign_selftype(this->_elem);
-      return tmp;
-    }
-    Scalar_base *copy() const {
-      FloatScalar *tmp = new FloatScalar(this->_elem);
-      return tmp;
-    };
-    void print(std::ostream &os) const { os << "< " << this->_elem << " >"; };
-  };
-
-  class Int64Scalar : public Scalar_base {
-   public:
-    cytnx_int64 _elem;
-
-    Int64Scalar() : _elem(0) { this->_dtype = Type.Int64; };
-    Int64Scalar(const cytnx_int64 &in) : _elem(0) {
-      this->_dtype = Type.Int64;
-      this->_elem = in;
-    }
-
-    cytnx_float to_cytnx_float() const { return this->_elem; };
-    cytnx_double to_cytnx_double() const { return this->_elem; };
-    cytnx_complex64 to_cytnx_complex64() const { return this->_elem; };
-    cytnx_complex128 to_cytnx_complex128() const { return this->_elem; };
-    cytnx_int64 to_cytnx_int64() const { return this->_elem; };
-    cytnx_uint64 to_cytnx_uint64() const { return this->_elem; };
-    cytnx_int32 to_cytnx_int32() const { return this->_elem; };
-    cytnx_uint32 to_cytnx_uint32() const { return this->_elem; };
-    cytnx_int16 to_cytnx_int16() const { return this->_elem; };
-    cytnx_uint16 to_cytnx_uint16() const { return this->_elem; };
-    cytnx_bool to_cytnx_bool() const { return this->_elem; };
-
-    void assign_selftype(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_double &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_float &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_bool &c) { this->_elem = c; }
-
-    void iadd(const Scalar_base *c) { this->_elem += c->to_cytnx_int64(); }
-    void iadd(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_double &c) { this->_elem += c; }
-    void iadd(const cytnx_float &c) { this->_elem += c; }
-    void iadd(const cytnx_uint64 &c) { this->_elem += c; }
-    void iadd(const cytnx_int64 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint32 &c) { this->_elem += c; }
-    void iadd(const cytnx_int32 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint16 &c) { this->_elem += c; }
-    void iadd(const cytnx_int16 &c) { this->_elem += c; }
-    void iadd(const cytnx_bool &c) { this->_elem += c; }
-
-    void isub(const Scalar_base *c) { this->_elem -= c->to_cytnx_int64(); }
-    void isub(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_double &c) { this->_elem -= c; }
-    void isub(const cytnx_float &c) { this->_elem -= c; }
-    void isub(const cytnx_uint64 &c) { this->_elem -= c; }
-    void isub(const cytnx_int64 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint32 &c) { this->_elem -= c; }
-    void isub(const cytnx_int32 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint16 &c) { this->_elem -= c; }
-    void isub(const cytnx_int16 &c) { this->_elem -= c; }
-    void isub(const cytnx_bool &c) { this->_elem -= c; }
-
-    void imul(const Scalar_base *c) { this->_elem *= c->to_cytnx_int64(); }
-    void imul(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_double &c) { this->_elem *= c; }
-    void imul(const cytnx_float &c) { this->_elem *= c; }
-    void imul(const cytnx_uint64 &c) { this->_elem *= c; }
-    void imul(const cytnx_int64 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint32 &c) { this->_elem *= c; }
-    void imul(const cytnx_int32 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint16 &c) { this->_elem *= c; }
-    void imul(const cytnx_int16 &c) { this->_elem *= c; }
-    void imul(const cytnx_bool &c) { this->_elem *= c; }
-
-    void idiv(const Scalar_base *c) { this->_elem /= c->to_cytnx_int64(); }
-    void idiv(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_double &c) { this->_elem /= c; }
-    void idiv(const cytnx_float &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_bool &c) { this->_elem /= c; }
-
-    void iabs() { this->_elem = std::abs(this->_elem); }
-    void isqrt() { this->_elem = std::sqrt(this->_elem); }
-
-    bool less(const Scalar_base *c) { return this->_elem < c->to_cytnx_int64(); }
-    bool less(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_double &c) { return this->_elem < c; }
-    bool less(const cytnx_float &c) { return this->_elem < c; }
-    bool less(const cytnx_uint64 &c) { return this->_elem < c; }
-    bool less(const cytnx_int64 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint32 &c) { return this->_elem < c; }
-    bool less(const cytnx_int32 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint16 &c) { return this->_elem < c; }
-    bool less(const cytnx_int16 &c) { return this->_elem < c; }
-    bool less(const cytnx_bool &c) { return this->_elem < c; }
-
-    bool greater(const Scalar_base *c) { return this->_elem > c->to_cytnx_int64(); }
-    bool greater(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_double &c) { return this->_elem > c; }
-    bool greater(const cytnx_float &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_bool &c) { return this->_elem > c; }
-
-    bool eq(const Scalar_base *c) { return this->_elem == c->to_cytnx_int64(); }
-    // bool approx_eq(const Scalar_base *c, const cytnx_double &tol = 1e-8) {
-    //   return std::abs((cytnx_double)this->_elem - (cytnx_double)c->to_cytnx_int64()) <= tol;
-    // }
-
-    void conj_() { return; }
-    Scalar_base *get_real() { return this->copy(); }
-    Scalar_base *get_imag() {
-      cytnx_error_msg(true, "[ERROR] real type Scalar does not have imag part!%s", "\n");
-      return nullptr;
-    }
-
-    void set_maxval() { this->_elem = std::numeric_limits<cytnx_int64>::max(); }
-    void set_minval() { this->_elem = std::numeric_limits<cytnx_int64>::min(); }
-
-    void *get_raw_address() const { return (void *)(&this->_elem); }
-    Scalar_base *astype(const unsigned int &dtype) {
-      Scalar_base *tmp = __ScII.UScIInit[dtype]();
-      tmp->assign_selftype(this->_elem);
-      return tmp;
-    }
-    Scalar_base *copy() const {
-      Int64Scalar *tmp = new Int64Scalar(this->_elem);
-      return tmp;
-    };
-    void print(std::ostream &os) const { os << "< " << this->_elem << " >"; };
-  };
-  class Uint64Scalar : public Scalar_base {
-   public:
-    cytnx_uint64 _elem;
-
-    Uint64Scalar() : _elem(0) { this->_dtype = Type.Uint64; };
-    Uint64Scalar(const cytnx_uint64 &in) : _elem(0) {
-      this->_dtype = Type.Uint64;
-      this->_elem = in;
-    }
-
-    cytnx_float to_cytnx_float() const { return this->_elem; };
-    cytnx_double to_cytnx_double() const { return this->_elem; };
-    cytnx_complex64 to_cytnx_complex64() const { return this->_elem; };
-    cytnx_complex128 to_cytnx_complex128() const { return this->_elem; };
-    cytnx_int64 to_cytnx_int64() const { return this->_elem; };
-    cytnx_uint64 to_cytnx_uint64() const { return this->_elem; };
-    cytnx_int32 to_cytnx_int32() const { return this->_elem; };
-    cytnx_uint32 to_cytnx_uint32() const { return this->_elem; };
-    cytnx_int16 to_cytnx_int16() const { return this->_elem; };
-    cytnx_uint16 to_cytnx_uint16() const { return this->_elem; };
-    cytnx_bool to_cytnx_bool() const { return this->_elem; };
-
-    void assign_selftype(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_double &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_float &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_bool &c) { this->_elem = c; }
-
-    void iadd(const Scalar_base *c) { this->_elem += c->to_cytnx_uint64(); }
-    void iadd(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_double &c) { this->_elem += c; }
-    void iadd(const cytnx_float &c) { this->_elem += c; }
-    void iadd(const cytnx_uint64 &c) { this->_elem += c; }
-    void iadd(const cytnx_int64 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint32 &c) { this->_elem += c; }
-    void iadd(const cytnx_int32 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint16 &c) { this->_elem += c; }
-    void iadd(const cytnx_int16 &c) { this->_elem += c; }
-    void iadd(const cytnx_bool &c) { this->_elem += c; }
-
-    void isub(const Scalar_base *c) { this->_elem -= c->to_cytnx_uint64(); }
-    void isub(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_double &c) { this->_elem -= c; }
-    void isub(const cytnx_float &c) { this->_elem -= c; }
-    void isub(const cytnx_uint64 &c) { this->_elem -= c; }
-    void isub(const cytnx_int64 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint32 &c) { this->_elem -= c; }
-    void isub(const cytnx_int32 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint16 &c) { this->_elem -= c; }
-    void isub(const cytnx_int16 &c) { this->_elem -= c; }
-    void isub(const cytnx_bool &c) { this->_elem -= c; }
-
-    void imul(const Scalar_base *c) { this->_elem *= c->to_cytnx_uint64(); }
-    void imul(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_double &c) { this->_elem *= c; }
-    void imul(const cytnx_float &c) { this->_elem *= c; }
-    void imul(const cytnx_uint64 &c) { this->_elem *= c; }
-    void imul(const cytnx_int64 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint32 &c) { this->_elem *= c; }
-    void imul(const cytnx_int32 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint16 &c) { this->_elem *= c; }
-    void imul(const cytnx_int16 &c) { this->_elem *= c; }
-    void imul(const cytnx_bool &c) { this->_elem *= c; }
-
-    void idiv(const Scalar_base *c) { this->_elem /= c->to_cytnx_uint64(); }
-    void idiv(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_double &c) { this->_elem /= c; }
-    void idiv(const cytnx_float &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_bool &c) { this->_elem /= c; }
-
-    void iabs() { this->_elem = std::abs(cytnx_double(this->_elem)); }
-    void isqrt() { this->_elem = std::sqrt(this->_elem); }
-
-    bool less(const Scalar_base *c) { return this->_elem < c->to_cytnx_uint64(); }
-    bool less(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_double &c) { return this->_elem < c; }
-    bool less(const cytnx_float &c) { return this->_elem < c; }
-    bool less(const cytnx_uint64 &c) { return this->_elem < c; }
-    bool less(const cytnx_int64 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint32 &c) { return this->_elem < c; }
-    bool less(const cytnx_int32 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint16 &c) { return this->_elem < c; }
-    bool less(const cytnx_int16 &c) { return this->_elem < c; }
-    bool less(const cytnx_bool &c) { return this->_elem < c; }
-
-    bool greater(const Scalar_base *c) { return this->_elem > c->to_cytnx_uint64(); }
-    bool greater(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_double &c) { return this->_elem > c; }
-    bool greater(const cytnx_float &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_bool &c) { return this->_elem > c; }
-
-    bool eq(const Scalar_base *c) { return this->_elem == c->to_cytnx_uint64(); }
-    // bool approx_eq(const Scalar_base *c, const cytnx_double &tol = 1e-8) {
-    //   return std::abs((cytnx_double)this->_elem - (cytnx_double)c->to_cytnx_uint64()) <= tol;
-    // }
-
-    void conj_() { return; }
-    Scalar_base *get_real() { return this->copy(); }
-    Scalar_base *get_imag() {
-      cytnx_error_msg(true, "[ERROR] real type Scalar does not have imag part!%s", "\n");
-      return nullptr;
-    }
-
-    void set_maxval() { this->_elem = std::numeric_limits<cytnx_uint64>::max(); }
-    void set_minval() { this->_elem = std::numeric_limits<cytnx_uint64>::min(); }
-
-    void *get_raw_address() const { return (void *)(&this->_elem); }
-    Scalar_base *astype(const unsigned int &dtype) {
-      Scalar_base *tmp = __ScII.UScIInit[dtype]();
-      tmp->assign_selftype(this->_elem);
-      return tmp;
-    }
-    Scalar_base *copy() const {
-      Uint64Scalar *tmp = new Uint64Scalar(this->_elem);
-      return tmp;
-    };
-    void print(std::ostream &os) const { os << "< " << this->_elem << " >"; };
-  };
-  class Int32Scalar : public Scalar_base {
-   public:
-    cytnx_int32 _elem;
-
-    Int32Scalar() : _elem(0) { this->_dtype = Type.Int32; };
-    Int32Scalar(const cytnx_int32 &in) : _elem(0) {
-      this->_dtype = Type.Int32;
-      this->_elem = in;
-    }
-
-    cytnx_float to_cytnx_float() const { return this->_elem; };
-    cytnx_double to_cytnx_double() const { return this->_elem; };
-    cytnx_complex64 to_cytnx_complex64() const { return this->_elem; };
-    cytnx_complex128 to_cytnx_complex128() const { return this->_elem; };
-    cytnx_int64 to_cytnx_int64() const { return this->_elem; };
-    cytnx_uint64 to_cytnx_uint64() const { return this->_elem; };
-    cytnx_int32 to_cytnx_int32() const { return this->_elem; };
-    cytnx_uint32 to_cytnx_uint32() const { return this->_elem; };
-    cytnx_int16 to_cytnx_int16() const { return this->_elem; };
-    cytnx_uint16 to_cytnx_uint16() const { return this->_elem; };
-    cytnx_bool to_cytnx_bool() const { return this->_elem; };
-
-    void assign_selftype(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_double &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_float &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_bool &c) { this->_elem = c; }
-
-    void iadd(const Scalar_base *c) { this->_elem += c->to_cytnx_int32(); }
-    void iadd(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_double &c) { this->_elem += c; }
-    void iadd(const cytnx_float &c) { this->_elem += c; }
-    void iadd(const cytnx_uint64 &c) { this->_elem += c; }
-    void iadd(const cytnx_int64 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint32 &c) { this->_elem += c; }
-    void iadd(const cytnx_int32 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint16 &c) { this->_elem += c; }
-    void iadd(const cytnx_int16 &c) { this->_elem += c; }
-    void iadd(const cytnx_bool &c) { this->_elem += c; }
-
-    void isub(const Scalar_base *c) { this->_elem -= c->to_cytnx_int32(); }
-    void isub(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_double &c) { this->_elem -= c; }
-    void isub(const cytnx_float &c) { this->_elem -= c; }
-    void isub(const cytnx_uint64 &c) { this->_elem -= c; }
-    void isub(const cytnx_int64 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint32 &c) { this->_elem -= c; }
-    void isub(const cytnx_int32 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint16 &c) { this->_elem -= c; }
-    void isub(const cytnx_int16 &c) { this->_elem -= c; }
-    void isub(const cytnx_bool &c) { this->_elem -= c; }
-
-    void imul(const Scalar_base *c) { this->_elem *= c->to_cytnx_int32(); }
-    void imul(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_double &c) { this->_elem *= c; }
-    void imul(const cytnx_float &c) { this->_elem *= c; }
-    void imul(const cytnx_uint64 &c) { this->_elem *= c; }
-    void imul(const cytnx_int64 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint32 &c) { this->_elem *= c; }
-    void imul(const cytnx_int32 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint16 &c) { this->_elem *= c; }
-    void imul(const cytnx_int16 &c) { this->_elem *= c; }
-    void imul(const cytnx_bool &c) { this->_elem *= c; }
-
-    void idiv(const Scalar_base *c) { this->_elem /= c->to_cytnx_int32(); }
-    void idiv(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_double &c) { this->_elem /= c; }
-    void idiv(const cytnx_float &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_bool &c) { this->_elem /= c; }
-
-    void iabs() { this->_elem = std::abs(this->_elem); }
-    void isqrt() { this->_elem = std::sqrt(this->_elem); }
-
-    bool less(const Scalar_base *c) { return this->_elem < c->to_cytnx_int32(); }
-    bool less(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_double &c) { return this->_elem < c; }
-    bool less(const cytnx_float &c) { return this->_elem < c; }
-    bool less(const cytnx_uint64 &c) { return this->_elem < c; }
-    bool less(const cytnx_int64 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint32 &c) { return this->_elem < c; }
-    bool less(const cytnx_int32 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint16 &c) { return this->_elem < c; }
-    bool less(const cytnx_int16 &c) { return this->_elem < c; }
-    bool less(const cytnx_bool &c) { return this->_elem < c; }
-
-    bool greater(const Scalar_base *c) { return this->_elem > c->to_cytnx_int32(); }
-    bool greater(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_double &c) { return this->_elem > c; }
-    bool greater(const cytnx_float &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_bool &c) { return this->_elem > c; }
-
-    bool eq(const Scalar_base *c) { return this->_elem == c->to_cytnx_int32(); }
-    // bool approx_eq(const Scalar_base *c, const cytnx_double &tol = 1e-8) {
-    //   return std::abs((cytnx_double)this->_elem - (cytnx_double)c->to_cytnx_int32()) <= tol;
-    // }
-
-    void conj_() { return; }
-    Scalar_base *get_real() { return this->copy(); }
-    Scalar_base *get_imag() {
-      cytnx_error_msg(true, "[ERROR] real type Scalar does not have imag part!%s", "\n");
-      return nullptr;
-    }
-
-    void set_maxval() { this->_elem = std::numeric_limits<cytnx_int32>::max(); }
-    void set_minval() { this->_elem = std::numeric_limits<cytnx_int32>::min(); }
-
-    void *get_raw_address() const { return (void *)(&this->_elem); }
-
-    Scalar_base *astype(const unsigned int &dtype) {
-      Scalar_base *tmp = __ScII.UScIInit[dtype]();
-      tmp->assign_selftype(this->_elem);
-      return tmp;
-    }
-    Scalar_base *copy() const {
-      Int32Scalar *tmp = new Int32Scalar(this->_elem);
-      return tmp;
-    };
-    void print(std::ostream &os) const { os << "< " << this->_elem << " >"; };
-  };
-  class Uint32Scalar : public Scalar_base {
-   public:
-    cytnx_uint32 _elem;
-
-    Uint32Scalar() : _elem(0) { this->_dtype = Type.Uint32; };
-    Uint32Scalar(const cytnx_uint32 &in) : _elem(0) {
-      this->_dtype = Type.Uint32;
-      this->_elem = in;
-    }
-
-    cytnx_float to_cytnx_float() const { return this->_elem; };
-    cytnx_double to_cytnx_double() const { return this->_elem; };
-    cytnx_complex64 to_cytnx_complex64() const { return this->_elem; };
-    cytnx_complex128 to_cytnx_complex128() const { return this->_elem; };
-    cytnx_int64 to_cytnx_int64() const { return this->_elem; };
-    cytnx_uint64 to_cytnx_uint64() const { return this->_elem; };
-    cytnx_int32 to_cytnx_int32() const { return this->_elem; };
-    cytnx_uint32 to_cytnx_uint32() const { return this->_elem; };
-    cytnx_int16 to_cytnx_int16() const { return this->_elem; };
-    cytnx_uint16 to_cytnx_uint16() const { return this->_elem; };
-    cytnx_bool to_cytnx_bool() const { return this->_elem; };
-
-    void assign_selftype(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_double &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_float &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_bool &c) { this->_elem = c; }
-
-    void iadd(const Scalar_base *c) { this->_elem += c->to_cytnx_uint32(); }
-    void iadd(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_double &c) { this->_elem += c; }
-    void iadd(const cytnx_float &c) { this->_elem += c; }
-    void iadd(const cytnx_uint64 &c) { this->_elem += c; }
-    void iadd(const cytnx_int64 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint32 &c) { this->_elem += c; }
-    void iadd(const cytnx_int32 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint16 &c) { this->_elem += c; }
-    void iadd(const cytnx_int16 &c) { this->_elem += c; }
-    void iadd(const cytnx_bool &c) { this->_elem += c; }
-
-    void isub(const Scalar_base *c) { this->_elem -= c->to_cytnx_uint32(); }
-    void isub(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_double &c) { this->_elem -= c; }
-    void isub(const cytnx_float &c) { this->_elem -= c; }
-    void isub(const cytnx_uint64 &c) { this->_elem -= c; }
-    void isub(const cytnx_int64 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint32 &c) { this->_elem -= c; }
-    void isub(const cytnx_int32 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint16 &c) { this->_elem -= c; }
-    void isub(const cytnx_int16 &c) { this->_elem -= c; }
-    void isub(const cytnx_bool &c) { this->_elem -= c; }
-
-    void imul(const Scalar_base *c) { this->_elem *= c->to_cytnx_uint32(); }
-    void imul(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_double &c) { this->_elem *= c; }
-    void imul(const cytnx_float &c) { this->_elem *= c; }
-    void imul(const cytnx_uint64 &c) { this->_elem *= c; }
-    void imul(const cytnx_int64 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint32 &c) { this->_elem *= c; }
-    void imul(const cytnx_int32 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint16 &c) { this->_elem *= c; }
-    void imul(const cytnx_int16 &c) { this->_elem *= c; }
-    void imul(const cytnx_bool &c) { this->_elem *= c; }
-
-    void idiv(const Scalar_base *c) { this->_elem /= c->to_cytnx_uint32(); }
-    void idiv(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_double &c) { this->_elem /= c; }
-    void idiv(const cytnx_float &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_bool &c) { this->_elem /= c; }
-
-    void iabs() { this->_elem = std::abs(cytnx_double(this->_elem)); }
-    void isqrt() { this->_elem = std::sqrt(this->_elem); }
-
-    bool less(const Scalar_base *c) { return this->_elem < c->to_cytnx_uint32(); }
-    bool less(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_double &c) { return this->_elem < c; }
-    bool less(const cytnx_float &c) { return this->_elem < c; }
-    bool less(const cytnx_uint64 &c) { return this->_elem < c; }
-    bool less(const cytnx_int64 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint32 &c) { return this->_elem < c; }
-    bool less(const cytnx_int32 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint16 &c) { return this->_elem < c; }
-    bool less(const cytnx_int16 &c) { return this->_elem < c; }
-    bool less(const cytnx_bool &c) { return this->_elem < c; }
-
-    bool greater(const Scalar_base *c) { return this->_elem > c->to_cytnx_uint32(); }
-    bool greater(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_double &c) { return this->_elem > c; }
-    bool greater(const cytnx_float &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_bool &c) { return this->_elem > c; }
-
-    bool eq(const Scalar_base *c) { return this->_elem == c->to_cytnx_uint32(); }
-    // bool approx_eq(const Scalar_base *c, const cytnx_double &tol = 1e-8) {
-    //   return std::abs((cytnx_double)this->_elem - (cytnx_double)c->to_cytnx_uint32()) <= tol;
-    // }
-
-    void conj_() { return; }
-    Scalar_base *get_real() { return this->copy(); }
-    Scalar_base *get_imag() {
-      cytnx_error_msg(true, "[ERROR] real type Scalar does not have imag part!%s", "\n");
-      return nullptr;
-    }
-
-    void set_maxval() { this->_elem = std::numeric_limits<cytnx_uint32>::max(); }
-    void set_minval() { this->_elem = std::numeric_limits<cytnx_uint32>::min(); }
-
-    void *get_raw_address() const { return (void *)(&this->_elem); }
-    Scalar_base *astype(const unsigned int &dtype) {
-      Scalar_base *tmp = __ScII.UScIInit[dtype]();
-      tmp->assign_selftype(this->_elem);
-      return tmp;
-    }
-    Scalar_base *copy() const {
-      Uint32Scalar *tmp = new Uint32Scalar(this->_elem);
-      return tmp;
-    };
-    void print(std::ostream &os) const { os << "< " << this->_elem << " >"; };
-  };
-  class Int16Scalar : public Scalar_base {
-   public:
-    cytnx_int16 _elem;
-
-    Int16Scalar() : _elem(0) { this->_dtype = Type.Int16; };
-    Int16Scalar(const cytnx_int16 &in) : _elem(0) {
-      this->_dtype = Type.Int16;
-      this->_elem = in;
-    }
-
-    cytnx_float to_cytnx_float() const { return this->_elem; };
-    cytnx_double to_cytnx_double() const { return this->_elem; };
-    cytnx_complex64 to_cytnx_complex64() const { return this->_elem; };
-    cytnx_complex128 to_cytnx_complex128() const { return this->_elem; };
-    cytnx_int64 to_cytnx_int64() const { return this->_elem; };
-    cytnx_uint64 to_cytnx_uint64() const { return this->_elem; };
-    cytnx_int32 to_cytnx_int32() const { return this->_elem; };
-    cytnx_uint32 to_cytnx_uint32() const { return this->_elem; };
-    cytnx_int16 to_cytnx_int16() const { return this->_elem; };
-    cytnx_uint16 to_cytnx_uint16() const { return this->_elem; };
-    cytnx_bool to_cytnx_bool() const { return this->_elem; };
-
-    void assign_selftype(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_double &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_float &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_bool &c) { this->_elem = c; }
-
-    void iadd(const Scalar_base *c) { this->_elem += c->to_cytnx_int16(); }
-    void iadd(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_double &c) { this->_elem += c; }
-    void iadd(const cytnx_float &c) { this->_elem += c; }
-    void iadd(const cytnx_uint64 &c) { this->_elem += c; }
-    void iadd(const cytnx_int64 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint32 &c) { this->_elem += c; }
-    void iadd(const cytnx_int32 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint16 &c) { this->_elem += c; }
-    void iadd(const cytnx_int16 &c) { this->_elem += c; }
-    void iadd(const cytnx_bool &c) { this->_elem += c; }
-
-    void isub(const Scalar_base *c) { this->_elem -= c->to_cytnx_int16(); }
-    void isub(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_double &c) { this->_elem -= c; }
-    void isub(const cytnx_float &c) { this->_elem -= c; }
-    void isub(const cytnx_uint64 &c) { this->_elem -= c; }
-    void isub(const cytnx_int64 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint32 &c) { this->_elem -= c; }
-    void isub(const cytnx_int32 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint16 &c) { this->_elem -= c; }
-    void isub(const cytnx_int16 &c) { this->_elem -= c; }
-    void isub(const cytnx_bool &c) { this->_elem -= c; }
-
-    void imul(const Scalar_base *c) { this->_elem *= c->to_cytnx_int16(); }
-    void imul(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_double &c) { this->_elem *= c; }
-    void imul(const cytnx_float &c) { this->_elem *= c; }
-    void imul(const cytnx_uint64 &c) { this->_elem *= c; }
-    void imul(const cytnx_int64 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint32 &c) { this->_elem *= c; }
-    void imul(const cytnx_int32 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint16 &c) { this->_elem *= c; }
-    void imul(const cytnx_int16 &c) { this->_elem *= c; }
-    void imul(const cytnx_bool &c) { this->_elem *= c; }
-
-    void idiv(const Scalar_base *c) { this->_elem /= c->to_cytnx_int16(); }
-    void idiv(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_double &c) { this->_elem /= c; }
-    void idiv(const cytnx_float &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_bool &c) { this->_elem /= c; }
-
-    void iabs() { this->_elem = std::abs(this->_elem); }
-    void isqrt() { this->_elem = std::sqrt(this->_elem); }
-
-    bool less(const Scalar_base *c) { return this->_elem < c->to_cytnx_int16(); }
-    bool less(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_double &c) { return this->_elem < c; }
-    bool less(const cytnx_float &c) { return this->_elem < c; }
-    bool less(const cytnx_uint64 &c) { return this->_elem < c; }
-    bool less(const cytnx_int64 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint32 &c) { return this->_elem < c; }
-    bool less(const cytnx_int32 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint16 &c) { return this->_elem < c; }
-    bool less(const cytnx_int16 &c) { return this->_elem < c; }
-    bool less(const cytnx_bool &c) { return this->_elem < c; }
-
-    bool greater(const Scalar_base *c) { return this->_elem > c->to_cytnx_int16(); }
-    bool greater(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_double &c) { return this->_elem > c; }
-    bool greater(const cytnx_float &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_bool &c) { return this->_elem > c; }
-
-    bool eq(const Scalar_base *c) { return this->_elem == c->to_cytnx_int16(); }
-    // bool approx_eq(const Scalar_base *c, const cytnx_double &tol = 1e-8) {
-    //   return std::abs((cytnx_double)this->_elem - (cytnx_double)c->to_cytnx_int16()) <= tol;
-    // }
-
-    void conj_() { return; }
-    Scalar_base *get_real() { return this->copy(); }
-    Scalar_base *get_imag() {
-      cytnx_error_msg(true, "[ERROR] real type Scalar does not have imag part!%s", "\n");
-      return nullptr;
-    }
-
-    void set_maxval() { this->_elem = std::numeric_limits<cytnx_int16>::max(); }
-    void set_minval() { this->_elem = std::numeric_limits<cytnx_int16>::min(); }
-
-    void *get_raw_address() const { return (void *)(&this->_elem); }
-    Scalar_base *astype(const unsigned int &dtype) {
-      Scalar_base *tmp = __ScII.UScIInit[dtype]();
-      tmp->assign_selftype(this->_elem);
-      return tmp;
-    }
-    Scalar_base *copy() const {
-      Int16Scalar *tmp = new Int16Scalar(this->_elem);
-      return tmp;
-    };
-    void print(std::ostream &os) const { os << "< " << this->_elem << " >"; };
-  };
-  class Uint16Scalar : public Scalar_base {
-   public:
-    cytnx_uint16 _elem;
-
-    Uint16Scalar() : _elem(0) { this->_dtype = Type.Uint16; };
-    Uint16Scalar(const cytnx_uint16 &in) : _elem(0) {
-      this->_dtype = Type.Uint16;
-      this->_elem = in;
-    }
-
-    cytnx_float to_cytnx_float() const { return this->_elem; };
-    cytnx_double to_cytnx_double() const { return this->_elem; };
-    cytnx_complex64 to_cytnx_complex64() const { return this->_elem; };
-    cytnx_complex128 to_cytnx_complex128() const { return this->_elem; };
-    cytnx_int64 to_cytnx_int64() const { return this->_elem; };
-    cytnx_uint64 to_cytnx_uint64() const { return this->_elem; };
-    cytnx_int32 to_cytnx_int32() const { return this->_elem; };
-    cytnx_uint32 to_cytnx_uint32() const { return this->_elem; };
-    cytnx_int16 to_cytnx_int16() const { return this->_elem; };
-    cytnx_uint16 to_cytnx_uint16() const { return this->_elem; };
-    cytnx_bool to_cytnx_bool() const { return this->_elem; };
-
-    void assign_selftype(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_double &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_float &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_bool &c) { this->_elem = c; }
-
-    void iadd(const Scalar_base *c) { this->_elem += c->to_cytnx_uint16(); }
-    void iadd(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_double &c) { this->_elem += c; }
-    void iadd(const cytnx_float &c) { this->_elem += c; }
-    void iadd(const cytnx_uint64 &c) { this->_elem += c; }
-    void iadd(const cytnx_int64 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint32 &c) { this->_elem += c; }
-    void iadd(const cytnx_int32 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint16 &c) { this->_elem += c; }
-    void iadd(const cytnx_int16 &c) { this->_elem += c; }
-    void iadd(const cytnx_bool &c) { this->_elem += c; }
-
-    void isub(const Scalar_base *c) { this->_elem -= c->to_cytnx_uint16(); }
-    void isub(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_double &c) { this->_elem -= c; }
-    void isub(const cytnx_float &c) { this->_elem -= c; }
-    void isub(const cytnx_uint64 &c) { this->_elem -= c; }
-    void isub(const cytnx_int64 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint32 &c) { this->_elem -= c; }
-    void isub(const cytnx_int32 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint16 &c) { this->_elem -= c; }
-    void isub(const cytnx_int16 &c) { this->_elem -= c; }
-    void isub(const cytnx_bool &c) { this->_elem -= c; }
-
-    void imul(const Scalar_base *c) { this->_elem *= c->to_cytnx_uint16(); }
-    void imul(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_double &c) { this->_elem *= c; }
-    void imul(const cytnx_float &c) { this->_elem *= c; }
-    void imul(const cytnx_uint64 &c) { this->_elem *= c; }
-    void imul(const cytnx_int64 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint32 &c) { this->_elem *= c; }
-    void imul(const cytnx_int32 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint16 &c) { this->_elem *= c; }
-    void imul(const cytnx_int16 &c) { this->_elem *= c; }
-    void imul(const cytnx_bool &c) { this->_elem *= c; }
-
-    void idiv(const Scalar_base *c) { this->_elem /= c->to_cytnx_uint16(); }
-    void idiv(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_double &c) { this->_elem /= c; }
-    void idiv(const cytnx_float &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_bool &c) { this->_elem /= c; }
-
-    void iabs() { this->_elem = std::abs(this->_elem); }
-    void isqrt() { this->_elem = std::sqrt(this->_elem); }
-
-    bool less(const Scalar_base *c) { return this->_elem < c->to_cytnx_uint16(); }
-    bool less(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_double &c) { return this->_elem < c; }
-    bool less(const cytnx_float &c) { return this->_elem < c; }
-    bool less(const cytnx_uint64 &c) { return this->_elem < c; }
-    bool less(const cytnx_int64 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint32 &c) { return this->_elem < c; }
-    bool less(const cytnx_int32 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint16 &c) { return this->_elem < c; }
-    bool less(const cytnx_int16 &c) { return this->_elem < c; }
-    bool less(const cytnx_bool &c) { return this->_elem < c; }
-
-    bool greater(const Scalar_base *c) { return this->_elem > c->to_cytnx_uint16(); }
-    bool greater(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_double &c) { return this->_elem > c; }
-    bool greater(const cytnx_float &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_bool &c) { return this->_elem > c; }
-
-    bool eq(const Scalar_base *c) { return this->_elem == c->to_cytnx_uint16(); }
-    // bool approx_eq(const Scalar_base *c, const cytnx_double &tol = 1e-8) {
-    //   return std::abs((cytnx_double)this->_elem - (cytnx_double)c->to_cytnx_uint16()) <= tol;
-    // }
-
-    void conj_() { return; }
-    Scalar_base *get_real() { return this->copy(); }
-    Scalar_base *get_imag() {
-      cytnx_error_msg(true, "[ERROR] real type Scalar does not have imag part!%s", "\n");
-      return nullptr;
-    }
-
-    void set_maxval() { this->_elem = std::numeric_limits<cytnx_uint16>::max(); }
-    void set_minval() { this->_elem = std::numeric_limits<cytnx_uint16>::min(); }
-
-    void *get_raw_address() const { return (void *)(&this->_elem); }
-    Scalar_base *astype(const unsigned int &dtype) {
-      Scalar_base *tmp = __ScII.UScIInit[dtype]();
-      tmp->assign_selftype(this->_elem);
-      return tmp;
-    }
-    Scalar_base *copy() const {
-      Uint16Scalar *tmp = new Uint16Scalar(this->_elem);
-      return tmp;
-    };
-    void print(std::ostream &os) const { os << "< " << this->_elem << " >"; };
-  };
-  class BoolScalar : public Scalar_base {
-   public:
-    cytnx_bool _elem;
-
-    BoolScalar() : _elem(0) { this->_dtype = Type.Bool; };
-    BoolScalar(const cytnx_bool &in) : _elem(0) {
-      this->_dtype = Type.Bool;
-      this->_elem = in;
-    }
-
-    cytnx_float to_cytnx_float() const { return this->_elem; };
-    cytnx_double to_cytnx_double() const { return this->_elem; };
-    cytnx_complex64 to_cytnx_complex64() const { return this->_elem; };
-    cytnx_complex128 to_cytnx_complex128() const { return this->_elem; };
-    cytnx_int64 to_cytnx_int64() const { return this->_elem; };
-    cytnx_uint64 to_cytnx_uint64() const { return this->_elem; };
-    cytnx_int32 to_cytnx_int32() const { return this->_elem; };
-    cytnx_uint32 to_cytnx_uint32() const { return this->_elem; };
-    cytnx_int16 to_cytnx_int16() const { return this->_elem; };
-    cytnx_uint16 to_cytnx_uint16() const { return this->_elem; };
-    cytnx_bool to_cytnx_bool() const { return this->_elem; };
-
-    void assign_selftype(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot convert complex to real%s", "\n");
-    }
-    void assign_selftype(const cytnx_double &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_float &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int64 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int32 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_uint16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_int16 &c) { this->_elem = c; }
-    void assign_selftype(const cytnx_bool &c) { this->_elem = c; }
-
-    void iadd(const Scalar_base *c) { this->_elem += c->to_cytnx_bool(); }
-    void iadd(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void iadd(const cytnx_double &c) { this->_elem += c; }
-    void iadd(const cytnx_float &c) { this->_elem += c; }
-    void iadd(const cytnx_uint64 &c) { this->_elem += c; }
-    void iadd(const cytnx_int64 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint32 &c) { this->_elem += c; }
-    void iadd(const cytnx_int32 &c) { this->_elem += c; }
-    void iadd(const cytnx_uint16 &c) { this->_elem += c; }
-    void iadd(const cytnx_int16 &c) { this->_elem += c; }
-    void iadd(const cytnx_bool &c) { this->_elem += c; }
-
-    void isub(const Scalar_base *c) { this->_elem -= c->to_cytnx_bool(); }
-    void isub(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void isub(const cytnx_double &c) { this->_elem -= c; }
-    void isub(const cytnx_float &c) { this->_elem -= c; }
-    void isub(const cytnx_uint64 &c) { this->_elem -= c; }
-    void isub(const cytnx_int64 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint32 &c) { this->_elem -= c; }
-    void isub(const cytnx_int32 &c) { this->_elem -= c; }
-    void isub(const cytnx_uint16 &c) { this->_elem -= c; }
-    void isub(const cytnx_int16 &c) { this->_elem -= c; }
-    void isub(const cytnx_bool &c) { this->_elem -= c; }
-
-    void imul(const Scalar_base *c) { this->_elem *= c->to_cytnx_bool(); }
-    void imul(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void imul(const cytnx_double &c) { this->_elem *= c; }
-    void imul(const cytnx_float &c) { this->_elem *= c; }
-    void imul(const cytnx_uint64 &c) { this->_elem *= c; }
-    void imul(const cytnx_int64 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint32 &c) { this->_elem *= c; }
-    void imul(const cytnx_int32 &c) { this->_elem *= c; }
-    void imul(const cytnx_uint16 &c) { this->_elem *= c; }
-    void imul(const cytnx_int16 &c) { this->_elem *= c; }
-    void imul(const cytnx_bool &c) { this->_elem *= c; }
-
-    void idiv(const Scalar_base *c) { this->_elem /= c->to_cytnx_bool(); }
-    void idiv(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] Cannot operate real and complex values%s", "\n");
-    }
-    void idiv(const cytnx_double &c) { this->_elem /= c; }
-    void idiv(const cytnx_float &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int64 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int32 &c) { this->_elem /= c; }
-    void idiv(const cytnx_uint16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_int16 &c) { this->_elem /= c; }
-    void idiv(const cytnx_bool &c) { this->_elem /= c; }
-
-    void iabs() { this->_elem = std::abs(this->_elem); }
-    void isqrt() { this->_elem = std::sqrt(this->_elem); }
-
-    bool less(const Scalar_base *c) { return this->_elem < c->to_cytnx_bool(); }
-    bool less(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool less(const cytnx_double &c) { return this->_elem < c; }
-    bool less(const cytnx_float &c) { return this->_elem < c; }
-    bool less(const cytnx_uint64 &c) { return this->_elem < c; }
-    bool less(const cytnx_int64 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint32 &c) { return this->_elem < c; }
-    bool less(const cytnx_int32 &c) { return this->_elem < c; }
-    bool less(const cytnx_uint16 &c) { return this->_elem < c; }
-    bool less(const cytnx_int16 &c) { return this->_elem < c; }
-    bool less(const cytnx_bool &c) { return this->_elem < c; }
-
-    bool greater(const Scalar_base *c) { return this->_elem > c->to_cytnx_bool(); }
-    bool greater(const cytnx_complex128 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_complex64 &c) {
-      cytnx_error_msg(true, "[ERROR] comparison not supported for complex type%s", "\n");
-      return 0;
-    }
-    bool greater(const cytnx_double &c) { return this->_elem > c; }
-    bool greater(const cytnx_float &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int64 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int32 &c) { return this->_elem > c; }
-    bool greater(const cytnx_uint16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_int16 &c) { return this->_elem > c; }
-    bool greater(const cytnx_bool &c) { return this->_elem > c; }
-
-    bool eq(const Scalar_base *c) { return this->_elem == c->to_cytnx_bool(); }
-    // bool approx_eq(const Scalar_base *c, const cytnx_double &tol = 1e-8) {
-    //   return std::abs((cytnx_double)this->_elem - (cytnx_double)c->to_cytnx_bool()) <= tol;
-    // }
-
-    void conj_() { return; }
-    Scalar_base *get_real() { return this->copy(); }
-    Scalar_base *get_imag() {
-      cytnx_error_msg(true, "[ERROR] real type Scalar does not have imag part!%s", "\n");
-      return nullptr;
-    }
-
-    void set_maxval() { this->_elem = true; }
-    void set_minval() { this->_elem = false; }
-
-    void *get_raw_address() const { return (void *)(&this->_elem); }
-    Scalar_base *astype(const unsigned int &dtype) {
-      Scalar_base *tmp = __ScII.UScIInit[dtype]();
-      tmp->assign_selftype(this->_elem);
-      return tmp;
-    }
-    Scalar_base *copy() const {
-      BoolScalar *tmp = new BoolScalar(this->_elem);
-      return tmp;
-    };
-    void print(std::ostream &os) const { os << "< " << this->_elem << " >"; };
-  };
-
   ///@endcond
 
   /**
    * @brief A class to represent a scalar.
    * @details This class is used to represent a scalar. You can construct a Scalar by
    * a given value and a dtype (see cytnx::Type for available dtype).
+   *
+   * @details Implementation note: the value is held inline in a std::variant
+   * (see #847), rather than a heap-allocated PIMPL hierarchy. std::monostate
+   * represents the Void/uninitialized state. All promotion routes through
+   * Type.type_promote() via std::visit; copy/move are `=default` (value
+   * semantics, no manual heap bookkeeping -- fixes #935's self-assignment UB
+   * and double-alloc copy ctor).
    */
   class Scalar {
    public:
     ///@cond
+    // The list of alternatives mirrors Type_list (see Type.hpp), with
+    // std::monostate standing in for "void" so an uninitialized Scalar is a
+    // real, distinguishable state rather than a null pointer.
+    using ScalarVariant =
+      std::variant<std::monostate, cytnx_complex128, cytnx_complex64, cytnx_double, cytnx_float,
+                   cytnx_int64, cytnx_uint64, cytnx_int32, cytnx_uint32, cytnx_int16, cytnx_uint16,
+                   cytnx_bool>;
+
+    // ScalarVariant is index-aligned with Type_list: alternative i holds the
+    // type whose dtype id is i (monostate <-> void at index Type.Void == 0).
+    // This is load-bearing -- dtype() is implemented as _val.index() -- so
+    // pin it at compile time. Adding a dtype to Type_list without extending
+    // ScalarVariant (or vice versa) fails right here.
+    static_assert(std::variant_size_v<ScalarVariant> == N_Type,
+                  "ScalarVariant must have exactly one alternative per Type_list entry");
+    static_assert(
+      std::is_same_v<std::variant_alternative_t<Type_class::ComplexDouble, ScalarVariant>,
+                     cytnx_complex128> &&
+        std::is_same_v<std::variant_alternative_t<Type_class::ComplexFloat, ScalarVariant>,
+                       cytnx_complex64> &&
+        std::is_same_v<std::variant_alternative_t<Type_class::Double, ScalarVariant>,
+                       cytnx_double> &&
+        std::is_same_v<std::variant_alternative_t<Type_class::Float, ScalarVariant>, cytnx_float> &&
+        std::is_same_v<std::variant_alternative_t<Type_class::Int64, ScalarVariant>, cytnx_int64> &&
+        std::is_same_v<std::variant_alternative_t<Type_class::Uint64, ScalarVariant>,
+                       cytnx_uint64> &&
+        std::is_same_v<std::variant_alternative_t<Type_class::Int32, ScalarVariant>, cytnx_int32> &&
+        std::is_same_v<std::variant_alternative_t<Type_class::Uint32, ScalarVariant>,
+                       cytnx_uint32> &&
+        std::is_same_v<std::variant_alternative_t<Type_class::Int16, ScalarVariant>, cytnx_int16> &&
+        std::is_same_v<std::variant_alternative_t<Type_class::Uint16, ScalarVariant>,
+                       cytnx_uint16> &&
+        std::is_same_v<std::variant_alternative_t<Type_class::Bool, ScalarVariant>, cytnx_bool>,
+      "each ScalarVariant alternative must sit at its Type_list dtype index");
+
     struct Sproxy {
       boost::intrusive_ptr<Storage_base> _insimpl;
       cytnx_uint64 _loc;
@@ -2556,45 +109,47 @@ namespace cytnx {
       // operator Scalar() const;
     };
 
-    Scalar_base *_impl;
-    ///@endcond
+    /// @cond
+    // The stored value. std::monostate == Void/uninitialized.
+    ScalarVariant _val;
+    /// @endcond
 
     /// @brief default constructor
-    Scalar() : _impl(new Scalar_base()){};
+    Scalar() : _val(std::monostate{}) {}
 
     // init!!
     /// @brief init a Scalar with a cytnx::cytnx_complex128
-    Scalar(const cytnx_complex128 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_complex128 &in) : _val(in) {}
 
     /// @brief init a Scalar with a cytnx::cytnx_complex64
-    Scalar(const cytnx_complex64 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_complex64 &in) : _val(in) {}
 
     /// @brief init a Scalar with a cytnx::cytnx_double
-    Scalar(const cytnx_double &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_double &in) : _val(in) {}
 
     /// @brief init a Scalar with a cytnx::cytnx_float
-    Scalar(const cytnx_float &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_float &in) : _val(in) {}
 
     /// @brief init a Scalar with a cytnx::cytnx_uint64
-    Scalar(const cytnx_uint64 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_uint64 &in) : _val(in) {}
 
     /// @brief init a Scalar with a cytnx::cytnx_int64
-    Scalar(const cytnx_int64 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_int64 &in) : _val(in) {}
 
     /// @brief init a Scalar with a cytnx::cytnx_uint32
-    Scalar(const cytnx_uint32 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_uint32 &in) : _val(in) {}
 
     /// @brief init a Scalar with a cytnx::cytnx_int32
-    Scalar(const cytnx_int32 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_int32 &in) : _val(in) {}
 
     /// @brief init a Scalar with a cytnx::cytnx_uint16
-    Scalar(const cytnx_uint16 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_uint16 &in) : _val(in) {}
 
     /// @brief init a Scalar with a cytnx::cytnx_int16
-    Scalar(const cytnx_int16 &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_int16 &in) : _val(in) {}
 
     /// @brief init a Scalar with a cytnx::cytnx_bool
-    Scalar(const cytnx_bool &in) : _impl(new Scalar_base()) { this->Init_by_number(in); }
+    Scalar(const cytnx_bool &in) : _val(in) {}
 
     /**
      * @brief Get the max value of the Scalar with the given \p dtype.
@@ -2604,11 +159,7 @@ namespace cytnx {
      * @param[in] dtype The data type of the Scalar.
      * @return The max value of the Scalar with the given \p dtype.
      */
-    static Scalar maxval(const unsigned int &dtype) {
-      Scalar out(0, dtype);
-      out._impl->set_maxval();
-      return out;
-    }
+    static Scalar maxval(const unsigned int &dtype);
 
     /**
      * @brief Get the min value of the Scalar with the given \p dtype.
@@ -2617,12 +168,11 @@ namespace cytnx {
      * \p dtype = cytnx::Type.Int16, then you will get the min value of a 16-bit integer -32768.
      * @param[in] dtype The data type of the Scalar.
      * @return The min value of the Scalar with the given \p dtype.
+     * @note For floating-point dtypes this returns the most negative finite value
+     * (`std::numeric_limits<T>::lowest()`), not the smallest positive normal
+     * value that `::min()` would give (fixes #935).
      */
-    static Scalar minval(const unsigned int &dtype) {
-      Scalar out(0, dtype);
-      out._impl->set_minval();
-      return out;
-    }
+    static Scalar minval(const unsigned int &dtype);
 
     /**
      * @brief The constructor of the Scalar class.
@@ -2634,82 +184,39 @@ namespace cytnx {
      * @note The \p dtype can be any of the cytnx::Type.
      */
     template <class T>
-    Scalar(const T &in, const unsigned int &dtype) : _impl(new Scalar_base()) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = __ScII.UScIInit[dtype]();
-      this->_impl->assign_selftype(in);
-    };
+    Scalar(const T &in, const unsigned int &dtype) {
+      this->Init_by_number(in);
+      *this = this->astype(dtype);
+    }
 
     /// @cond
     // move sproxy when use to get elements here.
     Scalar(const Sproxy &prox);
-
-    //[Internal!!]
-    Scalar(Scalar_base *in) { this->_impl = in; }
     /// @endcond
 
     // specialization of init:
     ///@cond
-    void Init_by_number(const cytnx_complex128 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new ComplexDoubleScalar(in);
-    };
-    void Init_by_number(const cytnx_complex64 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new ComplexFloatScalar(in);
-    };
-    void Init_by_number(const cytnx_double &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new DoubleScalar(in);
-    }
-    void Init_by_number(const cytnx_float &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new FloatScalar(in);
-    }
-    void Init_by_number(const cytnx_int64 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Int64Scalar(in);
-    }
-    void Init_by_number(const cytnx_uint64 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Uint64Scalar(in);
-    }
-    void Init_by_number(const cytnx_int32 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Int32Scalar(in);
-    }
-    void Init_by_number(const cytnx_uint32 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Uint32Scalar(in);
-    }
-    void Init_by_number(const cytnx_int16 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Int16Scalar(in);
-    }
-    void Init_by_number(const cytnx_uint16 &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new Uint16Scalar(in);
-    }
-    void Init_by_number(const cytnx_bool &in) {
-      if (this->_impl != nullptr) delete this->_impl;
-      this->_impl = new BoolScalar(in);
-    }
+    void Init_by_number(const cytnx_complex128 &in) { this->_val = in; }
+    void Init_by_number(const cytnx_complex64 &in) { this->_val = in; }
+    void Init_by_number(const cytnx_double &in) { this->_val = in; }
+    void Init_by_number(const cytnx_float &in) { this->_val = in; }
+    void Init_by_number(const cytnx_int64 &in) { this->_val = in; }
+    void Init_by_number(const cytnx_uint64 &in) { this->_val = in; }
+    void Init_by_number(const cytnx_int32 &in) { this->_val = in; }
+    void Init_by_number(const cytnx_uint32 &in) { this->_val = in; }
+    void Init_by_number(const cytnx_int16 &in) { this->_val = in; }
+    void Init_by_number(const cytnx_uint16 &in) { this->_val = in; }
+    void Init_by_number(const cytnx_bool &in) { this->_val = in; }
+    ///@endcond
 
-    // The copy constructor
-    Scalar(const Scalar &rhs) : _impl(new Scalar_base()) {
-      if (this->_impl != nullptr) delete this->_impl;
-
-      this->_impl = rhs._impl->copy();
-    }
-    /// @endcond
-
-    /// @brief The copy assignment of the Scalar class.
-    Scalar &operator=(const Scalar &rhs) {
-      if (this->_impl != nullptr) delete this->_impl;
-
-      this->_impl = rhs._impl->copy();
-      return *this;
-    };
+    // Copy/move/assign are trivial value-type operations now: default them.
+    // This fixes #935's self-assignment UB (the old hand-rolled operator=
+    // deleted _impl before reading rhs._impl, and did not check for
+    // self-assignment) and the double-allocation copy ctor.
+    Scalar(const Scalar &rhs) = default;
+    Scalar(Scalar &&rhs) = default;
+    Scalar &operator=(const Scalar &rhs) = default;
+    Scalar &operator=(Scalar &&rhs) = default;
 
     // copy assignment [Number]:
     /** @brief The copy assignment operator of the Scalar class with a given number
@@ -2808,148 +315,142 @@ namespace cytnx {
      * cytnx::Scalar::real() or cytnx::Scalar::imag() to get the real or imaginary
      * part of the Scalar instead.
      */
-    Scalar astype(const unsigned int &dtype) const {
-      Scalar out(this->_impl->astype(dtype));
-      return out;
-    }
+    Scalar astype(const unsigned int &dtype) const;
 
     /**
      * @brief Get the conjugate of the Scalar. That means return \f$ c^* \f$ if
      * the Scalar is \f$ c \f$.
      * @return The conjugate of the Scalar.
      */
-    Scalar conj() const {
-      Scalar out = *this;
-      out._impl->conj_();
-      return out;
-    }
+    Scalar conj() const;
 
     /**
      * @brief Get the imaginary part of the Scalar. That means return \f$ \Im(c) \f$ if
      * the Scalar is \f$ c \f$.
      * @return The imaginary part of the Scalar.
      */
-    Scalar imag() const { return Scalar(this->_impl->get_imag()); }
+    Scalar imag() const;
 
     /**
      * @brief Get the real part of the Scalar. That means return \f$ \Re(c) \f$ if
      * the Scalar is \f$ c \f$.
      * @return The real part of the Scalar.
      */
-    Scalar real() const { return Scalar(this->_impl->get_real()); }
-    // Scalar& set_imag(const Scalar &in){   return *this;}
-    // Scalar& set_real(const Scalar &in){   return *this;}
+    Scalar real() const;
 
     /**
      * @brief Get the dtype of the Scalar (see cytnx::Type for more details).
      */
-    int dtype() const { return this->_impl->_dtype; }
+    int dtype() const;
 
     // print()
     /**
      * @brief Print the Scalar to the standard output.
      */
-    void print() const {
-      this->_impl->print(std::cout);
-      std::cout << std::string(" Scalar dtype: [") << Type.getname(this->_impl->_dtype)
-                << std::string("]") << std::endl;
-    }
+    void print() const;
 
     // casting
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_double.
-    explicit operator cytnx_double() const { return this->_impl->to_cytnx_double(); }
+    explicit operator cytnx_double() const;
 
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_float
-    explicit operator cytnx_float() const { return this->_impl->to_cytnx_float(); }
+    explicit operator cytnx_float() const;
 
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_uint64.
-    explicit operator cytnx_uint64() const { return this->_impl->to_cytnx_uint64(); }
+    explicit operator cytnx_uint64() const;
 
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_int64.
-    explicit operator cytnx_int64() const { return this->_impl->to_cytnx_int64(); }
+    explicit operator cytnx_int64() const;
 
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_uint32.
-    explicit operator cytnx_uint32() const { return this->_impl->to_cytnx_uint32(); }
+    explicit operator cytnx_uint32() const;
 
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_int32.
-    explicit operator cytnx_int32() const { return this->_impl->to_cytnx_int32(); }
+    explicit operator cytnx_int32() const;
 
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_uint16.
-    explicit operator cytnx_uint16() const { return this->_impl->to_cytnx_uint16(); }
+    explicit operator cytnx_uint16() const;
 
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_int16.
-    explicit operator cytnx_int16() const { return this->_impl->to_cytnx_int16(); }
+    explicit operator cytnx_int16() const;
 
     /// @brief The explicit casting operator of the Scalar class to cytnx::cytnx_bool.
-    explicit operator cytnx_bool() const { return this->_impl->to_cytnx_bool(); }
+    explicit operator cytnx_bool() const;
+
+    // Also need explicit conversion to the complex types (used internally by
+    // complex128()/complex64() and by cross-type arithmetic); these were
+    // reachable in the old PIMPL via to_cytnx_complex128()/64() but had no
+    // public Scalar-level cast operator. Kept as named accessors, not
+    // operators, to avoid changing overload resolution of the public API.
+    /// @cond
+    cytnx_complex128 to_complex128() const;
+    cytnx_complex64 to_complex64() const;
+    ///@endcond
 
     /// @cond
-    // destructor
-    ~Scalar() {
-      if (this->_impl != nullptr) delete this->_impl;
-    };
+    // destructor: trivial, variant handles cleanup.
+    ~Scalar() = default;
     /// @endcond
 
     // arithmetic:
     ///@brief The addition assignment operator of the Scalar class with a given number (template).
     template <class T>
     void operator+=(const T &rc) {
-      this->_impl->iadd(rc);
+      *this += Scalar(rc);
     }
 
     ///@brief The addition assignment operator of the Scalar class with a given Scalar.
-    void operator+=(const Scalar &rhs) { this->_impl->iadd(rhs._impl); }
+    void operator+=(const Scalar &rhs);
 
     ///@brief The subtraction assignment operator of the Scalar class with a given number
     ///(template).
     template <class T>
     void operator-=(const T &rc) {
-      this->_impl->isub(rc);
+      *this -= Scalar(rc);
     }
 
     ///@brief The subtraction assignment operator of the Scalar class with a given Scalar.
-    void operator-=(const Scalar &rhs) { this->_impl->isub(rhs._impl); }
-    template <class T>
+    void operator-=(const Scalar &rhs);
 
     ///@brief The multiplication assignment operator of the Scalar class with a given number
     ///(template).
+    template <class T>
     void operator*=(const T &rc) {
-      this->_impl->imul(rc);
+      *this *= Scalar(rc);
     }
 
     ///@brief The multiplication assignment operator of the Scalar class with a given Scalar.
-    void operator*=(const Scalar &rhs) { this->_impl->imul(rhs._impl); }
-    template <class T>
+    void operator*=(const Scalar &rhs);
 
     /**
      * @brief The division assignment operator of the Scalar class with a given number (template).
      */
+    template <class T>
     void operator/=(const T &rc) {
-      this->_impl->idiv(rc);
+      *this /= Scalar(rc);
     }
 
     /**
      * @brief The division assignment operator of the Scalar class with a given Scalar.
      */
-    void operator/=(const Scalar &rhs) { this->_impl->idiv(rhs._impl); }
+    void operator/=(const Scalar &rhs);
 
     /// @brief Set the Scalar to absolute value. (inplace)
-    void iabs() { this->_impl->iabs(); }
+    void iabs();
 
     /// @brief Set the Scalar to square root. (inplace)
-    void isqrt() { this->_impl->isqrt(); }
+    void isqrt();
 
     /**
      * @brief The member function to get the absolute value of the Scalar.
      * @note Compare to the iabs() function, this function will return a new Scalar object.
+     * @details The result always has a real (non-complex) dtype: abs() of a complex
+     * Scalar returns the Float/Double magnitude, not a complex value with a zero
+     * imaginary part (fixes the iabs()/abs() dtype inconsistency documented in #935).
      * @return The absolute value of the Scalar.
      * @see iabs()
      */
-    Scalar abs() const {
-      Scalar out = *this;
-      out._impl->iabs();
-      return out.real();
-    }
+    Scalar abs() const;
 
     /**
      * @brief The member function to get the square root of the Scalar.
@@ -2957,11 +458,7 @@ namespace cytnx {
      * @return The square root of the Scalar.
      * @see isqrt()
      */
-    Scalar sqrt() const {
-      Scalar out = *this;
-      out._impl->isqrt();
-      return out;
-    }
+    Scalar sqrt() const;
 
     // comparison <
     /**
@@ -2972,14 +469,7 @@ namespace cytnx {
      */
     template <class T>
     bool less(const T &rc) const {
-      Scalar tmp;
-      int rid = Type.cy_typeid(rc);
-      if (rid < this->dtype()) {
-        tmp = this->astype(rid);
-        return tmp._impl->less(rc);
-      } else {
-        return this->_impl->less(rc);
-      }
+      return this->less(Scalar(rc));
     }
 
     /**
@@ -2988,15 +478,7 @@ namespace cytnx {
      * itself and \f$ r \f$ is the given Scalar \p rhs.
      * @see operator<(const Scalar &lhs, const Scalar &rhs)
      */
-    bool less(const Scalar &rhs) const {
-      Scalar tmp;
-      if (rhs.dtype() < this->dtype()) {
-        tmp = this->astype(rhs.dtype());
-        return tmp._impl->less(rhs._impl);
-      } else {
-        return this->_impl->less(rhs._impl);
-      }
-    }
+    bool less(const Scalar &rhs) const;
 
     // comparison <=
 
@@ -3009,14 +491,7 @@ namespace cytnx {
      */
     template <class T>
     bool leq(const T &rc) const {
-      Scalar tmp;
-      int rid = Type.cy_typeid(rc);
-      if (rid < this->dtype()) {
-        tmp = this->astype(rid);
-        return !(tmp._impl->greater(rc));
-      } else {
-        return !(this->_impl->greater(rc));
-      }
+      return this->leq(Scalar(rc));
     }
 
     /**
@@ -3025,15 +500,7 @@ namespace cytnx {
      * itself and \f$ r \f$ is the given Scalar \p rhs.
      * @see operator<=(const Scalar &lhs, const Scalar &rhs)
      */
-    bool leq(const Scalar &rhs) const {
-      Scalar tmp;
-      if (rhs.dtype() < this->dtype()) {
-        tmp = this->astype(rhs.dtype());
-        return !(tmp._impl->greater(rhs._impl));
-      } else {
-        return !(this->_impl->greater(rhs._impl));
-      }
-    }
+    bool leq(const Scalar &rhs) const;
 
     // comparison >
     /**
@@ -3044,14 +511,7 @@ namespace cytnx {
      */
     template <class T>
     bool greater(const T &rc) const {
-      Scalar tmp;
-      int rid = Type.cy_typeid(rc);
-      if (rid < this->dtype()) {
-        tmp = this->astype(rid);
-        return tmp._impl->greater(rc);
-      } else {
-        return this->_impl->greater(rc);
-      }
+      return this->greater(Scalar(rc));
     }
 
     /**
@@ -3060,15 +520,7 @@ namespace cytnx {
      * itself and \f$ r \f$ is the given Scalar \p rhs.
      * @see operator>(const Scalar &lhs, const Scalar &rhs)
      */
-    bool greater(const Scalar &rhs) const {
-      Scalar tmp;
-      if (rhs.dtype() < this->dtype()) {
-        tmp = this->astype(rhs.dtype());
-        return tmp._impl->greater(rhs._impl);
-      } else {
-        return this->_impl->greater(rhs._impl);
-      }
-    }
+    bool greater(const Scalar &rhs) const;
 
     // comparison >=
 
@@ -3081,14 +533,7 @@ namespace cytnx {
      */
     template <class T>
     bool geq(const T &rc) const {
-      Scalar tmp;
-      int rid = Type.cy_typeid(rc);
-      if (rid < this->dtype()) {
-        tmp = this->astype(rid);
-        return !(tmp._impl->less(rc));
-      } else {
-        return !(this->_impl->less(rc));
-      }
+      return this->geq(Scalar(rc));
     }
 
     /**
@@ -3097,15 +542,7 @@ namespace cytnx {
      * itself and \f$ r \f$ is the given Scalar \p rhs.
      * @see operator>=(const Scalar &lhs, const Scalar &rhs)
      */
-    bool geq(const Scalar &rhs) const {
-      Scalar tmp;
-      if (rhs.dtype() < this->dtype()) {
-        tmp = this->astype(rhs.dtype());
-        return !(tmp._impl->less(rhs._impl));
-      } else {
-        return !(this->_impl->less(rhs._impl));
-      }
-    }
+    bool geq(const Scalar &rhs) const;
 
     // comparison ==
 
@@ -3117,33 +554,8 @@ namespace cytnx {
      */
     template <class T>
     bool eq(const T &rc) const {
-      Scalar tmp;
-      int rid = Type.cy_typeid(rc);
-      if (rid < this->dtype()) {
-        tmp = this->astype(rid);
-        return tmp._impl->eq(rc);
-      } else {
-        return this->_impl->eq(rc);
-      }
+      return this->eq(Scalar(rc));
     }
-    // /**
-    //  * @brief Return whether the current Scalar is approximately equal to a given template number
-    //  \p
-    //  * rc.
-    //  * @details That is, whether \f$ abs(s-r)<tol \f$, where \f$ s \f$ is the current Scalar
-    //  * itself, \f$ r \f$ is the given number \p rc and \p tol is the tolerance value.
-    //  */
-    // template <class T>
-    // bool approx_eq(const T &rc, cytnx_double tol = 1e-8) const {
-    //   Scalar tmp;
-    //   int rid = Type.cy_typeid(rc);
-    //   if (rid < this->dtype()) {
-    //     tmp = this->astype(rid);
-    //     return tmp._impl->approx_eq(rc, tol);
-    //   } else {
-    //     return this->_impl->approx_eq(rc, tol);
-    //   }
-    // }
 
     /**
      * @brief Return whether the current Scalar is equal to a given Scalar \p rhs.
@@ -3151,29 +563,7 @@ namespace cytnx {
      * itself and \f$ r \f$ is the given Scalar \p rhs.
      * @see operator==(const Scalar &lhs, const Scalar &rhs)
      */
-    bool eq(const Scalar &rhs) const {
-      Scalar tmp;
-      if (rhs.dtype() < this->dtype()) {
-        tmp = this->astype(rhs.dtype());
-        return tmp._impl->eq(rhs._impl);
-      } else {
-        return this->_impl->eq(rhs._impl);
-      }
-    }
-    // /**
-    //  * @brief Return whether the current Scalar is approximately equal to a given Scalar \p rhs.
-    //  * @details That is, whether \f$ abs(s-r)<tol \f$, where \f$ s \f$ is the current Scalar
-    //  * itself, \f$ r \f$ is the given Scalar \p rhs and \p tol is the tolerance value.
-    //  */
-    // bool approx_eq(const Scalar &rhs, cytnx_double tol = 1e-8) const {
-    //   Scalar tmp;
-    //   if (rhs.dtype() < this->dtype()) {
-    //     tmp = this->astype(rhs.dtype());
-    //     return tmp._impl->approx_eq(rhs._impl, tol);
-    //   } else {
-    //     return this->_impl->approx_eq(rhs._impl, tol);
-    //   }
-    // }
+    bool eq(const Scalar &rhs) const;
 
     // radd: Scalar + c
 
@@ -3183,31 +573,14 @@ namespace cytnx {
      */
     template <class T>
     Scalar radd(const T &rc) const {
-      Scalar out;
-      int rid = Type.cy_typeid(rc);
-      if (this->dtype() < rid) {
-        out = *this;
-      } else {
-        out = this->astype(rid);
-      }
-      out._impl->iadd(rc);
-      return out;
+      return this->radd(Scalar(rc));
     }
 
     /**
      * @brief Return the addition of the current Scalar and a given Scalar \p rhs.
      * @see operator+(const Scalar &lhs, const Scalar &rhs)
      */
-    Scalar radd(const Scalar &rhs) const {
-      Scalar out;
-      if (this->dtype() < rhs.dtype()) {
-        out = *this;
-      } else {
-        out = this->astype(rhs.dtype());
-      }
-      out._impl->iadd(rhs._impl);
-      return out;
-    }
+    Scalar radd(const Scalar &rhs) const;
 
     // rmul: Scalar * c
 
@@ -3217,31 +590,14 @@ namespace cytnx {
      */
     template <class T>
     Scalar rmul(const T &rc) const {
-      Scalar out;
-      int rid = Type.cy_typeid(rc);
-      if (this->dtype() < rid) {
-        out = *this;
-      } else {
-        out = this->astype(rid);
-      }
-      out._impl->imul(rc);
-      return out;
+      return this->rmul(Scalar(rc));
     }
 
     /**
      * @brief Return the multiplication of the current Scalar and a given Scalar \p rhs.
      * @see operator*(const Scalar &lhs, const Scalar &rhs)
      */
-    Scalar rmul(const Scalar &rhs) const {
-      Scalar out;
-      if (this->dtype() < rhs.dtype()) {
-        out = *this;
-      } else {
-        out = this->astype(rhs.dtype());
-      }
-      out._impl->imul(rhs._impl);
-      return out;
-    }
+    Scalar rmul(const Scalar &rhs) const;
 
     // rsub: Scalar - c
 
@@ -3251,31 +607,14 @@ namespace cytnx {
      */
     template <class T>
     Scalar rsub(const T &rc) const {
-      Scalar out;
-      int rid = Type.cy_typeid(rc);
-      if (this->dtype() < rid) {
-        out = *this;
-      } else {
-        out = this->astype(rid);
-      }
-      out._impl->isub(rc);
-      return out;
+      return this->rsub(Scalar(rc));
     }
 
     /**
      * @brief Return the subtraction of the current Scalar and a given Scalar \p rhs.
      * @see operator-(const Scalar &lhs, const Scalar &rhs)
      */
-    Scalar rsub(const Scalar &rhs) const {
-      Scalar out;
-      if (this->dtype() < rhs.dtype()) {
-        out = *this;
-      } else {
-        out = this->astype(rhs.dtype());
-      }
-      out._impl->isub(rhs._impl);
-      return out;
-    }
+    Scalar rsub(const Scalar &rhs) const;
 
     // rdiv: Scalar / c
 
@@ -3285,72 +624,14 @@ namespace cytnx {
      */
     template <class T>
     Scalar rdiv(const T &rc) const {
-      Scalar out;
-      int rid = Type.cy_typeid(rc);
-      if (this->dtype() < rid) {
-        out = *this;
-      } else {
-        out = this->astype(rid);
-      }
-      out._impl->idiv(rc);
-      return out;
+      return this->rdiv(Scalar(rc));
     }
 
     /**
      * @brief Return the division of the current Scalar and a given Scalar \p rhs.
      * @see operator/(const Scalar &lhs, const Scalar &rhs)
      */
-    Scalar rdiv(const Scalar &rhs) const {
-      Scalar out;
-      if (this->dtype() < rhs.dtype()) {
-        out = *this;
-      } else {
-        out = this->astype(rhs.dtype());
-      }
-      out._impl->idiv(rhs._impl);
-      return out;
-    }
-
-    /*
-    //operator:
-    template<class T>
-    Scalar operator+(const T &rc){
-        return this->radd(rc);
-    }
-    template<class T>
-    Scalar operator*(const T &rc){
-        return this->rmul(rc);
-    }
-    template<class T>
-    Scalar operator-(const T &rc){
-        return this->rsub(rc);
-    }
-    template<class T>
-    Scalar operator/(const T &rc){
-        return this->rdiv(rc);
-    }
-
-    template<class T>
-    bool operator<(const T &rc){
-        return this->less(rc);
-    }
-
-    template<class T>
-    bool operator>(const T &rc){
-        return this->greater(rc);
-    }
-
-
-    template<class T>
-    bool operator<=(const T &rc){
-        return this->leq(rc);
-    }
-
-    template<class T>
-    bool operator>=(const T &rc){
-        return this->geq(rc);
-    }
-    */
+    Scalar rdiv(const Scalar &rhs) const;
   };
 
   // ladd: c + Scalar:
@@ -3361,7 +642,7 @@ namespace cytnx {
    * \f[ l+r \f],
    * where \f$ l \f$ is the left Scalar \p lc and \f$ r \f$ is the right Scalar \p rs .
    */
-  Scalar operator+(const Scalar &lc, const Scalar &rs);  //{return rs.radd(lc);};
+  Scalar operator+(const Scalar &lc, const Scalar &rs);
 
   // lmul c * Scalar;
   /**
@@ -3370,7 +651,7 @@ namespace cytnx {
    * \f[ l \cdot r \f],
    * where \f$ l \f$ is the left Scalar \p lc and \f$ r \f$ is the right Scalar \p rs .
    */
-  Scalar operator*(const Scalar &lc, const Scalar &rs);  //{return rs.rmul(lc);};
+  Scalar operator*(const Scalar &lc, const Scalar &rs);
 
   // lsub c * Scalar;
   /**
@@ -3379,7 +660,7 @@ namespace cytnx {
    * \f[ l-r \f],
    * where \f$ l \f$ is the left Scalar \p lc and \f$ r \f$ is the right Scalar \p rs .
    */
-  Scalar operator-(const Scalar &lc, const Scalar &rs);  //{return Scalar(lc).rsub(rs);};
+  Scalar operator-(const Scalar &lc, const Scalar &rs);
 
   // ldiv c / Scalar;
   /**
@@ -3388,7 +669,7 @@ namespace cytnx {
    * \f[ l/r \f],
    * where \f$ l \f$ is the left Scalar \p lc and \f$ r \f$ is the right Scalar \p rs .
    */
-  Scalar operator/(const Scalar &lc, const Scalar &rs);  //{return Scalar(lc).rdiv(rs);};
+  Scalar operator/(const Scalar &lc, const Scalar &rs);
 
   // lless c < Scalar;
   /**

--- a/pybind/scalar_py.cpp
+++ b/pybind/scalar_py.cpp
@@ -13,10 +13,12 @@
 #include "cytnx.hpp"
 // #include "../include/cytnx_error.hpp"
 #include "complex.h"
+#include "pyint_dispatch.hpp"
 
 namespace py = pybind11;
 using namespace pybind11::literals;
 using namespace cytnx;
+using pybind_cytnx::dispatch_pyint;
 
 #ifdef BACKEND_TORCH
 #else
@@ -24,39 +26,22 @@ using namespace cytnx;
 void scalar_binding(py::module &m) {
   py::class_<cytnx::Scalar>(m, "Scalar")
     .def(py::init<>())
-    .def(py::init<const cytnx::cytnx_complex128 &>(), py::arg("a"))
-    .def(py::init<const cytnx::cytnx_complex64 &>(), py::arg("a"))
-    .def(py::init<const cytnx::cytnx_double &>(), py::arg("a"))
-    .def(py::init<const cytnx::cytnx_float &>(), py::arg("a"))
-    .def(py::init<const cytnx::cytnx_uint64 &>(), py::arg("a"))
-    .def(py::init<const cytnx::cytnx_int64 &>(), py::arg("a"))
-    .def(py::init<const cytnx::cytnx_uint32 &>(), py::arg("a"))
-    .def(py::init<const cytnx::cytnx_int32 &>(), py::arg("a"))
-    .def(py::init<const cytnx::cytnx_uint16 &>(), py::arg("a"))
-    .def(py::init<const cytnx::cytnx_int16 &>(), py::arg("a"))
-    .def(py::init<const cytnx::cytnx_bool &>(), py::arg("a"))
+    // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in
+    // pybind/pyint_dispatch.hpp. Group-specific notes: Python bool must be
+    // bound ahead of the py::int_ overload (bool subclasses int, so the
+    // py::int_ caster accepts it even in the no-convert pass), and
+    // np.float64 / np.complex128 subclass float / complex, so the trailing
+    // cytnx_double / cytnx_complex128 constructors absorb them.
     .def(
       "__init__",
-      [](Scalar &self, const py::numpy_scalar<std::complex<double>> value) {
-        new (&self) Scalar(static_cast<cytnx::cytnx_complex128>(value));
+      [](Scalar &self, const py::numpy_scalar<float> value) {
+        new (&self) Scalar(static_cast<cytnx::cytnx_float>(value));
       },
       py::arg("a"))
     .def(
       "__init__",
       [](Scalar &self, const py::numpy_scalar<std::complex<float>> value) {
         new (&self) Scalar(static_cast<cytnx::cytnx_complex64>(value));
-      },
-      py::arg("a"))
-    .def(
-      "__init__",
-      [](Scalar &self, const py::numpy_scalar<double> value) {
-        new (&self) Scalar(static_cast<cytnx::cytnx_double>(value));
-      },
-      py::arg("a"))
-    .def(
-      "__init__",
-      [](Scalar &self, const py::numpy_scalar<float> value) {
-        new (&self) Scalar(static_cast<cytnx::cytnx_float>(value));
       },
       py::arg("a"))
     .def(
@@ -101,6 +86,12 @@ void scalar_binding(py::module &m) {
         new (&self) Scalar(static_cast<cytnx::cytnx_bool>(value));
       },
       py::arg("a"))
+    .def(py::init<const cytnx::cytnx_bool &>(), py::arg("a"))
+    .def(py::init(
+           [](const py::int_ &a) { return dispatch_pyint(a, [](auto v) { return Scalar(v); }); }),
+         py::arg("a"))
+    .def(py::init<const cytnx::cytnx_double &>(), py::arg("a"))
+    .def(py::init<const cytnx::cytnx_complex128 &>(), py::arg("a"))
 
     // ---- Static methods ----
     .def_static("maxval", &Scalar::maxval)
@@ -155,6 +146,17 @@ void scalar_binding(py::module &m) {
     .def(py::self >= py::self)
 
     // ---- Conversion operators ----
+    // numpy-consistent truthiness: nonzero value -> True; a complex Scalar
+    // is True when either component is nonzero (the plain double cast
+    // throws on complex dtypes, so branch first).
+    .def("__bool__",
+         [](const Scalar &s) {
+           if (Type.is_complex(s.dtype())) {
+             return static_cast<cytnx_double>(s.real()) != 0.0 ||
+                    static_cast<cytnx_double>(s.imag()) != 0.0;
+           }
+           return static_cast<cytnx_double>(s) != 0.0;
+         })
     .def("__float__", [](const Scalar &s) { return static_cast<cytnx_double>(s); })
     .def("__int__", [](const Scalar &s) { return static_cast<cytnx_int64>(s); })
     .def("__complex__",

--- a/pytests/scalar_variant_test.py
+++ b/pytests/scalar_variant_test.py
@@ -1,0 +1,285 @@
+"""Tests for Phase-3 T2 (#847/#935/#937): Scalar's PIMPL+virtual-dispatch
+hierarchy replaced by a std::variant-backed value type.
+
+Covers the Python-visible surface: arithmetic across dtypes, the new
+mixed-dtype in-place throw behavior (Ruling 1 -- surfaces as RuntimeError on
+this base, since #989's cytnx.CytnxError translation has not merged here),
+Sproxy round-trip via Storage indexing, and numpy-scalar constructor paths.
+"""
+
+import numpy as np
+import pytest
+
+import cytnx
+from cytnx import Type
+
+
+def _s(value, np_dtype):
+    """Construct a cytnx.Scalar with an explicit dtype via a numpy scalar,
+    since the Python binding only exposes the 11 single-arg typed
+    constructors (+ numpy-scalar overloads), not the C++-only (value, dtype)
+    two-argument constructor."""
+    return cytnx.Scalar(np_dtype(value))
+
+
+# ---------------------------------------------------------------------------
+# Basic arithmetic across types
+# ---------------------------------------------------------------------------
+
+
+def test_float_arithmetic_correct_values():
+    a = cytnx.Scalar(np.float64(3.0))
+    b = cytnx.Scalar(np.float64(2.0))
+    assert (a + b).dtype() == Type.Double
+    assert float(a + b) == pytest.approx(5.0)
+    assert float(a - b) == pytest.approx(1.0)
+    assert float(a * b) == pytest.approx(6.0)
+    assert float(a / b) == pytest.approx(1.5)
+
+
+def test_complex_arithmetic_correct_values():
+    a = cytnx.Scalar(np.complex128(3 + 4j))
+    b = cytnx.Scalar(np.complex128(1 - 2j))
+    r = a + b
+    assert r.dtype() == Type.ComplexDouble
+    assert complex(r) == pytest.approx(4 + 2j)
+
+
+@pytest.mark.parametrize(
+    "np_l,np_r,expected_dtype",
+    [
+        (np.int64, np.int32, Type.Int64),
+        (np.float64, np.float32, Type.Double),
+        (np.complex128, np.float64, Type.ComplexDouble),
+        (np.complex64, np.float64, Type.ComplexDouble),  # #935 fix: not ComplexFloat
+    ],
+)
+def test_binary_arithmetic_promotes_via_type_promote(np_l, np_r, expected_dtype):
+    a = _s(3, np_l)
+    b = _s(2, np_r)
+    r = a + b
+    assert r.dtype() == expected_dtype
+
+
+def test_mixed_signed_unsigned_binary_arithmetic_does_not_raise():
+    # Out-of-place arithmetic between signed/unsigned integers always
+    # promotes via Type.type_promote and never raises.
+    a = cytnx.Scalar(np.int64(3))
+    b = cytnx.Scalar(np.uint64(2))
+    r = a + b
+    assert float(r) == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# Ruling 1: in-place mixed-dtype ops raise (RuntimeError on this base, ahead
+# of #989's cytnx.CytnxError translation).
+# ---------------------------------------------------------------------------
+
+
+def test_inplace_int_plus_float_raises_runtime_error():
+    s = cytnx.Scalar(np.int64(3))
+    with pytest.raises(RuntimeError):
+        s += cytnx.Scalar(np.float64(2.0))
+
+
+def test_inplace_signed_unsigned_mix_raises_runtime_error():
+    # Unsigned-dtype Scalars are constructed via astype() here: the pybind
+    # numpy-scalar constructor overloads currently resolve every integer
+    # numpy type except int64 to the Int64 constructor (a pre-existing
+    # binding quirk, see test_numpy_scalar_constructor_paths_narrower_ints_
+    # preexisting_quirk below), so astype() is the reliable way to pin an
+    # unsigned dtype from Python.
+    s = cytnx.Scalar(np.int64(3)).astype(Type.Uint64)
+    assert s.dtype() == Type.Uint64
+    with pytest.raises(RuntimeError):
+        s -= cytnx.Scalar(np.int64(2))
+
+
+def test_inplace_real_complex_mix_raises_runtime_error():
+    s = cytnx.Scalar(np.float64(3.0))
+    with pytest.raises(RuntimeError):
+        s *= cytnx.Scalar(np.complex128(2 + 1j))
+
+
+def test_inplace_bool_with_nonbool_raises_runtime_error():
+    s = cytnx.Scalar(np.bool_(True))
+    with pytest.raises(RuntimeError):
+        s += cytnx.Scalar(np.int64(1))
+
+
+def test_inplace_lossless_widening_does_not_raise():
+    # Ruling 1 is permissive whenever Type.type_promote(lhs, rhs) ==
+    # lhs.dtype(): Int64 += Int32, Double += Float, ComplexDouble += Double
+    # all remain valid in-place, matching #937's own migration guidance
+    # ("cast to a floating type first" is unnecessary when the destination
+    # already losslessly contains the source).
+    s = cytnx.Scalar(np.int64(3))
+    s += cytnx.Scalar(np.int32(2))
+    assert s.dtype() == Type.Int64
+    assert int(s) == 5
+
+    d = cytnx.Scalar(np.float64(3.0))
+    d += cytnx.Scalar(np.float32(2.0))
+    assert d.dtype() == Type.Double
+    assert float(d) == pytest.approx(5.0)
+
+    cd = cytnx.Scalar(np.complex128(3 + 0j))
+    cd += cytnx.Scalar(np.float64(2.0))
+    assert cd.dtype() == Type.ComplexDouble
+    assert complex(cd) == pytest.approx(5 + 0j)
+
+
+def test_inplace_same_dtype_never_raises():
+    s = cytnx.Scalar(np.int32(3))
+    s += cytnx.Scalar(np.int32(2))
+    s -= cytnx.Scalar(np.int32(1))
+    s *= cytnx.Scalar(np.int32(2))
+    assert int(s) == 8
+
+
+def test_numpy_scalar_inplace_operators_raise_on_lossy_mix():
+    # The pybind FOR_EACH_NUMPY_ITYPE overloads route through Scalar's C++
+    # operator+=/-=/*=//=, so a numpy-scalar RHS is subject to the same
+    # Ruling 1 guard as a Scalar RHS.
+    s = cytnx.Scalar(np.int64(3))
+    with pytest.raises(RuntimeError):
+        s += np.float64(2.0)
+
+
+# ---------------------------------------------------------------------------
+# #935 fixes visible from Python: abs()/iabs() dtype, minval, self-assignment
+# ---------------------------------------------------------------------------
+
+
+def test_abs_returns_real_dtype_for_complex():
+    z = cytnx.Scalar(np.complex128(3 + 4j))
+    a = z.abs()
+    assert a.dtype() == Type.Double
+    assert float(a) == pytest.approx(5.0)
+
+
+def test_minval_double_is_most_negative_not_smallest_positive():
+    m = cytnx.Scalar.minval(Type.Double)
+    assert float(m) < 0.0
+    assert float(m) == pytest.approx(np.finfo(np.float64).min)
+
+
+def test_self_assignment_and_self_inplace_are_safe():
+    s = cytnx.Scalar(np.float64(3.5))
+    s += s
+    assert float(s) == pytest.approx(7.0)
+
+
+# ---------------------------------------------------------------------------
+# Storage indexed assignment from a Scalar (the Python-visible entry point
+# into Scalar::Sproxy / Storage::set_item(idx, const Scalar&) -- see
+# pybind/storage_py.cpp's __setitem__/__getitem__, which cast the Scalar via
+# its __int__/__float__/__complex__ operators into self.at<T>(idx) rather
+# than returning a Scalar from __getitem__. Bool storage is excluded: casting
+# a Scalar to C++ bool has no pybind path today (no __bool__ registered in
+# scalar_py.cpp) -- a pre-existing gap, unchanged by this refactor.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "dtype,np_dtype",
+    [
+        (Type.ComplexDouble, np.complex128),
+        (Type.ComplexFloat, np.complex64),
+        (Type.Double, np.float64),
+        (Type.Float, np.float32),
+        (Type.Int64, np.int64),
+        (Type.Uint64, np.uint64),
+        (Type.Int32, np.int32),
+        (Type.Uint32, np.uint32),
+        (Type.Int16, np.int16),
+        (Type.Uint16, np.uint16),
+    ],
+)
+def test_storage_setitem_getitem_scalar_roundtrip(dtype, np_dtype):
+    storage = cytnx.Storage(4, dtype)
+    value = cytnx.Scalar(np_dtype(3))
+    storage[1] = value
+    got = storage[1]
+    if isinstance(got, (float, complex)):
+        assert got == pytest.approx(3)
+    else:
+        assert got == 3
+
+
+def test_storage_setitem_cross_dtype_scalar_converts():
+    storage = cytnx.Storage(2, Type.Double)
+    storage[0] = cytnx.Scalar(np.int64(7))
+    got = storage[0]
+    assert got == pytest.approx(7.0)
+
+
+def test_tensor_setitem_with_scalar_still_works():
+    t = cytnx.zeros([3], dtype=Type.Double)
+    t[1] = cytnx.Scalar(np.float64(9.0))
+    assert t[1].item() == pytest.approx(9.0)
+
+
+# ---------------------------------------------------------------------------
+# numpy scalar constructor paths (all 11 dtypes + complex)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "np_dtype,dtype",
+    [
+        (np.complex128, Type.ComplexDouble),
+        (np.complex64, Type.ComplexFloat),
+        (np.float64, Type.Double),
+        (np.float32, Type.Float),
+        (np.int64, Type.Int64),
+        (np.bool_, Type.Bool),
+    ],
+)
+def test_numpy_scalar_constructor_paths(np_dtype, dtype):
+    val = np_dtype(True) if dtype == Type.Bool else np_dtype(5)
+    s = cytnx.Scalar(val)
+    assert s.dtype() == dtype
+
+
+@pytest.mark.parametrize(
+    "np_dtype",
+    [np.uint64, np.int32, np.uint32, np.int16, np.uint16],
+)
+def test_numpy_scalar_constructor_paths_narrower_ints_preexisting_quirk(np_dtype):
+    # Pre-existing pybind11 overload-resolution behavior (confirmed present
+    # on master d6dcd160, before this refactor): numpy scalar types narrower
+    # than int64/uint64 (uint64, int32, uint32, int16, uint16) all resolve to
+    # the Int64 constructor overload instead of their own. This is a
+    # pre-existing pybind/numpy_scalar dispatch quirk in scalar_py.cpp's
+    # __init__ overload set, not something introduced or fixed by the
+    # Scalar->std::variant refactor (T2's scope is Scalar's internals; the
+    # pybind constructor overload set is unchanged). Documented here so a
+    # future fix has a regression test to flip green; not treated as a T2
+    # gate failure.
+    s = cytnx.Scalar(np_dtype(5))
+    assert s.dtype() == Type.Int64  # pinned pre-existing behavior, not the "correct" dtype
+
+
+def test_comparison_operators_across_dtypes():
+    a = cytnx.Scalar(np.int64(3))
+    b = cytnx.Scalar(np.int32(3))
+    assert a == b
+    assert not (a != b)
+    assert a <= b
+    assert a >= b
+
+
+def test_complex_equality_does_not_raise():
+    # Equality is well-defined for complex Scalars (unlike ordering), and
+    # must not raise.
+    a = cytnx.Scalar(np.complex128(1 + 2j))
+    b = cytnx.Scalar(np.complex128(1 + 2j))
+    assert a == b
+
+
+def test_complex_ordering_raises():
+    a = cytnx.Scalar(np.complex128(1 + 2j))
+    b = cytnx.Scalar(np.complex128(3 + 4j))
+    with pytest.raises(RuntimeError):
+        _ = a < b

--- a/pytests/scalar_variant_test.py
+++ b/pytests/scalar_variant_test.py
@@ -15,10 +15,9 @@ from cytnx import Type
 
 
 def _s(value, np_dtype):
-    """Construct a cytnx.Scalar with an explicit dtype via a numpy scalar,
-    since the Python binding only exposes the 11 single-arg typed
-    constructors (+ numpy-scalar overloads), not the C++-only (value, dtype)
-    two-argument constructor."""
+    """Construct a cytnx.Scalar with an explicit dtype via a numpy scalar:
+    each numpy scalar type maps to its own constructor overload, while the
+    C++-only (value, dtype) two-argument constructor is not bound."""
     return cytnx.Scalar(np_dtype(value))
 
 
@@ -83,13 +82,7 @@ def test_inplace_int_plus_float_raises_runtime_error():
 
 
 def test_inplace_signed_unsigned_mix_raises_runtime_error():
-    # Unsigned-dtype Scalars are constructed via astype() here: the pybind
-    # numpy-scalar constructor overloads currently resolve every integer
-    # numpy type except int64 to the Int64 constructor (a pre-existing
-    # binding quirk, see test_numpy_scalar_constructor_paths_narrower_ints_
-    # preexisting_quirk below), so astype() is the reliable way to pin an
-    # unsigned dtype from Python.
-    s = cytnx.Scalar(np.int64(3)).astype(Type.Uint64)
+    s = cytnx.Scalar(np.uint64(3))
     assert s.dtype() == Type.Uint64
     with pytest.raises(RuntimeError):
         s -= cytnx.Scalar(np.int64(2))
@@ -174,10 +167,10 @@ def test_self_assignment_and_self_inplace_are_safe():
 # Storage indexed assignment from a Scalar (the Python-visible entry point
 # into Scalar::Sproxy / Storage::set_item(idx, const Scalar&) -- see
 # pybind/storage_py.cpp's __setitem__/__getitem__, which cast the Scalar via
-# its __int__/__float__/__complex__ operators into self.at<T>(idx) rather
-# than returning a Scalar from __getitem__. Bool storage is excluded: casting
-# a Scalar to C++ bool has no pybind path today (no __bool__ registered in
-# scalar_py.cpp) -- a pre-existing gap, unchanged by this refactor.
+# its __bool__/__int__/__float__/__complex__ operators into self.at<T>(idx)
+# rather than returning a Scalar from __getitem__. The Bool row needs the
+# __bool__ binding: pybind's bool caster only accepts objects whose type
+# fills the nb_bool slot.
 # ---------------------------------------------------------------------------
 
 
@@ -194,14 +187,17 @@ def test_self_assignment_and_self_inplace_are_safe():
         (Type.Uint32, np.uint32),
         (Type.Int16, np.int16),
         (Type.Uint16, np.uint16),
+        (Type.Bool, np.bool_),
     ],
 )
 def test_storage_setitem_getitem_scalar_roundtrip(dtype, np_dtype):
     storage = cytnx.Storage(4, dtype)
-    value = cytnx.Scalar(np_dtype(3))
-    storage[1] = value
+    value = np_dtype(True) if dtype == Type.Bool else np_dtype(3)
+    storage[1] = cytnx.Scalar(value)
     got = storage[1]
-    if isinstance(got, (float, complex)):
+    if dtype == Type.Bool:
+        assert got is True
+    elif isinstance(got, (float, complex)):
         assert got == pytest.approx(3)
     else:
         assert got == 3
@@ -221,7 +217,13 @@ def test_tensor_setitem_with_scalar_still_works():
 
 
 # ---------------------------------------------------------------------------
-# numpy scalar constructor paths (all 11 dtypes + complex)
+# numpy scalar constructor paths (all 11 dtypes + complex): every numpy
+# scalar type resolves to its own constructor overload. Before the keep-set
+# reorder of scalar_py.cpp's __init__ overloads (see "KEEP-SET ORDERING" in
+# pybind/pyint_dispatch.hpp), the plain integral constructors were registered
+# ahead of the numpy_scalar ones, so every in-range numpy integer scalar was
+# consumed via __index__ by the first plain integral overload and came out
+# dtype Int64.
 # ---------------------------------------------------------------------------
 
 
@@ -233,6 +235,11 @@ def test_tensor_setitem_with_scalar_still_works():
         (np.float64, Type.Double),
         (np.float32, Type.Float),
         (np.int64, Type.Int64),
+        (np.uint64, Type.Uint64),
+        (np.int32, Type.Int32),
+        (np.uint32, Type.Uint32),
+        (np.int16, Type.Int16),
+        (np.uint16, Type.Uint16),
         (np.bool_, Type.Bool),
     ],
 )
@@ -242,23 +249,72 @@ def test_numpy_scalar_constructor_paths(np_dtype, dtype):
     assert s.dtype() == dtype
 
 
+def test_numpy_uint64_above_int64_max_preserves_value():
+    big = np.uint64(2**64 - 1)
+    s = cytnx.Scalar(big)
+    assert s.dtype() == Type.Uint64
+    assert float(s) == pytest.approx(float(big))
+
+
+# ---------------------------------------------------------------------------
+# plain Python scalar constructor keep-set: int dispatches on magnitude
+# (int64 when it fits, covering all negatives; uint64 otherwise; clean error
+# beyond uint64 range instead of a silent complex upcast), and bool/float/
+# complex map to Bool/Double/ComplexDouble.
+# ---------------------------------------------------------------------------
+
+
+def test_python_int_constructor_dispatches_on_magnitude():
+    assert cytnx.Scalar(5).dtype() == Type.Int64
+    assert cytnx.Scalar(-5).dtype() == Type.Int64
+    assert cytnx.Scalar(2**63).dtype() == Type.Uint64
+    assert cytnx.Scalar(2**64 - 1).dtype() == Type.Uint64
+
+
+def test_python_int_constructor_out_of_range_raises():
+    with pytest.raises(RuntimeError):
+        cytnx.Scalar(2**64)
+    with pytest.raises(RuntimeError):
+        cytnx.Scalar(-(2**63) - 1)
+
+
+def test_python_bool_float_complex_constructor_dtypes():
+    assert cytnx.Scalar(True).dtype() == Type.Bool
+    assert cytnx.Scalar(0.5).dtype() == Type.Double
+    assert cytnx.Scalar(1 + 2j).dtype() == Type.ComplexDouble
+
+
+# ---------------------------------------------------------------------------
+# __bool__: numpy-consistent truthiness (nonzero value -> True; for complex,
+# nonzero real OR imaginary part).
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.parametrize(
     "np_dtype",
-    [np.uint64, np.int32, np.uint32, np.int16, np.uint16],
+    [
+        np.complex128,
+        np.complex64,
+        np.float64,
+        np.float32,
+        np.int64,
+        np.uint64,
+        np.int32,
+        np.uint32,
+        np.int16,
+        np.uint16,
+        np.bool_,
+    ],
 )
-def test_numpy_scalar_constructor_paths_narrower_ints_preexisting_quirk(np_dtype):
-    # Pre-existing pybind11 overload-resolution behavior (confirmed present
-    # on master d6dcd160, before this refactor): numpy scalar types narrower
-    # than int64/uint64 (uint64, int32, uint32, int16, uint16) all resolve to
-    # the Int64 constructor overload instead of their own. This is a
-    # pre-existing pybind/numpy_scalar dispatch quirk in scalar_py.cpp's
-    # __init__ overload set, not something introduced or fixed by the
-    # Scalar->std::variant refactor (T2's scope is Scalar's internals; the
-    # pybind constructor overload set is unchanged). Documented here so a
-    # future fix has a regression test to flip green; not treated as a T2
-    # gate failure.
-    s = cytnx.Scalar(np_dtype(5))
-    assert s.dtype() == Type.Int64  # pinned pre-existing behavior, not the "correct" dtype
+def test_bool_matches_numpy_truthiness(np_dtype):
+    assert bool(cytnx.Scalar(np_dtype(0))) is False
+    assert bool(cytnx.Scalar(np_dtype(1))) is True
+
+
+def test_bool_complex_pure_imaginary_is_true():
+    # numpy: bool(np.complex128(1j)) is True -- truthiness must consider the
+    # imaginary part, not just the real part.
+    assert bool(cytnx.Scalar(np.complex128(1j))) is True
 
 
 def test_comparison_operators_across_dtypes():

--- a/src/BlockFermionicUniTensor.cpp
+++ b/src/BlockFermionicUniTensor.cpp
@@ -1806,7 +1806,11 @@ namespace cytnx {
 
   void BlockFermionicUniTensor::normalize_() {
     //[21 Aug 2024] This is a copy from BlockUniTensor;
-    Scalar out(0, this->dtype());
+    // See BlockUniTensor::normalize_() for why the accumulator must be
+    // seeded with the dtype linalg::Norm() produces rather than
+    // this->dtype(): Ruling 1 (#935/#937) makes Scalar in-place ops throw
+    // on a lossy dtype change.
+    Scalar out(0, Type_class::norm_result_dtype(this->dtype()));
     for (auto &block : this->_blocks) {
       out += Scalar(linalg::Pow(linalg::Norm(block), 2).item());
     }

--- a/src/BlockUniTensor.cpp
+++ b/src/BlockUniTensor.cpp
@@ -1232,7 +1232,12 @@ namespace cytnx {
   };
 
   void BlockUniTensor::normalize_() {
-    Scalar out(0, this->dtype());
+    // The accumulator must be seeded with the dtype linalg::Norm() actually
+    // produces, not this->dtype(): Norm() always returns a real
+    // floating-point result, so accumulating norm^2 into an integer-dtype
+    // Scalar would throw under Scalar's in-place dtype rule (Ruling 1,
+    // #935/#937) instead of silently truncating as it used to.
+    Scalar out(0, Type_class::norm_result_dtype(this->dtype()));
     for (auto &block : this->_blocks) {
       out += Scalar(linalg::Pow(linalg::Norm(block), 2).item());
     }

--- a/src/DenseUniTensor.cpp
+++ b/src/DenseUniTensor.cpp
@@ -1375,8 +1375,17 @@ namespace cytnx {
         (long long)n);
       if (this->_block.device() == Device.cpu) {
         for (cytnx_uint64 i = 0; i < n; i++) {
+          // Out-of-place addition: `this` and `rhs` are independent
+          // UniTensors and are not guaranteed to share a dtype, so the two
+          // Scalars here can legitimately differ in dtype (e.g. Int64 vs
+          // Double). Scalar's in-place += now throws on a lossy dtype
+          // change (Ruling 1, #935/#937); out-of-place + always promotes via
+          // Type.type_promote and never throws, matching #937's own
+          // migration guidance ("replace in-place arithmetic by out-of-place
+          // arithmetic"). The result is narrowed back to this->_block's
+          // dtype by the following assignment, same as before.
           Scalar v = Scalar(this->_block.at({i, i}));
-          v += Scalar(rhs_diag.at({i}));
+          v = v + Scalar(rhs_diag.at({i}));
           this->_block.at({i, i}) = v;
         }
       } else {
@@ -1425,8 +1434,11 @@ namespace cytnx {
         (long long)n);
       if (this->_block.device() == Device.cpu) {
         for (cytnx_uint64 i = 0; i < n; i++) {
+          // See the analogous comment in Add_(): out-of-place subtraction
+          // avoids Ruling 1's in-place lossy-dtype throw between two
+          // independent UniTensors' potentially differing dtypes.
           Scalar v = Scalar(this->_block.at({i, i}));
-          v -= Scalar(rhs_diag.at({i}));
+          v = v - Scalar(rhs_diag.at({i}));
           this->_block.at({i, i}) = v;
         }
       } else {

--- a/src/backend/Scalar.cpp
+++ b/src/backend/Scalar.cpp
@@ -1,58 +1,591 @@
 #include "backend/Scalar.hpp"
 #include "backend/Storage.hpp"
 
+#include <complex>
+#include <limits>
+#include <type_traits>
+#include <variant>
+
 namespace cytnx {
 
-  cytnx_complex128 complex128(const Scalar& in) { return in._impl->to_cytnx_complex128(); }
+  namespace {
 
-  cytnx_complex64 complex64(const Scalar& in) { return in._impl->to_cytnx_complex64(); }
+    // ---- dtype / promotion helpers -----------------------------------------
+    //
+    // Every promotion decision below routes through Type_class::type_promote
+    // (Type.hpp), which is the single source of truth for "what dtype should
+    // the result of combining typeL and typeR have". Before this refactor,
+    // Scalar re-derived a promotion order by hand (comparing raw enum values),
+    // which silently disagreed with type_promote for signed/unsigned integer
+    // mixes and gave the wrong (lossy) answer for ComplexFloat vs Double (see
+    // #935). Centralizing on type_promote means Scalar automatically inherits
+    // any future fix to the promotion table.
 
-  std::ostream& operator<<(std::ostream& os, const Scalar& in) {
-    in._impl->print(os);
-    os << std::string(" dtype: [") << Type.getname(in._impl->_dtype) << std::string("]");
+    void ensure_not_void(const Scalar &s, const char *what) {
+      cytnx_error_msg(s.dtype() == (int)Type.Void, "[ERROR] %s: Scalar is Void (uninitialized).%s",
+                      what, "\n");
+    }
+
+    // Prints "< value >" exactly as the old per-dtype Scalar_base::print()
+    // implementations did (the Void base class printed nothing).
+    void print_value(std::ostream &os, const Scalar &in) {
+      std::visit(
+        [&](auto &&v) {
+          using T = std::decay_t<decltype(v)>;
+          if constexpr (!std::is_same_v<T, std::monostate>) {
+            os << "< " << v << " >";
+          }
+        },
+        in._val);
+    }
+
+    // Ruling 1 (issues #935/#937): in-place arithmetic (+= -= *= /=) throws
+    // unless combining the two dtypes under type_promote would stay at the
+    // LHS dtype. This is exactly the "does the in-place op need to silently
+    // change dtype" test:
+    //   - same dtype: promote(L,L) == L -> always allowed.
+    //   - Int64 += Int32, Double += Float, ComplexDouble += Double, etc.:
+    //     promote(L,R) == L -> allowed: the conversion of R into L is
+    //     value-preserving per the sanctioned type_promote table (see
+    //     include/Type.hpp type_promote; maintainer sign-off 2026-07-07).
+    //     Note this includes same-width unsigned->signed RHS conversions
+    //     (e.g. Int64 += Uint64), which the table resolves to the signed
+    //     LHS by explicit maintainer ruling: in-place and out-of-place stay
+    //     consistent, and any future tightening happens in the table.
+    //   - Uint64 += Int64, Int64 += Double, Double += ComplexDouble, Bool +=
+    //     anything-but-Bool: promote(L,R) != L -> would require changing the
+    //     LHS's dtype (or silently truncating, e.g. old integer-preserving
+    //     in-place division) -> throw, telling the caller to use astype().
+    void ensure_inplace_dtype_unchanged_by_promote(unsigned int lhs_dtype, unsigned int rhs_dtype,
+                                                   const char *op, const char *op_symbol) {
+      if (rhs_dtype == Type.Void || lhs_dtype == Type.Void) {
+        cytnx_error_msg(true, "[ERROR] Scalar %s: cannot operate on a Void Scalar.%s", op, "\n");
+      }
+      unsigned int promoted = Type_class::type_promote(lhs_dtype, rhs_dtype);
+      cytnx_error_msg(promoted != lhs_dtype,
+                      "[ERROR] Scalar in-place %s between dtype [%s] and [%s] would change or "
+                      "truncate the destination dtype (result dtype would be [%s]). Use "
+                      "out-of-place arithmetic (e.g. `a = a %s b`) or `astype()` to convert "
+                      "explicitly.%s",
+                      op, Type.getname(lhs_dtype).c_str(), Type.getname(rhs_dtype).c_str(),
+                      Type.getname(promoted).c_str(), op_symbol, "\n");
+    }
+
+    // ---- generic per-alternative helpers ------------------------------------
+
+    // Cast a source value of type TSrc to the destination type TDst,
+    // following the pre-existing Scalar conversion rules:
+    //  - real <- complex is disallowed (use real()/imag() instead).
+    //  - anything else is a plain static_cast (matches the old
+    //    assign_selftype()/to_cytnx_XXX() behavior).
+    template <typename TDst, typename TSrc>
+    TDst convert_value(const TSrc &src) {
+      if constexpr (is_complex_v<TDst> || !is_complex_v<TSrc>) {
+        return static_cast<TDst>(src);
+      } else {
+        cytnx_error_msg(true,
+                        "[ERROR] Cannot convert a complex Scalar to a real dtype. Use real() or "
+                        "imag() to extract a component first.%s",
+                        "\n");
+        return TDst{};
+      }
+    }
+
+    // Visitor: convert whatever is active into dtype `dtype` on the Type_list,
+    // returning a new ScalarVariant.
+    struct AstypeVisitor {
+      unsigned int dtype;
+
+      Scalar::ScalarVariant operator()(std::monostate) const { return std::monostate{}; }
+
+      template <typename TSrc>
+      Scalar::ScalarVariant operator()(const TSrc &src) const {
+        Scalar::ScalarVariant out;
+        VisitByDtype(dtype, [&](auto tag) {
+          using TDst = typename decltype(tag)::type;
+          out = convert_value<TDst>(src);
+        });
+        return out;
+      }
+
+      // Dispatch a runtime dtype id to a compile-time type tag, calling
+      // `fn(type_identity<T>{})`. Kept local to this visitor: it is the
+      // inverse operation of Scalar::dtype() and is only needed for astype().
+      template <typename Fn>
+      static void VisitByDtype(unsigned int dtype, Fn &&fn) {
+        switch (dtype) {
+          case Type.ComplexDouble:
+            fn(std::type_identity<cytnx_complex128>{});
+            return;
+          case Type.ComplexFloat:
+            fn(std::type_identity<cytnx_complex64>{});
+            return;
+          case Type.Double:
+            fn(std::type_identity<cytnx_double>{});
+            return;
+          case Type.Float:
+            fn(std::type_identity<cytnx_float>{});
+            return;
+          case Type.Int64:
+            fn(std::type_identity<cytnx_int64>{});
+            return;
+          case Type.Uint64:
+            fn(std::type_identity<cytnx_uint64>{});
+            return;
+          case Type.Int32:
+            fn(std::type_identity<cytnx_int32>{});
+            return;
+          case Type.Uint32:
+            fn(std::type_identity<cytnx_uint32>{});
+            return;
+          case Type.Int16:
+            fn(std::type_identity<cytnx_int16>{});
+            return;
+          case Type.Uint16:
+            fn(std::type_identity<cytnx_uint16>{});
+            return;
+          case Type.Bool:
+            fn(std::type_identity<cytnx_bool>{});
+            return;
+          default:
+            cytnx_error_msg(true, "[ERROR] invalid target dtype for Scalar::astype: %d%s", dtype,
+                            "\n");
+        }
+      }
+    };
+
+    // ---- arithmetic -----------------------------------------------------
+
+    // Perform the requested binary arithmetic op between the (already
+    // type_promote-selected) representations of lhs and rhs, returning the
+    // promoted-dtype result. `Op` is one of +,-,*,/ passed as a lambda.
+    template <typename BinOp>
+    Scalar binary_arith(const Scalar &lhs, const Scalar &rhs, BinOp &&op, const char *opname) {
+      ensure_not_void(lhs, opname);
+      ensure_not_void(rhs, opname);
+      unsigned int out_dtype = Type_class::type_promote(lhs.dtype(), rhs.dtype());
+      Scalar L = lhs.astype(out_dtype);
+      Scalar R = rhs.astype(out_dtype);
+      Scalar out;
+      std::visit(
+        [&](auto &&lv, auto &&rv) {
+          using TL = std::decay_t<decltype(lv)>;
+          using TR = std::decay_t<decltype(rv)>;
+          // TL and TR are guaranteed identical here since both operands were
+          // just astype()'d to the same promoted dtype; the mismatched-type
+          // branches below are unreachable at runtime but must still be
+          // well-formed for std::visit's exhaustiveness requirement.
+          if constexpr (std::is_same_v<TL, TR> && !std::is_same_v<TL, std::monostate>) {
+            out._val = static_cast<TL>(op(lv, rv));
+          } else {
+            cytnx_error_msg(true, "[ERROR] Scalar %s: unexpected Void operand.%s", opname, "\n");
+          }
+        },
+        L._val, R._val);
+      return out;
+    }
+
+    template <typename CmpOp>
+    bool binary_cmp(const Scalar &lhs, const Scalar &rhs, CmpOp &&op, const char *opname,
+                    bool forbid_complex) {
+      ensure_not_void(lhs, opname);
+      ensure_not_void(rhs, opname);
+      if (forbid_complex) {
+        cytnx_error_msg(Type.is_complex(lhs.dtype()) || Type.is_complex(rhs.dtype()),
+                        "[ERROR] Scalar %s: comparison not supported for complex type%s", opname,
+                        "\n");
+      }
+      unsigned int out_dtype = Type_class::type_promote(lhs.dtype(), rhs.dtype());
+      Scalar L = lhs.astype(out_dtype);
+      Scalar R = rhs.astype(out_dtype);
+      bool result = false;
+      std::visit(
+        [&](auto &&lv, auto &&rv) {
+          using TL = std::decay_t<decltype(lv)>;
+          using TR = std::decay_t<decltype(rv)>;
+          // See binary_arith(): TL and TR are guaranteed identical at
+          // runtime since both operands were astype()'d to the promoted
+          // dtype; other branches exist only to satisfy std::visit.
+          if constexpr (!std::is_same_v<TL, TR>) {
+            cytnx_error_msg(true, "[ERROR] Scalar %s: unexpected Void operand.%s", opname, "\n");
+          } else if constexpr (std::is_same_v<TL, std::monostate>) {
+            cytnx_error_msg(true, "[ERROR] Scalar %s: unexpected Void operand.%s", opname, "\n");
+          } else if constexpr (is_complex_v<TL>) {
+            // Ordering comparisons (< <= > >=) forbid complex entirely
+            // (checked eagerly above via `forbid_complex`, so this is
+            // unreachable in that case); equality (`forbid_complex == false`)
+            // is well-defined for complex via operator== and must not throw.
+            if (forbid_complex) {
+              cytnx_error_msg(true,
+                              "[ERROR] Scalar %s: comparison not supported for complex type%s",
+                              opname, "\n");
+            } else {
+              result = op(lv, rv);
+            }
+          } else {
+            result = op(lv, rv);
+          }
+        },
+        L._val, R._val);
+      return result;
+    }
+
+  }  // namespace
+
+  // ---- Scalar member functions --------------------------------------------
+
+  Scalar Scalar::maxval(const unsigned int &dtype) {
+    Scalar out(0, dtype);
+    std::visit(
+      [](auto &&v) {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, std::monostate>) {
+          cytnx_error_msg(true, "[ERROR] maxval not supported for Void type%s", "\n");
+        } else if constexpr (is_complex_v<T>) {
+          cytnx_error_msg(true, "[ERROR] maxval not supported for complex type%s", "\n");
+        } else {
+          v = std::numeric_limits<T>::max();
+        }
+      },
+      out._val);
+    return out;
+  }
+
+  Scalar Scalar::minval(const unsigned int &dtype) {
+    Scalar out(0, dtype);
+    std::visit(
+      [](auto &&v) {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, std::monostate>) {
+          cytnx_error_msg(true, "[ERROR] minval not supported for Void type%s", "\n");
+        } else if constexpr (is_complex_v<T>) {
+          cytnx_error_msg(true, "[ERROR] minval not supported for complex type%s", "\n");
+        } else if constexpr (std::is_floating_point_v<T>) {
+          // #935: floating-point minval must be the most negative finite
+          // value (lowest()), not numeric_limits<T>::min() (smallest
+          // positive normal value).
+          v = std::numeric_limits<T>::lowest();
+        } else {
+          v = std::numeric_limits<T>::min();
+        }
+      },
+      out._val);
+    return out;
+  }
+
+  Scalar::Scalar(const Sproxy &prox) : _val(prox._insimpl->get_item(prox._loc)._val) {}
+
+  Scalar Scalar::astype(const unsigned int &dtype) const {
+    Scalar out;
+    out._val = std::visit(AstypeVisitor{dtype}, this->_val);
+    return out;
+  }
+
+  Scalar Scalar::conj() const {
+    Scalar out = *this;
+    std::visit(
+      [](auto &&v) {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (is_complex_v<T>) v = std::conj(v);
+      },
+      out._val);
+    return out;
+  }
+
+  Scalar Scalar::imag() const {
+    ensure_not_void(*this, "imag");
+    Scalar out;
+    std::visit(
+      [&](auto &&v) {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, cytnx_complex128>) {
+          out._val = v.imag();
+        } else if constexpr (std::is_same_v<T, cytnx_complex64>) {
+          out._val = v.imag();
+        } else if constexpr (std::is_same_v<T, std::monostate>) {
+          // Unreachable after the ensure_not_void guard; kept for
+          // std::visit exhaustiveness with a consistent message.
+          cytnx_error_msg(true, "[ERROR] imag(): Scalar is Void (uninitialized).%s", "\n");
+        } else {
+          cytnx_error_msg(true, "[ERROR] real type Scalar does not have imag part!%s", "\n");
+        }
+      },
+      this->_val);
+    return out;
+  }
+
+  Scalar Scalar::real() const {
+    ensure_not_void(*this, "real");
+    Scalar out;
+    std::visit(
+      [&](auto &&v) {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, cytnx_complex128>) {
+          out._val = v.real();
+        } else if constexpr (std::is_same_v<T, cytnx_complex64>) {
+          out._val = v.real();
+        } else if constexpr (std::is_same_v<T, std::monostate>) {
+          // Unreachable after the ensure_not_void guard; kept for
+          // std::visit exhaustiveness with a consistent message.
+          cytnx_error_msg(true, "[ERROR] real(): Scalar is Void (uninitialized).%s", "\n");
+        } else {
+          out._val = v;
+        }
+      },
+      this->_val);
+    return out;
+  }
+
+  // ScalarVariant is index-aligned with Type_list (static_asserts in
+  // Scalar.hpp pin this), so the active alternative's index IS the dtype id.
+  int Scalar::dtype() const { return (int)this->_val.index(); }
+
+  void Scalar::print() const {
+    print_value(std::cout, *this);
+    std::cout << std::string(" Scalar dtype: [") << Type.getname(this->dtype()) << std::string("]")
+              << std::endl;
+  }
+
+  namespace {
+    template <typename TDst>
+    TDst explicit_cast(const Scalar &s) {
+      TDst out{};
+      std::visit(
+        [&](auto &&v) {
+          using T = std::decay_t<decltype(v)>;
+          if constexpr (std::is_same_v<T, std::monostate>) {
+            cytnx_error_msg(
+              true, "[ERROR] Cannot cast a Void (uninitialized) Scalar to any type.%s", "\n");
+          } else {
+            out = convert_value<TDst>(v);
+          }
+        },
+        s._val);
+      return out;
+    }
+  }  // namespace
+
+  Scalar::operator cytnx_double() const { return explicit_cast<cytnx_double>(*this); }
+  Scalar::operator cytnx_float() const { return explicit_cast<cytnx_float>(*this); }
+  Scalar::operator cytnx_uint64() const { return explicit_cast<cytnx_uint64>(*this); }
+  Scalar::operator cytnx_int64() const { return explicit_cast<cytnx_int64>(*this); }
+  Scalar::operator cytnx_uint32() const { return explicit_cast<cytnx_uint32>(*this); }
+  Scalar::operator cytnx_int32() const { return explicit_cast<cytnx_int32>(*this); }
+  Scalar::operator cytnx_uint16() const { return explicit_cast<cytnx_uint16>(*this); }
+  Scalar::operator cytnx_int16() const { return explicit_cast<cytnx_int16>(*this); }
+  Scalar::operator cytnx_bool() const { return explicit_cast<cytnx_bool>(*this); }
+  cytnx_complex128 Scalar::to_complex128() const { return explicit_cast<cytnx_complex128>(*this); }
+  cytnx_complex64 Scalar::to_complex64() const { return explicit_cast<cytnx_complex64>(*this); }
+
+  // ---- in-place arithmetic (Ruling 1: throw on lossy mixed-dtype) --------
+
+  namespace {
+    // Shared body of the four in-place operators, mirroring binary_arith();
+    // a future in-place op (e.g. %=) only needs a new one-line call. After
+    // `rhs.astype(lhs.dtype())`, the two variants are guaranteed to hold the
+    // *same* alternative (both equal to lhs.dtype()), so the std::visit
+    // callback only ever needs the TL==TR branch to be live at runtime. It
+    // must still be well-formed (if constexpr-guarded) for every (TL, TR)
+    // combination the compiler instantiates, including monostate and
+    // mismatched-type pairs, since std::visit requires the visitor to be
+    // callable for the full cross product of alternatives.
+    template <typename InplaceOp>
+    void inplace_arith(Scalar &lhs, const Scalar &rhs, InplaceOp &&op, const char *opname,
+                       const char *op_symbol) {
+      ensure_inplace_dtype_unchanged_by_promote(lhs.dtype(), rhs.dtype(), opname, op_symbol);
+      Scalar rhs_conv = rhs.astype(lhs.dtype());
+      std::visit(
+        [&](auto &&lv, auto &&rv) {
+          using TL = std::decay_t<decltype(lv)>;
+          using TR = std::decay_t<decltype(rv)>;
+          if constexpr (std::is_same_v<TL, TR> && !std::is_same_v<TL, std::monostate>) {
+            op(lv, rv);
+          }
+        },
+        lhs._val, rhs_conv._val);
+    }
+  }  // namespace
+
+  void Scalar::operator+=(const Scalar &rhs) {
+    inplace_arith(
+      *this, rhs, [](auto &lv, const auto &rv) { lv += rv; }, "addition (+=)", "+");
+  }
+
+  void Scalar::operator-=(const Scalar &rhs) {
+    inplace_arith(
+      *this, rhs, [](auto &lv, const auto &rv) { lv -= rv; }, "subtraction (-=)", "-");
+  }
+
+  void Scalar::operator*=(const Scalar &rhs) {
+    inplace_arith(
+      *this, rhs, [](auto &lv, const auto &rv) { lv *= rv; }, "multiplication (*=)", "*");
+  }
+
+  void Scalar::operator/=(const Scalar &rhs) {
+    inplace_arith(
+      *this, rhs, [](auto &lv, const auto &rv) { lv /= rv; }, "division (/=)", "/");
+  }
+
+  void Scalar::iabs() {
+    ensure_not_void(*this, "iabs");
+    std::visit(
+      [](auto &&v) {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, std::monostate>) {
+          // unreachable, guarded above.
+        } else if constexpr (is_complex_v<T>) {
+          // #935: iabs() on a complex Scalar used to keep the dtype complex
+          // and store the (real) magnitude as the real part with a zero
+          // imaginary part -- inconsistent with the non-inplace abs(), which
+          // always returns a real dtype. We keep iabs() dtype-preserving
+          // (as every other in-place op is), so the chosen, documented
+          // semantics is: iabs() stores the magnitude as the real part and
+          // zeros the imaginary part. This matches abs()'s *value* (the
+          // magnitude), differing only in that iabs() cannot change dtype
+          // (no in-place op does), while abs() (out-of-place) additionally
+          // narrows the result to the real dtype.
+          v = T(std::abs(v), 0);
+        } else if constexpr (std::is_unsigned_v<T>) {
+          // Unsigned integer / bool: abs() is a no-op (already non-negative);
+          // std::abs has no unsigned overload and is ambiguous if called
+          // directly on these types.
+          // (leave v unchanged)
+        } else {
+          v = std::abs(v);
+        }
+      },
+      this->_val);
+  }
+
+  void Scalar::isqrt() {
+    ensure_not_void(*this, "isqrt");
+    std::visit(
+      [](auto &&v) {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, std::monostate>) {
+          // unreachable, guarded above.
+        } else if constexpr (std::is_same_v<T, cytnx_bool>) {
+          cytnx_error_msg(true, "[ERROR] isqrt not supported for Bool type%s", "\n");
+        } else {
+          v = std::sqrt(v);
+        }
+      },
+      this->_val);
+  }
+
+  Scalar Scalar::abs() const {
+    ensure_not_void(*this, "abs");
+    Scalar out;
+    std::visit(
+      [&](auto &&v) {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, std::monostate>) {
+          // unreachable, guarded above.
+        } else if constexpr (is_complex_v<T>) {
+          // abs() of a complex Scalar always returns the (real-dtype)
+          // magnitude -- fixes #935's abs()/iabs() dtype inconsistency.
+          out._val = std::abs(v);
+        } else if constexpr (std::is_unsigned_v<T>) {
+          // Already non-negative; std::abs has no unsigned overload.
+          out._val = v;
+        } else {
+          out._val = static_cast<T>(std::abs(v));
+        }
+      },
+      this->_val);
+    return out;
+  }
+
+  Scalar Scalar::sqrt() const {
+    Scalar out = *this;
+    out.isqrt();
+    return out;
+  }
+
+  bool Scalar::less(const Scalar &rhs) const {
+    return binary_cmp(
+      *this, rhs, [](auto &&a, auto &&b) { return a < b; }, "less-than (<)", true);
+  }
+  bool Scalar::leq(const Scalar &rhs) const {
+    return binary_cmp(
+      *this, rhs, [](auto &&a, auto &&b) { return a <= b; }, "less-equal (<=)", true);
+  }
+  bool Scalar::greater(const Scalar &rhs) const {
+    return binary_cmp(
+      *this, rhs, [](auto &&a, auto &&b) { return a > b; }, "greater-than (>)", true);
+  }
+  bool Scalar::geq(const Scalar &rhs) const {
+    return binary_cmp(
+      *this, rhs, [](auto &&a, auto &&b) { return a >= b; }, "greater-equal (>=)", true);
+  }
+  bool Scalar::eq(const Scalar &rhs) const {
+    return binary_cmp(
+      *this, rhs, [](auto &&a, auto &&b) { return a == b; }, "equal (==)", false);
+  }
+
+  Scalar Scalar::radd(const Scalar &rhs) const {
+    return binary_arith(
+      *this, rhs, [](auto &&a, auto &&b) { return a + b; }, "addition (+)");
+  }
+  Scalar Scalar::rmul(const Scalar &rhs) const {
+    return binary_arith(
+      *this, rhs, [](auto &&a, auto &&b) { return a * b; }, "multiplication (*)");
+  }
+  Scalar Scalar::rsub(const Scalar &rhs) const {
+    return binary_arith(
+      *this, rhs, [](auto &&a, auto &&b) { return a - b; }, "subtraction (-)");
+  }
+  Scalar Scalar::rdiv(const Scalar &rhs) const {
+    return binary_arith(
+      *this, rhs, [](auto &&a, auto &&b) { return a / b; }, "division (/)");
+  }
+
+  // ---- free functions -------------------------------------------------
+
+  cytnx_complex128 complex128(const Scalar &in) { return in.to_complex128(); }
+
+  cytnx_complex64 complex64(const Scalar &in) { return in.to_complex64(); }
+
+  std::ostream &operator<<(std::ostream &os, const Scalar &in) {
+    print_value(os, in);
+    os << std::string(" dtype: [") << Type.getname(in.dtype()) << std::string("]");
     return os;
   }
 
   // ladd: c + Scalar:
-  Scalar operator+(const Scalar& lc, const Scalar& rs) { return rs.radd(lc); };
+  Scalar operator+(const Scalar &lc, const Scalar &rs) { return rs.radd(lc); }
 
   // lmul c * Scalar;
-  Scalar operator*(const Scalar& lc, const Scalar& rs) { return rs.rmul(lc); };
+  Scalar operator*(const Scalar &lc, const Scalar &rs) { return rs.rmul(lc); }
 
   // lsub c - Scalar;
-  Scalar operator-(const Scalar& lc, const Scalar& rs) { return lc.rsub(rs); };
+  Scalar operator-(const Scalar &lc, const Scalar &rs) { return lc.rsub(rs); }
 
   // ldiv c / Scalar;
-  Scalar operator/(const Scalar& lc, const Scalar& rs) { return lc.rdiv(rs); };
+  Scalar operator/(const Scalar &lc, const Scalar &rs) { return lc.rdiv(rs); }
 
   // lless c < Scalar;
-  bool operator<(const Scalar& lc, const Scalar& rs) { return lc.less(rs); };
+  bool operator<(const Scalar &lc, const Scalar &rs) { return lc.less(rs); }
 
   // lless c > Scalar;
-  bool operator>(const Scalar& lc, const Scalar& rs) { return lc.greater(rs); };
+  bool operator>(const Scalar &lc, const Scalar &rs) { return lc.greater(rs); }
 
   // lless c <= Scalar;
-  bool operator<=(const Scalar& lc, const Scalar& rs) { return lc.leq(rs); };
+  bool operator<=(const Scalar &lc, const Scalar &rs) { return lc.leq(rs); }
 
   // lless c >= Scalar;
-  bool operator>=(const Scalar& lc, const Scalar& rs) { return lc.geq(rs); };
+  bool operator>=(const Scalar &lc, const Scalar &rs) { return lc.geq(rs); }
 
   // eq c == Scalar;
-  bool operator==(const Scalar& lc, const Scalar& rs) {
-    // if (lc.dtype() < rs.dtype())
-    //   return lc.geq(rs);
-    // else
-    //   return rs.geq(lc);
-    return lc.eq(rs);
-  };
+  bool operator==(const Scalar &lc, const Scalar &rs) { return lc.eq(rs); }
 
-  Scalar abs(const Scalar& c) { return c.abs(); };
+  Scalar abs(const Scalar &c) { return c.abs(); }
 
-  Scalar sqrt(const Scalar& c) { return c.sqrt(); };
+  Scalar sqrt(const Scalar &c) { return c.sqrt(); }
 
   // Scalar proxy:
   // Sproxy
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const Scalar::Sproxy& rc) {
+  Scalar::Sproxy &Scalar::Sproxy::operator=(const Scalar::Sproxy &rc) {
     if (this->_insimpl.get() == 0) {
       //  not init:
       this->_insimpl = rc._insimpl;
@@ -68,130 +601,58 @@ namespace cytnx {
       }
     }
   }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const Scalar& rc) {
+  Scalar::Sproxy &Scalar::Sproxy::operator=(const Scalar &rc) {
     this->_insimpl->set_item(this->_loc, rc);
     return *this;
   }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_complex128& rc) {
+  Scalar::Sproxy &Scalar::Sproxy::operator=(const cytnx_complex128 &rc) {
     this->_insimpl->set_item(this->_loc, rc);
     return *this;
   }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_complex64& rc) {
+  Scalar::Sproxy &Scalar::Sproxy::operator=(const cytnx_complex64 &rc) {
     this->_insimpl->set_item(this->_loc, rc);
     return *this;
   }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_double& rc) {
+  Scalar::Sproxy &Scalar::Sproxy::operator=(const cytnx_double &rc) {
     this->_insimpl->set_item(this->_loc, rc);
     return *this;
   }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_float& rc) {
+  Scalar::Sproxy &Scalar::Sproxy::operator=(const cytnx_float &rc) {
     this->_insimpl->set_item(this->_loc, rc);
     return *this;
   }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_uint64& rc) {
+  Scalar::Sproxy &Scalar::Sproxy::operator=(const cytnx_uint64 &rc) {
     this->_insimpl->set_item(this->_loc, rc);
     return *this;
   }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_int64& rc) {
+  Scalar::Sproxy &Scalar::Sproxy::operator=(const cytnx_int64 &rc) {
     this->_insimpl->set_item(this->_loc, rc);
     return *this;
   }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_uint32& rc) {
+  Scalar::Sproxy &Scalar::Sproxy::operator=(const cytnx_uint32 &rc) {
     this->_insimpl->set_item(this->_loc, rc);
     return *this;
   }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_int32& rc) {
+  Scalar::Sproxy &Scalar::Sproxy::operator=(const cytnx_int32 &rc) {
     this->_insimpl->set_item(this->_loc, rc);
     return *this;
   }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_uint16& rc) {
+  Scalar::Sproxy &Scalar::Sproxy::operator=(const cytnx_uint16 &rc) {
     this->_insimpl->set_item(this->_loc, rc);
     return *this;
   }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_int16& rc) {
+  Scalar::Sproxy &Scalar::Sproxy::operator=(const cytnx_int16 &rc) {
     this->_insimpl->set_item(this->_loc, rc);
     return *this;
   }
-  Scalar::Sproxy& Scalar::Sproxy::operator=(const cytnx_bool& rc) {
+  Scalar::Sproxy &Scalar::Sproxy::operator=(const cytnx_bool &rc) {
     this->_insimpl->set_item(this->_loc, rc);
     return *this;
   }
 
-  bool Scalar::Sproxy::exists() const { return this->_insimpl->dtype() != Type.Void; };
+  bool Scalar::Sproxy::exists() const { return this->_insimpl->dtype() != Type.Void; }
 
   Scalar Scalar::Sproxy::real() { return Scalar(*this).real(); }
   Scalar Scalar::Sproxy::imag() { return Scalar(*this).imag(); }
-
-  Scalar::Scalar(const Sproxy& prox) : _impl(new Scalar_base()) {
-    if (this->_impl != nullptr) {
-      delete this->_impl;
-    }
-    this->_impl = prox._insimpl->get_item(prox._loc)._impl->copy();
-  }
-
-  // Storage Init interface.
-  //=============================
-  inline Scalar_base* ScIInit_cd() {
-    Scalar_base* out = new ComplexDoubleScalar();
-    return out;
-  }
-  inline Scalar_base* ScIInit_cf() {
-    Scalar_base* out = new ComplexFloatScalar();
-    return out;
-  }
-  inline Scalar_base* ScIInit_d() {
-    Scalar_base* out = new DoubleScalar();
-    return out;
-  }
-  inline Scalar_base* ScIInit_f() {
-    Scalar_base* out = new FloatScalar();
-    return out;
-  }
-  inline Scalar_base* ScIInit_u64() {
-    Scalar_base* out = new Uint64Scalar();
-    return out;
-  }
-  inline Scalar_base* ScIInit_i64() {
-    Scalar_base* out = new Int64Scalar();
-    return out;
-  }
-  inline Scalar_base* ScIInit_u32() {
-    Scalar_base* out = new Uint32Scalar();
-    return out;
-  }
-  inline Scalar_base* ScIInit_i32() {
-    Scalar_base* out = new Int32Scalar();
-    return out;
-  }
-  inline Scalar_base* ScIInit_u16() {
-    Scalar_base* out = new Uint16Scalar();
-    return out;
-  }
-  inline Scalar_base* ScIInit_i16() {
-    Scalar_base* out = new Int16Scalar();
-    return out;
-  }
-  inline Scalar_base* ScIInit_b() {
-    Scalar_base* out = new BoolScalar();
-    return out;
-  }
-  Scalar_init_interface::Scalar_init_interface() {
-    if (!inited) {
-      UScIInit[this->Double] = ScIInit_d;
-      UScIInit[this->Float] = ScIInit_f;
-      UScIInit[this->ComplexDouble] = ScIInit_cd;
-      UScIInit[this->ComplexFloat] = ScIInit_cf;
-      UScIInit[this->Uint64] = ScIInit_u64;
-      UScIInit[this->Int64] = ScIInit_i64;
-      UScIInit[this->Uint32] = ScIInit_u32;
-      UScIInit[this->Int32] = ScIInit_i32;
-      UScIInit[this->Uint16] = ScIInit_u16;
-      UScIInit[this->Int16] = ScIInit_i16;
-      UScIInit[this->Bool] = ScIInit_b;
-      inited = true;
-    }
-  }
-
-  Scalar_init_interface __ScII;
 
 }  // namespace cytnx

--- a/src/backend/StorageImplementation.cpp
+++ b/src/backend/StorageImplementation.cpp
@@ -806,13 +806,31 @@ namespace cytnx {
 
   template <typename DType>
   void StorageImplementation<DType>::SetItem(cytnx_uint64 index, const Scalar &value) {
-    if constexpr (std::is_same_v<DType, cytnx_complex128>) {
-      this->at<DType>(index) = complex128(value);
-    } else if constexpr (std::is_same_v<DType, cytnx_complex64>) {
-      this->at<DType>(index) = complex64(value);
-    } else {
-      this->at<DType>(index) = static_cast<DType>(value);
-    }
+    // Dispatch on the Scalar's actual active alternative via std::visit,
+    // then forward the concretely-typed value into the existing templated
+    // SetItem<OtherDType> overload above -- rather than going through
+    // Scalar's static_cast<DType>() conversion operators (which route
+    // through Scalar::astype()/to_cytnx_XXX() and used to reject some
+    // otherwise-valid conversions, e.g. real-to-real narrowing performed
+    // differently than std::is_constructible_v allows). This keeps
+    // set_item(idx, Scalar) exactly as permissive as set_item(idx, T) for
+    // every concrete T, and gives a single, consistent error message
+    // (from the OtherDType overload) when a conversion is not constructible.
+    // A Void (monostate) Scalar has no concrete value to forward, so it is
+    // rejected explicitly rather than silently doing nothing.
+    std::visit(
+      [&](auto &&v) {
+        using OtherDType = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<OtherDType, std::monostate>) {
+          cytnx_error_msg(true,
+                          "[ERROR] Cannot set_item from a Void (uninitialized) Scalar into "
+                          "Storage of dtype %s%s",
+                          Type.getname(Type.cy_typeid(DType())).c_str(), "\n");
+        } else {
+          this->SetItem(index, v);
+        }
+      },
+      value._val);
   }
 
   template <typename DType>

--- a/src/backend/linalg_internal_cpu/Add_internal.hpp
+++ b/src/backend/linalg_internal_cpu/Add_internal.hpp
@@ -16,7 +16,7 @@ namespace cytnx {
                                 const std::vector<cytnx_uint64> &shape,
                                 const std::vector<cytnx_uint64> &invmapper_L,
                                 const std::vector<cytnx_uint64> &invmapper_R) {
-      using TOut = cytnx::Scalar_init_interface::type_promote_t<TLin, TRin>;
+      using TOut = cytnx::Type_class::type_promote_t<TLin, TRin>;
       TOut *_out = reinterpret_cast<TOut *>(out->data());
       const TLin *_Lin = reinterpret_cast<const TLin *>(Lin->data());
       const TRin *_Rin = reinterpret_cast<const TRin *>(Rin->data());

--- a/src/backend/linalg_internal_cpu/Cpr_internal.hpp
+++ b/src/backend/linalg_internal_cpu/Cpr_internal.hpp
@@ -17,7 +17,7 @@ namespace cytnx {
                                 const std::vector<cytnx_uint64> &invmapper_L,
                                 const std::vector<cytnx_uint64> &invmapper_R) {
       using Tout = cytnx_bool;
-      using TPromote = cytnx::Scalar_init_interface::type_promote_t<TLin, TRin>;
+      using TPromote = cytnx::Type_class::type_promote_t<TLin, TRin>;
       Tout *_out = reinterpret_cast<Tout *>(out->data());
       const TLin *_Lin = reinterpret_cast<const TLin *>(Lin->data());
       const TRin *_Rin = reinterpret_cast<const TRin *>(Rin->data());

--- a/src/backend/linalg_internal_cpu/Gemm_Batch_internal.hpp
+++ b/src/backend/linalg_internal_cpu/Gemm_Batch_internal.hpp
@@ -45,9 +45,9 @@ namespace cytnx {
       T ScalarTo(const Scalar& x) {
         if constexpr (is_complex_v<T>) {
           if constexpr (std::is_same_v<T, cytnx_complex128>)
-            return x._impl->to_cytnx_complex128();
+            return complex128(x);
           else
-            return x._impl->to_cytnx_complex64();
+            return complex64(x);
         } else {
           return static_cast<T>(x);
         }

--- a/src/backend/linalg_internal_cpu/Mul_internal.hpp
+++ b/src/backend/linalg_internal_cpu/Mul_internal.hpp
@@ -15,7 +15,7 @@ namespace cytnx {
                                 const std::vector<cytnx_uint64> &shape,
                                 const std::vector<cytnx_uint64> &invmapper_L,
                                 const std::vector<cytnx_uint64> &invmapper_R) {
-      using TOut = cytnx::Scalar_init_interface::type_promote_t<TLin, TRin>;
+      using TOut = cytnx::Type_class::type_promote_t<TLin, TRin>;
       TOut *_out = reinterpret_cast<TOut *>(out->data());
       const TLin *_Lin = reinterpret_cast<const TLin *>(Lin->data());
       const TRin *_Rin = reinterpret_cast<const TRin *>(Rin->data());

--- a/src/backend/linalg_internal_cpu/Sub_internal.hpp
+++ b/src/backend/linalg_internal_cpu/Sub_internal.hpp
@@ -16,7 +16,7 @@ namespace cytnx {
                                 const std::vector<cytnx_uint64> &shape,
                                 const std::vector<cytnx_uint64> &invmapper_L,
                                 const std::vector<cytnx_uint64> &invmapper_R) {
-      using TOut = cytnx::Scalar_init_interface::type_promote_t<TLin, TRin>;
+      using TOut = cytnx::Type_class::type_promote_t<TLin, TRin>;
       TOut *_out = reinterpret_cast<TOut *>(out->data());
       const TLin *_Lin = reinterpret_cast<const TLin *>(Lin->data());
       const TRin *_Rin = reinterpret_cast<const TRin *>(Rin->data());

--- a/src/linalg/Norm.cpp
+++ b/src/linalg/Norm.cpp
@@ -13,25 +13,22 @@ namespace cytnx {
       // rank-1 Tensor.%s","\n"); cytnx_error_msg(!Tl.is_contiguous(), "[Norm] error tensor Tl must
       // be contiguous. Call Contiguous_() or Contiguous() first%s","\n");
 
-      // check type:
+      // check type: floating/complex inputs keep their precision; anything
+      // else (integer/bool) is computed in double precision. The output
+      // dtype policy lives in Type_class::norm_result_dtype, shared with
+      // callers that pre-size norm accumulators (e.g. UniTensor's
+      // normalize_()) so the two cannot drift apart.
       Tensor _tl;
       Tensor out;
 
-      if (Tl.dtype() > 4) {
+      if (Type.is_float(Tl.dtype())) {
+        _tl = Tl;
+      } else {
         // do conversion:
         _tl = Tl.astype(Type.Double);
-
-      } else {
-        _tl = Tl;
       }
 
-      if (Tl.dtype() == Type.ComplexDouble) {
-        out.Init({1}, Type.Double, _tl.device());
-      } else if (Tl.dtype() == Type.ComplexFloat) {
-        out.Init({1}, Type.Float, _tl.device());
-      } else {
-        out.Init({1}, _tl.dtype(), _tl.device());
-      }
+      out.Init({1}, Type_class::norm_result_dtype(Tl.dtype()), _tl.device());
 
       if (Tl.device() == Device.cpu) {
         cytnx::linalg_internal::lii.Norm_ii[_tl.dtype()](out._impl->storage()._impl->data(),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   cytnx_error_test.cpp
   Tensor_strides_test.cpp
   Storage_test.cpp
+  Scalar_test.cpp
   search_tree_test.cpp
   utils_test/vec_concatenate.cpp
   utils_test/vec_unique.cpp

--- a/tests/Scalar_test.cpp
+++ b/tests/Scalar_test.cpp
@@ -1,0 +1,663 @@
+#include <cmath>
+#include <complex>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "backend/Scalar.hpp"
+#include "backend/Storage.hpp"
+#include "gtest/gtest.h"
+
+// This suite absorbs and extends PR #937's tests/Scalar_test.cpp (credit to
+// @ianmccul for the original guard semantics and test coverage). #937 disabled
+// a subset of lossy Scalar arithmetic by throwing std::logic_error; this
+// refactor (#847/#935) replaces the PIMPL+virtual-dispatch Scalar with
+// std::variant, and implements the maintainer's Ruling 1: in-place ops throw
+// cytnx::error (a std::logic_error) whenever the RHS dtype does not
+// losslessly convert into the LHS dtype (checked via
+// Type.type_promote(lhs, rhs) == lhs.dtype()). Same-dtype and lossless
+// widening in-place ops (Int64 += Int32, Double += Float, ComplexDouble +=
+// Double, ...) remain valid -- this is strictly more permissive than #937's
+// original "any differing integer dtype throws" guard, while still rejecting
+// every case #937 targeted (signed/unsigned mixes, int-with-float,
+// real-with-complex).
+
+namespace {
+
+  using cytnx::cytnx_bool;
+  using cytnx::cytnx_complex128;
+  using cytnx::cytnx_complex64;
+  using cytnx::cytnx_double;
+  using cytnx::cytnx_float;
+  using cytnx::cytnx_int16;
+  using cytnx::cytnx_int32;
+  using cytnx::cytnx_int64;
+  using cytnx::cytnx_uint16;
+  using cytnx::cytnx_uint32;
+  using cytnx::cytnx_uint64;
+  using cytnx::Scalar;
+  using cytnx::Type;
+  using cytnx::Type_class;
+
+  void ExpectDoubleScalarEq(const Scalar &value, double expected) {
+    EXPECT_EQ(value.dtype(), Type.Double);
+    EXPECT_DOUBLE_EQ(static_cast<cytnx_double>(value), expected);
+  }
+
+  void ExpectInt64ScalarEq(const Scalar &value, cytnx_int64 expected) {
+    EXPECT_EQ(value.dtype(), Type.Int64);
+    EXPECT_EQ(static_cast<cytnx_int64>(value), expected);
+  }
+
+  void ExpectUint64ScalarEq(const Scalar &value, cytnx_uint64 expected) {
+    EXPECT_EQ(value.dtype(), Type.Uint64);
+    EXPECT_EQ(static_cast<cytnx_uint64>(value), expected);
+  }
+
+  void ExpectComplexDoubleScalarEq(const Scalar &value, const cytnx_complex128 &expected) {
+    EXPECT_EQ(value.dtype(), Type.ComplexDouble);
+    const auto got = cytnx::complex128(value);
+    EXPECT_DOUBLE_EQ(got.real(), expected.real());
+    EXPECT_DOUBLE_EQ(got.imag(), expected.imag());
+  }
+
+  template <typename Fn>
+  void ExpectThrows(Fn &&fn) {
+    EXPECT_THROW({ fn(); }, std::logic_error);
+  }
+
+  // The full list of non-Void dtypes, in the same order the 11x11 promotion
+  // matrix below iterates them.
+  const std::vector<unsigned int> kAllDtypes = {
+    Type.ComplexDouble, Type.ComplexFloat, Type.Double, Type.Float,  Type.Int64, Type.Uint64,
+    Type.Int32,         Type.Uint32,       Type.Int16,  Type.Uint16, Type.Bool,
+  };
+
+  // A representative nonzero value for each dtype, chosen so that +,-,*,/ all
+  // produce exact (no-rounding-ambiguity) results when both operands are
+  // small integers, and so that division never hits zero.
+  Scalar RepresentativeValue(unsigned int dtype) {
+    if (dtype == Type.ComplexDouble) return Scalar(cytnx_complex128(6.0, 2.0));
+    if (dtype == Type.ComplexFloat) return Scalar(cytnx_complex64(6.0, 2.0));
+    if (dtype == Type.Double) return Scalar(cytnx_double(6.0));
+    if (dtype == Type.Float) return Scalar(cytnx_float(6.0));
+    if (dtype == Type.Int64) return Scalar(cytnx_int64(6));
+    if (dtype == Type.Uint64) return Scalar(cytnx_uint64(6));
+    if (dtype == Type.Int32) return Scalar(cytnx_int32(6));
+    if (dtype == Type.Uint32) return Scalar(cytnx_uint32(6));
+    if (dtype == Type.Int16) return Scalar(cytnx_int16(6));
+    if (dtype == Type.Uint16) return Scalar(cytnx_uint16(6));
+    if (dtype == Type.Bool) return Scalar(cytnx_bool(true));
+    cytnx_error_msg(true, "unreachable dtype in test helper%s", "\n");
+    return Scalar();
+  }
+
+  Scalar RepresentativeSecondValue(unsigned int dtype) {
+    if (dtype == Type.ComplexDouble) return Scalar(cytnx_complex128(3.0, 1.0));
+    if (dtype == Type.ComplexFloat) return Scalar(cytnx_complex64(3.0, 1.0));
+    if (dtype == Type.Double) return Scalar(cytnx_double(3.0));
+    if (dtype == Type.Float) return Scalar(cytnx_float(3.0));
+    if (dtype == Type.Int64) return Scalar(cytnx_int64(3));
+    if (dtype == Type.Uint64) return Scalar(cytnx_uint64(3));
+    if (dtype == Type.Int32) return Scalar(cytnx_int32(3));
+    if (dtype == Type.Uint32) return Scalar(cytnx_uint32(3));
+    if (dtype == Type.Int16) return Scalar(cytnx_int16(3));
+    if (dtype == Type.Uint16) return Scalar(cytnx_uint16(3));
+    if (dtype == Type.Bool) return Scalar(cytnx_bool(true));
+    cytnx_error_msg(true, "unreachable dtype in test helper%s", "\n");
+    return Scalar();
+  }
+
+  // Reference value as a complex128, used to check numeric correctness of the
+  // promoted result regardless of which dtype it ended up in.
+  cytnx_complex128 AsComplex(const Scalar &s) {
+    return cytnx::complex128(s.astype(Type.ComplexDouble));
+  }
+
+}  // namespace
+
+// ===========================================================================
+// #937-derived core suite (credit: @ianmccul). Adjusted for the variant
+// rewrite: `abs`/`sqrt`/bool-arithmetic are no longer blanket-disabled --
+// only genuinely lossy in-place combinations throw.
+// ===========================================================================
+
+TEST(ScalarTest, FloatingBinaryArithmeticReturnsCorrectValues) {
+  const Scalar a(cytnx_double(3.0));
+  const Scalar b(cytnx_double(2.0));
+
+  ExpectDoubleScalarEq(a + b, 5.0);
+  ExpectDoubleScalarEq(a - b, 1.0);
+  ExpectDoubleScalarEq(a * b, 6.0);
+  ExpectDoubleScalarEq(a / b, 1.5);
+}
+
+TEST(ScalarTest, ComplexBinaryArithmeticReturnsCorrectValues) {
+  const Scalar a(cytnx_complex128(3.0, 4.0));
+  const Scalar b(cytnx_complex128(1.0, -2.0));
+
+  ExpectComplexDoubleScalarEq(a + b, cytnx_complex128(4.0, 2.0));
+  ExpectComplexDoubleScalarEq(a - b, cytnx_complex128(2.0, 6.0));
+  ExpectComplexDoubleScalarEq(a * b, cytnx_complex128(11.0, -2.0));
+  ExpectComplexDoubleScalarEq(a / b, cytnx_complex128(-1.0, 2.0));
+}
+
+TEST(ScalarTest, FloatingInPlaceArithmeticReturnsCorrectValues) {
+  Scalar value(cytnx_double(3.0));
+  value += Scalar(cytnx_double(2.0));
+  ExpectDoubleScalarEq(value, 5.0);
+  value -= Scalar(cytnx_double(1.0));
+  ExpectDoubleScalarEq(value, 4.0);
+  value *= Scalar(cytnx_double(3.0));
+  ExpectDoubleScalarEq(value, 12.0);
+  value /= Scalar(cytnx_double(4.0));
+  ExpectDoubleScalarEq(value, 3.0);
+}
+
+TEST(ScalarTest, IntegerConstructionAndConversionStillWork) {
+  EXPECT_EQ(Scalar(cytnx_int64(-3)).dtype(), Type.Int64);
+  EXPECT_EQ(static_cast<cytnx_int64>(Scalar(cytnx_int64(-3))), cytnx_int64(-3));
+  EXPECT_EQ(Scalar(cytnx_uint64(3)).dtype(), Type.Uint64);
+  EXPECT_EQ(static_cast<cytnx_uint64>(Scalar(cytnx_uint64(3))), cytnx_uint64(3));
+  EXPECT_EQ(Scalar(cytnx_bool(true)).dtype(), Type.Bool);
+  EXPECT_EQ(static_cast<cytnx_bool>(Scalar(cytnx_bool(true))), true);
+}
+
+TEST(ScalarTest, CytnxTypeAssignmentPreservesInputDtype) {
+  Scalar value(cytnx_double(3.0));
+
+  value = cytnx_float(2.0);
+  EXPECT_EQ(value.dtype(), Type.Float);
+  EXPECT_FLOAT_EQ(static_cast<cytnx_float>(value), cytnx_float(2.0));
+
+  value = cytnx_int32(-4);
+  EXPECT_EQ(value.dtype(), Type.Int32);
+  EXPECT_EQ(static_cast<cytnx_int32>(value), cytnx_int32(-4));
+}
+
+TEST(ScalarTest, IntegerBinaryArithmeticReturnsCorrectValues) {
+  // Out-of-place arithmetic always promotes via Type.type_promote and never
+  // throws (unlike #937's guard, which conservatively disabled all
+  // integer-result arithmetic; now that promotion is centralized on
+  // type_promote, these are simply correct).
+  ExpectDoubleScalarEq(Scalar(cytnx_int64(3)) + Scalar(cytnx_double(2.0)), 5.0);
+  ExpectDoubleScalarEq(Scalar(cytnx_int64(3)) - Scalar(cytnx_double(2.0)), 1.0);
+  ExpectDoubleScalarEq(Scalar(cytnx_int64(3)) * Scalar(cytnx_double(2.0)), 6.0);
+  ExpectDoubleScalarEq(Scalar(cytnx_int64(3)) / Scalar(cytnx_double(2.0)), 1.5);
+}
+
+TEST(ScalarTest, SameIntegerDtypeBinaryArithmeticReturnsCorrectValues) {
+  ExpectInt64ScalarEq(Scalar(cytnx_int64(3)) + Scalar(cytnx_int64(2)), cytnx_int64(5));
+  ExpectUint64ScalarEq(Scalar(cytnx_uint64(3)) - Scalar(cytnx_uint64(2)), cytnx_uint64(1));
+  EXPECT_EQ(static_cast<cytnx_int32>(Scalar(cytnx_int32(3)) * Scalar(cytnx_int32(2))),
+            cytnx_int32(6));
+  EXPECT_EQ(static_cast<cytnx_uint32>(Scalar(cytnx_uint32(3)) / Scalar(cytnx_uint32(2))),
+            cytnx_uint32(1));
+  EXPECT_EQ(static_cast<cytnx_int16>(Scalar(cytnx_int16(3)) + Scalar(cytnx_int16(2))),
+            cytnx_int16(5));
+  EXPECT_EQ(static_cast<cytnx_uint16>(Scalar(cytnx_uint16(3)) - Scalar(cytnx_uint16(2))),
+            cytnx_uint16(1));
+}
+
+TEST(ScalarTest, MixedIntegerBinaryArithmeticPromotesCorrectly) {
+  // Same-signedness mixed-width integers promote to the wider of the two
+  // operand types (out of place always succeeds, matching Type.type_promote
+  // exactly -- the wider type is not always Int64/Uint64, it is whichever of
+  // the two inputs has more precision).
+  ExpectInt64ScalarEq(Scalar(cytnx_int64(3)) + Scalar(cytnx_int32(2)), cytnx_int64(5));
+  Scalar r = Scalar(cytnx_int32(3)) * Scalar(cytnx_int16(2));
+  EXPECT_EQ(r.dtype(), Type.Int32);
+  EXPECT_EQ(static_cast<cytnx_int32>(r), cytnx_int32(6));
+  Scalar r2 = Scalar(cytnx_uint32(3)) / Scalar(cytnx_uint16(2));
+  EXPECT_EQ(r2.dtype(), Type.Uint32);
+  EXPECT_EQ(static_cast<cytnx_uint32>(r2), cytnx_uint32(1));
+}
+
+TEST(ScalarTest, MixedSignedUnsignedIntegerBinaryArithmeticPromotesPerTypePromote) {
+  // Out-of-place arithmetic between signed/unsigned integers never throws:
+  // it promotes via Type.type_promote (which resolves the mix to the signed
+  // type when widths differ, or matches the documented promotion table).
+  Scalar r1 = Scalar(cytnx_int64(3)) + Scalar(cytnx_uint64(2));
+  EXPECT_EQ(r1.dtype(), Type_class::type_promote(Type.Int64, Type.Uint64));
+  EXPECT_DOUBLE_EQ(AsComplex(r1).real(), 5.0);
+
+  Scalar r2 = Scalar(cytnx_uint32(3)) - Scalar(cytnx_int32(2));
+  EXPECT_EQ(r2.dtype(), Type_class::type_promote(Type.Uint32, Type.Int32));
+  EXPECT_DOUBLE_EQ(AsComplex(r2).real(), 1.0);
+}
+
+TEST(ScalarTest, SameSignednessIntegerComparisonsReturnCorrectValues) {
+  EXPECT_TRUE(Scalar(cytnx_int64(3)) > Scalar(cytnx_int32(2)));
+  EXPECT_TRUE(Scalar(cytnx_int32(3)) >= Scalar(cytnx_int16(3)));
+  EXPECT_TRUE(Scalar(cytnx_uint64(2)) < Scalar(cytnx_uint32(3)));
+  EXPECT_TRUE(Scalar(cytnx_uint32(3)) <= Scalar(cytnx_uint16(3)));
+  EXPECT_TRUE(Scalar(cytnx_int16(3)) == Scalar(cytnx_int64(3)));
+}
+
+TEST(ScalarTest, BoolBinaryArithmeticPromotesToBool) {
+  // Bool + Bool stays Bool under Type.type_promote; out-of-place arithmetic
+  // never throws.
+  Scalar r = Scalar(cytnx_bool(true)) + Scalar(cytnx_bool(false));
+  EXPECT_EQ(r.dtype(), Type.Bool);
+}
+
+TEST(ScalarTest, SameIntegerDtypeInPlaceArithmeticReturnsCorrectValues) {
+  Scalar value(cytnx_int64(3));
+  value += Scalar(cytnx_int64(2));
+  ExpectInt64ScalarEq(value, cytnx_int64(5));
+  value -= Scalar(cytnx_int64(1));
+  ExpectInt64ScalarEq(value, cytnx_int64(4));
+  value *= Scalar(cytnx_int64(3));
+  ExpectInt64ScalarEq(value, cytnx_int64(12));
+  value /= Scalar(cytnx_int64(5));
+  ExpectInt64ScalarEq(value, cytnx_int64(2));
+
+  Scalar unsigned_value(cytnx_uint64(3));
+  unsigned_value -= Scalar(cytnx_uint64(2));
+  ExpectUint64ScalarEq(unsigned_value, cytnx_uint64(1));
+
+  Scalar int32_value(cytnx_int32(3));
+  int32_value *= Scalar(cytnx_int32(2));
+  EXPECT_EQ(static_cast<cytnx_int32>(int32_value), cytnx_int32(6));
+}
+
+TEST(ScalarTest, LosslessWideningInPlaceArithmeticIsAllowed) {
+  // Ruling 1 (#935/#937): in-place ops are allowed whenever
+  // Type.type_promote(lhs, rhs) == lhs.dtype() -- i.e. the RHS converts
+  // losslessly into the LHS's dtype. This is strictly more permissive than
+  // #937's original guard (which disabled ALL differing-dtype integer
+  // in-place ops); Int64 += Int32 is a same-signedness lossless widening and
+  // must remain valid.
+  Scalar i64(cytnx_int64(3));
+  i64 += Scalar(cytnx_int32(2));
+  ExpectInt64ScalarEq(i64, cytnx_int64(5));
+
+  Scalar d(cytnx_double(3.0));
+  d += Scalar(cytnx_float(2.0));
+  ExpectDoubleScalarEq(d, 5.0);
+
+  Scalar cd(cytnx_complex128(3.0, 0.0));
+  cd += Scalar(cytnx_double(2.0));
+  ExpectComplexDoubleScalarEq(cd, cytnx_complex128(5.0, 0.0));
+
+  Scalar u64(cytnx_uint64(3));
+  u64 += Scalar(cytnx_bool(true));
+  ExpectUint64ScalarEq(u64, cytnx_uint64(4));
+}
+
+TEST(ScalarTest, MixedSignedUnsignedIntegerInPlaceArithmeticIsDisabled) {
+  // Under Type.type_promote, a signed/unsigned mix of equal width promotes
+  // to the *signed* type (see Type.hpp's type_promote implementation and
+  // Type_test.cpp's documentation of it). So when the unsigned dtype is the
+  // in-place LHS, promotion picks the *other* (signed) dtype, which differs
+  // from the LHS -> throws. (When the signed dtype is the LHS, promotion
+  // stays at the LHS's own dtype, so it is allowed -- see
+  // LosslessWideningInPlaceArithmeticIsAllowed.)
+  ExpectThrows([] {
+    Scalar value(cytnx_uint64(3));
+    value -= Scalar(cytnx_int64(2));
+  });
+  ExpectThrows([] {
+    Scalar value(cytnx_uint32(3));
+    value -= Scalar(cytnx_int32(2));
+  });
+  ExpectThrows([] {
+    Scalar value(cytnx_uint16(3));
+    value *= Scalar(cytnx_int16(2));
+  });
+}
+
+TEST(ScalarTest, IntWithFloatInPlaceArithmeticIsDisabled) {
+  ExpectThrows([] {
+    Scalar value(cytnx_int64(3));
+    value += Scalar(cytnx_double(2.0));
+  });
+  ExpectThrows([] {
+    Scalar value(cytnx_uint32(3));
+    value /= Scalar(cytnx_double(2.0));
+  });
+}
+
+TEST(ScalarTest, RealWithComplexInPlaceArithmeticIsDisabled) {
+  ExpectThrows([] {
+    Scalar value(cytnx_double(3.0));
+    value += Scalar(cytnx_complex128(2.0, 1.0));
+  });
+  ExpectThrows([] {
+    Scalar value(cytnx_float(3.0));
+    value *= Scalar(cytnx_complex64(2.0, 1.0));
+  });
+}
+
+TEST(ScalarTest, BoolInPlaceArithmeticWithNonBoolIsDisabled) {
+  ExpectThrows([] {
+    Scalar value(cytnx_bool(true));
+    value += Scalar(cytnx_int64(1));
+  });
+}
+
+TEST(ScalarTest, SelfAssignmentPreservesValue) {
+  Scalar value(cytnx_double(3.5));
+  value = value;
+  ExpectDoubleScalarEq(value, 3.5);
+}
+
+TEST(ScalarTest, SelfInPlaceArithmeticIsSafe) {
+  // Exercises the self-assignment/self-arithmetic path that used to be UB
+  // under the old hand-written copy-assignment operator (#935).
+  Scalar value(cytnx_double(3.0));
+  value += value;
+  ExpectDoubleScalarEq(value, 6.0);
+}
+
+// ===========================================================================
+// #935 fix coverage
+// ===========================================================================
+
+TEST(ScalarTest, CopyAssignmentIsDefaultedValueSemantics) {
+  Scalar a(cytnx_int64(7));
+  Scalar b = a;
+  b += Scalar(cytnx_int64(1));
+  // b is an independent copy: mutating b must not affect a.
+  ExpectInt64ScalarEq(a, cytnx_int64(7));
+  ExpectInt64ScalarEq(b, cytnx_int64(8));
+}
+
+TEST(ScalarTest, MoveConstructionLeavesSourceValid) {
+  Scalar a(cytnx_double(9.0));
+  Scalar b = std::move(a);
+  ExpectDoubleScalarEq(b, 9.0);
+}
+
+TEST(ScalarTest, MinvalForFloatingDtypesUsesLowest) {
+  // #935: minval used numeric_limits<T>::min() (smallest positive normal),
+  // not lowest() (most negative finite value).
+  Scalar min_d = Scalar::minval(Type.Double);
+  EXPECT_DOUBLE_EQ(static_cast<cytnx_double>(min_d), std::numeric_limits<cytnx_double>::lowest());
+  EXPECT_LT(static_cast<cytnx_double>(min_d), 0.0);
+
+  Scalar min_f = Scalar::minval(Type.Float);
+  EXPECT_FLOAT_EQ(static_cast<cytnx_float>(min_f), std::numeric_limits<cytnx_float>::lowest());
+  EXPECT_LT(static_cast<cytnx_float>(min_f), 0.0f);
+}
+
+TEST(ScalarTest, MaxvalForFloatingDtypesUsesMax) {
+  Scalar max_d = Scalar::maxval(Type.Double);
+  EXPECT_DOUBLE_EQ(static_cast<cytnx_double>(max_d), std::numeric_limits<cytnx_double>::max());
+}
+
+TEST(ScalarTest, MinvalMaxvalForIntegerDtypes) {
+  EXPECT_EQ(static_cast<cytnx_int64>(Scalar::minval(Type.Int64)),
+            std::numeric_limits<cytnx_int64>::min());
+  EXPECT_EQ(static_cast<cytnx_int64>(Scalar::maxval(Type.Int64)),
+            std::numeric_limits<cytnx_int64>::max());
+  EXPECT_EQ(static_cast<cytnx_uint64>(Scalar::minval(Type.Uint64)),
+            std::numeric_limits<cytnx_uint64>::min());
+}
+
+TEST(ScalarTest, AbsReturnsRealDtypeForComplex) {
+  // #935: abs() must return a real dtype, not a complex dtype with zero
+  // imaginary part.
+  Scalar z(cytnx_complex128(3.0, 4.0));
+  Scalar a = z.abs();
+  EXPECT_EQ(a.dtype(), Type.Double);
+  EXPECT_DOUBLE_EQ(static_cast<cytnx_double>(a), 5.0);
+
+  Scalar zf(cytnx_complex64(3.0f, 4.0f));
+  Scalar af = zf.abs();
+  EXPECT_EQ(af.dtype(), Type.Float);
+  EXPECT_FLOAT_EQ(static_cast<cytnx_float>(af), 5.0f);
+}
+
+TEST(ScalarTest, IabsOnComplexKeepsDtypeAndMatchesAbsMagnitude) {
+  // #935 asked for iabs()/abs() to be made *consistent*. Since no in-place
+  // op is allowed to change dtype (that is the whole point of "in-place"),
+  // iabs() on a complex Scalar keeps the ComplexDouble/ComplexFloat dtype
+  // and stores the magnitude as the real part with a zero imaginary part.
+  // Its *value* (the magnitude) matches abs()'s value exactly; only the
+  // dtype differs (abs() narrows to real, iabs() cannot narrow in place).
+  Scalar z(cytnx_complex128(3.0, 4.0));
+  Scalar reference_abs = z.abs();
+  z.iabs();
+  EXPECT_EQ(z.dtype(), Type.ComplexDouble);
+  cytnx_complex128 v = cytnx::complex128(z);
+  EXPECT_DOUBLE_EQ(v.real(), static_cast<cytnx_double>(reference_abs));
+  EXPECT_DOUBLE_EQ(v.imag(), 0.0);
+}
+
+TEST(ScalarTest, AbsOnUnsignedIsIdentity) {
+  Scalar u(cytnx_uint64(42));
+  Scalar a = u.abs();
+  EXPECT_EQ(a.dtype(), Type.Uint64);
+  EXPECT_EQ(static_cast<cytnx_uint64>(a), cytnx_uint64(42));
+}
+
+TEST(ScalarTest, PromotionCentralizedOnTypePromoteForComplexFloatDoubleMix) {
+  // #935: ComplexFloat + Double must promote to ComplexDouble, not
+  // ComplexFloat (the old hand-rolled enum-order promotion picked the wrong
+  // one because the enum interleaves complexness and precision).
+  Scalar cf(cytnx_complex64(1.0f, 1.0f));
+  Scalar d(cytnx_double(2.0));
+  Scalar r = cf + d;
+  EXPECT_EQ(r.dtype(), Type.ComplexDouble);
+}
+
+// ===========================================================================
+// Programmatic 11x11 promotion matrix for +, -, *, / and comparisons.
+// Loops over every ordered pair of the 11 non-Void dtypes, asserting:
+//   - out-of-place binary op result dtype == Type.type_promote(a, b)
+//   - the numeric value is correct (checked via complex128 widening)
+//   - comparisons agree with the complex128-widened reference; mixed
+//     signed/unsigned integer operands promote via Type.type_promote and
+//     compare normally (they must NOT throw). Only ordering comparisons
+//     (< <= > >=) with a complex operand throw (complex has no total
+//     order); complex equality is allowed.
+// ===========================================================================
+
+class ScalarPromotionMatrixTest
+    : public ::testing::TestWithParam<std::pair<unsigned int, unsigned int>> {};
+
+TEST_P(ScalarPromotionMatrixTest, ArithmeticResultDtypeAndValueMatchTypePromote) {
+  const unsigned int lt = GetParam().first;
+  const unsigned int rt = GetParam().second;
+  const Scalar a = RepresentativeValue(lt);
+  const Scalar b = RepresentativeSecondValue(rt);
+  const unsigned int expected_dtype = Type_class::type_promote(lt, rt);
+
+  const cytnx_complex128 av = AsComplex(a);
+  const cytnx_complex128 bv = AsComplex(b);
+
+  // Exact value checks only make sense when the promoted dtype can
+  // represent the mathematically-exact result without truncation,
+  // saturation, or wraparound:
+  //  - Bool saturates (true+true == true, not 2) -- never exact-comparable.
+  //  - Unsigned dtypes wrap around on results that go negative
+  //    mathematically (e.g. bool(1) - uint64(3)) -- not exact-comparable for
+  //    -,  since our representative values (6, 3) can produce a negative
+  //    mathematical difference when the Bool representative (1) is
+  //    involved.
+  const bool result_is_bool = (expected_dtype == Type.Bool);
+  const bool result_is_unsigned = Type.is_unsigned(expected_dtype);
+
+  {
+    Scalar r = a + b;
+    EXPECT_EQ(r.dtype(), expected_dtype) << Type.getname(lt) << " + " << Type.getname(rt);
+    if (!result_is_bool) {
+      cytnx_complex128 got = AsComplex(r);
+      EXPECT_NEAR(got.real(), (av + bv).real(), 1e-6);
+      EXPECT_NEAR(got.imag(), (av + bv).imag(), 1e-6);
+    }
+  }
+  {
+    Scalar r = a - b;
+    EXPECT_EQ(r.dtype(), expected_dtype) << Type.getname(lt) << " - " << Type.getname(rt);
+    const bool would_underflow_unsigned = result_is_unsigned && (av - bv).real() < 0;
+    if (!result_is_bool && !would_underflow_unsigned) {
+      cytnx_complex128 got = AsComplex(r);
+      EXPECT_NEAR(got.real(), (av - bv).real(), 1e-6);
+      EXPECT_NEAR(got.imag(), (av - bv).imag(), 1e-6);
+    }
+  }
+  {
+    Scalar r = a * b;
+    EXPECT_EQ(r.dtype(), expected_dtype) << Type.getname(lt) << " * " << Type.getname(rt);
+    if (!result_is_bool) {
+      cytnx_complex128 got = AsComplex(r);
+      EXPECT_NEAR(got.real(), (av * bv).real(), 1e-6);
+      EXPECT_NEAR(got.imag(), (av * bv).imag(), 1e-6);
+    }
+  }
+  {
+    Scalar r = a / b;
+    EXPECT_EQ(r.dtype(), expected_dtype) << Type.getname(lt) << " / " << Type.getname(rt);
+    cytnx_complex128 got = AsComplex(r);
+    cytnx_complex128 expected = av / bv;
+    // Integer division truncates; only compare exactly for float/complex
+    // promoted results, otherwise just check the promoted dtype and that no
+    // exception was thrown (integer truncation/saturation is
+    // dtype-appropriate).
+    if (Type.is_float(expected_dtype)) {
+      EXPECT_NEAR(got.real(), expected.real(), 1e-6);
+      EXPECT_NEAR(got.imag(), expected.imag(), 1e-6);
+    }
+  }
+}
+
+TEST_P(ScalarPromotionMatrixTest, EqualityMatchesComplexWidenedReference) {
+  const unsigned int lt = GetParam().first;
+  const unsigned int rt = GetParam().second;
+  const Scalar a = RepresentativeValue(lt);
+  const Scalar b = RepresentativeValue(rt);  // same representative -> equal magnitude pattern
+  bool expect_eq = (AsComplex(a) == AsComplex(b));
+  EXPECT_EQ(a.eq(b), expect_eq) << Type.getname(lt) << " == " << Type.getname(rt);
+}
+
+TEST_P(ScalarPromotionMatrixTest, OrderingComparisonThrowsOnlyForComplexOtherwiseMatches) {
+  // Ordering comparisons (< <= > >=) promote via Type.type_promote just like
+  // arithmetic, and are well-defined for any real (non-complex) promoted
+  // dtype -- including mixed signed/unsigned integers, which promote
+  // unambiguously to a definite dtype before comparing. Only complex
+  // operands are rejected (complex has no total order).
+  const unsigned int lt = GetParam().first;
+  const unsigned int rt = GetParam().second;
+  const Scalar a = RepresentativeValue(lt);
+  const Scalar b = RepresentativeSecondValue(rt);
+
+  const bool involves_complex = Type.is_complex(lt) || Type.is_complex(rt);
+
+  if (involves_complex) {
+    ExpectThrows([&] { return a < b; });
+  } else {
+    bool expected = AsComplex(a).real() < AsComplex(b).real();
+    EXPECT_EQ(a < b, expected) << Type.getname(lt) << " < " << Type.getname(rt);
+  }
+}
+
+TEST(ScalarTest, MixedSignedUnsignedEqualityFollowsTypePromoteTableQuirk) {
+  // Pins a known consequence of the sanctioned type_promote table (#982):
+  // type_promote(Int64, Uint64) == Int64, so comparing Int64(-1) against
+  // Uint64 max converts the unsigned value into Int64 (wrapping to -1) and
+  // the equality evaluates TRUE, even though the two values are
+  // mathematically different. This is intentional, per explicit maintainer
+  // ruling (2026-07-07): Scalar comparisons and arithmetic follow the
+  // type_promote table uniformly (in-place and out-of-place consistent);
+  // any future tightening of this mixed-signedness behavior happens in the
+  // table itself, not in Scalar. (#937 had instead disabled mixed
+  // signed/unsigned comparisons outright; that guard is superseded.)
+  const Scalar a(cytnx_int64(-1));
+  const Scalar b(std::numeric_limits<cytnx_uint64>::max());
+  EXPECT_TRUE(a == b);
+}
+
+std::vector<std::pair<unsigned int, unsigned int>> AllDtypePairs() {
+  std::vector<std::pair<unsigned int, unsigned int>> pairs;
+  for (unsigned int lt : kAllDtypes) {
+    for (unsigned int rt : kAllDtypes) {
+      pairs.emplace_back(lt, rt);
+    }
+  }
+  return pairs;
+}
+
+// Short, unambiguous per-dtype tag for parameterized-test names (the full
+// Type.getname() strings contain spaces/parentheses and collide when
+// truncated).
+std::string DtypeShortName(unsigned int dtype) {
+  if (dtype == Type.ComplexDouble) return "CD";
+  if (dtype == Type.ComplexFloat) return "CF";
+  if (dtype == Type.Double) return "F64";
+  if (dtype == Type.Float) return "F32";
+  if (dtype == Type.Int64) return "I64";
+  if (dtype == Type.Uint64) return "U64";
+  if (dtype == Type.Int32) return "I32";
+  if (dtype == Type.Uint32) return "U32";
+  if (dtype == Type.Int16) return "I16";
+  if (dtype == Type.Uint16) return "U16";
+  if (dtype == Type.Bool) return "B";
+  return "X" + std::to_string(dtype);
+}
+
+std::string DtypePairTestName(
+  const ::testing::TestParamInfo<std::pair<unsigned int, unsigned int>> &info) {
+  return DtypeShortName(info.param.first) + "_" + DtypeShortName(info.param.second);
+}
+
+INSTANTIATE_TEST_SUITE_P(AllDtypeCombinations, ScalarPromotionMatrixTest,
+                         ::testing::ValuesIn(AllDtypePairs()), DtypePairTestName);
+
+// ===========================================================================
+// In-place throw matrix: for every ordered dtype pair, in-place += must
+// throw iff Type.type_promote(lhs, rhs) != lhs.dtype().
+// ===========================================================================
+
+class ScalarInplaceThrowMatrixTest
+    : public ::testing::TestWithParam<std::pair<unsigned int, unsigned int>> {};
+
+TEST_P(ScalarInplaceThrowMatrixTest, InplaceAddThrowsExactlyWhenLossy) {
+  const unsigned int lt = GetParam().first;
+  const unsigned int rt = GetParam().second;
+  const bool should_throw = Type_class::type_promote(lt, rt) != lt;
+
+  Scalar lhs = RepresentativeValue(lt);
+  Scalar rhs = RepresentativeSecondValue(rt);
+
+  if (should_throw) {
+    ExpectThrows([&] { lhs += rhs; });
+  } else {
+    EXPECT_NO_THROW({ lhs += rhs; }) << Type.getname(lt) << " += " << Type.getname(rt);
+    EXPECT_EQ(lhs.dtype(), lt);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllDtypeCombinations, ScalarInplaceThrowMatrixTest,
+                         ::testing::ValuesIn(AllDtypePairs()), DtypePairTestName);
+
+// ===========================================================================
+// Storage::set_item(idx, Scalar) / Sproxy round-trip
+// ===========================================================================
+
+TEST(ScalarStorageSproxyTest, SetItemViaSproxyRoundTripsAcrossDtypes) {
+  for (unsigned int dt : kAllDtypes) {
+    cytnx::Storage s(4, dt);
+    Scalar v = RepresentativeValue(dt);
+    s(1) = v;
+    Scalar got = s(1);
+    EXPECT_EQ(got.dtype(), dt) << Type.getname(dt);
+    EXPECT_TRUE(got.eq(v)) << Type.getname(dt);
+  }
+}
+
+TEST(ScalarStorageSproxyTest, SetItemFromCrossDtypeScalarConvertsIntoStorageDtype) {
+  cytnx::Storage s(2, Type.Double);
+  s(0) = Scalar(cytnx_int64(7));
+  Scalar got = s(0);
+  EXPECT_EQ(got.dtype(), Type.Double);
+  EXPECT_DOUBLE_EQ(static_cast<cytnx_double>(got), 7.0);
+}
+
+TEST(ScalarStorageSproxyTest, SetItemFromVoidScalarThrows) {
+  cytnx::Storage s(2, Type.Double);
+  Scalar void_scalar;
+  EXPECT_THROW({ s(0) = void_scalar; }, std::logic_error);
+}


### PR DESCRIPTION
Stacked on #1011 (`refactor/scalar-variant`) — the fixed behavior is pre-existing on master `d6dcd160`, but the regression tests that pinned the old behavior live in that branch's `pytests/scalar_variant_test.py`, so this lands on top of it and flips them in the same commit.

## Problem

`scalar_py.cpp` registered the plain C++ integral constructors ahead of the `py::numpy_scalar<T>` `__init__` overloads. pybind11's plain arithmetic casters accept any `__index__`-capable object even in the no-convert pass — the exact trap documented under "KEEP-SET ORDERING" in `pybind/pyint_dispatch.hpp` (PR #991). Observed on the previous overload set:

| input | before | after |
|---|---|---|
| `np.uint64/int32/uint32/int16/uint16` (in range) | `Int64` | own dtype |
| `np.uint64(2**64-1)` | `Uint64` (int64 caster overflows, falls through) | `Uint64` (unchanged) |
| `Scalar(5)` / `Scalar(2**63)` | `Uint64` / `Uint64` | `Int64` / `Uint64` (magnitude dispatch) |
| `Scalar(2**64)` | **silently `ComplexDouble`** (complex ctor convert pass) | clean error |
| `Scalar(True)` | `Uint64` | `Bool` |
| `bool(Scalar(np.int32(0)))` | `True` (no `__bool__`, default truthiness) | `False` |
| Bool-storage `storage[i] = Scalar(np.bool_(True))` | `RuntimeError: Unable to cast` | works |

## Fix

- Rebind the constructor overload set in the canonical keep-set order: numpy scalars first, then Python `bool` (must precede `py::int_`, which accepts `bool` as an `int` subclass), then a single `py::int_` overload dispatching on magnitude via `dispatch_pyint`, then `double`/`complex128` (absorbing their `np.float64`/`np.complex128` subclasses). Per the discipline, the per-C++-dtype integral constructors and the redundant `numpy_scalar<double>`/`numpy_scalar<complex<double>>` overloads are dropped.
- Add `Scalar.__bool__` with numpy-consistent semantics (nonzero → `True`; either component for complex). This also fills the `nb_bool` slot pybind11's bool caster requires, unblocking Bool-storage round-trips through Scalar.

## Tests

TDD: tests flipped/added first and confirmed failing (21 red) on the unfixed build, then green after the reorder. `pytests/scalar_variant_test.py`: the former `*_narrower_ints_preexisting_quirk` test now asserts correct dtypes inside `test_numpy_scalar_constructor_paths` (all 11 dtypes); new coverage for uint64-above-int64-max value preservation, plain-int magnitude dispatch + out-of-range error, bool/float/complex constructor dtypes, `__bool__` truthiness across all dtypes, and the Bool row in the Storage round-trip.

Full pytest suite against the dev build: **117 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
