### PR TITLE
ci(release): prune old nightly wheels to stay under anaconda.org quota

### DIFF
--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -16,6 +16,11 @@ name: Release wheels
 #     `cytnx-nightly-wheels` organisation channel on anaconda.org. The
 #     official `cytnx` PyPI project is never touched by this path, so
 #     production PyPI only ever holds tagged stable releases.
+#     anaconda.org enforces a 10GB storage quota on the channel, so
+#     before each upload tools/prune_nightly_wheels.py deletes old
+#     nightly releases down to 4, keeping the channel at 5 versions
+#     (4 kept + the one about to be uploaded) regardless of how the
+#     channel got there (#1021).
 #
 # Pull requests always resolve to the nightly channel with publishing
 # disabled: the PR is merged with its target branch and the nightly
@@ -258,7 +263,26 @@ jobs:
     needs: [DetermineChannel, BuildWheel]
     if: needs.DetermineChannel.outputs.channel == 'nightly' && needs.DetermineChannel.outputs.publish == 'true'
     runs-on: ubuntu-24.04
+    concurrency:
+      # Serializes prune+upload pairs so two nearby master merges can't
+      # interleave their prunes; a run that loses the race simply
+      # waits its turn rather than racing the channel state.
+      group: publish-nightly-anaconda
+      cancel-in-progress: false
     steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      with:
+        sparse-checkout: tools
+
+    - name: Prune old nightly releases
+      # Deletes nightly releases beyond the newest 4, so the channel
+      # holds at most 5 versions after this job's upload step runs.
+      # Runs before the upload so an already-over-quota channel (#1021)
+      # is brought back under budget instead of failing the upload.
+      env:
+        ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
+      run: python3 tools/prune_nightly_wheels.py --keep 4
+
     - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
       with:
         pattern: cibw-wheels-*

--- a/pytests/prune_nightly_wheels_test.py
+++ b/pytests/prune_nightly_wheels_test.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+
+from prune_nightly_wheels import select_versions_to_delete  # noqa: E402
+
+
+def test_fewer_than_keep_deletes_nothing():
+    versions = ["1.2.0.dev202601010000", "1.2.0.dev202601020000"]
+    assert select_versions_to_delete(versions, keep=5) == []
+
+
+def test_exactly_keep_deletes_nothing():
+    versions = [f"1.2.0.dev20260101{i:04d}" for i in range(5)]
+    assert select_versions_to_delete(versions, keep=5) == []
+
+
+def test_excess_deletes_oldest_first():
+    versions = [
+        "1.2.0.dev202601010000",  # oldest, should be deleted
+        "1.2.0.dev202601020000",
+        "1.2.0.dev202601030000",
+        "1.2.0.dev202601040000",
+        "1.2.0.dev202601050000",
+        "1.2.0.dev202601060000",  # newest
+    ]
+    assert select_versions_to_delete(versions, keep=5) == ["1.2.0.dev202601010000"]
+
+
+def test_already_over_quota_deletes_all_excess_at_once():
+    versions = [f"1.2.0.dev20260101{i:04d}" for i in range(12)]
+    to_delete = select_versions_to_delete(versions, keep=5)
+    assert len(to_delete) == 7
+    assert to_delete == versions[:7]
+
+
+def test_non_nightly_versions_are_never_selected_or_counted():
+    versions = [
+        "1.2.0",  # stable release, must never be touched
+        "1.2.0.dev202601010000",
+        "1.2.0.dev202601020000",
+        "1.2.0.dev202601030000",
+    ]
+    assert select_versions_to_delete(versions, keep=2) == ["1.2.0.dev202601010000"]
+
+
+def test_orders_across_base_version_bump():
+    versions = [
+        "0.10.0.dev202601010000",  # newer base version, older-looking string
+        "0.9.9.dev202601020000",
+    ]
+    assert select_versions_to_delete(versions, keep=1) == ["0.9.9.dev202601020000"]

