### PR TITLE
fix(search_tree): avoid OOB adjacencyMatrix lookup for merged nodes

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(
   benchmarks_main.cpp
   Tensor_bm.cpp
   UniTensor_bm.cpp
+  search_tree_bm.cpp
   algo/Vsplit_bm.cpp
   algo/Vstack_bm.cpp
   algo/Hsplit_bm.cpp

--- a/benchmarks/search_tree_bm.cpp
+++ b/benchmarks/search_tree_bm.cpp
@@ -1,0 +1,80 @@
+#include <benchmark/benchmark.h>
+#include <string>
+
+#include "search_tree.hpp"
+
+// Benchmarks for cytnx::OptimalTreeSolver::solve (via SearchTree::search_order()), the
+// contraction-order planner used by Network. Guards the algorithmic complexity of the
+// pair-selection loop, which runs an adjacency check on every candidate pair once per
+// contraction round: an O(1) adjacency lookup keeps a single connected component of n
+// leaves at roughly O(n^2), while re-deriving adjacency from label lists on every
+// candidate pair pushes that to O(n^3). Since this benchmark file's own source does not
+// change across the history of issue #853, run it (via `git checkout <rev> --
+// benchmarks/search_tree_bm.cpp include/search_tree.hpp src/search_tree.cpp`, or by
+// simply comparing it built at different revisions) at any two commits to compare their
+// OptimalTreeSolver::solve performance directly, without needing a second implementation
+// duplicated in this file.
+namespace BMTest_SearchTree {
+
+  // Chain topology: leaf i shares one label with leaf i+1, so the whole network is a
+  // single connected component that needs n-1 sequential contractions to collapse.
+  std::vector<cytnx::PseudoUniTensor> BuildChain(std::size_t n) {
+    std::vector<cytnx::PseudoUniTensor> tensors;
+    tensors.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) {
+      cytnx::PseudoUniTensor t(i);
+      t.labels = {std::to_string(i), std::to_string(i + 1)};
+      t.shape = {2, 2};
+      t.cost = 0;
+      tensors.push_back(t);
+    }
+    return tensors;
+  }
+
+  // Complete-graph topology: every pair of the n leaves shares one unique label, so each
+  // leaf starts with n-1 labels. Stresses per-node label-list length (which grows further
+  // as nodes merge) on top of the pair-count growth that BuildChain already exercises.
+  std::vector<cytnx::PseudoUniTensor> BuildComplete(std::size_t n) {
+    std::vector<cytnx::PseudoUniTensor> tensors;
+    tensors.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) {
+      cytnx::PseudoUniTensor t(i);
+      for (std::size_t j = 0; j < n; ++j) {
+        if (j == i) continue;
+        std::size_t a = std::min(i, j), b = std::max(i, j);
+        t.labels.push_back("e" + std::to_string(a) + "_" + std::to_string(b));
+        t.shape.push_back(2);
+      }
+      t.cost = 0;
+      tensors.push_back(t);
+    }
+    return tensors;
+  }
+
+  static void SearchOrder_Chain(benchmark::State& state) {
+    std::size_t n = state.range(0);
+    for (auto _ : state) {
+      state.PauseTiming();
+      auto tensors = BuildChain(n);
+      state.ResumeTiming();
+      auto result = cytnx::OptimalTreeSolver::solve(tensors);
+      benchmark::DoNotOptimize(result);
+    }
+  }
+  // Up to 64, the largest input OptimalTreeSolver::solve accepts (leaf IDs are
+  // 64-bit, adjacency rows are std::bitset<128>).
+  BENCHMARK(SearchOrder_Chain)->Args({8})->Args({16})->Args({32})->Args({48})->Args({64});
+
+  static void SearchOrder_Complete(benchmark::State& state) {
+    std::size_t n = state.range(0);
+    for (auto _ : state) {
+      state.PauseTiming();
+      auto tensors = BuildComplete(n);
+      state.ResumeTiming();
+      auto result = cytnx::OptimalTreeSolver::solve(tensors);
+      benchmark::DoNotOptimize(result);
+    }
+  }
+  BENCHMARK(SearchOrder_Complete)->Args({6})->Args({8})->Args({10})->Args({12});
+
+}  // namespace BMTest_SearchTree

