### PR TITLE
fix(UniTensor): make clone_meta() exception-safe to stop leaking on validation throws

### DIFF
--- a/include/UniTensor.hpp
+++ b/include/UniTensor.hpp
@@ -452,8 +452,8 @@ namespace cytnx {
    public:
     Tensor _block;
     std::vector<Tensor> _interface_block;  // this is serves as interface for get_blocks_();
-    DenseUniTensor *clone_meta() const {
-      DenseUniTensor *tmp = new DenseUniTensor();
+    boost::intrusive_ptr<DenseUniTensor> clone_meta() const {
+      boost::intrusive_ptr<DenseUniTensor> tmp(new DenseUniTensor());
       tmp->_bonds = vec_clone(this->_bonds);
       tmp->_labels = this->_labels;
       tmp->_is_braket_form = this->_is_braket_form;
@@ -514,18 +514,16 @@ namespace cytnx {
     }
 
     boost::intrusive_ptr<UniTensor_base> set_rowrank(const cytnx_uint64 &new_rowrank) const {
-      DenseUniTensor *out_raw = this->clone_meta();
+      boost::intrusive_ptr<DenseUniTensor> out_raw = this->clone_meta();
       out_raw->_block = this->_block;
       out_raw->set_rowrank_(new_rowrank);
-      boost::intrusive_ptr<UniTensor_base> out(out_raw);
-      return out;
+      return out_raw;
     }
 
     boost::intrusive_ptr<UniTensor_base> clone() const {
-      DenseUniTensor *tmp = this->clone_meta();
+      boost::intrusive_ptr<DenseUniTensor> tmp = this->clone_meta();
       tmp->_block = this->_block.clone();
-      boost::intrusive_ptr<UniTensor_base> out(tmp);
-      return out;
+      return tmp;
     };
     bool is_contiguous() const { return this->_block.is_contiguous(); }
     unsigned int dtype() const { return this->_block.dtype(); }
@@ -595,9 +593,8 @@ namespace cytnx {
                                                  const std::string &new_label);
 
     boost::intrusive_ptr<UniTensor_base> astype(const unsigned int &dtype) const {
-      DenseUniTensor *tmp = this->clone_meta();
+      boost::intrusive_ptr<DenseUniTensor> tmp = this->clone_meta();
       tmp->_block = this->_block.astype(dtype);
-      boost::intrusive_ptr<UniTensor_base> out(tmp);
       return tmp;
     }
 
@@ -621,10 +618,9 @@ namespace cytnx {
         boost::intrusive_ptr<UniTensor_base> out(this);
         return out;
       } else {
-        DenseUniTensor *tmp = this->clone_meta();
+        boost::intrusive_ptr<DenseUniTensor> tmp = this->clone_meta();
         tmp->_block = this->_block.contiguous();
-        boost::intrusive_ptr<UniTensor_base> out(tmp);
-        return out;
+        return tmp;
       }
     }
 
@@ -1162,9 +1158,9 @@ namespace cytnx {
       }
     }
 
-    BlockUniTensor *clone_meta(const bool &inner, const bool &outer) const {
-      BlockUniTensor *tmp = new BlockUniTensor();
-      this->set_meta(tmp, inner, outer);
+    boost::intrusive_ptr<BlockUniTensor> clone_meta(const bool &inner, const bool &outer) const {
+      boost::intrusive_ptr<BlockUniTensor> tmp(new BlockUniTensor());
+      this->set_meta(tmp.get(), inner, outer);
       return tmp;
     };
 
@@ -1227,10 +1223,9 @@ namespace cytnx {
     };
 
     boost::intrusive_ptr<UniTensor_base> clone() const {
-      BlockUniTensor *tmp = this->clone_meta(true, true);
+      boost::intrusive_ptr<BlockUniTensor> tmp = this->clone_meta(true, true);
       tmp->_blocks = vec_clone(this->_blocks);
-      boost::intrusive_ptr<UniTensor_base> out(tmp);
-      return out;
+      return tmp;
     };
 
     unsigned int dtype() const {
@@ -1416,11 +1411,10 @@ namespace cytnx {
     }
 
     boost::intrusive_ptr<UniTensor_base> set_rowrank(const cytnx_uint64 &new_rowrank) const {
-      BlockUniTensor *tmp = this->clone_meta(true, true);
+      boost::intrusive_ptr<BlockUniTensor> tmp = this->clone_meta(true, true);
       tmp->_blocks = this->_blocks;
       tmp->set_rowrank_(new_rowrank);
-      boost::intrusive_ptr<UniTensor_base> out(tmp);
-      return out;
+      return tmp;
     }
 
     boost::intrusive_ptr<UniTensor_base> permute(const std::vector<cytnx_int64> &mapper,
@@ -1500,13 +1494,12 @@ namespace cytnx {
     void to_dense_();
 
     boost::intrusive_ptr<UniTensor_base> astype(const unsigned int &dtype) const {
-      BlockUniTensor *tmp = this->clone_meta(true, true);
+      boost::intrusive_ptr<BlockUniTensor> tmp = this->clone_meta(true, true);
       tmp->_blocks.resize(this->_blocks.size());
       for (cytnx_int64 blk = 0; blk < this->_blocks.size(); blk++) {
         tmp->_blocks[blk] = this->_blocks[blk].astype(dtype);
       }
-      boost::intrusive_ptr<UniTensor_base> out(tmp);
-      return out;
+      return tmp;
     };
 
     // this will only work on non-symm tensor (DenseUniTensor)
@@ -1894,10 +1887,11 @@ namespace cytnx {
       }
     }
 
-    BlockFermionicUniTensor *clone_meta(const bool &inner, const bool &outer) const {
+    boost::intrusive_ptr<BlockFermionicUniTensor> clone_meta(const bool &inner,
+                                                             const bool &outer) const {
       //[21 Aug 2024] This is a copy from BlockUniTensor;
-      BlockFermionicUniTensor *tmp = new BlockFermionicUniTensor();
-      this->set_meta(tmp, inner, outer);
+      boost::intrusive_ptr<BlockFermionicUniTensor> tmp(new BlockFermionicUniTensor());
+      this->set_meta(tmp.get(), inner, outer);
       return tmp;
     };
 
@@ -1973,10 +1967,9 @@ namespace cytnx {
     boost::intrusive_ptr<UniTensor_base> clone() const {
       //[21 Aug 2024] This is a copy from BlockUniTensor; changed to BlockFermionicUniTensor as
       // output
-      BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
+      boost::intrusive_ptr<BlockFermionicUniTensor> tmp = this->clone_meta(true, true);
       tmp->_blocks = vec_clone(this->_blocks);
-      boost::intrusive_ptr<UniTensor_base> out(tmp);
-      return out;
+      return tmp;
     };
 
     unsigned int dtype() const {
@@ -2184,11 +2177,10 @@ namespace cytnx {
     boost::intrusive_ptr<UniTensor_base> set_rowrank(const cytnx_uint64 &new_rowrank) const {
       //[21 Aug 2024] This is a copy from BlockUniTensor; output type changed to
       // BlockFermionicUniTensor
-      BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
+      boost::intrusive_ptr<BlockFermionicUniTensor> tmp = this->clone_meta(true, true);
       tmp->_blocks = this->_blocks;
       tmp->set_rowrank_(new_rowrank);
-      boost::intrusive_ptr<UniTensor_base> out(tmp);
-      return out;
+      return tmp;
     }
 
     boost::intrusive_ptr<UniTensor_base> permute(const std::vector<cytnx_int64> &mapper,
@@ -2270,13 +2262,12 @@ namespace cytnx {
 
     boost::intrusive_ptr<UniTensor_base> astype(const unsigned int &dtype) const {
       //[21 Aug 2024] This is a copy from BlockUniTensor; the tensor type was adapted
-      BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
+      boost::intrusive_ptr<BlockFermionicUniTensor> tmp = this->clone_meta(true, true);
       tmp->_blocks.resize(this->_blocks.size());
       for (cytnx_int64 blk = 0; blk < this->_blocks.size(); blk++) {
         tmp->_blocks[blk] = this->_blocks[blk].astype(dtype);
       }
-      boost::intrusive_ptr<UniTensor_base> out(tmp);
-      return out;
+      return tmp;
     };
 
     // this will only work on non-symm tensor (DenseUniTensor)

--- a/src/BlockFermionicUniTensor.cpp
+++ b/src/BlockFermionicUniTensor.cpp
@@ -520,8 +520,7 @@ namespace cytnx {
       boost::intrusive_ptr<UniTensor_base> out(this);
       return out;
     } else {
-      BlockFermionicUniTensor *tmp = new BlockFermionicUniTensor();
-      tmp = this->clone_meta(true, true);
+      boost::intrusive_ptr<BlockFermionicUniTensor> tmp = this->clone_meta(true, true);
       tmp->_blocks.resize(this->_blocks.size());
       for (unsigned int b = 0; b < this->_blocks.size(); b++) {
         if (this->_blocks[b].is_contiguous()) {
@@ -530,8 +529,7 @@ namespace cytnx {
           tmp->_blocks[b] = this->_blocks[b].contiguous();
         }
       }
-      boost::intrusive_ptr<UniTensor_base> out(tmp);
-      return out;
+      return tmp;
     }
   }
 
@@ -546,7 +544,7 @@ namespace cytnx {
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockFermionicUniTensor::apply() {
-    BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockFermionicUniTensor> tmp = this->clone_meta(true, true);
     for (cytnx_int64 i = 0; i < this->_blocks.size(); i++) {
       if (tmp->_signflip[i]) {
         tmp->_blocks.push_back(-(this->_blocks[i]));
@@ -555,7 +553,7 @@ namespace cytnx {
         tmp->_blocks.push_back(this->_blocks[i].clone());
       }
     }
-    return boost::intrusive_ptr<UniTensor_base>(tmp);
+    return tmp;
   }
 
   std::vector<Symmetry> BlockFermionicUniTensor::syms() const {
@@ -567,7 +565,7 @@ namespace cytnx {
     const std::vector<cytnx_int64> &mapper, const cytnx_int64 &rowrank) {
     //[21 Aug 2024] This is a copy from BlockUniTensor; additionally, _swapsigns_ is called to
     // update the sign struture
-    BlockFermionicUniTensor *out_raw = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockFermionicUniTensor> out_raw = this->clone_meta(true, true);
     out_raw->_blocks.resize(this->_blocks.size());
 
     std::vector<cytnx_uint64> mapper_u64 = std::vector<cytnx_uint64>(mapper.begin(), mapper.end());
@@ -606,16 +604,15 @@ namespace cytnx {
       }
       out_raw->_is_braket_form = out_raw->_update_braket();
     }
-    boost::intrusive_ptr<UniTensor_base> out(out_raw);
 
-    return out;
+    return out_raw;
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockFermionicUniTensor::permute(
     const std::vector<std::string> &mapper, const cytnx_int64 &rowrank) {
     //[21 Aug 2024] This is a copy from BlockUniTensor; calls permute(std::vector<cytnx_int64>)
     // which takes care of the fermionic sign struture; also, creates a BlockFermionicUniTensor
-    BlockFermionicUniTensor *out_raw = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockFermionicUniTensor> out_raw = this->clone_meta(true, true);
     out_raw->_blocks.resize(this->_blocks.size());
 
     std::vector<cytnx_int64> mapper_i64;
@@ -699,7 +696,7 @@ namespace cytnx {
     const std::vector<cytnx_int64> &mapper, const cytnx_int64 &rowrank) {
     //[21 Aug 2024] This is a copy from BlockUniTensor; no sign flips are applied. Use with caution,
     // this is usually not what you want!!!
-    BlockFermionicUniTensor *out_raw = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockFermionicUniTensor> out_raw = this->clone_meta(true, true);
     out_raw->_blocks.resize(this->_blocks.size());
 
     // based on BlockUniTensor.permute but calls _swapsigns_
@@ -739,16 +736,15 @@ namespace cytnx {
       }
       out_raw->_is_braket_form = out_raw->_update_braket();
     }
-    boost::intrusive_ptr<UniTensor_base> out(out_raw);
 
-    return out;
+    return out_raw;
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockFermionicUniTensor::permute_nosignflip(
     const std::vector<std::string> &mapper, const cytnx_int64 &rowrank) {
     //[21 Aug 2024] This is a copy from BlockUniTensor; no sign flips are applied. Use with caution,
     // this is usually not what you want!!!
-    BlockFermionicUniTensor *out_raw = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockFermionicUniTensor> out_raw = this->clone_meta(true, true);
     out_raw->_blocks.resize(this->_blocks.size());
 
     std::vector<cytnx_int64> mapper_i64;
@@ -1154,61 +1150,55 @@ namespace cytnx {
   boost::intrusive_ptr<UniTensor_base> BlockFermionicUniTensor::relabel(
     //[21 Aug 2024] This is a copy from BlockUniTensor; creates a BlockFermionicUniTensor
     const std::vector<std::string> &new_labels) {
-    BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockFermionicUniTensor> tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->set_labels(new_labels);
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockFermionicUniTensor::relabel(
     //[21 Aug 2024] This is a copy from BlockUniTensor; creates a BlockFermionicUniTensor
     const std::vector<std::string> &old_labels, const std::vector<std::string> &new_labels) {
-    BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockFermionicUniTensor> tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->relabel_(old_labels, new_labels);
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockFermionicUniTensor::relabels(
     //[21 Aug 2024] This is a copy from BlockUniTensor; creates a BlockFermionicUniTensor
     const std::vector<std::string> &new_labels) {
-    BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockFermionicUniTensor> tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->set_labels(new_labels);
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockFermionicUniTensor::relabels(
     //[21 Aug 2024] This is a copy from BlockUniTensor; creates a BlockFermionicUniTensor
     const std::vector<std::string> &old_labels, const std::vector<std::string> &new_labels) {
-    BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockFermionicUniTensor> tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->relabels_(old_labels, new_labels);
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockFermionicUniTensor::relabel(
     const cytnx_int64 &inx, const std::string &new_label) {
     //[21 Aug 2024] This is a copy from BlockUniTensor; creates a BlockFermionicUniTensor
-    BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockFermionicUniTensor> tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->set_label(inx, new_label);
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockFermionicUniTensor::relabel(
     const std::string &inx, const std::string &new_label) {
     //[21 Aug 2024] This is a copy from BlockUniTensor; creates a BlockFermionicUniTensor
-    BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockFermionicUniTensor> tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->set_label(inx, new_label);
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockFermionicUniTensor::to_dense() {
@@ -1216,13 +1206,12 @@ namespace cytnx {
       boost::intrusive_ptr<UniTensor_base> out(this);
       return out;
     }
-    BlockFermionicUniTensor *tmp = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockFermionicUniTensor> tmp = this->clone_meta(true, true);
     tmp->_blocks.resize(this->_blocks.size());
     for (std::size_t i = 0; i < tmp->_blocks.size(); i++)
       tmp->_blocks[i] = cytnx::linalg::Diag(this->_blocks[i]);
     tmp->_is_diag = false;
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
   void BlockFermionicUniTensor::to_dense_() {
     if (this->_is_diag) {

--- a/src/BlockUniTensor.cpp
+++ b/src/BlockUniTensor.cpp
@@ -502,8 +502,7 @@ namespace cytnx {
       boost::intrusive_ptr<UniTensor_base> out(this);
       return out;
     } else {
-      BlockUniTensor *tmp = new BlockUniTensor();
-      tmp = this->clone_meta(true, true);
+      boost::intrusive_ptr<BlockUniTensor> tmp = this->clone_meta(true, true);
       tmp->_blocks.resize(this->_blocks.size());
       for (unsigned int b = 0; b < this->_blocks.size(); b++) {
         if (this->_blocks[b].is_contiguous()) {
@@ -512,8 +511,7 @@ namespace cytnx {
           tmp->_blocks[b] = this->_blocks[b].contiguous();
         }
       }
-      boost::intrusive_ptr<UniTensor_base> out(tmp);
-      return out;
+      return tmp;
     }
   }
 
@@ -521,7 +519,7 @@ namespace cytnx {
 
   boost::intrusive_ptr<UniTensor_base> BlockUniTensor::permute(
     const std::vector<cytnx_int64> &mapper, const cytnx_int64 &rowrank) {
-    BlockUniTensor *out_raw = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockUniTensor> out_raw = this->clone_meta(true, true);
     out_raw->_blocks.resize(this->_blocks.size());
 
     std::vector<cytnx_uint64> mapper_u64 = std::vector<cytnx_uint64>(mapper.begin(), mapper.end());
@@ -558,14 +556,13 @@ namespace cytnx {
       }
       out_raw->_is_braket_form = out_raw->_update_braket();
     }
-    boost::intrusive_ptr<UniTensor_base> out(out_raw);
 
-    return out;
+    return out_raw;
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockUniTensor::permute(
     const std::vector<std::string> &mapper, const cytnx_int64 &rowrank) {
-    BlockUniTensor *out_raw = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockUniTensor> out_raw = this->clone_meta(true, true);
     out_raw->_blocks.resize(this->_blocks.size());
 
     std::vector<cytnx_int64> mapper_i64;
@@ -643,56 +640,50 @@ namespace cytnx {
 
   boost::intrusive_ptr<UniTensor_base> BlockUniTensor::relabel(
     const std::vector<std::string> &new_labels) {
-    BlockUniTensor *tmp = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockUniTensor> tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->set_labels(new_labels);
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockUniTensor::relabel(
     const std::vector<std::string> &old_labels, const std::vector<std::string> &new_labels) {
-    BlockUniTensor *tmp = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockUniTensor> tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->relabel_(old_labels, new_labels);
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockUniTensor::relabels(
     const std::vector<std::string> &new_labels) {
-    BlockUniTensor *tmp = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockUniTensor> tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->set_labels(new_labels);
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockUniTensor::relabels(
     const std::vector<std::string> &old_labels, const std::vector<std::string> &new_labels) {
-    BlockUniTensor *tmp = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockUniTensor> tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->relabels_(old_labels, new_labels);
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockUniTensor::relabel(const cytnx_int64 &inx,
                                                                const std::string &new_label) {
-    BlockUniTensor *tmp = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockUniTensor> tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->set_label(inx, new_label);
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockUniTensor::relabel(const std::string &inx,
                                                                const std::string &new_label) {
-    BlockUniTensor *tmp = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockUniTensor> tmp = this->clone_meta(true, true);
     tmp->_blocks = this->_blocks;
     tmp->set_label(inx, new_label);
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
 
   boost::intrusive_ptr<UniTensor_base> BlockUniTensor::to_dense() {
@@ -700,13 +691,12 @@ namespace cytnx {
       boost::intrusive_ptr<UniTensor_base> out(this);
       return out;
     }
-    BlockUniTensor *tmp = this->clone_meta(true, true);
+    boost::intrusive_ptr<BlockUniTensor> tmp = this->clone_meta(true, true);
     tmp->_blocks.resize(this->_blocks.size());
     for (std::size_t i = 0; i < tmp->_blocks.size(); i++)
       tmp->_blocks[i] = cytnx::linalg::Diag(this->_blocks[i]);
     tmp->_is_diag = false;
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
   void BlockUniTensor::to_dense_() {
     if (this->_is_diag) {

--- a/src/DenseUniTensor.cpp
+++ b/src/DenseUniTensor.cpp
@@ -209,56 +209,50 @@ namespace cytnx {
 
   boost::intrusive_ptr<UniTensor_base> DenseUniTensor::relabel(
     const std::vector<std::string> &new_labels) {
-    DenseUniTensor *out_raw = this->clone_meta();
+    boost::intrusive_ptr<DenseUniTensor> out_raw = this->clone_meta();
     out_raw->_block = this->_block;
     out_raw->set_labels(new_labels);
-    boost::intrusive_ptr<UniTensor_base> out(out_raw);
-    return out;
+    return out_raw;
   }
 
   boost::intrusive_ptr<UniTensor_base> DenseUniTensor::relabel(
     const std::vector<std::string> &old_labels, const std::vector<std::string> &new_labels) {
-    DenseUniTensor *tmp = this->clone_meta();
+    boost::intrusive_ptr<DenseUniTensor> tmp = this->clone_meta();
     tmp->_block = this->_block;
     tmp->relabel_(old_labels, new_labels);
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
 
   boost::intrusive_ptr<UniTensor_base> DenseUniTensor::relabels(
     const std::vector<std::string> &new_labels) {
-    DenseUniTensor *out_raw = this->clone_meta();
+    boost::intrusive_ptr<DenseUniTensor> out_raw = this->clone_meta();
     out_raw->_block = this->_block;
     out_raw->set_labels(new_labels);
-    boost::intrusive_ptr<UniTensor_base> out(out_raw);
-    return out;
+    return out_raw;
   }
 
   boost::intrusive_ptr<UniTensor_base> DenseUniTensor::relabels(
     const std::vector<std::string> &old_labels, const std::vector<std::string> &new_labels) {
-    DenseUniTensor *tmp = this->clone_meta();
+    boost::intrusive_ptr<DenseUniTensor> tmp = this->clone_meta();
     tmp->_block = this->_block;
     tmp->relabels_(old_labels, new_labels);
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
 
   boost::intrusive_ptr<UniTensor_base> DenseUniTensor::relabel(const cytnx_int64 &inx,
                                                                const std::string &new_label) {
-    DenseUniTensor *out_raw = this->clone_meta();
+    boost::intrusive_ptr<DenseUniTensor> out_raw = this->clone_meta();
     out_raw->_block = this->_block;
     out_raw->set_label(inx, new_label);
-    boost::intrusive_ptr<UniTensor_base> out(out_raw);
-    return out;
+    return out_raw;
   }
 
   boost::intrusive_ptr<UniTensor_base> DenseUniTensor::relabel(const std::string &inx,
                                                                const std::string &new_label) {
-    DenseUniTensor *out_raw = this->clone_meta();
+    boost::intrusive_ptr<DenseUniTensor> out_raw = this->clone_meta();
     out_raw->_block = this->_block;
     out_raw->set_label(inx, new_label);
-    boost::intrusive_ptr<UniTensor_base> out(out_raw);
-    return out;
+    return out_raw;
   }
 
   boost::intrusive_ptr<UniTensor_base> DenseUniTensor::permute(
@@ -266,8 +260,7 @@ namespace cytnx {
     // boost::intrusive_ptr<UniTensor_base> out = this->clone();
     // out->permute_(mapper,rowrank,by_label);
     // return out;
-    DenseUniTensor *out_raw = this->clone_meta();
-    // boost::intrusive_ptr<UniTensor_base> out(this->clone_meta());
+    boost::intrusive_ptr<DenseUniTensor> out_raw = this->clone_meta();
 
     std::vector<cytnx_uint64> mapper_u64;
 
@@ -297,8 +290,7 @@ namespace cytnx {
       }
       out_raw->_is_braket_form = out_raw->_update_braket();
     }
-    boost::intrusive_ptr<UniTensor_base> out(out_raw);
-    return out;
+    return out_raw;
   }
 
   boost::intrusive_ptr<UniTensor_base> DenseUniTensor::permute(
@@ -306,8 +298,7 @@ namespace cytnx {
     // boost::intrusive_ptr<UniTensor_base> out = this->clone();
     // out->permute_(mapper,rowrank,by_label);
     // return out;
-    DenseUniTensor *out_raw = this->clone_meta();
-    // boost::intrusive_ptr<UniTensor_base> out(this->clone_meta());
+    boost::intrusive_ptr<DenseUniTensor> out_raw = this->clone_meta();
 
     std::vector<cytnx_uint64> mapper_u64;
     // cytnx_error_msg(true,"[Developing!]%s","\n");
@@ -347,8 +338,7 @@ namespace cytnx {
       }
       out_raw->_is_braket_form = out_raw->_update_braket();
     }
-    boost::intrusive_ptr<UniTensor_base> out(out_raw);
-    return out;
+    return out_raw;
   }
   void DenseUniTensor::permute_(const std::vector<cytnx_int64> &mapper,
                                 const cytnx_int64 &rowrank) {
@@ -645,7 +635,7 @@ namespace cytnx {
 
   boost::intrusive_ptr<UniTensor_base> DenseUniTensor::get(const std::vector<Accessor> &accessors) {
     if (accessors.empty()) return this->clone_meta();
-    DenseUniTensor *out_raw = this->clone_meta();
+    boost::intrusive_ptr<DenseUniTensor> out_raw = this->clone_meta();
     std::vector<cytnx_int64> removed;  // bonds to be removed
     if (this->_is_diag) {
       if (accessors.size() == 1) {
@@ -1007,11 +997,10 @@ namespace cytnx {
       boost::intrusive_ptr<UniTensor_base> out(this);
       return out;
     }
-    DenseUniTensor *tmp = this->clone_meta();
+    boost::intrusive_ptr<DenseUniTensor> tmp = this->clone_meta();
     tmp->_block = cytnx::linalg::Diag(this->_block);
     tmp->_is_diag = false;
-    boost::intrusive_ptr<UniTensor_base> out(tmp);
-    return out;
+    return tmp;
   }
   void DenseUniTensor::to_dense_() {
     if (this->_is_diag) {

--- a/src/linalg/ExpH.cpp
+++ b/src/linalg/ExpH.cpp
@@ -250,17 +250,18 @@ namespace cytnx {
         return out;
       } else if (Tin.uten_type() == UTenType.Block) {
         // copy everything except _blocks and _inner_to_outer_idx
-        BlockUniTensor *raw_out = ((BlockUniTensor *)Tin._impl.get())->clone_meta(false, true);
+        boost::intrusive_ptr<BlockUniTensor> raw_out =
+          ((BlockUniTensor *)Tin._impl.get())->clone_meta(false, true);
         UniTensor out;
-        out._impl = boost::intrusive_ptr<UniTensor_base>(raw_out);
+        out._impl = raw_out;
         ExpH_BlockUT_internal<BlockUniTensor>(out, Tin, a, b);
         return out;
       } else if (Tin.uten_type() == UTenType.BlockFermionic) {
         // copy everything except _blocks and _inner_to_outer_idx
-        BlockFermionicUniTensor *raw_out =
+        boost::intrusive_ptr<BlockFermionicUniTensor> raw_out =
           ((BlockFermionicUniTensor *)Tin._impl.get())->clone_meta(false, true);
         UniTensor out;
-        out._impl = boost::intrusive_ptr<UniTensor_base>(raw_out);
+        out._impl = raw_out;
         ExpH_BlockUT_internal<BlockFermionicUniTensor>(out, Tin, a, b);
         return out;
       } else {

--- a/src/linalg/ExpM.cpp
+++ b/src/linalg/ExpM.cpp
@@ -242,17 +242,18 @@ namespace cytnx {
         return out;
       } else if (Tin.uten_type() == UTenType.Block) {
         // copy everything except _blocks and _inner_to_outer_idx
-        BlockUniTensor *raw_out = ((BlockUniTensor *)Tin._impl.get())->clone_meta(false, true);
+        boost::intrusive_ptr<BlockUniTensor> raw_out =
+          ((BlockUniTensor *)Tin._impl.get())->clone_meta(false, true);
         UniTensor out;
-        out._impl = boost::intrusive_ptr<UniTensor_base>(raw_out);
+        out._impl = raw_out;
         ExpM_BlockUT_internal<BlockUniTensor>(out, Tin, a, b);
         return out;
       } else if (Tin.uten_type() == UTenType.BlockFermionic) {
         // copy everything except _blocks and _inner_to_outer_idx
-        BlockFermionicUniTensor *raw_out =
+        boost::intrusive_ptr<BlockFermionicUniTensor> raw_out =
           ((BlockFermionicUniTensor *)Tin._impl.get())->clone_meta(false, true);
         UniTensor out;
-        out._impl = boost::intrusive_ptr<UniTensor_base>(raw_out);
+        out._impl = raw_out;
         ExpM_BlockUT_internal<BlockFermionicUniTensor>(out, Tin, a, b);
         return out;
       } else {


### PR DESCRIPTION
## Problem

While verifying #1027 (the fix for #853), I ran the full `ctest` suite under `debug-openblas-cpu` and `debug-mkl-cpu` and found 27 failing tests, all `LeakSanitizer: detected memory leaks` (a different ASan detector than #852's `heap-buffer-overflow`/`strlen` root cause) — reported in [a comment on #852](https://github.com/Cytnx-dev/Cytnx/issues/852#issuecomment-4928277007). @ianmccul then diagnosed the mechanism in [a follow-up comment](https://github.com/Cytnx-dev/Cytnx/issues/852#issuecomment-4928400402): `DenseUniTensor::clone_meta()` returns a raw pointer instead of an owned smart pointer.

Concretely: `DenseUniTensor::clone_meta()`, `BlockUniTensor::clone_meta(bool, bool)`, and `BlockFermionicUniTensor::clone_meta(bool, bool)` allocate a new node with a bare `new` and return a raw pointer. Every caller (`relabel`, `relabels`, `set_rowrank`, `permute`, `permute_nosignflip`, `astype`, `contiguous`, `to_dense`, `get`) then runs further mutation on that raw pointer — typically through `set_label`/`set_labels`/`set_rowrank_`/`Tensor::astype`, all of which validate their arguments via `cytnx_error_msg` and can throw — before finally wrapping the pointer in a `boost::intrusive_ptr`. Since the object has no owner until that final wrap, a throw partway through leaks the allocation.

## Fix

`Tensor_impl::_clone_meta_only()` (`include/backend/Tensor_impl.hpp`) already gets this right: it returns a `boost::intrusive_ptr` from the point of allocation, so the object is owned throughout the caller's body regardless of what throws. This PR changes the three `UniTensor` `clone_meta()` overloads to do the same, and updates every call site's local variable from a raw `T *` to `boost::intrusive_ptr`. No caller's logic changes — ownership now starts at allocation instead of at the end of the function body, so a mid-function throw unwinds through the `intrusive_ptr`'s destructor instead of leaking.

Two related bugs fixed in the same pass since they were touched anyway:
- `BlockUniTensor::contiguous()` and `BlockFermionicUniTensor::contiguous()` each allocated a throwaway node with `new` and immediately discarded it by reassigning the variable to `clone_meta()`'s result on the next line.
- `DenseUniTensor::astype()` returned the pre-wrap raw pointer (`tmp`) instead of the wrapped `out`, leaving `out` computed and discarded — harmless under the old add-ref semantics, but dead code that no longer compiles once `tmp` becomes an `intrusive_ptr`.

`DenseUniTensor::contract()` and the `BlockUniTensor`/`BlockFermionicUniTensor` `contract()` overloads build their result the same unowned-raw-pointer way, but through a direct `new`, not `clone_meta()`; none of the currently failing tests exercise their error paths, so that's left for a follow-up rather than folded into this diff.

## Testing

- `ctest --preset cpu-only` (`debug-openblas-cpu`): all 27 previously-failing tests (`linalg_Test.BkFUt_*`, `Arnoldi_Ut.fermionic_ArnoldiFermionic`, `Lanczos_Gnd.fermionic_LanczosFermionic`, `Lanczos.fermionic_LanczosArpackFermionic`, `DenseUniTensorTest.{set_rowrank_err,relabel,relabels,astype,permute_err,permute__err}`, `BlockFermionicUniTensorTest.{LinAlgElementwise,PermuteInPlaceOnSharedBlockDoesNotCorruptOtherHolder,convert_from_permute_roundtrip}`, `BlockUniTensorTest.{set_rowrank,relabels,relabel,contiguous,same_data}`, `NetworkTest.Network_fermionic_matches_contract`) now pass. Only remaining failure is `SearchTreeTest.BasicSearchOrder2`, a separate pre-existing issue tracked by #853 / #1027, unaffected by this change.
- `ctest --test-dir build/debug-mkl-cpu` (`debug-mkl-cpu`): same result — same 27 tests fixed, same single unrelated pre-existing failure.
- `pytest pytests/`: 75 passed, 1 skipped (unrelated to this change).
- `pre-commit run --files include/UniTensor.hpp src/BlockFermionicUniTensor.cpp src/BlockUniTensor.cpp src/DenseUniTensor.cpp src/linalg/ExpH.cpp src/linalg/ExpM.cpp`: clang-format (v14) clean.

Closes the 27-test leak class reported against #852; `SearchTreeTest.BasicSearchOrder2` itself is tracked separately by #853.