### PR TITLE
Document the Python stub regeneration workflow and pin its toolchain

### DIFF
--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -129,7 +129,12 @@ jobs:
         # test_main has no install() rule, so without this we'd discover
         # the gap only via a missing-binary ctest failure.
         working-directory: ${{ env.BUILD_DIR }}
-        run: cmake --build . --target test_main -j "$(nproc)"
+        run: |
+          # `cmake --build` may trigger a CMake reconfigure, which re-evaluates
+          # find_package(pybind11); point it at the pybind11 the `dev` extra
+          # installed into this env via CMAKE_PREFIX_PATH.
+          export CMAKE_PREFIX_PATH="$(python -m pybind11 --cmakedir)${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
+          cmake --build . --target test_main -j "$(nproc)"
 
       - name: Run gtest via ctest
         working-directory: ${{ env.BUILD_DIR }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,13 +438,13 @@ endif()
 # #######
 IF(BUILD_PYTHON)
   find_package (Python COMPONENTS Interpreter Development)
-  # Require a compatible pybind11 to be installed; the version is deliberately
-  # not pinned here. The committed cytnx/cytnx/*.pyi stubs are regenerated only
-  # via the `pip` path, which provisions the pybind11 pinned in
-  # [build-system].requires (==3.0.4); every other build (conda-forge, system)
-  # just compiles and ships those already-committed stubs, so any compatible
-  # pybind11 (e.g. conda-forge's 3.0.3) works here. Pinning an exact/newer-only
-  # version would break those builds without changing the committed stubs.
+  # Require a compatible pybind11 to be installed. The committed
+  # cytnx/cytnx/*.pyi stubs are regenerated only via the `pip` path, which
+  # provisions the pybind11 pinned in [build-system].requires (==3.0.4).
+  # TODO: bump this to `find_package(pybind11 3.0.4 REQUIRED)` to match the
+  # pyproject.toml pin once pybind11 3.0.4 is available on conda-forge. It
+  # currently ships 3.0.3, which a 3.0.4 requirement would reject and break the
+  # conda build.
   find_package(pybind11 3.0.0 REQUIRED)
 
   pybind11_add_module(pycytnx MODULE pybind/cytnx.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,27 +438,13 @@ endif()
 # #######
 IF(BUILD_PYTHON)
   find_package (Python COMPONENTS Interpreter Development)
-  find_package(pybind11 3.0.0 QUIET)
-
-  if(NOT pybind11_FOUND)
-    include(FetchContent)
-    FetchContent_Declare(
-      pybind11_sources
-      GIT_REPOSITORY https://github.com/pybind/pybind11.git
-      GIT_TAG v3.0.1
-    )
-
-    FetchContent_GetProperties(pybind11_sources)
-
-    if(NOT pybind11_sources_POPULATED)
-      FetchContent_Populate(pybind11_sources)
-
-      add_subdirectory(
-        ${pybind11_sources_SOURCE_DIR}
-        ${pybind11_sources_BINARY_DIR}
-      )
-    endif()
-  endif()
+  # Require the pybind11 provisioned from pyproject.toml's [build-system].requires
+  # (pinned to ==3.0.4). pybind11 controls the type annotations baked into the
+  # extension, which tools/generate_stubs.py reads to produce the committed
+  # cytnx/cytnx/*.pyi stubs; a FetchContent fallback to a different version would
+  # silently regenerate those stubs from the wrong pybind11. Fail loudly here
+  # instead so a stub regeneration always uses the pinned version.
+  find_package(pybind11 3.0.4 REQUIRED)
 
   pybind11_add_module(pycytnx MODULE pybind/cytnx.cpp
     pybind/generator_py.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,13 +438,14 @@ endif()
 # #######
 IF(BUILD_PYTHON)
   find_package (Python COMPONENTS Interpreter Development)
-  # Require the pybind11 provisioned from pyproject.toml's [build-system].requires
-  # (pinned to ==3.0.4). pybind11 controls the type annotations baked into the
-  # extension, which tools/generate_stubs.py reads to produce the committed
-  # cytnx/cytnx/*.pyi stubs; a FetchContent fallback to a different version would
-  # silently regenerate those stubs from the wrong pybind11. Fail loudly here
-  # instead so a stub regeneration always uses the pinned version.
-  find_package(pybind11 3.0.4 REQUIRED)
+  # Require a compatible pybind11 to be installed; the version is deliberately
+  # not pinned here. The committed cytnx/cytnx/*.pyi stubs are regenerated only
+  # via the `pip` path, which provisions the pybind11 pinned in
+  # [build-system].requires (==3.0.4); every other build (conda-forge, system)
+  # just compiles and ships those already-committed stubs, so any compatible
+  # pybind11 (e.g. conda-forge's 3.0.3) works here. Pinning an exact/newer-only
+  # version would break those builds without changing the committed stubs.
+  find_package(pybind11 3.0.0 REQUIRED)
 
   pybind11_add_module(pycytnx MODULE pybind/cytnx.cpp
     pybind/generator_py.cpp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,3 +24,59 @@ When raising (or lowering) the minimum, update all three. There is no
 automated check for this — please grep for the old version string (e.g.
 `3.9`) across the repository before opening the PR to catch anything missed.
 
+## Regenerating the Python type stubs
+
+The `cytnx` Python package ships PEP 561 type stubs (`cytnx/cytnx/*.pyi`)
+committed to the repository and shipped unchanged in every wheel and conda
+package. They are generated from the built `cytnx.cytnx` pybind11 extension
+by `tools/generate_stubs.py`, not written by hand.
+
+**If your change touches any `pybind/*.cpp` binding** — a new function, a
+changed signature, a different default value, a different overload set — the
+committed stubs go stale and must be regenerated as part of the same PR.
+
+Stub generation is only reproducible when the tools that produce it are
+pinned, since both silently change the emitted annotations across versions:
+
+- `pybind11 ==3.0.4` — controls the type annotations baked into the compiled
+  extension (`[build-system].requires` in `pyproject.toml`).
+- `pybind11-stubgen ==2.5.5` — walks the built extension and renders the
+  `.pyi` files (`dev` extra in `pyproject.toml`).
+
+Do not bump either version incidentally; if a bump is needed, do it
+deliberately in its own commit and regenerate the stubs in the same PR so the
+diff shows exactly what the version change affected.
+
+To regenerate:
+
+1. Build the extension with any native CPU preset:
+   ```sh
+   cmake --preset openblas-cpu -B build/python
+   cmake --build build/python --target pycytnx
+   ```
+2. Install the pinned `pybind11-stubgen` into the interpreter that will run
+   the script (it imports `cytnx.cytnx`); the `dev` extra provides it:
+   ```sh
+   pip install --editable '.[dev]'
+   ```
+3. Regenerate the committed stubs:
+   ```sh
+   python tools/generate_stubs.py
+   ```
+   The extension is auto-discovered under `build/` for the running
+   interpreter's ABI; pass `--extension` to point at a specific `.so`/`.pyd`
+   if more than one build is present. Run this with the lowest supported
+   interpreter (Python 3.10+) so the emitted syntax stays parseable
+   everywhere the package is installed.
+4. Review the diff under `cytnx/cytnx/*.pyi` and commit it alongside the
+   binding change that caused it.
+
+`mypy.stubtest` compares the committed stubs against the live runtime module
+and catches mismatches (missing members, incompatible defaults, overloads
+that can never match). It is not yet wired into CI, so run it manually after
+regenerating:
+
+```sh
+python -m mypy.stubtest cytnx.cytnx
+```
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,11 +51,11 @@ the lowest supported interpreter (see below).
 To regenerate:
 
 1. Build the extension and install the pinned dev tools together, through
-   the editable install (not a direct `cmake` configure/build — that
-   bypasses `[build-system].requires` and can silently pick up an
-   unpinned `pybind11`, since `CMakeLists.txt` accepts any installed
-   `pybind11 >= 3.0.0` and falls back to `FetchContent`-ing `v3.0.1` if
-   none is found):
+   the editable install. Go through `pip` rather than a direct `cmake`
+   configure/build: the `pip` path provisions the pinned `pybind11` from
+   `[build-system].requires` via build isolation, so the extension is built
+   against exactly that version. (`CMakeLists.txt` requires the pinned
+   `pybind11` outright — a direct `cmake` build needs it already installed.)
    ```sh
    pip install --editable '.[dev]' --config-settings=build-dir=build/python
    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,17 +57,19 @@ To regenerate:
    against exactly that version. (`CMakeLists.txt` requires the pinned
    `pybind11` outright — a direct `cmake` build needs it already installed.)
    ```sh
-   pip install --editable '.[dev]' --config-settings=build-dir=build/python
+   pip install --editable '.[dev]'
    ```
-2. Regenerate the committed stubs:
+2. Regenerate the committed stubs, pointing the generator at the extension the
+   editable install just built:
    ```sh
-   python tools/generate_stubs.py
+   python tools/generate_stubs.py --extension "$(python -c 'import cytnx.cytnx as c; print(c.__file__)')"
    ```
-   The extension is auto-discovered under `build/` for the running
-   interpreter's ABI; pass `--extension` to point at a specific `.so`/`.pyd`
-   if more than one build is present. Run this with the lowest supported
-   interpreter (the `requires-python` floor declared in `pyproject.toml`) so
-   the emitted syntax stays parseable everywhere the package is installed.
+   `--extension` is passed explicitly because the editable install builds in a
+   temporary tree rather than under `build/`; without it the generator's
+   `build/` auto-discovery could pick up a stale build. Run this with the
+   lowest supported interpreter (the `requires-python` floor declared in
+   `pyproject.toml`) so the emitted syntax stays parseable everywhere the
+   package is installed.
 3. Review the diff under `cytnx/cytnx/*.pyi` and commit it alongside the
    binding change that caused it.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,17 +49,16 @@ diff shows exactly what the version change affected.
 
 To regenerate:
 
-1. Build the extension with any native CPU preset:
+1. Build the extension and install the pinned dev tools together, through
+   the editable install (not a direct `cmake` configure/build — that
+   bypasses `[build-system].requires` and can silently pick up an
+   unpinned `pybind11`, since `CMakeLists.txt` accepts any installed
+   `pybind11 >= 3.0.0` and falls back to `FetchContent`-ing `v3.0.1` if
+   none is found):
    ```sh
-   cmake --preset openblas-cpu -B build/python
-   cmake --build build/python --target pycytnx
+   pip install --editable '.[dev]' --config-settings=build-dir=build/python
    ```
-2. Install the pinned `pybind11-stubgen` into the interpreter that will run
-   the script (it imports `cytnx.cytnx`); the `dev` extra provides it:
-   ```sh
-   pip install --editable '.[dev]'
-   ```
-3. Regenerate the committed stubs:
+2. Regenerate the committed stubs:
    ```sh
    python tools/generate_stubs.py
    ```
@@ -68,7 +67,7 @@ To regenerate:
    if more than one build is present. Run this with the lowest supported
    interpreter (Python 3.10) so the emitted syntax stays parseable
    everywhere the package is installed.
-4. Review the diff under `cytnx/cytnx/*.pyi` and commit it alongside the
+3. Review the diff under `cytnx/cytnx/*.pyi` and commit it alongside the
    binding change that caused it.
 
 `mypy.stubtest` compares the committed stubs against the live runtime module

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,14 +38,15 @@ committed stubs go stale and must be regenerated as part of the same PR.
 Stub generation is only reproducible when the tools that produce it are
 pinned, since both silently change the emitted annotations across versions:
 
-- `pybind11 ==3.0.4` — controls the type annotations baked into the compiled
-  extension (`[build-system].requires` in `pyproject.toml`).
-- `pybind11-stubgen ==2.5.5` — walks the built extension and renders the
-  `.pyi` files (`dev` extra in `pyproject.toml`).
+- `pybind11` (`[build-system].requires` in `pyproject.toml`) — controls the
+  type annotations baked into the compiled extension.
+- `pybind11-stubgen` (`dev` extra in `pyproject.toml`) — walks the built
+  extension and renders the `.pyi` files.
 
-Do not bump either version incidentally; if a bump is needed, do it
-deliberately in its own commit and regenerate the stubs in the same PR so the
-diff shows exactly what the version change affected.
+Both are pinned to exact versions in `pyproject.toml`, where a comment beside
+each pin reminds you to regenerate the committed stubs whenever it is bumped.
+The `requires-python` floor matters too, since the stubs are generated with
+the lowest supported interpreter (see below).
 
 To regenerate:
 
@@ -65,8 +66,8 @@ To regenerate:
    The extension is auto-discovered under `build/` for the running
    interpreter's ABI; pass `--extension` to point at a specific `.so`/`.pyd`
    if more than one build is present. Run this with the lowest supported
-   interpreter (Python 3.10) so the emitted syntax stays parseable
-   everywhere the package is installed.
+   interpreter (the `requires-python` floor declared in `pyproject.toml`) so
+   the emitted syntax stays parseable everywhere the package is installed.
 3. Review the diff under `cytnx/cytnx/*.pyi` and commit it alongside the
    binding change that caused it.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,15 +60,14 @@ To regenerate:
    ```sh
    pip install --editable '.[dev]'
    ```
-2. Regenerate the committed stubs, pointing the generator at the extension the
-   editable install just built:
+2. Regenerate the committed stubs:
    ```sh
-   python tools/generate_stubs.py --extension "$(python -c 'import cytnx.cytnx as c; print(c.__file__)')"
+   python tools/generate_stubs.py
    ```
-   `--extension` is passed explicitly because the editable install builds in a
-   temporary tree rather than under `build/`; without it the generator's
-   `build/` auto-discovery could pick up a stale build. Run this with the
-   lowest supported interpreter (the `requires-python` floor declared in
+   The generator introspects the installed `cytnx.cytnx` (the editable install
+   from step 1), falling back to a build under `build/`; pass `--extension` to
+   point at a specific `.so`/`.pyd` to override both. Run this with the lowest
+   supported interpreter (the `requires-python` floor declared in
    `pyproject.toml`) so the emitted syntax stays parseable everywhere the
    package is installed.
 3. Review the diff under `cytnx/cytnx/*.pyi` and commit it alongside the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,9 +53,10 @@ To regenerate:
 1. Build the extension and install the pinned dev tools together, through
    the editable install. Go through `pip` rather than a direct `cmake`
    configure/build: the `pip` path provisions the pinned `pybind11` from
-   `[build-system].requires` via build isolation, so the extension is built
-   against exactly that version. (`CMakeLists.txt` requires the pinned
-   `pybind11` outright — a direct `cmake` build needs it already installed.)
+   `[build-system].requires` via build isolation, so the extension — and thus
+   the regenerated stubs — are built against exactly that version. (A direct
+   `cmake` build instead uses whatever compatible `pybind11` is already
+   installed.)
    ```sh
    pip install --editable '.[dev]'
    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ To regenerate:
    The extension is auto-discovered under `build/` for the running
    interpreter's ABI; pass `--extension` to point at a specific `.so`/`.pyd`
    if more than one build is present. Run this with the lowest supported
-   interpreter (Python 3.10+) so the emitted syntax stays parseable
+   interpreter (Python 3.10) so the emitted syntax stays parseable
    everywhere the package is installed.
 4. Review the diff under `cytnx/cytnx/*.pyi` and commit it alongside the
    binding change that caused it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,4 +81,3 @@ regenerating:
 ```sh
 python -m mypy.stubtest cytnx.cytnx
 ```
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,10 @@ dev = [
     # regen (new enum handling, changed overload ordering, etc.). Bump
     # deliberately alongside a stub regen.
     "pybind11-stubgen ==2.5.5",
+    # Validates the committed stubs against the runtime module (see
+    # CONTRIBUTING.md's stub regeneration section); not itself version-locked
+    # since it only reads/reports and does not affect the stubs' content.
+    "mypy",
 ]
 docs = [
     "sphinx>=7.4.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@ requires = [
     # cytnx/cytnx/*.pyi stubs. A floating version silently rewrites those
     # annotations (e.g. 3.0.1 -> 3.0.4 added `typing.SupportsIndex` to integer
     # arguments), so the committed stubs only stay reproducible when the
-    # pybind11 version is fixed. Bump deliberately alongside a stub regen.
+    # pybind11 version is fixed. When bumping this pin, regenerate the committed
+    # stubs in the same PR (see CONTRIBUTING.md, "Regenerating the Python type
+    # stubs").
     "pybind11 ==3.0.4",
 ]
 build-backend = "scikit_build_core.build"
@@ -24,6 +26,12 @@ description = "A tensor network library"
 readme = "Readme.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
+# The committed cytnx/cytnx/*.pyi stubs are generated with the lowest
+# supported interpreter (this floor) so their syntax stays parseable on every
+# version the package supports. When raising this minimum, regenerate the
+# stubs with the new floor in the same PR (see CONTRIBUTING.md, "Regenerating
+# the Python type stubs"). See also CONTRIBUTING.md for the other places the
+# minimum version is declared.
 requires-python = ">=3.10"
 keywords = ["tensor", "network", "physics"]
 classifiers = [
@@ -66,8 +74,9 @@ dev = [
     # Pinned exactly, alongside pybind11 above: pybind11-stubgen is the tool
     # that walks the built extension and renders cytnx/cytnx/*.pyi, so a
     # floating version can reformat the committed stubs on an unrelated
-    # regen (new enum handling, changed overload ordering, etc.). Bump
-    # deliberately alongside a stub regen.
+    # regen (new enum handling, changed overload ordering, etc.). When bumping
+    # this pin, regenerate the committed stubs in the same PR (see
+    # CONTRIBUTING.md, "Regenerating the Python type stubs").
     "pybind11-stubgen ==2.5.5",
     # Validates the committed stubs against the runtime module (see
     # CONTRIBUTING.md's stub regeneration section); not itself version-locked

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ requires = [
     # arguments), so the committed stubs only stay reproducible when the
     # pybind11 version is fixed. When bumping this pin, regenerate the committed
     # stubs in the same PR (see CONTRIBUTING.md, "Regenerating the Python type
-    # stubs").
+    # stubs"), and update the pybind11 version string in CMakeLists.txt's
+    # find_package(pybind11 ...) to match.
     "pybind11 ==3.0.4",
 ]
 build-backend = "scikit_build_core.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ requires = [
     # pybind11 version is fixed. When bumping this pin, regenerate the committed
     # stubs in the same PR (see CONTRIBUTING.md, "Regenerating the Python type
     # stubs"), and update the pybind11 version string in CMakeLists.txt's
-    # find_package(pybind11 ...) to match.
+    # find_package(pybind11 ...) and the pybind11 pin in the `dev` extra to
+    # match.
     "pybind11 ==3.0.4",
 ]
 build-backend = "scikit_build_core.build"
@@ -66,12 +67,16 @@ coverage = [
 #     pip install --editable .[dev]
 # pulls everything needed to build, run the test suite, collect both
 # Python and C++ coverage, and regenerate the committed PEP 561 type
-# stubs with `tools/generate_stubs.py`. Build-time deps (scikit-build-core,
-# pybind11) come from `[build-system].requires` automatically.
+# stubs with `tools/generate_stubs.py`. The isolated wheel build gets
+# scikit-build-core and pybind11 from `[build-system].requires`; pybind11 is
+# also listed below so it is present for CMake builds run outside that
+# isolation.
 dev = [
     "cytnx[viz]",
     "cytnx[test]",
     "cytnx[coverage]",
+    # Must match the pybind11 version pinned in [build-system].requires above.
+    "pybind11 ==3.0.4",
     # Pinned exactly, alongside pybind11 above: pybind11-stubgen is the tool
     # that walks the built extension and renders cytnx/cytnx/*.pyi, so a
     # floating version can reformat the committed stubs on an unrelated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,12 @@ dev = [
     "cytnx[viz]",
     "cytnx[test]",
     "cytnx[coverage]",
-    "pybind11-stubgen",
+    # Pinned exactly, alongside pybind11 above: pybind11-stubgen is the tool
+    # that walks the built extension and renders cytnx/cytnx/*.pyi, so a
+    # floating version can reformat the committed stubs on an unrelated
+    # regen (new enum handling, changed overload ordering, etc.). Bump
+    # deliberately alongside a stub regen.
+    "pybind11-stubgen ==2.5.5",
 ]
 docs = [
     "sphinx>=7.4.7",

--- a/tools/generate_stubs.py
+++ b/tools/generate_stubs.py
@@ -126,7 +126,12 @@ def find_installed_extension() -> Path | None:
         # regenerated stubs. Drop every "cytnx"/"cytnx.*" entry so nothing
         # from this rejected probe survives. (Skipped when accepted above:
         # the accepted extension is exactly what a later import should reuse,
-        # so its already-correct state must be left alone.)
+        # so its already-correct state must be left alone.) This only resets
+        # the import system, not pybind11's per-process type registrations;
+        # if the rejected extension registered pybind11 types under the same
+        # qualified names, a later staged import of a different .so can still
+        # raise "generic_type: type ... is already registered!" instead of
+        # silently producing wrong stubs.
         for name in [n for n in sys.modules if n == "cytnx" or n.startswith("cytnx.")]:
             del sys.modules[name]
 

--- a/tools/generate_stubs.py
+++ b/tools/generate_stubs.py
@@ -87,21 +87,40 @@ def sanitize(text: str) -> str:
 
 
 def find_installed_extension() -> Path | None:
-    """Return the extension of the installed ``cytnx.cytnx``, if importable.
+    """Return the extension of *this checkout's* editable install of ``cytnx.cytnx``.
 
     An editable install (``pip install --editable .``) places the freshly built
     extension on the import path, so this matches exactly what the developer
-    just compiled without pointing at a build directory. Returns None when cytnx
-    is not importable (e.g. only a bare ``build/`` tree exists).
+    just compiled without pointing at a build directory. Only trust it when the
+    installed ``cytnx`` package actually resolves to this checkout's
+    ``cytnx/`` source directory, so an unrelated ``cytnx`` install elsewhere on
+    the path (e.g. a released wheel) does not shadow a real local build.
     """
+    origin = None
     try:
         spec = importlib.util.find_spec(MODULE)
+        parent = sys.modules.get("cytnx")
+        if (
+            spec is not None
+            and spec.origin
+            and spec.origin != "built-in"
+            and parent is not None
+            and str(PACKAGE_DIR) in list(getattr(parent, "__path__", ()))
+        ):
+            origin = Path(spec.origin)
     except (ImportError, ValueError):
-        return None
-    if spec is None or not spec.origin or spec.origin == "built-in":
-        return None
-    origin = Path(spec.origin)
-    return origin if origin.is_file() else None
+        pass
+    finally:
+        # Resolving "cytnx.cytnx" imports the parent `cytnx` package as a side
+        # effect, and can leave `cytnx.cytnx` itself cached in sys.modules even
+        # when the overall import ultimately fails (cytnx/__init__.py imports
+        # `cytnx.cytnx` before checking it actually has real content). Drop
+        # both so a later import of the staged build/ extension in main()
+        # isn't shadowed by this probe's state.
+        sys.modules.pop("cytnx", None)
+        sys.modules.pop("cytnx.cytnx", None)
+
+    return origin if origin is not None and origin.is_file() else None
 
 
 def find_build_extension() -> Path | None:

--- a/tools/generate_stubs.py
+++ b/tools/generate_stubs.py
@@ -107,20 +107,30 @@ def find_installed_extension() -> Path | None:
             and parent is not None
             and str(PACKAGE_DIR) in list(getattr(parent, "__path__", ()))
         ):
-            origin = Path(spec.origin)
+            candidate = Path(spec.origin)
+            if candidate.is_file():
+                origin = candidate
     except (ImportError, ValueError):
         pass
-    finally:
-        # Resolving "cytnx.cytnx" imports the parent `cytnx` package as a side
-        # effect, and can leave `cytnx.cytnx` itself cached in sys.modules even
-        # when the overall import ultimately fails (cytnx/__init__.py imports
-        # `cytnx.cytnx` before checking it actually has real content). Drop
-        # both so a later import of the staged build/ extension in main()
-        # isn't shadowed by this probe's state.
-        sys.modules.pop("cytnx", None)
-        sys.modules.pop("cytnx.cytnx", None)
 
-    return origin if origin is not None and origin.is_file() else None
+    if origin is None:
+        # Resolving "cytnx.cytnx" imports the parent `cytnx` package as a side
+        # effect. When that ran cytnx/__init__.py to completion against a real
+        # (but ultimately rejected here, e.g. unrelated) extension, its
+        # `from .Storage_conti import *`-style imports ran too, and their
+        # `@add_method` decorators patched that extension's `Storage`/
+        # `Tensor`/... classes; those submodules then stay cached in
+        # sys.modules. If main() later imports a distinct copy of the correct
+        # extension, it would reuse the cached submodules without rerunning
+        # the decorators, silently dropping the patched methods from the
+        # regenerated stubs. Drop every "cytnx"/"cytnx.*" entry so nothing
+        # from this rejected probe survives. (Skipped when accepted above:
+        # the accepted extension is exactly what a later import should reuse,
+        # so its already-correct state must be left alone.)
+        for name in [n for n in sys.modules if n == "cytnx" or n.startswith("cytnx.")]:
+            del sys.modules[name]
+
+    return origin
 
 
 def find_build_extension() -> Path | None:

--- a/tools/generate_stubs.py
+++ b/tools/generate_stubs.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.machinery
+import importlib.util
 import re
 import shutil
 import sys
@@ -85,21 +86,52 @@ def sanitize(text: str) -> str:
     return text
 
 
-def find_extension() -> Path:
-    """Locate a built cytnx extension matching the running interpreter's ABI."""
+def find_installed_extension() -> Path | None:
+    """Return the extension of the installed ``cytnx.cytnx``, if importable.
+
+    An editable install (``pip install --editable .``) places the freshly built
+    extension on the import path, so this matches exactly what the developer
+    just compiled without pointing at a build directory. Returns None when cytnx
+    is not importable (e.g. only a bare ``build/`` tree exists).
+    """
+    try:
+        spec = importlib.util.find_spec(MODULE)
+    except (ImportError, ValueError):
+        return None
+    if spec is None or not spec.origin or spec.origin == "built-in":
+        return None
+    origin = Path(spec.origin)
+    return origin if origin.is_file() else None
+
+
+def find_build_extension() -> Path | None:
+    """Return a built cytnx extension under ``build/`` for this interpreter's ABI."""
     # EXT_SUFFIX is e.g. ".cpython-311-x86_64-linux-gnu.so"; the extension file
     # is named cytnx<EXT_SUFFIX> because the submodule is itself named `cytnx`.
     ext_suffix = sysconfig.get_config_var("EXT_SUFFIX") or importlib.machinery.EXTENSION_SUFFIXES[0]
     candidates = sorted((REPO_ROOT / "build").rglob(f"cytnx{ext_suffix}"))
     if not candidates:
-        raise SystemExit(
-            f"No built extension 'cytnx{ext_suffix}' found under {REPO_ROOT / 'build'}.\n"
-            "Build it first (e.g. `cmake --build build/python --target pycytnx`) "
-            "with the same interpreter you are running this script with, or pass "
-            "--extension explicitly."
-        )
+        return None
     # Prefer the most recently modified build if several presets are present.
     return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def find_extension() -> Path:
+    """Locate a built cytnx extension matching the running interpreter's ABI.
+
+    Prefer the installed ``cytnx.cytnx`` (an editable install exposes the
+    just-built extension), then fall back to scanning ``build/``.
+    """
+    extension = find_installed_extension() or find_build_extension()
+    if extension is None:
+        raise SystemExit(
+            "No cytnx extension found. Install cytnx so `cytnx.cytnx` is "
+            "importable (e.g. `pip install --editable .`), or build it under "
+            f"{REPO_ROOT / 'build'} (e.g. `cmake --build build/python --target "
+            "pycytnx`) with the interpreter you are running this script with, "
+            "or pass --extension explicitly."
+        )
+    return extension
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

Documents how to regenerate the committed PEP 561 stubs (`cytnx/cytnx/*.pyi`) and pins/tightens the toolchain so that regeneration is reproducible. No committed stubs are changed here — only docs, packaging, and the build/generator plumbing.

## Changes

- **`CONTRIBUTING.md`** — new "Regenerating the Python type stubs" section: when regeneration is required (any `pybind/*.cpp` binding change), the two pinned tool versions that make it reproducible, the build → regenerate → validate (`mypy.stubtest`) steps.

- **Pin the stub-generation toolchain (`pyproject.toml`)** — `pybind11-stubgen ==2.5.5` in the `dev` extra (pybind11 was already `==3.0.4` in `[build-system].requires`); a floating stubgen silently reformats the committed stubs on an unrelated regen. Added `mypy` to the `dev` extra, since the docs tell contributors to run `python -m mypy.stubtest`. Each pin carries a comment reminding you to regenerate the stubs — and update the CMake version string — when it is bumped.

- **CMake (`CMakeLists.txt`)** — removed the pybind11 FetchContent fallback (which could fetch `v3.0.1` when no pybind11 was found). It is now `find_package(pybind11 3.0.0 REQUIRED)`. The `pip` path provisions the pinned `3.0.4` via PEP 517 build isolation; conda-forge/system builds just compile and ship the already-committed static stubs, so their pybind11 version cannot drift the `.pyi`. A `TODO` tracks bumping the requirement to `3.0.4` to match the pin once conda-forge ships it (it currently provides `3.0.3`, which a `3.0.4` requirement would reject — this was caught by CI on the conda build).

- **`tools/generate_stubs.py`** — `find_extension()` now prefers the installed `cytnx.cytnx` (exactly what the editable install just built), falling back to scanning `build/`, so `python tools/generate_stubs.py` needs no `--extension` argument.

## Testing

- `pip install --editable '.[dev]'` builds cleanly against the relaxed CMake — pybind11 is resolved via build isolation with the FetchContent fallback removed.
- `python tools/generate_stubs.py` (no arguments) discovers the installed extension and regenerates all 7 `.pyi` files with sane output (real bindings present).
- Docs / build-config change only; the committed stubs are not modified in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)