### PR TITLE
fix(tools): retry transient network failures in prune_nightly_wheels

### DIFF
--- a/pytests/prune_nightly_wheels_test.py
+++ b/pytests/prune_nightly_wheels_test.py
@@ -1,9 +1,14 @@
+import http.client
 import sys
+import urllib.error
 from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
 
-from prune_nightly_wheels import select_versions_to_delete  # noqa: E402
+from prune_nightly_wheels import _urlopen_with_retry, select_versions_to_delete  # noqa: E402
 
 
 def test_fewer_than_keep_deletes_nothing():
@@ -51,3 +56,60 @@ def test_orders_across_base_version_bump():
         "0.9.9.dev202601020000",
     ]
     assert select_versions_to_delete(versions, keep=1) == ["0.9.9.dev202601020000"]
+
+
+def _fake_response(body: bytes) -> MagicMock:
+    response = MagicMock()
+    response.read.return_value = body
+    response.__enter__.return_value = response
+    return response
+
+
+def _response_failing_read(error: Exception) -> MagicMock:
+    response = MagicMock()
+    response.read.side_effect = error
+    response.__enter__.return_value = response
+    return response
+
+
+@patch("prune_nightly_wheels.time.sleep")
+@patch("prune_nightly_wheels.urllib.request.urlopen")
+def test_retry_succeeds_after_transient_timeouts(mock_urlopen, mock_sleep):
+    mock_urlopen.side_effect = [TimeoutError(), TimeoutError(), _fake_response(b"body")]
+    assert _urlopen_with_retry(Mock(), timeout=30) == b"body"
+    assert mock_urlopen.call_count == 3
+    assert mock_sleep.call_count == 2
+
+
+@patch("prune_nightly_wheels.time.sleep")
+@patch("prune_nightly_wheels.urllib.request.urlopen")
+def test_retry_succeeds_after_incomplete_read(mock_urlopen, mock_sleep):
+    mock_urlopen.side_effect = [
+        _response_failing_read(http.client.IncompleteRead(b"partial")),
+        _fake_response(b"body"),
+    ]
+    assert _urlopen_with_retry(Mock(), timeout=30) == b"body"
+    assert mock_urlopen.call_count == 2
+    assert mock_sleep.call_count == 1
+
+
+@patch("prune_nightly_wheels.time.sleep")
+@patch("prune_nightly_wheels.urllib.request.urlopen")
+def test_retry_raises_after_exhausting_attempts(mock_urlopen, mock_sleep):
+    mock_urlopen.side_effect = TimeoutError()
+    with pytest.raises(TimeoutError):
+        _urlopen_with_retry(Mock(), timeout=30)
+    assert mock_urlopen.call_count == 3
+    assert mock_sleep.call_count == 2
+
+
+@patch("prune_nightly_wheels.time.sleep")
+@patch("prune_nightly_wheels.urllib.request.urlopen")
+def test_http_error_is_not_retried(mock_urlopen, mock_sleep):
+    mock_urlopen.side_effect = urllib.error.HTTPError(
+        "url", 404, "not found", hdrs=None, fp=None
+    )
+    with pytest.raises(urllib.error.HTTPError):
+        _urlopen_with_retry(Mock(), timeout=30)
+    assert mock_urlopen.call_count == 1
+    mock_sleep.assert_not_called()

