### PR TITLE
(AI guidance) document C++ robustness guidance for coding agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ Green locally before opening a PR. CI enforces:
   `{}` and one element. For plain dense `Tensor`, a single-element tensor may be
   convertible to a scalar as a convenience. For `UniTensor`, scalar semantics
   should mean rank 0; do not treat storage size 1 or all extents equal to 1 as
-  scalar because bonds, labels, quantum numbers, directions, and symmetry
+  a scalar because bonds, labels, quantum numbers, directions, and symmetry
   conventions are part of the object.
 - **Symmetric `UniTensor` element access is coefficient access.** `ut.at(...)`
   exposes a raw stored coefficient in a chosen basis/sector. It is not generally

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,28 @@ The rules agents most often get wrong:
 - **C++20 / CUDA 20 are the standard** — use them; never add C++17-compat
   workarounds.
 
+### Robust C++ in touched code
+
+Treat surrounding Cytnx code as historical context, not as an automatic style
+guide. When writing or modifying code:
+
+- Pass cheap scalar values by value, not by `const&`. This includes `bool`,
+  integral types, enum-like dtype/device values, floating-point values, `Scalar`,
+  and complex scalar types.
+- Avoid `cytnx_XXXX` typedefs for ordinary local programming types. Use standard
+  C++ types for counters, sizes, flags, loop indices, tolerances, and local
+  arithmetic unless the value is specifically a dtype-backed tensor/storage
+  scalar.
+- Do not add magic dtype integers. Use named dtype constants, type traits, or
+  established dispatch helpers.
+- Do not copy raw-memory idioms such as `&vec[0]`, vector-plus-`memcpy`, manual
+  container copies, or untyped `void*` handling unless the code is genuinely
+  doing representation-level storage or serialization work.
+- Prefer `std::vector::data()`, iterator construction, `std::copy`, range
+  algorithms, and typed loops when the operation is logically typed.
+- Keep this as a touched-code cleanup policy. Do not mechanically churn unrelated
+  files.
+
 ## Before you push — the CI gates
 
 Green locally before opening a PR. CI enforces:
@@ -123,6 +145,15 @@ Green locally before opening a PR. CI enforces:
   not alter algorithmic or mathematical behavior unprompted — flag it explicitly.
 - **Call out any mixed-dtype or type-promotion change** — it is easy to get subtly
   wrong (see gotchas below).
+- **Tests must check independent expected values.** Do not compare one Cytnx
+  implementation path against another path with the same possible bug. For
+  arithmetic and dtype changes, check both the result dtype and the numeric value.
+  Include values that expose common failures: fractional values, negative values,
+  mixed signed/unsigned cases, complex cases, rank-0 cases, and nontrivial shapes.
+- **Fix the relevant object families, or state the scope.** If a semantic fix
+  applies to `Tensor`, `DenseUniTensor`, `BlockUniTensor`, and
+  `BlockFermionicUniTensor`, either fix all relevant paths or state explicitly why
+  the PR scope is narrower.
 
 ## Domain gotchas (these bite agents)
 
