### PR TITLE
fix(ci): gate C++ coverage on lines only, drop branch coverage

### DIFF
--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -156,9 +156,16 @@ jobs:
         #   - C++ paths exercised through the Python bindings under pytest
         # pybind/ is intentionally kept; codecov.yml gives it its own
         # component in the PR comment.
+        #
+        # --exclude-branches-by-pattern '.*' strips ALL branch records from
+        # the XML, so the `cpp` flag gates on line coverage only (#932):
+        # gcov branch data counts compiler-generated CFG arcs (exception
+        # unwind, destructors, inlined STL) that tests cannot exercise.
+        # Python coverage is unaffected and keeps --cov-branch.
         run: |
           gcovr -r ${{ github.workspace }} . \
             --xml-pretty -o coverage-cpp.xml \
+            --exclude-branches-by-pattern '.*' \
             --exclude '.*_deps.*' \
             --exclude '.*thirdparty.*' \
             --exclude '.*tests/.*' \


### PR DESCRIPTION
## Problem

Codecov's `codecov/patch` status gates C++ (`cpp` flag) on both line and branch coverage. gcov/gcovr branch coverage for compiled C++ counts compiler-generated CFG arcs — exception-unwind edges, destructor/static-init arcs, inlined STL branches — alongside author-written control flow. Those arcs can't be exercised by ordinary tests, so a PR's branch percentage can stay low even when every patched line is fully executed (see #932 for the measured breakdown on #927).

## Fix

Option B from #932: strip branch records at the source. The gcovr invocation in `.github/workflows/ci-cmake_tests.yml` now passes `--exclude-branches-by-pattern '.*'`, so the Cobertura XML uploaded under the `cpp` flag carries no branch data (`branches-valid="0"`, every line `branch="false"`) and Codecov scores C++ on line coverage only.

Option A from #932 (`parsers.gcov.branch_detection` in `codecov.yml`) was evaluated first on this PR and shown to be ineffective: that setting only configures Codecov's parser for raw gcov-format text reports, while this CI uploads gcovr-generated Cobertura XML, which goes through the Cobertura parser — the setting never takes effect (the initial Codecov report on this PR, with only the Option A change pushed, showed branch/partial counts unchanged at 13823/7391).

- **C++ (`cpp` flag):** line coverage only.
- **Python (`python` flag):** unchanged — pytest-cov still runs with `--cov-branch` and gates on both line and branch coverage, since coverage.py branches are real author-written control flow.

## Testing

- Verified locally with gcovr 8.6 on a small C++ program with a throwing branch: without the flag the Cobertura XML reports `branches-valid="4"` with partials; with `--exclude-branches-by-pattern '.*'` it reports `branches-valid="0"` and every line `branch="false"`, while line coverage is identical.
- `yaml.safe_load` passes on the edited workflow file.
- End-to-end effect (branch/partial counts dropping to 0 for the `cpp` flag) will be visible in this PR's own Codecov report once CI runs.

Closes #932.