--- a/tools/prune_nightly_wheels.py
+++ b/tools/prune_nightly_wheels.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Delete old nightly releases from the anaconda.org nightly channel.
+
+anaconda.org enforces a 10GB storage quota per organisation
+(cytnx-nightly-wheels). Since a nightly wheel set is uploaded on every push
+to master, the channel fills up in a matter of days (#1021). This script
+keeps the channel bounded by deleting every nightly release beyond the
+newest ``--keep`` versions, regardless of how the excess accumulated --
+whether from a burst of merges or from running for the first time against
+an already-over-quota channel.
+
+Only versions matching the stamp produced by
+tools/prepare_nightly_release.py (``MAJOR.MINOR.PATCH.devYYYYMMDDHHMM``)
+are ever considered for deletion. Anything else on the channel is left
+untouched and reported as unexpected, since deleting it could destroy a
+release this script was never meant to manage.
+
+Requires ``ANACONDA_API_TOKEN`` in the environment with delete permission
+on the channel. Uses only the standard library so no extra dependency is
+needed in the release-tools group.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+API_BASE = "https://api.anaconda.org"
+ORGANIZATION = "cytnx-nightly-wheels"
+PACKAGE = "cytnx"
+NIGHTLY_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)\.dev(\d{12})$")
+
+
+def fetch_versions() -> list[str]:
+    url = f"{API_BASE}/package/{ORGANIZATION}/{PACKAGE}"
+    with urllib.request.urlopen(url, timeout=30) as response:
+        return list(json.load(response)["versions"])
+
+
+def sort_key(version: str) -> tuple[int, int, int, str]:
+    major, minor, patch, dev_stamp = NIGHTLY_VERSION_RE.match(version).groups()
+    return (int(major), int(minor), int(patch), dev_stamp)
+
+
+def select_versions_to_delete(versions: list[str], keep: int) -> list[str]:
+    """Return the nightly versions to delete, oldest excess first.
+
+    Non-nightly-shaped versions are never selected and do not count
+    against ``keep``, so a stray non-dev release can't push a real
+    nightly out of the retained window.
+    """
+    nightly_versions = []
+    for version in versions:
+        if NIGHTLY_VERSION_RE.match(version):
+            nightly_versions.append(version)
+        else:
+            print(f"skipping non-nightly version on channel: {version}", file=sys.stderr)
+
+    nightly_versions.sort(key=sort_key)
+    excess = len(nightly_versions) - keep
+    return nightly_versions[:excess] if excess > 0 else []
+
+
+def delete_version(version: str, token: str) -> None:
+    url = f"{API_BASE}/release/{ORGANIZATION}/{PACKAGE}/{version}"
+    request = urllib.request.Request(
+        url, method="DELETE", headers={"Authorization": f"token {token}"}
+    )
+    try:
+        urllib.request.urlopen(request, timeout=30)
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            print(f"{version}: already gone, skipping")
+            return
+        raise
+    print(f"{version}: deleted")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--keep",
+        type=int,
+        required=True,
+        help="number of newest nightly versions to retain",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the versions that would be deleted without deleting them",
+    )
+    args = parser.parse_args()
+
+    versions = fetch_versions()
+    to_delete = select_versions_to_delete(versions, args.keep)
+
+    if not to_delete:
+        print(f"nothing to prune: {len(versions)} version(s) on channel, keeping {args.keep}")
+        return 0
+
+    if args.dry_run:
+        for version in to_delete:
+            print(f"{version}: would delete (dry run)")
+        return 0
+
+    token = os.environ.get("ANACONDA_API_TOKEN")
+    if not token:
+        sys.exit("ANACONDA_API_TOKEN is required to delete releases")
+
+    for version in to_delete:
+        delete_version(version, token)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/prune_nightly_wheels.py
+++ b/tools/prune_nightly_wheels.py
@@ -93,6 +93,8 @@ def main() -> int:
         help="print the versions that would be deleted without deleting them",
     )
     args = parser.parse_args()
+    if args.keep < 0:
+        parser.error("--keep must be a non-negative integer")
 
     versions = fetch_versions()
     to_delete = select_versions_to_delete(versions, args.keep)

--- a/tools/prune_nightly_wheels.py
+++ b/tools/prune_nightly_wheels.py
@@ -75,6 +75,11 @@ def delete_version(version: str, token: str) -> None:
         if error.code == 404:
             print(f"{version}: already gone, skipping")
             return
+        if error.code in (401, 403):
+            sys.exit(
+                f"{version}: permission denied ({error.code}) deleting release -- "
+                "the token needs delete permission on the channel, not just upload"
+            )
         raise
     print(f"{version}: deleted")
 


### PR DESCRIPTION
## Problem

`cytnx-nightly-wheels` uploads a new wheel set to anaconda.org on every push to `master`, with no retention limit. anaconda.org enforces a 10GB storage quota per organisation, and the channel exhausted it within about 17 days (#1021).

## Fix

- `tools/prune_nightly_wheels.py` — lists the channel's releases via the anaconda.org API, keeps only versions matching the `MAJOR.MINOR.PATCH.devYYYYMMDDHHMM` stamp produced by `tools/prepare_nightly_release.py`, and deletes every nightly release beyond the newest `--keep`. Anything not shaped like a nightly stamp is left untouched and reported, so the script can't destroy a release it wasn't meant to manage. Uses only the standard library, so no new dependency is needed.
- `PublishNightlyAnaconda` in `.github/workflows/release_pypi.yml` now runs `tools/prune_nightly_wheels.py --keep 4` **before** the upload step, so the channel holds at most 5 nightly versions (4 kept + the one about to be uploaded) after every run — regardless of how many versions were already there. Pruning first means a channel that's already over quota gets room freed before the upload is attempted, rather than the upload failing first. The job also gains the checkout step it was missing (`tools/` wasn't present before, since the job only downloaded wheel artifacts) and a concurrency group so two nearby `master` merges can't interleave prune/upload.

## Testing

- `pytest pytests/prune_nightly_wheels_test.py` — 6 unit tests on the pure selection function: nothing to prune, exactly at cap, excess trimmed, an already-way-over-quota channel trimmed in one pass, non-nightly versions excluded from both deletion and the keep-count, and correct ordering across a base-version bump (e.g. `0.9.9.dev…` vs `0.10.0.dev…`).
- Verified the fetch/parse/select path end-to-end against a mocked HTTP response (this sandbox's network policy doesn't allow reaching `api.anaconda.org` directly, so a live dry-run against the real channel wasn't possible from here).
- `pre-commit run --all-files` passes.

**Note for whoever merges this:** the existing `ANACONDA_ORG_UPLOAD_TOKEN` secret was provisioned for uploads only. If the first prune step on `master` gets a 401/403 from the delete call, the token needs reissuing with delete permission on the channel.

Closes #1021.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn7Smxf3M9JLjd6KjGWVbp)_