@@ -132,6 +163,21 @@ Green locally before opening a PR. CI enforces:
 - **Type promotion goes through `Type.type_promote(a, b)`**, which promotes across
   the real/complex boundary by precision (#858, #982). Never hand-roll a
   "min enum index" rule — always fold with `type_promote`.
+- **Rank, scalar, and void states are semantic states.** Use `is_void()`,
+  `is_scalar()`, and `rank()` instead of inferring state from `shape()[0]`,
+  `shape().size()`, or direct storage access. Check rank before indexing
+  `shape()[n]` or `bonds()[n]`.
+- **Rank-0 scalar is not the same as shape `{1}`.** A rank-0 tensor has shape
+  `{}` and one element. For plain dense `Tensor`, a single-element tensor may be
+  convertible to a scalar as a convenience. For `UniTensor`, scalar semantics
+  should mean rank 0; do not treat storage size 1 or all extents equal to 1 as
+  scalar because bonds, labels, quantum numbers, directions, and symmetry
+  conventions are part of the object.
+- **Symmetric `UniTensor` element access is coefficient access.** `ut.at(...)`
+  exposes a raw stored coefficient in a chosen basis/sector. It is not generally
+  a physical scalar observable. User-facing code should prefer tensor-network
+  operations such as contraction, factorization, permutation, conjugation, and
+  scalar extraction only after a mathematically scalar result has been produced.
 - **GPU in-place arithmetic has kernel gaps.** `cuMul`/`cuDiv` lack the
   non-contiguous tensor⊗tensor kernels that `cuAdd`/`cuSub` have — contiguous-ize
   first or results are silently wrong; a narrow LHS can OOB-write; a length-1

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -31,6 +31,12 @@ the things actually worth flagging.
   `cytnx_uint64`, `Scalar`, and even `complex<double>`, by-value is never slower
   in Cytnx and is often faster (values ride in registers). Do not suggest
   converting scalar parameters to `const&`.
+- For new or touched code, avoid propagating legacy `cytnx_XXXX` typedefs as
+  ordinary loop counters, sizes, flags, or local arithmetic types. Prefer standard
+  C++ types unless the value is specifically a dtype-backed tensor/storage scalar.
+- Do not recommend vector-plus-`memcpy`, `&vec[0]`, or raw `void*` idioms for
+  typed operations. Those patterns are only appropriate for intentional
+  representation-level storage or serialization code.
 - **A trailing underscore on a method name (`Add_`, `contiguous_`, `Inv_`) marks
   an in-place mutator that returns `*this`.** This is Cytnx's convention and is
   *not* Google's "member variable" meaning — do not flag it or suggest renaming.
@@ -59,6 +65,16 @@ Focus reviews on what actually bites this codebase:
   boundary (`Type.type_promote`) and mixed-dtype paths.
 - **GPU kernel correctness** — in-place `cuMul`/`cuDiv` non-contiguous gaps
   (#988), contiguity assumptions, and out-of-bounds writes on a narrow LHS.
+- **Rank/scalar/void correctness** — missing rank checks before `shape()[n]` or
+  `bonds()[n]`, treating shape `{1}` as rank-0 scalar, or using direct storage
+  access where `item()`, `is_scalar()`, or `is_void()` is the intended API.
+- **Symmetric `UniTensor` semantics** — raw `ut.at(...)` coefficient access should
+  not be treated as producing a tensor-network scalar, and single-element
+  symmetric tensors should not be used as generic scalar broadcasts.
+- **Tests with independent expectations** — flag tests that compare one Cytnx
+  implementation path against another path with the same suspected bug. Prefer
+  tests that check independent expected values, and check both dtype and numeric
+  value for arithmetic changes.
 - Missing or weak tests; thread-safety and reentrancy; leaked resources.
 - Public-API / exported-target breakage (downstream `find_package(Cytnx)`).
 - Documentation drift.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -66,7 +66,7 @@ Focus reviews on what actually bites this codebase:
 - **GPU kernel correctness** — in-place `cuMul`/`cuDiv` non-contiguous gaps
   (#988), contiguity assumptions, and out-of-bounds writes on a narrow LHS.
 - **Rank/scalar/void correctness** — missing rank checks before `shape()[n]` or
-  `bonds()[n]`, treating shape `{1}` as rank-0 scalar, or using direct storage
+  `bonds()[n]`, treating shape `{1}` as a rank-0 scalar, or using direct storage
   access where `item()`, `is_scalar()`, or `is_void()` is the intended API.
 - **Symmetric `UniTensor` semantics** — raw `ut.at(...)` coefficient access should
   not be treated as producing a tensor-network scalar, and single-element


### PR DESCRIPTION
This PR updates the coding-agent guidance to document recurring C++ correctness and style rules that have come up in recent fixes.  Some of the issues are intended for post- #1026, so recommend that is landed before this one.

The main intent is to stop new patches from copying fragile legacy Cytnx idioms. This does not ask contributors to mechanically churn old files; it applies to new or touched code.

### What changed

- Add guidance to prefer robust modern C++ over legacy local idioms such as scalar parameters passed by `const&`, `cytnx_XXXX` loop counters, magic dtype integers, vector-plus-`memcpy`, and raw `void*` handling.
- Add guidance for explicit rank/scalar/void handling using `is_void()`, `is_scalar()`, and `rank()`.
- Clarify that `UniTensor` scalar semantics should mean rank 0, not storage size 1 or all extents equal to 1.
- Clarify that elements of a symmetric `UniTensor` are raw stored coefficients, not physical scalar observables, to gently discourage (but not ban) direct element access to `UniTensor`.
- Add review guidance around dtype promotion, mixed dtype arithmetic, dispatch, and tests that check independent expected values.
- Keep `AGENTS.md` as a pointer to `CLAUDE.md`; synchronize only the review-specific reminders in `GEMINI.md`.

### Why

Several recent fixes showed that the same classes of bugs appear across unrelated code paths: missing rank checks, scalar-like values passed by reference, ambiguous single-element tensor semantics, mixed dtype promotion bugs, and tests that compare against another broken internal path.

AI coding agents tend to imitate surrounding code. In this repository, the surrounding code often reflects historical implementation choices rather than the style or robustness expected in new work. The guidance should say that explicitly.

### Testing

Documentation-only change.