### PR TITLE
fix(UniTensor): read file names without requiring null terminator

### DIFF
--- a/src/UniTensor.cpp
+++ b/src/UniTensor.cpp
@@ -119,10 +119,8 @@ namespace cytnx {
     cytnx_uint32 len_name;
     f.read((char *)&len_name, sizeof(cytnx_uint32));
     if (len_name != 0) {
-      char *cname = (char *)malloc(sizeof(char) * len_name);
-      f.read(cname, sizeof(char) * len_name);
-      this->_impl->_name = std::string(cname);
-      free(cname);
+      this->_impl->_name.resize(len_name);
+      f.read(this->_impl->_name.data(), sizeof(char) * len_name);
     }
 
     cytnx_uint64 rank;


### PR DESCRIPTION
## Problem
`UniTensor::Load` reads a length-prefixed tensor name from the file, allocates exactly `len_name` bytes, and then constructs `std::string(cname)`. That constructor expects a null-terminated C string, so it can read past the allocated buffer when the serialized name is not null-terminated.

## Fix
Resize the destination `std::string` to the serialized length and read directly into `string::data()`. This preserves the length-prefixed file format and avoids the out-of-bounds read.

## Testing
- `clang-format-14 -i src/UniTensor.cpp`
- `git diff --check`
- `ASAN_OPTIONS=protect_shadow_gap=0:replace_intrin=0:detect_leaks=0 GCOV_PREFIX=/tmp/cytnx-gcov ./build_codex/debug-openblas-cpu/tests/test_main --gtest_filter=Rsvd.dense_exp_svals_test --gtest_brief=1`

Resolves #852 (but not the SearchTreeTest.BasicSearchOrder2 part)