--- a/tools/prune_nightly_wheels.py
+++ b/tools/prune_nightly_wheels.py
@@ -21,10 +21,12 @@ needed in the release-tools group.
 """
 
 import argparse
+import http.client
 import json
 import os
 import re
 import sys
+import time
 import urllib.error
 import urllib.request
 
@@ -32,12 +34,51 @@ API_BASE = "https://api.anaconda.org"
 ORGANIZATION = "cytnx-nightly-wheels"
 PACKAGE = "cytnx"
 NIGHTLY_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)\.dev(\d{12})$")
+MAX_ATTEMPTS = 3
+RETRY_BACKOFF_SECONDS = 2.0
+
+
+def _urlopen_with_retry(request: urllib.request.Request, *, timeout: int) -> bytes:
+    """Retry a full request/response cycle on transient network failures.
+
+    anaconda.org occasionally stalls a response -- whether while establishing
+    the connection or while streaming the body -- past the socket timeout
+    (surfaced as a bare ``TimeoutError``, since urllib only wraps
+    connection-establishment failures in ``URLError``), drops the connection
+    mid-request (``ConnectionError``), or closes it after sending only part
+    of the body (``http.client.IncompleteRead``, which subclasses
+    ``HTTPException`` rather than ``OSError`` and so isn't caught by
+    ``ConnectionError``/``URLError``). The body is read to completion inside
+    the same attempt so a stall during any of these phases is retried the
+    same way. ``HTTPError`` is a real response from the server (e.g.
+    404/401/403) and is never retried -- it propagates on the first attempt.
+    """
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return response.read()
+        except urllib.error.HTTPError:
+            raise
+        except (
+            TimeoutError,
+            ConnectionError,
+            http.client.IncompleteRead,
+            urllib.error.URLError,
+        ) as error:
+            if attempt == MAX_ATTEMPTS:
+                raise
+            print(
+                f"attempt {attempt}/{MAX_ATTEMPTS} failed ({error!r}), retrying",
+                file=sys.stderr,
+            )
+            time.sleep(RETRY_BACKOFF_SECONDS * attempt)
+    raise AssertionError("unreachable: the last attempt always returns or raises")
 
 
 def fetch_versions() -> list[str]:
     url = f"{API_BASE}/package/{ORGANIZATION}/{PACKAGE}"
-    with urllib.request.urlopen(url, timeout=30) as response:
-        return list(json.load(response)["versions"])
+    body = _urlopen_with_retry(urllib.request.Request(url), timeout=30)
+    return list(json.loads(body)["versions"])
 
 
 def sort_key(version: str) -> tuple[int, int, int, str]:
@@ -70,7 +111,7 @@ def delete_version(version: str, token: str) -> None:
         url, method="DELETE", headers={"Authorization": f"token {token}"}
     )
     try:
-        urllib.request.urlopen(request, timeout=30)
+        _urlopen_with_retry(request, timeout=30)
     except urllib.error.HTTPError as error:
         if error.code == 404:
             print(f"{version}: already gone, skipping")


### PR DESCRIPTION
## Problem

The `PublishNightlyAnaconda` job in `release_pypi.yml` ([run 29139955459](https://github.com/Cytnx-dev/Cytnx/actions/runs/29139955459/job/86524214608)) failed with a raw `TimeoutError` from `urllib` while `tools/prune_nightly_wheels.py` was deleting an old release from the `cytnx-nightly-wheels` channel on anaconda.org. The socket read stalled past the 30s timeout mid-response; `urllib` only wraps *connection-establishment* failures in `URLError`, so a stall during response reading propagates as a bare `TimeoutError` instead. Other runs of the same job around the same time completed successfully, indicating the anaconda.org API is occasionally slow rather than consistently broken.

## Fix

Added `_urlopen_with_retry`, used by both `fetch_versions` and `delete_version`, which retries the full request/response cycle up to 3 attempts with exponential backoff on `TimeoutError`, `ConnectionError`, and `URLError`. The response body is read to completion inside the retry loop, so a stall while streaming the body (not just while establishing the connection) is retried the same way; this also closes the response on every attempt via its own `with` block, avoiding a socket/file-descriptor leak in `delete_version`'s per-version loop. `HTTPError` (a real response from the server, e.g. 404/401/403) is excluded from the retry and propagates on the first attempt, since `delete_version` already handles those codes explicitly.

## Testing

- `pytests/prune_nightly_wheels_test.py` covers `_urlopen_with_retry` (retry-then-succeed, retry-exhaustion, no-retry-on-`HTTPError`) alongside the pre-existing `select_versions_to_delete` coverage.
- Exercised the fixed script manually against the live anaconda.org API:
  - `python3 tools/prune_nightly_wheels.py --keep 4 --dry-run` — confirmed `fetch_versions`/`select_versions_to_delete` work end-to-end against the real channel.
  - `python3 tools/prune_nightly_wheels.py --keep 3` — forced a real excess version and confirmed `delete_version` deletes it successfully; a follow-up dry run confirmed the channel dropped from 4 to 3 versions as expected.

This is a Python-tooling-only change (no C++/build code touched), so the full C++ build/test cycle wasn't required.