### PR TITLE
ci: include runner.arch in ccache cache keys

### DIFF
--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -63,9 +63,9 @@ jobs:
       with:
         path: |
           ~/.ccache
-        key: ccache-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+        key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.ref_name }}-${{ github.sha }}
         restore-keys: |
-          ccache-${{ runner.os }}-${{ github.ref_name }}-
+          ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.ref_name }}-
 
     - name: Cache Ccache Directory (pull_request)
       if: ${{ github.event_name == 'pull_request' }}
@@ -73,10 +73,10 @@ jobs:
       with:
         path: |
           ~/.ccache
-        key: ccache-${{ runner.os }}-${{ github.event.pull_request.head.ref }}-${{ github.sha }}
+        key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event.pull_request.head.ref }}-${{ github.sha }}
         restore-keys: |
-          ccache-${{ runner.os }}-${{ github.event.pull_request.head.ref }}-
-          ccache-${{ runner.os }}-${{ github.event.pull_request.base.ref }}-
+          ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event.pull_request.head.ref }}-
+          ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event.pull_request.base.ref }}-
 
     - name: start building
       # TODO: Consider to replace conda-build with rattler-build to speed up

--- a/.github/workflows/conda_build_release.yml
+++ b/.github/workflows/conda_build_release.yml
@@ -43,9 +43,9 @@ jobs:
       with:
         path: |
           ~/.ccache
-        key: ccache-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+        key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.ref_name }}-${{ github.sha }}
         restore-keys: |
-          ccache-${{ runner.os }}-${{ github.ref_name }}-
+          ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.ref_name }}-
 
     - name: start building
       # TODO: Consider to replace conda-build with rattler-build to speed up

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -184,10 +184,10 @@ jobs:
       with:
         path: |
           ~/.ccache
-        key: ccache-wheel-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+        key: ccache-wheel-${{ runner.os }}-${{ runner.arch }}-${{ github.ref_name }}-${{ github.sha }}
         restore-keys: |
-          ccache-wheel-${{ runner.os }}-${{ github.ref_name }}-
-          ccache-wheel-${{ runner.os }}-
+          ccache-wheel-${{ runner.os }}-${{ runner.arch }}-${{ github.ref_name }}-
+          ccache-wheel-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Set Ccache Directory
       run: |


### PR DESCRIPTION
*Posted by Claude Code on behalf of @pcchen*

## Problem

`runner.os` does not distinguish architectures: it is `macOS` for both `macos-latest` (ARM64) and `macos-15-intel` (X64), and `Linux` for both `ubuntu-24.04` and `ubuntu-24.04-arm`. Every ccache cache key in our workflows is built from `runner.os`, so matrix legs of different architectures share one key family. The consequence chain (full evidence in #1034):

1. The faster leg finishes first and saves the exact key `ccache-<os>-<branch>-<sha>`.
2. The slower leg's save of the same key is rejected as a duplicate — its compiled objects are discarded every run.
3. On the next run it restores the other architecture's cache, gets ~0% ccache hits, and recompiles all of Cytnx from scratch. `BuildAndTest-macos-15-intel` runs ~1h44m vs ~11m for the ARM leg, permanently.

## Fix

Add `${{ runner.arch }}` to every ccache `key` and `restore-keys` entry, giving each architecture its own cache family:

- `.github/workflows/conda_build.yml` — push + pull_request cache steps (macOS ARM/Intel collision)
- `.github/workflows/conda_build_release.yml` — same key pattern, same matrix
- `.github/workflows/release_pypi.yml` — wheel-build cache (both the macOS ARM/Intel and the Linux x64/ARM collisions)

The diff is exactly the 10 key/restore-key lines; no step logic changes.

## Testing

- `git diff` audited: only `key:`/`restore-keys:` lines change; expressions otherwise identical.
- The first run per architecture after merge starts cold (new key namespace — old `ccache-macOS-*`/`ccache-wheel-Linux-*` entries no longer match), so the *first* post-merge run stays slow; the speedup shows from the second run per architecture onward.
- Verifiable after merge via `GET /repos/Cytnx-dev/Cytnx/actions/caches`: expect separate `ccache-macOS-ARM64-*` and `ccache-macOS-X64-*` entries, with the X64 one at a realistic size (hundreds of MB) instead of the current shared ~33 MB.

Closes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)