--- a/include/search_tree.hpp
+++ b/include/search_tree.hpp
@@ -26,6 +26,12 @@ namespace cytnx {
     bool is_assigned;
     cytnx_uint64 tensorIndex;
 
+    // Row into OptimalTreeSolver::solve's adjacency matrix. Solver-internal
+    // bookkeeping only, reassigned by solve() for every node it creates
+    // (leaf or merged); callers constructing a PseudoUniTensor directly
+    // should not rely on its value.
+    std::size_t adj_index = 0;
+
     // Internal node data
     std::unique_ptr<PseudoUniTensor> left;
     std::unique_ptr<PseudoUniTensor> right;

--- a/src/search_tree.cpp
+++ b/src/search_tree.cpp
@@ -1,5 +1,8 @@
 #include "search_tree.hpp"
 #include <stack>
+#include <queue>
+#include <functional>
+#include <algorithm>
 
 #ifdef BACKEND_TORCH
 #else
@@ -103,6 +106,26 @@ namespace cytnx {
       return components;
     }
 
+    // A candidate contraction of the two adjacent nodes with adjacency-matrix
+    // rows lhs_adj_index and rhs_adj_index (kept lhs_adj_index < rhs_adj_index),
+    // tagged with its already-computed get_cost. get_cost depends only on the
+    // two nodes' shapes/labels/costs, all fixed once a node is created, so this
+    // cost never needs recomputing while the pair survives -- caching it here
+    // is what turns the per-round rescan into a heap pop.
+    struct PairCandidate {
+      cytnx_float cost;
+      std::size_t lhs_adj_index;
+      std::size_t rhs_adj_index;
+
+      // Order by cost, then by the node indices, so the min-heap reproduces a
+      // deterministic tie-break (lowest lhs_adj_index, then rhs_adj_index).
+      bool operator>(const PairCandidate& rhs) const {
+        if (cost != rhs.cost) return cost > rhs.cost;
+        if (lhs_adj_index != rhs.lhs_adj_index) return lhs_adj_index > rhs.lhs_adj_index;
+        return rhs_adj_index > rhs.rhs_adj_index;
+      }
+    };
+
     std::unique_ptr<PseudoUniTensor> solve(const std::vector<PseudoUniTensor>& tensors,
                                            bool verbose) {
       if (tensors.empty()) {
@@ -152,110 +175,123 @@ namespace cytnx {
       }
 
       // Find connected components
-      auto components = findConnectedComponents(adjacencyMatrix);
+      std::vector<std::vector<std::size_t>> components = findConnectedComponents(adjacencyMatrix);
       if (verbose && components.size() > 1) {
         std::cout << "Found " << components.size() << " disconnected components" << std::endl;
       }
 
       // Process each component separately
       std::vector<std::unique_ptr<PseudoUniTensor>> component_results;
-      for (const auto& component : components) {
-        // Move this component's leaves into the working set directly -- no
-        // separate index-into-a-master-list bookkeeping needed, since each
-        // node already knows its own adjacencyMatrix row via adj_index.
-        std::vector<std::unique_ptr<PseudoUniTensor>> remaining_nodes;
-        remaining_nodes.reserve(component.size());
+      for (const std::vector<std::size_t>& component : components) {
+        // Alive nodes of this component, keyed by their adjacencyMatrix row
+        // (adj_index) so a candidate pair can be validated and its nodes
+        // fetched in O(1). Each node already knows its own row via adj_index,
+        // so no separate index-into-a-master-list bookkeeping is needed.
+        std::unordered_map<std::size_t, std::unique_ptr<PseudoUniTensor>> alive_nodes;
+        alive_nodes.reserve(component.size());
         for (std::size_t leaf_idx : component) {
-          remaining_nodes.push_back(std::move(leaves[leaf_idx]));
+          std::size_t adj = leaves[leaf_idx]->adj_index;
+          alive_nodes.emplace(adj, std::move(leaves[leaf_idx]));
         }
 
-        while (remaining_nodes.size() > 1) {
-          // Find best contraction pair within component
-          std::size_t best_i = 0, best_j = 1;
-          cytnx_float min_cost = std::numeric_limits<cytnx_float>::max();
+        // Min-heap of candidate contractions. Every adjacent pair's cost is
+        // computed exactly once -- when the pair first forms -- and stays
+        // valid until one of its nodes is contracted (get_cost is a pure
+        // function of the two nodes). A round then costs one O(log) pop plus
+        // O(degree) fresh pushes for the new merged node, instead of an
+        // O(alive^2) rescan; a candidate whose node has since been contracted
+        // is skipped lazily on pop.
+        std::priority_queue<PairCandidate, std::vector<PairCandidate>, std::greater<>> candidates;
 
-          for (std::size_t ii = 0; ii < remaining_nodes.size(); ++ii) {
-            for (std::size_t jj = ii + 1; jj < remaining_nodes.size(); ++jj) {
-              if (adjacencyMatrix[remaining_nodes[ii]->adj_index].test(
-                    remaining_nodes[jj]->adj_index)) {
-                cytnx_float cost = get_cost(*remaining_nodes[ii], *remaining_nodes[jj]);
-                if (cost < min_cost) {
-                  min_cost = cost;
-                  best_i = ii;
-                  best_j = jj;
-                }
-              }
+        // Seed the heap with the component's current adjacent pairs.
+        for (std::size_t a = 0; a < component.size(); ++a) {
+          for (std::size_t b = a + 1; b < component.size(); ++b) {
+            std::size_t a_adj = component[a];
+            std::size_t b_adj = component[b];
+            if (adjacencyMatrix[a_adj].test(b_adj)) {
+              PseudoUniTensor& na = *alive_nodes[a_adj];
+              PseudoUniTensor& nb = *alive_nodes[b_adj];
+              candidates.push({get_cost(na, nb), std::min(a_adj, b_adj), std::max(a_adj, b_adj)});
             }
+          }
+        }
+
+        while (alive_nodes.size() > 1) {
+          // Pop the cheapest candidate whose two nodes are both still alive.
+          PairCandidate best = candidates.top();
+          candidates.pop();
+          if (alive_nodes.find(best.lhs_adj_index) == alive_nodes.end() ||
+              alive_nodes.find(best.rhs_adj_index) == alive_nodes.end()) {
+            continue;
           }
 
           if (verbose) {
-            std::cout << "Contracting nodes " << remaining_nodes[best_i]->adj_index << " and "
-                      << remaining_nodes[best_j]->adj_index << " with cost " << min_cost
-                      << std::endl;
+            std::cout << "Contracting nodes " << best.lhs_adj_index << " and " << best.rhs_adj_index
+                      << " with cost " << best.cost << std::endl;
           }
 
-          // Contract best pair
-          std::unique_ptr<PseudoUniTensor> left = std::move(remaining_nodes[best_i]);
-          std::unique_ptr<PseudoUniTensor> right = std::move(remaining_nodes[best_j]);
+          std::unique_ptr<PseudoUniTensor> left =
+            std::move(alive_nodes.extract(best.lhs_adj_index).mapped());
+          std::unique_ptr<PseudoUniTensor> right =
+            std::move(alive_nodes.extract(best.rhs_adj_index).mapped());
 
           // The merged node is adjacent to exactly the union of what its two
           // parents were adjacent to: any label surviving into the merged
           // node's label list came from one parent or the other, so a node
           // sharing a label with either parent still shares it with the
           // merge. Bits for the parents' own rows are harmless leftovers in
-          // that union -- neither parent remains in remaining_nodes, so
-          // those bits are never looked up again.
+          // that union -- neither parent remains alive, so those bits are
+          // never looked up again.
           std::size_t merged_adj_index = adjacencyMatrix.size();
           IndexSet merged_row =
             adjacencyMatrix[left->adj_index] | adjacencyMatrix[right->adj_index];
-
-          // Record the edge from the neighbour's side too, keeping the matrix
-          // symmetric. The merged node's index is the largest, so it is always
-          // the second operand of adjacencyMatrix[i].test(j) in the loop above;
-          // without setting the bit in each neighbour's (i's) row, that edge
-          // would only live in the merged node's own row and never be seen.
-          for (std::size_t k = 0; k < adjacencyMatrix.size(); ++k) {
-            if (merged_row.test(k)) {
-              adjacencyMatrix[k].set(merged_adj_index);
-            }
-          }
           adjacencyMatrix.push_back(merged_row);
 
-          auto result = pContract(*left, *right);
+          PseudoUniTensor result = pContract(*left, *right);
           auto result_ptr = std::make_unique<PseudoUniTensor>(std::move(result));
           result_ptr->adj_index = merged_adj_index;
 
-          // Update remaining nodes
-          remaining_nodes.erase(remaining_nodes.begin() + best_j);
-          remaining_nodes.erase(remaining_nodes.begin() + best_i);
-          remaining_nodes.push_back(std::move(result_ptr));
+          // Record the edge from the neighbour's side and add candidates for the merged node
+          // against every still-alive neighbour it inherited an edge to.
+          for (const auto& [neighbour_adj, neighbour] : alive_nodes) {
+            if (merged_row.test(neighbour_adj)) {
+              adjacencyMatrix[neighbour_adj].set(merged_adj_index);
+              candidates.push({get_cost(*result_ptr, *neighbour), neighbour_adj, merged_adj_index});
+            }
+          }
+          alive_nodes.emplace(merged_adj_index, std::move(result_ptr));
         }
 
         // Store the component result
-        component_results.push_back(std::move(remaining_nodes[0]));
+        component_results.push_back(std::move(alive_nodes.begin()->second));
       }
 
-      // If there were multiple components, combine them
-      while (component_results.size() > 1) {
-        // Create new node for combining components
-        auto new_node = std::make_unique<PseudoUniTensor>();
-        new_node->isLeaf = false;
-
-        // Move the first two components as children
-        new_node->left = std::move(component_results[0]);
-        new_node->right = std::move(component_results[1]);
+      std::unique_ptr<PseudoUniTensor> root_node = std::move(component_results[0]);
+      /**
+       * If there were multiple components, combine them. The final structure looks like:
+       *
+       *     x
+       *    / \
+       *   x   2
+       *  / \
+       * 0   1
+       *
+       * The numbers are the index in `component_results` and `x` are the new nodes.
+       */
+      for (size_t i = 1; i < components.size(); ++i) {
+        auto new_node =
+          std::make_unique<PseudoUniTensor>(std::move(root_node), std::move(component_results[i]));
 
         // Calculate cost and set properties
+        // XXX: `left` and `right` are not connected. Should the product of their dimensions also be
+        // included in the cost?
         new_node->cost = get_cost(*new_node->left, *new_node->right);
         new_node->accu_str = "(" + new_node->left->accu_str + "," + new_node->right->accu_str + ")";
         new_node->ID = new_node->left->ID ^ new_node->right->ID;
-
-        // Update component list
-        component_results.erase(component_results.begin(), component_results.begin() + 2);
-        component_results.insert(component_results.begin(), std::move(new_node));
+        root_node = std::move(new_node);
       }
 
-      return std::move(component_results[0]);
+      return std::move(root_node);
     }
   }  // namespace OptimalTreeSolver
 
@@ -266,7 +302,7 @@ namespace cytnx {
     }
 
     // Run optimal tree solver directly with base_nodes
-    root_ptr = OptimalTreeSolver::solve(base_nodes, false);
+    this->root_ptr = OptimalTreeSolver::solve(base_nodes, false);
   }
 
   PseudoUniTensor& PseudoUniTensor::operator=(const PseudoUniTensor& rhs) {

--- a/src/search_tree.cpp
+++ b/src/search_tree.cpp
@@ -109,6 +109,16 @@ namespace cytnx {
         return nullptr;
       }
 
+      // A leaf's ID is 1ULL << leaf_index (a 64-bit mask), and the adjacency
+      // rows are IndexSet = std::bitset<128>. Contracting a single connected
+      // component of k leaves creates k-1 merged nodes, so up to 2k-1 nodes
+      // and adjacency indices exist; with k <= 64 that is <= 127 < 128, and
+      // the leaf index stays <= 63 so 1ULL << leaf_index does not overflow.
+      // More than 64 tensors would shift past the width of both, so reject it.
+      cytnx_error_msg(tensors.size() > 64,
+                      "[ERROR][OptimalTreeSolver] solve() supports at most 64 tensors, got %d.\n",
+                      static_cast<int>(tensors.size()));
+
       // Build leaf nodes. Each leaf's adj_index is its row in adjacencyMatrix;
       // merged nodes get theirs assigned below, as adjacencyMatrix is extended
       // for them.

--- a/src/search_tree.cpp
+++ b/src/search_tree.cpp
@@ -59,6 +59,20 @@ namespace cytnx {
   }
 
   namespace OptimalTreeSolver {
+    // Whether two (leaf or already-contracted) nodes share at least one label.
+    // Only used to build the initial per-leaf adjacency matrix below -- the
+    // pair-selection loop in solve() looks adjacency up in that matrix
+    // instead of re-deriving it, so this never runs in that O(n^2)-per-round
+    // hot loop.
+    bool has_common_label(const PseudoUniTensor& t1, const PseudoUniTensor& t2) {
+      for (const auto& l1 : t1.labels) {
+        for (const auto& l2 : t2.labels) {
+          if (l1 == l2) return true;
+        }
+      }
+      return false;
+    }
+
     // Helper function to find connected components using DFS
     void dfs(std::size_t node, const std::vector<IndexSet>& adjacencyMatrix, IndexSet& visited,
              std::vector<std::size_t>& component) {
@@ -95,29 +109,32 @@ namespace cytnx {
         return nullptr;
       }
 
-      // Initialize nodes with copies of input tensors
-      std::vector<std::unique_ptr<PseudoUniTensor>> nodes;
-      nodes.reserve(tensors.size());
+      // Build leaf nodes. Each leaf's adj_index is its row in adjacencyMatrix;
+      // merged nodes get theirs assigned below, as adjacencyMatrix is extended
+      // for them.
+      std::vector<std::unique_ptr<PseudoUniTensor>> leaves;
+      leaves.reserve(tensors.size());
       for (std::size_t i = 0; i < tensors.size(); ++i) {
-        auto node = std::make_unique<PseudoUniTensor>(i);
-        *node = tensors[i];
-        node->ID = 1ULL << i;
-        nodes.push_back(std::move(node));
+        auto leaf = std::make_unique<PseudoUniTensor>(i);
+        *leaf = tensors[i];
+        leaf->ID = 1ULL << i;
+        leaf->adj_index = i;
+        leaves.push_back(std::move(leaf));
       }
 
-      const std::size_t n = nodes.size();
-      // Build adjacency matrix with proper size
+      const std::size_t n = leaves.size();
+      // One adjacency row per node that will ever exist. Leaves fill rows
+      // [0, n); each contraction below appends one more row for the merged
+      // node it creates (addressed via that node's adj_index), so
+      // adjacencyMatrix[...].test(...) stays a valid O(1) lookup for merged
+      // nodes too, not just the leaves. This caps the total leaf+merged node
+      // count at IndexSet's 128 bits.
       std::vector<IndexSet> adjacencyMatrix(n);
 
       // Fill adjacency matrix
       for (std::size_t i = 0; i < n; ++i) {
         for (std::size_t j = i + 1; j < n; ++j) {
-          // Find common labels
-          std::vector<std::string> common_lbl;
-          std::vector<cytnx_uint64> comm_idx1, comm_idx2;
-          vec_intersect_(common_lbl, nodes[i]->labels, nodes[j]->labels, comm_idx1, comm_idx2);
-
-          if (!common_lbl.empty()) {
+          if (has_common_label(*leaves[i], *leaves[j])) {
             adjacencyMatrix[i].set(j);
             adjacencyMatrix[j].set(i);
           }
@@ -133,21 +150,25 @@ namespace cytnx {
       // Process each component separately
       std::vector<std::unique_ptr<PseudoUniTensor>> component_results;
       for (const auto& component : components) {
-        // Extract nodes for this component
-        std::vector<std::unique_ptr<PseudoUniTensor>> component_nodes;
-        std::vector<std::size_t> remaining_indices = component;
+        // Move this component's leaves into the working set directly -- no
+        // separate index-into-a-master-list bookkeeping needed, since each
+        // node already knows its own adjacencyMatrix row via adj_index.
+        std::vector<std::unique_ptr<PseudoUniTensor>> remaining_nodes;
+        remaining_nodes.reserve(component.size());
+        for (std::size_t leaf_idx : component) {
+          remaining_nodes.push_back(std::move(leaves[leaf_idx]));
+        }
 
-        while (remaining_indices.size() > 1) {
+        while (remaining_nodes.size() > 1) {
           // Find best contraction pair within component
           std::size_t best_i = 0, best_j = 1;
           cytnx_float min_cost = std::numeric_limits<cytnx_float>::max();
 
-          for (std::size_t ii = 0; ii < remaining_indices.size(); ++ii) {
-            std::size_t i = remaining_indices.at(ii);
-            for (std::size_t jj = ii + 1; jj < remaining_indices.size(); ++jj) {
-              std::size_t j = remaining_indices.at(jj);
-              if (adjacencyMatrix[i].test(j)) {
-                cytnx_float cost = get_cost(*nodes[i], *nodes[j]);
+          for (std::size_t ii = 0; ii < remaining_nodes.size(); ++ii) {
+            for (std::size_t jj = ii + 1; jj < remaining_nodes.size(); ++jj) {
+              if (adjacencyMatrix[remaining_nodes[ii]->adj_index].test(
+                    remaining_nodes[jj]->adj_index)) {
+                cytnx_float cost = get_cost(*remaining_nodes[ii], *remaining_nodes[jj]);
                 if (cost < min_cost) {
                   min_cost = cost;
                   best_i = ii;
@@ -158,28 +179,50 @@ namespace cytnx {
           }
 
           if (verbose) {
-            std::cout << "Contracting nodes " << remaining_indices[best_i] << " and "
-                      << remaining_indices[best_j] << " with cost " << min_cost << std::endl;
+            std::cout << "Contracting nodes " << remaining_nodes[best_i]->adj_index << " and "
+                      << remaining_nodes[best_j]->adj_index << " with cost " << min_cost
+                      << std::endl;
           }
 
           // Contract best pair
-          auto left = std::move(nodes[remaining_indices[best_i]]);
-          auto right = std::move(nodes[remaining_indices[best_j]]);
+          std::unique_ptr<PseudoUniTensor> left = std::move(remaining_nodes[best_i]);
+          std::unique_ptr<PseudoUniTensor> right = std::move(remaining_nodes[best_j]);
+
+          // The merged node is adjacent to exactly the union of what its two
+          // parents were adjacent to: any label surviving into the merged
+          // node's label list came from one parent or the other, so a node
+          // sharing a label with either parent still shares it with the
+          // merge. Bits for the parents' own rows are harmless leftovers in
+          // that union -- neither parent remains in remaining_nodes, so
+          // those bits are never looked up again.
+          std::size_t merged_adj_index = adjacencyMatrix.size();
+          IndexSet merged_row =
+            adjacencyMatrix[left->adj_index] | adjacencyMatrix[right->adj_index];
+
+          // Record the edge from the neighbour's side too, keeping the matrix
+          // symmetric. The merged node's index is the largest, so it is always
+          // the second operand of adjacencyMatrix[i].test(j) in the loop above;
+          // without setting the bit in each neighbour's (i's) row, that edge
+          // would only live in the merged node's own row and never be seen.
+          for (std::size_t k = 0; k < adjacencyMatrix.size(); ++k) {
+            if (merged_row.test(k)) {
+              adjacencyMatrix[k].set(merged_adj_index);
+            }
+          }
+          adjacencyMatrix.push_back(merged_row);
+
           auto result = pContract(*left, *right);
           auto result_ptr = std::make_unique<PseudoUniTensor>(std::move(result));
+          result_ptr->adj_index = merged_adj_index;
 
-          // Update remaining indices
-          remaining_indices.erase(remaining_indices.begin() + best_j);
-          remaining_indices.erase(remaining_indices.begin() + best_i);
-
-          // Store result in original nodes vector
-          std::size_t new_idx = nodes.size();
-          nodes.push_back(std::move(result_ptr));
-          remaining_indices.push_back(new_idx);
+          // Update remaining nodes
+          remaining_nodes.erase(remaining_nodes.begin() + best_j);
+          remaining_nodes.erase(remaining_nodes.begin() + best_i);
+          remaining_nodes.push_back(std::move(result_ptr));
         }
 
         // Store the component result
-        component_results.push_back(std::move(nodes[remaining_indices[0]]));
+        component_results.push_back(std::move(remaining_nodes[0]));
       }
 
       // If there were multiple components, combine them

--- a/tests/search_tree_test.cpp
+++ b/tests/search_tree_test.cpp
@@ -1,5 +1,6 @@
 #include "cytnx.hpp"
 #include "search_tree.hpp"
+#include <algorithm>
 #include <gtest/gtest.h>
 
 using namespace cytnx;
@@ -109,6 +110,75 @@ TEST_F(SearchTreeTest, BasicSearchOrder2) {
   EXPECT_EQ(result->accu_str, "((2,3),(0,1))");
 }
 
+/*=====test info=====
+describe:regression test for issue #853. A single connected component of 5
+         tensors needs 4 sequential contractions to collapse to one node, so
+         by the second contraction the pair-selection loop must look up
+         adjacency for a merged node whose index is >= the original leaf
+         count. Bounds-checking that lookup (e.g. adjacencyMatrix.at(i))
+         instead of re-deriving adjacency from the merged node's current
+         labels would turn the heap-buffer-overflow into a clean
+         std::out_of_range, which still fails this test: the merged node's
+         index is used for every remaining node, so search_order() would
+         throw before result->labels/result->ID could be checked. Reproduces
+         the exact node count (n=4 leaves reachable) and connectivity shape
+         called out in the issue's ASan trace, extended by one node to also
+         exercise a second out-of-range lookup.
+====================*/
+TEST_F(SearchTreeTest, ChainNetworkNoOutOfBoundsOnMultiStepContraction) {
+  // Chain topology a-T0-b-T1-c-T2-d-T3-e-T4-f: every adjacent pair shares
+  // exactly one label, so the whole network is one connected component and
+  // only "a" and "f" remain uncontracted in the final result.
+  std::vector<PseudoUniTensor> tensors;
+
+  PseudoUniTensor t0(0);
+  t0.shape = {2, 3};
+  t0.labels = {"a", "b"};
+  t0.cost = 0;
+  tensors.push_back(t0);
+
+  PseudoUniTensor t1(1);
+  t1.shape = {3, 4};
+  t1.labels = {"b", "c"};
+  t1.cost = 0;
+  tensors.push_back(t1);
+
+  PseudoUniTensor t2(2);
+  t2.shape = {4, 5};
+  t2.labels = {"c", "d"};
+  t2.cost = 0;
+  tensors.push_back(t2);
+
+  PseudoUniTensor t3(3);
+  t3.shape = {5, 6};
+  t3.labels = {"d", "e"};
+  t3.cost = 0;
+  tensors.push_back(t3);
+
+  PseudoUniTensor t4(4);
+  t4.shape = {6, 7};
+  t4.labels = {"e", "f"};
+  t4.cost = 0;
+  tensors.push_back(t4);
+
+  SearchTree tree;
+  tree.base_nodes = tensors;
+
+  EXPECT_NO_THROW(tree.search_order());
+
+  auto result = tree.get_root().back()[0];
+  ASSERT_NE(result, nullptr);
+
+  // All 5 leaves must be folded into the result (ID is the XOR, i.e. union,
+  // of the leaves' distinct power-of-two IDs).
+  EXPECT_EQ(result->ID, (1ULL << 0) | (1ULL << 1) | (1ULL << 2) | (1ULL << 3) | (1ULL << 4));
+
+  // Only the two external labels survive contraction.
+  std::vector<std::string> labels = result->labels;
+  std::sort(labels.begin(), labels.end());
+  EXPECT_EQ(labels, std::vector<std::string>({"a", "f"}));
+}
+
 TEST_F(SearchTreeTest, EmptyTree) {
   SearchTree tree;
 
@@ -128,6 +198,64 @@ TEST_F(SearchTreeTest, SingleNode) {
 
   // Should throw error - need at least 2 nodes
   EXPECT_THROW(tree.search_order(), std::logic_error);
+}
+
+/*=====test info=====
+describe:guards that a merged node's adjacency is visible from BOTH
+         directions. When two nodes are contracted, the incremental
+         adjacency scheme must record the merged node as a neighbour of
+         every node it inherits an edge from -- not only store the merged
+         node's own outgoing row. The merged node always has the largest
+         index and is compared as the second operand of the pair-selection
+         loop's adjacencyMatrix[i].test(j), so if only its own row were
+         updated the edge (older_node -> merged_node) would never be seen
+         and the greedy planner would skip a cheap contraction it should
+         have taken.
+
+         Topology (chain, one shared label per adjacent pair):
+           t0{x,y} t1{y,z} t2{z,w} t3{w,v}, dims x=y=10, z=3, w=4, v=2.
+         With correct adjacency the greedy order is (t2,t3) -> t1 -> t0 at
+         total cost 284. If the merged (t2,t3) node's adjacency to t1 is
+         missed, the planner instead contracts (t0,t1) and finishes at the
+         higher cost 384, so asserting on the cost (and accu_str) distinguishes
+         the two.
+====================*/
+TEST_F(SearchTreeTest, MergedNodeAdjacencyIsSymmetric) {
+  std::vector<PseudoUniTensor> tensors;
+
+  PseudoUniTensor t0(0);
+  t0.shape = {10, 10};
+  t0.labels = {"x", "y"};
+  t0.cost = 0;
+  tensors.push_back(t0);
+
+  PseudoUniTensor t1(1);
+  t1.shape = {10, 3};
+  t1.labels = {"y", "z"};
+  t1.cost = 0;
+  tensors.push_back(t1);
+
+  PseudoUniTensor t2(2);
+  t2.shape = {3, 4};
+  t2.labels = {"z", "w"};
+  t2.cost = 0;
+  tensors.push_back(t2);
+
+  PseudoUniTensor t3(3);
+  t3.shape = {4, 2};
+  t3.labels = {"w", "v"};
+  t3.cost = 0;
+  tensors.push_back(t3);
+
+  SearchTree tree;
+  tree.base_nodes = tensors;
+  tree.search_order();
+  auto result = tree.get_root().back()[0];
+  ASSERT_NE(result, nullptr);
+
+  // Cheapest greedy order keeps the merged (t2,t3) node adjacent to t1.
+  EXPECT_EQ(result->cost, 284);
+  EXPECT_EQ(result->accu_str, "(0,(1,(2,3)))");
 }
 
 TEST_F(SearchTreeTest, DisconnectedNetwork) {

--- a/tests/search_tree_test.cpp
+++ b/tests/search_tree_test.cpp
@@ -1,6 +1,7 @@
 #include "cytnx.hpp"
 #include "search_tree.hpp"
 #include <algorithm>
+#include <set>
 #include <gtest/gtest.h>
 
 using namespace cytnx;
@@ -300,4 +301,70 @@ TEST_F(SearchTreeTest, DisconnectedNetwork) {
 
   EXPECT_EQ(result->cost, 120);  // 2*3*4*5 = 120
   EXPECT_EQ(result->accu_str, "(0,1)");
+}
+
+/*=====test info=====
+describe:regression test for issue #506. The 21-tensor iPEPS observable
+         network below is the one whose optimal contraction order the CPU
+         solver "could not finish in 1 day". It is a single connected
+         component that needs 20 sequential contractions, so an
+         O(nodes^2)-per-round rescan that recomputes every pair's cost each
+         round spends O(nodes^3) get_cost calls -- each allocating -- and does
+         not terminate in practical time. Guards that solve() completes and
+         fully contracts the network (every shared bond is summed, the network
+         file's TOUT is empty, so no label survives). The exact cost is not
+         asserted: the greedy planner's tie-breaking is not part of the
+         contract here, only that it terminates and collapses the whole
+         network.
+
+         Bonds are taken verbatim from iPEPS_observe.net; bond dimensions are
+         chi = 8 for every leg except the physical d = 2 legs (O's four legs
+         and the A/B tensors' last legs: labels 7, 8, 11, 12, 25, 30).
+====================*/
+TEST_F(SearchTreeTest, IPEPSObservableNetworkContractsQuickly) {
+  // Labels carrying the physical dimension d = 2; every other bond is chi = 8.
+  const std::set<std::string> d2 = {"7", "8", "11", "12", "25", "30"};
+  auto dim_of = [&](const std::string& label) -> cytnx_uint64 { return d2.count(label) ? 2 : 8; };
+
+  const std::vector<std::vector<std::string>> net = {
+    {"1", "2"},  // C1
+    {"34", "35"},  // C2
+    {"41", "42"},  // C3
+    {"19", "16"},  // C4
+    {"1", "20", "3", "4"},  // T1b
+    {"20", "34", "21", "22"},  // T1a
+    {"35", "38", "36", "37"},  // T2a
+    {"38", "41", "39", "40"},  // T2b
+    {"42", "33", "31", "32"},  // T3b
+    {"33", "19", "17", "18"},  // T3a
+    {"16", "13", "14", "15"},  // T4a
+    {"13", "2", "5", "6"},  // T4b
+    {"4", "24", "10", "6", "8"},  // A1
+    {"3", "23", "9", "5", "7"},  // A1T
+    {"22", "37", "27", "24", "25"},  // B1
+    {"21", "36", "26", "23", "25"},  // B1T
+    {"27", "40", "32", "29", "30"},  // A2
+    {"26", "39", "31", "28", "30"},  // A2T
+    {"10", "29", "18", "15", "12"},  // B2
+    {"9", "28", "17", "14", "11"},  // B2T
+    {"7", "8", "11", "12"},  // O
+  };
+
+  SearchTree tree;
+  for (cytnx_uint64 i = 0; i < net.size(); ++i) {
+    PseudoUniTensor t(i);
+    t.labels = net[i];
+    for (const std::string& label : net[i]) t.shape.push_back(dim_of(label));
+    t.cost = 0;
+    tree.base_nodes.push_back(t);
+  }
+
+  ASSERT_NO_THROW(tree.search_order());
+  auto result = tree.get_root().back()[0];
+  ASSERT_NE(result, nullptr);
+
+  // Every one of the 21 leaves is folded into the result exactly once.
+  EXPECT_EQ(result->ID, (1ULL << net.size()) - 1);
+  // The network is fully contracted: no bond survives (TOUT is empty).
+  EXPECT_TRUE(result->labels.empty());
 }

--- a/tests/search_tree_test.cpp
+++ b/tests/search_tree_test.cpp
@@ -258,6 +258,26 @@ TEST_F(SearchTreeTest, MergedNodeAdjacencyIsSymmetric) {
   EXPECT_EQ(result->accu_str, "(0,(1,(2,3)))");
 }
 
+TEST_F(SearchTreeTest, TooManyNodesThrows) {
+  // The solver caps at 64 tensors: leaf IDs are 1ULL << leaf_index (64-bit)
+  // and adjacency rows are std::bitset<128> (up to 2*64-1 = 127 nodes), so a
+  // 65th tensor would shift/index past both. Expect a clean error, not UB.
+  //
+  // solve() rejects the input on size alone, before building any leaf, so the
+  // dummy nodes' contents are irrelevant. Use a fixed in-range constructor
+  // index: PseudoUniTensor sets ID to 1ULL << index, so passing 64 would be
+  // undefined behavior at construction, before the guard runs.
+  SearchTree tree;
+  for (cytnx_uint64 i = 0; i < 65; ++i) {
+    PseudoUniTensor t(0);
+    t.shape = {2, 2};
+    t.labels = {std::to_string(i), std::to_string(i + 1)};
+    t.cost = 0;
+    tree.base_nodes.push_back(t);
+  }
+  EXPECT_THROW(tree.search_order(), std::logic_error);
+}
+
 TEST_F(SearchTreeTest, DisconnectedNetwork) {
   SearchTree tree;
 


### PR DESCRIPTION
## Problem

Two problems in `OptimalTreeSolver::solve`, the contraction-order planner behind `SearchTree::search_order()` (used by `Network`):

**1. Out-of-bounds read (#853).** `SearchTreeTest.BasicSearchOrder2` fails under an AddressSanitizer build with a `heap-buffer-overflow` READ. `adjacencyMatrix` was sized to the original leaf-tensor count `n`. Once a connected component needs more than one contraction, each contraction pushes the index of the newly merged node (`>= n`) into the working set, and the next iteration of the pair-selection loop does `adjacencyMatrix[i].test(j)` with `i` or `j` equal to that merged-node index — one or more elements past the end of the `n`-sized vector. It's a production-path OOB (silent UB in release), not a test-only artifact.

**2. Non-termination on realistic networks (#506).** The pair-selection loop rescanned every alive adjacent pair each round and recomputed `get_cost` (which allocates) for each surviving pair — `O(nodes^3)` allocating `get_cost` calls on dense components. The 21-tensor iPEPS observable network in #506 "could not finish in 1 day" on CPU.

## Fix

**Bounds (#853).** Every node — leaf or merged — carries its own `adj_index`, a stable row into `adjacencyMatrix` assigned once at creation (its position among the leaves, or `adjacencyMatrix.size()` right before a merged node's row is appended). The matrix grows by one row per contraction — the bitwise OR of the two parents' rows — so the O(1) bitset lookup stays valid for merged-node indices too.

The new row is stored **symmetrically**: the merged node's bit is also set in each neighbour's row. The merged node always has the largest index and is therefore the second operand of `adjacencyMatrix[i].test(j)`; without the reverse bit the edge would live only in the merged node's own row and never be seen from a neighbour's row, so the greedy planner would miss cheap contractions and return a costlier — or, for a network held together only through a merged node, structurally wrong — tree. (Latent bug pinned by `MergedNodeAdjacencyIsSymmetric`.) Only *alive* neighbours get the reverse bit set: a contracted node's row is never read again, so setting it in dead rows would be wasted work.

**64-tensor guard.** `solve()` rejects more than 64 tensors up front: leaf `ID` is `1ULL << leaf_index` (64-bit) and adjacency rows are `std::bitset<128>` (a single component of 64 leaves reaches `2·64−1 = 127` nodes), so a 65th tensor would shift/index past both — previously silent UB, now a clean `cytnx::error`.

**Min-heap pair selection (#506).** `get_cost(a, b)` depends only on the two nodes' shapes/labels/costs, all fixed once a node is created, so a pair's cost is stable until one of its nodes is contracted. Cache each adjacent pair's cost once, in a min-heap keyed by `(cost, lhs_adj_index, rhs_adj_index)`; each round pops the cheapest live candidate (lazy-deleting any whose node has since merged) and pushes one fresh candidate per neighbour of the new merged node. This turns the per-round rescan into an O(log) pop + O(degree) pushes and computes each pair cost exactly once. The #506 network now solves in well under a millisecond.

**Tie-breaking note.** The heap resolves equal-cost candidates by `(lhs_adj_index, rhs_adj_index)` instead of the pre-heap scan's positional order. The planner is a greedy heuristic (not an exact optimizer), and both orders are valid contractions; on networks with cost ties the chosen order — and hence the final greedy cost — can differ from `master`'s. This is an accepted behavior change, not a correctness bug.

## Commits

1. `test(search_tree)`: add `benchmarks/search_tree_bm.cpp`.
2. `fix(search_tree)`: OOB fix — incremental symmetric adjacency, `adj_index`, vector working set (`ChainNetworkNoOutOfBoundsOnMultiStepContraction`, `MergedNodeAdjacencyIsSymmetric`).
3. `fix(search_tree)`: 64-tensor guard (`TooManyNodesThrows`).
4. `perf(search_tree)`: min-heap pair selection.
5. `test(search_tree)`: avoid a `1ULL << 64` shift in `TooManyNodesThrows` (construction-time UB fix).
6. `Optimize solving algorithm`: fold the symmetric adjacency update into the alive-neighbour loop; use `extract`; simplify disconnected-component combination.
7. `test(search_tree)`: add the #506 iPEPS-network regression (`IPEPSObservableNetworkContractsQuickly`).

## Testing

- `ctest --preset cpu-only` (debug-openblas-cpu): all `SearchTreeTest.*` pass, ASan-clean — including `BasicSearchOrder2`'s and `MergedNodeAdjacencyIsSymmetric`'s exact `cost`/`accu_str` assertions and the new `IPEPSObservableNetworkContractsQuickly` (#506), which solves in ~18 ms under ASan and fully contracts the 21-tensor network.
- **Differential**: the min-heap solver is byte-identical (cost *and* `accu_str`) to a full per-round rescan using the same tie-break across **52,300** random networks — connected, disconnected, and up to the 64-tensor limit — so the heap caching, lazy deletion, and alive-only reverse-bit update reproduce the rescan exactly.
- `pre-commit run` over the changed files passes (clang-format v14).

### Benchmark: master vs. adjacency-only fix vs. min-heap

`benchmarks/search_tree_bm.cpp` calls `cytnx::OptimalTreeSolver::solve` directly, so building it at each revision measures that revision. `openblas-cpu` Release preset (`-O3 -DNDEBUG`, no ASan), same machine, mean of 5 repetitions (ns):

| topology / n | master (`6927349`) | adjacency-only fix (`d6891d8`) | min-heap (`f288445`) | heap vs adj-only | heap vs master |
|---|---:|---:|---:|---:|---:|
| chain / 8 | 18,659 | 17,761 | 15,831 | 1.12× | 1.18× |
| chain / 16 | 66,784 | 55,807 | 37,547 | 1.49× | 1.78× |
| chain / 32 | 207,584 | 192,763 | 93,059 | 2.07× | 2.23× |
| chain / 48 | 478,332 | 407,545 | 155,287 | 2.62× | 3.08× |
| chain / 64 | 961,611 | 690,913 | 234,593 | 2.95× | 4.10× |
| complete / 6 | 28,185 | 33,136 | 32,242 | 1.03× | 0.87× |
| complete / 8 | 72,326 | 97,175 | 78,089 | 1.24× | 0.93× |
| complete / 10 | 145,029 | 244,707 | 169,040 | 1.45× | 0.86× |
| complete / 12 | 392,202 | 595,549 | 359,532 | 1.66× | 1.09× |

- **min-heap vs. the correct baseline** (`adjacency-only fix`, which preserves master's contraction order): faster at every size, and the margin grows with `n` — up to **2.95×** on chain/64 and **1.66×** on complete/12. Chains are the realistic tensor-network shape (MPS/PEPS/…).
- **min-heap vs. master**: `master` reads out of bounds for every merged node, so its numbers are the runtime of a code path that computes a *wrong* tree from garbage adjacency bits (not reproducible — depends on heap contents). It looks fast on small complete graphs only because the OOB reads make it *skip* real `get_cost` work; the min-heap still beats it on chains (up to 4.1×) and by complete/12 overtakes it while staying correct.

Closes #853.