### PR TITLE
refactor(UniTensor): add versioned file header

### DIFF
--- a/src/UniTensor.cpp
+++ b/src/UniTensor.cpp
@@ -11,6 +11,38 @@
 #else
 
 namespace cytnx {
+  namespace {
+    constexpr unsigned int kLegacyUniTensorMagic = 555;
+    constexpr unsigned int kVersionedUniTensorMagic = 556;
+    constexpr unsigned int kCurrentUniTensorFileVersion = 1;
+
+    boost::intrusive_ptr<UniTensor_base> make_unitensor_impl_from_type(const int utentype) {
+      if (utentype == UTenType.Dense) {
+        return boost::intrusive_ptr<UniTensor_base>(new DenseUniTensor());
+      }
+      if (utentype == UTenType.Block) {
+        return boost::intrusive_ptr<UniTensor_base>(new BlockUniTensor());
+      }
+      if (utentype == UTenType.BlockFermionic) {
+        return boost::intrusive_ptr<UniTensor_base>(new BlockFermionicUniTensor());
+      }
+
+      cytnx_error_msg(utentype == UTenType.Void,
+                      "[ERROR][UniTensor::_Load] The file contains an uninitialized UniTensor of "
+                      "type Void. The file seems corrupt.%s",
+                      "\n");
+      cytnx_error_msg(utentype == UTenType.Sparse,
+                      "[ERROR][UniTensor::_Load] The file contains a SparseUniTensor, which is "
+                      "deprecated (saved with an old Cytnx version, or the file is corrupt). Use "
+                      "BlockUniTensor or LinOp instead.%s",
+                      "\n");
+      cytnx_error_msg(true,
+                      "[ERROR][UniTensor::_Load] Unknown UniTensor type id '%d' (corrupt or "
+                      "incompatible file?)\n",
+                      utentype);
+      return boost::intrusive_ptr<UniTensor_base>();
+    }
+  }  // namespace
 
   UniTensor UniTensor::Pow(const double &p) const { return cytnx::linalg::Pow(*this, p); }
   UniTensor &UniTensor::Pow_(const double &p) {
@@ -44,8 +76,11 @@ namespace cytnx {
                     "[ERROR] SparseUniTensor is deprecated. Use BlockUniTensor or LinOp instead.%s",
                     "\n");
 
-    unsigned int IDDs = 555;
+    unsigned int IDDs = kVersionedUniTensorMagic;
     f.write((char *)&IDDs, sizeof(unsigned int));
+    unsigned int version = kCurrentUniTensorFileVersion;
+    f.write((char *)&version, sizeof(unsigned int));
+
     // first, save common meta data:
     f.write((char *)&this->_impl->uten_type_id,
             sizeof(int));  // uten type, this is used to determine Block/Dense upon load
@@ -84,32 +119,21 @@ namespace cytnx {
 
     unsigned int tmpIDDs;
     f.read((char *)&tmpIDDs, sizeof(unsigned int));
-    cytnx_error_msg(tmpIDDs != 555, "[ERROR] the object is not a cytnx UniTensor!%s", "\n");
+    if (tmpIDDs == kVersionedUniTensorMagic) {
+      unsigned int version;
+      f.read((char *)&version, sizeof(unsigned int));
+      cytnx_error_msg(version != kCurrentUniTensorFileVersion,
+                      "[ERROR][UniTensor::_Load] Unsupported UniTensor file format version '%u'.%s",
+                      version, "\n");
+    } else {
+      cytnx_error_msg(tmpIDDs != kLegacyUniTensorMagic,
+                      "[ERROR] the object is not a cytnx UniTensor!%s", "\n");
+    }
 
     int utentype;
     f.read((char *)&utentype,
            sizeof(int));  // uten type, this is used to determine Block/Dense upon load
-    if (utentype == UTenType.Dense) {
-      this->_impl = boost::intrusive_ptr<UniTensor_base>(new DenseUniTensor());
-    } else if (utentype == UTenType.Block) {
-      this->_impl = boost::intrusive_ptr<UniTensor_base>(new BlockUniTensor());
-    } else if (utentype == UTenType.BlockFermionic) {
-      this->_impl = boost::intrusive_ptr<UniTensor_base>(new BlockFermionicUniTensor());
-    } else {
-      cytnx_error_msg(utentype == UTenType.Void,
-                      "[ERROR][UniTensor::_Load] The file contains an uninitialized UniTensor of "
-                      "type Void. The file seems corrupt.%s",
-                      "\n");
-      cytnx_error_msg(utentype == UTenType.Sparse,
-                      "[ERROR][UniTensor::_Load] The file contains a SparseUniTensor, which is "
-                      "deprecated (saved with an old Cytnx version, or the file is corrupt). Use "
-                      "BlockUniTensor or LinOp instead.%s",
-                      "\n");
-      cytnx_error_msg(true,
-                      "[ERROR][UniTensor::_Load] Unknown UniTensor type id '%d' (corrupt or "
-                      "incompatible file?)\n",
-                      utentype);
-    }
+    this->_impl = make_unitensor_impl_from_type(utentype);
 
     f.read((char *)&this->_impl->_is_braket_form, sizeof(bool));
     f.read((char *)&this->_impl->_is_tag, sizeof(bool));

--- a/tests/DenseUniTensor_test.cpp
+++ b/tests/DenseUniTensor_test.cpp
@@ -1,6 +1,7 @@
 #include "DenseUniTensor_test.h"
 
 #include <cstdio>
+#include <fstream>
 #include <filesystem>
 
 #include "test_tools.h"
@@ -4974,6 +4975,17 @@ TEST_F(DenseUniTensorTest, Save) {
   auto ut = UniTensor(bonds, labels, row_rank);
   random::uniform_(ut, 0.0, 5.0, seed);
   ut.Save(temp_file_path);
+  {
+    std::ifstream header(temp_file_path, std::ios::binary);
+    ASSERT_TRUE(header.is_open());
+    unsigned int magic = 0;
+    unsigned int version = 0;
+    header.read(reinterpret_cast<char *>(&magic), sizeof(magic));
+    header.read(reinterpret_cast<char *>(&version), sizeof(version));
+    EXPECT_EQ(magic, 556);
+    EXPECT_EQ(version, 1);
+  }
+
   UniTensor ut_loaded = UniTensor::Load(temp_file_path);
   EXPECT_TRUE(AreEqUniTensor(ut_loaded, ut));
   // for char*


### PR DESCRIPTION
Add an explicit file-format version to UniTensor serialization.

Cytnx UniTensor files previously used only the magic value `555`, followed immediately by the serialized payload. That leaves no clean way to evolve the format for future changes such as new quantum-number/sector types, updated block metadata, or revised storage layouts.

This PR introduces a versioned UniTensor header:

```text
magic = 556
version = 1
payload = existing UniTensor payload
```

The payload for version 1 is unchanged from the existing format. The loader accepts both the new versioned header and the legacy `555` header, so existing UniTensor files remain readable.

Using a new magic value avoids making old Cytnx versions silently misread a versioned file as if the version field were the UniTensor type. Old versions will reject the new file immediately instead of corrupting the load state.

The load-side UniTensor implementation selection was also factored into a small helper, keeping the Dense/Block/BlockFermionic dispatch in one place and preserving the existing error paths for Void, Sparse, and unknown UniTensor type ids.