### PR TITLE
fix(linalg): handle zero-extent tensors

### DIFF
--- a/src/backend/linalg_internal_cpu/Mod_internal.hpp
+++ b/src/backend/linalg_internal_cpu/Mod_internal.hpp
@@ -47,6 +47,10 @@ namespace cytnx {
                                 const std::vector<cytnx_uint64> &invmapper_L,
                                 const std::vector<cytnx_uint64> &invmapper_R) {
       using TOut = cytnx::Type_class::type_promote_t<TLin, TRin>;
+      if constexpr (cytnx::is_complex_v<TOut>) {
+        cytnx_error_msg(true, "[Mod] Cannot mod complex numbers%s", "\n");
+      }
+
       TOut *_out = reinterpret_cast<TOut *>(out->data());
       const TLin *_Lin = reinterpret_cast<const TLin *>(Lin->data());
       const TRin *_Rin = reinterpret_cast<const TRin *>(Rin->data());

--- a/src/backend/linalg_internal_gpu/cuCpr_dispatch.cu
+++ b/src/backend/linalg_internal_gpu/cuCpr_dispatch.cu
@@ -214,6 +214,7 @@ namespace cytnx {
                         const std::vector<cytnx_uint64> &invmapper_R) {
       cytnx_error_msg(out->dtype() != Type.Bool,
                       "[cuCpr_dispatch] output dtype must be Bool, got=%d%s", out->dtype(), "\n");
+      if (len == 0) return;
 
       switch (Lin->dtype()) {
         case Type.ComplexDouble:

--- a/src/backend/linalg_internal_gpu/cuMod_dispatch.cu
+++ b/src/backend/linalg_internal_gpu/cuMod_dispatch.cu
@@ -224,6 +224,7 @@ namespace cytnx {
       cytnx_error_msg(out->dtype() != expected_dtype,
                       "[cuMod_dispatch] output dtype mismatch. got=%d expected=%d%s", out->dtype(),
                       expected_dtype, "\n");
+      if (len == 0) return;
 
       switch (Lin->dtype()) {
         case Type.Double:

--- a/src/linalg/Abs.cpp
+++ b/src/linalg/Abs.cpp
@@ -8,6 +8,7 @@
 namespace cytnx {
   namespace linalg {
     Tensor Abs(const Tensor &Tin) {
+      cytnx_error_msg(Tin.is_void(), "[Abs] cannot operate on an uninitialized Tensor.%s", "\n");
       Tensor out;
 
       // if the type is unsigned, clone and return.
@@ -23,6 +24,8 @@ namespace cytnx {
         out.storage() = Storage(Tin.storage().size(), Type.Float, Tin.device());
       else
         out.storage() = Storage(Tin.storage().size(), Tin.dtype(), Tin.device());
+
+      if (out.is_empty()) return out;
 
       if (Tin.device() == Device.cpu) {
         std::visit(

--- a/src/linalg/Abs_.cpp
+++ b/src/linalg/Abs_.cpp
@@ -8,6 +8,7 @@
 namespace cytnx {
   namespace linalg {
     void Abs_(Tensor &Tin) {
+      cytnx_error_msg(Tin.is_void(), "[Abs_] cannot operate on an uninitialized Tensor.%s", "\n");
       // Tensor out;
 
       // if the type is unsigned, clone and return.
@@ -22,6 +23,11 @@ namespace cytnx {
 
         } else {
           out = Tin;
+        }
+
+        if (out.is_empty()) {
+          if (Tin.dtype() == Type.ComplexDouble || Tin.dtype() == Type.ComplexFloat) Tin = out;
+          return;
         }
 
         if (Tin.device() == Device.cpu) {

--- a/src/linalg/Conj.cpp
+++ b/src/linalg/Conj.cpp
@@ -11,6 +11,7 @@ namespace cytnx {
 
   namespace linalg {
     Tensor Conj(const Tensor &Tin) {
+      cytnx_error_msg(Tin.is_void(), "[Conj] cannot operate on an uninitialized Tensor.%s", "\n");
       // cytnx_error_msg(Tin.shape().size() != 2,"[Inv] error, Inv can only operate on rank-2
       // Tensor.%s","\n"); cytnx_error_msg(!Tin.is_contiguous(), "[Inv] error tensor must be
       // contiguous. Call Contiguous_() or Contiguous() first%s","\n");
@@ -20,6 +21,7 @@ namespace cytnx {
 
       Tensor out;
       out = Tin.clone();
+      if (out.is_empty()) return out;
 
       if (Tin.device() == Device.cpu) {
         if (Type.is_complex(out.dtype()))

--- a/src/linalg/Conj_.cpp
+++ b/src/linalg/Conj_.cpp
@@ -11,12 +11,15 @@
 namespace cytnx {
   namespace linalg {
     void Conj_(Tensor &Tin) {
+      cytnx_error_msg(Tin.is_void(), "[Conj_] cannot operate on an uninitialized Tensor.%s", "\n");
       // cytnx_error_msg(Tin.shape().size() != 2,"[Inv] error, Inv can only operate on rank-2
       // Tensor.%s","\n"); cytnx_error_msg(!Tin.is_contiguous(), "[Inv] error tensor must be
       // contiguous. Call Contiguous_() or Contiguous() first%s","\n");
 
       // cytnx_error_msg(Tin.shape()[0] != Tin.shape()[1], "[Inv] error, the size of last two rank
       // should be the same.%s","\n");
+
+      if (Tin.is_empty()) return;
 
       if (Tin.device() == Device.cpu) {
         if (Type.is_complex(Tin.dtype()))

--- a/src/linalg/Det.cpp
+++ b/src/linalg/Det.cpp
@@ -1,6 +1,7 @@
 #include "linalg.hpp"
 
 #include <iostream>
+#include "Generator.hpp"
 #include "Tensor.hpp"
 
 #ifdef BACKEND_TORCH
@@ -25,6 +26,10 @@ namespace cytnx {
         out.Init({}, Type.Double, Device.cpu);  // scalar, so on cpu always!
       } else {
         out.Init({}, _tl.dtype(), Device.cpu);  // scalar, so on cpu always!
+      }
+
+      if (Tl.is_empty()) {
+        return ones({}, out.dtype(), Device.cpu);
       }
 
       if (Tl.device() == Device.cpu) {

--- a/src/linalg/Diag.cpp
+++ b/src/linalg/Diag.cpp
@@ -10,36 +10,35 @@
 namespace cytnx {
   namespace linalg {
     Tensor Diag(const Tensor &Tin) {
-      const cytnx_uint64 rank = Tin.rank();
+      cytnx_error_msg(Tin.is_void(), "[Diag] cannot operate on an uninitialized Tensor.%s", "\n");
+      const int rank = Tin.rank();
       cytnx_error_msg(rank == 0 || rank > 2,
                       "[ERROR] the input tensor should be rank-1 or rank-2 Tensor.%s", "\n");
 
-      Tensor out;
+      if (rank == 2) {
+        cytnx_error_msg(Tin.shape()[0] != Tin.shape()[1],
+                        "[ERROR] the input tensor is not a square matrix.%s", "\n");
+      }
+
+      Tensor out = rank == 1 ? zeros({Tin.shape()[0], Tin.shape()[0]}, Tin.dtype(), Tin.device())
+                             : zeros({Tin.shape()[0]}, Tin.dtype(), Tin.device());
+      if (out.is_empty()) return out;
 
       if (Tin.device() == Device.cpu) {
         if (rank == 1) {
-          out = zeros({Tin.shape()[0], Tin.shape()[0]}, Tin.dtype(), Tin.device());
           cytnx::linalg_internal::lii.Diag_ii[out.dtype()](
             out._impl->storage()._impl, Tin._impl->storage()._impl, Tin.shape()[0], 0);
         } else {
-          cytnx_error_msg(Tin.shape()[0] != Tin.shape()[1],
-                          "[ERROR] the input tensor is not a square matrix.%s", "\n");
-          out = zeros({Tin.shape()[0]}, Tin.dtype(), Tin.device());
           cytnx::linalg_internal::lii.Diag_ii[out.dtype()](
             out._impl->storage()._impl, Tin._impl->storage()._impl, Tin.shape()[0], 1);
         }
       } else {
   #ifdef UNI_GPU
-        // cytnx_error_msg(Tin.shape().size() != 1,
-        //                 "[ERROR] the input tensor should be a rank-1 Tensor.%s", "\n");
+        checkCudaErrors(cudaSetDevice(out.device()));
         if (rank == 1) {
-          out = zeros({Tin.shape()[0], Tin.shape()[0]}, Tin.dtype(), Tin.device());
-          checkCudaErrors(cudaSetDevice(out.device()));
           cytnx::linalg_internal::lii.cuDiag_ii[out.dtype()](
             out._impl->storage()._impl, Tin._impl->storage()._impl, Tin.shape()[0], 0);
         } else {
-          out = zeros({Tin.shape()[0]}, Tin.dtype(), Tin.device());
-          checkCudaErrors(cudaSetDevice(out.device()));
           cytnx::linalg_internal::lii.cuDiag_ii[out.dtype()](
             out._impl->storage()._impl, Tin._impl->storage()._impl, Tin.shape()[0], 1);
         }

--- a/src/linalg/Dot.cpp
+++ b/src/linalg/Dot.cpp
@@ -10,6 +10,8 @@
 namespace cytnx {
   namespace linalg {
     Tensor Dot(const Tensor &Tl, const Tensor &Tr) {
+      cytnx_error_msg(Tl.is_void() || Tr.is_void(),
+                      "[Dot] cannot operate on an uninitialized Tensor.%s", "\n");
       // checking contiguous
       // cytnx_error_msg(!Tl.is_contiguous(), "[Dot] error tensor Tl must be contiguous. Call
       // Contiguous_() or Contiguous() first%s","\n"); cytnx_error_msg(!Tr.is_contiguous(), "[Dot]
@@ -43,22 +45,24 @@ namespace cytnx {
         // from both inputs (e.g. ComplexFloat x Double -> ComplexDouble), so
         // cast both operands; astype is a no-op when the dtype already matches.
         const unsigned int out_dtype = Type.type_promote(Tl.dtype(), Tr.dtype());
-        Tensor _tl = Tl.contiguous().astype(out_dtype);
-        Tensor _tr = Tr.contiguous().astype(out_dtype);
         Tensor out;
         std::vector<cytnx_uint64> newshape = Tl.shape();
         newshape.pop_back();
-        cytnx_int32 lin_dim = 1;
+        std::size_t lin_dim = 1;
         for (int i = 0; i < newshape.size(); i++) lin_dim *= newshape[i];
 
-        // Matvec fully overwrites out (BLAS gemv uses beta=0; the integer kernel
-        // self-zeros each element), so skip the redundant zero-initialization.
-        out.Init(newshape, out_dtype, Tl.device(), false);
+        const bool zero_inner_dimension = Tr.shape()[0] == 0;
+        // A zero inner dimension gives a zero result. Other kernels fully overwrite out.
+        out.Init(newshape, out_dtype, Tl.device(), zero_inner_dimension);
+        if (zero_inner_dimension || out.is_empty()) return out;
+
+        Tensor tl = Tl.contiguous().astype(out_dtype);
+        Tensor tr = Tr.contiguous().astype(out_dtype);
 
         if (Tl.device() == Device.cpu) {
           cytnx::linalg_internal::lii.Matvec_ii[out.dtype()](
-            out._impl->storage()._impl, _tl._impl->storage()._impl, _tr._impl->storage()._impl,
-            lin_dim, _tr.shape()[0]);
+            out._impl->storage()._impl, tl._impl->storage()._impl, tr._impl->storage()._impl,
+            lin_dim, tr.shape()[0]);
 
           return out;
 
@@ -66,8 +70,8 @@ namespace cytnx {
   #ifdef UNI_GPU
           checkCudaErrors(cudaSetDevice(Tl.device()));
           cytnx::linalg_internal::lii.cuMatvec_ii[out.dtype()](
-            out._impl->storage()._impl, _tl._impl->storage()._impl, _tr._impl->storage()._impl,
-            lin_dim, _tr.shape()[0]);
+            out._impl->storage()._impl, tl._impl->storage()._impl, tr._impl->storage()._impl,
+            lin_dim, tr.shape()[0]);
 
           return out;
   #else

--- a/src/linalg/Eig.cpp
+++ b/src/linalg/Eig.cpp
@@ -45,6 +45,12 @@ namespace cytnx {
         V.Init(in.shape(), in.dtype(), in.device()); /*V.storage().set_zeros();*/
       }
 
+      if (in.is_empty()) {
+        std::vector<Tensor> out{S};
+        if (is_V) out.push_back(V);
+        return out;
+      }
+
       if (Tin.device() == Device.cpu) {
         cytnx::linalg_internal::lii.Eig_ii[in.dtype()](in._impl->storage()._impl,
                                                        S._impl->storage()._impl,

--- a/src/linalg/Eigh.cpp
+++ b/src/linalg/Eigh.cpp
@@ -36,6 +36,12 @@ namespace cytnx {
         V.Init(in.shape(), in.dtype(), in.device());
       }
 
+      if (in.is_empty()) {
+        std::vector<Tensor> out{S};
+        if (is_V) out.push_back(V);
+        return out;
+      }
+
       if (Tin.device() == Device.cpu) {
         cytnx::linalg_internal::lii.Eigh_ii[in.dtype()](in._impl->storage()._impl,
                                                         S._impl->storage()._impl,

--- a/src/linalg/Exp.cpp
+++ b/src/linalg/Exp.cpp
@@ -19,6 +19,8 @@ namespace cytnx {
       else
         cytnx_error_msg(true, "[Cannot have void (Uninitialize) Tensor]%s", "\n");
 
+      if (out.is_empty()) return out;
+
       // `out` already holds Tin cast to the dispatch dtype, so feed it as the kernel input too:
       // dispatching Exp_ii[out.dtype()] with Tin's original storage would reinterpret e.g. a
       // float buffer as double*. The kernels support in == out (see Exp_.cpp).

--- a/src/linalg/ExpM.cpp
+++ b/src/linalg/ExpM.cpp
@@ -24,8 +24,6 @@ namespace cytnx {
       cytnx_error_msg(Tin.shape()[0] != Tin.shape()[1],
                       "[ExpM] error, ExpM can only operator on square Tensor (#row = #col%s", "\n");
 
-      std::vector<Tensor> su = cytnx::linalg::Eig(Tin, true);
-      Tensor s, u, ut;
       // exp(a*M + b*I) with a == 0 is exp(b)*I: keep the bias b (matches ExpH).
       if (a == 0) {
         if (b == 0)
@@ -33,6 +31,9 @@ namespace cytnx {
         else
           return cytnx::identity(Tin.shape()[0], Tin.dtype(), Tin.device()) * exp(b);
       }
+
+      std::vector<Tensor> su = cytnx::linalg::Eig(Tin, true);
+      Tensor s, u, ut;
 
       if (b == 0)
         s = cytnx::linalg::Exp(a * su[0]);

--- a/src/linalg/Exp_.cpp
+++ b/src/linalg/Exp_.cpp
@@ -18,6 +18,8 @@ namespace cytnx {
       else
         cytnx_error_msg(true, "[Cannot have void (Uninitialize) Tensor]%s", "\n");
 
+      if (Tin.is_empty()) return;
+
       if (Tin.device() == Device.cpu) {
         cytnx::linalg_internal::lii.Exp_ii[Tin.dtype()](Tin._impl->storage()._impl,
                                                         Tin._impl->storage()._impl,

--- a/src/linalg/Expf.cpp
+++ b/src/linalg/Expf.cpp
@@ -19,6 +19,8 @@ namespace cytnx {
       else
         cytnx_error_msg(true, "[Cannot have void (Uninitialize) Tensor]%s", "\n");
 
+      if (out.is_empty()) return out;
+
       // `out` already holds Tin cast to the dispatch dtype, so feed it as the kernel input too:
       // dispatching Exp_ii[out.dtype()] with Tin's original storage would reinterpret e.g. a
       // double buffer as float*. The kernels support in == out (see Expf_.cpp).

--- a/src/linalg/Expf_.cpp
+++ b/src/linalg/Expf_.cpp
@@ -19,6 +19,8 @@ namespace cytnx {
       else
         cytnx_error_msg(true, "[Cannot have void (Uninitialize) Tensor]%s", "\n");
 
+      if (Tin.is_empty()) return;
+
       if (Tin.device() == Device.cpu) {
         cytnx::linalg_internal::lii.Exp_ii[Tin.dtype()](Tin._impl->storage()._impl,
                                                         Tin._impl->storage()._impl,

--- a/src/linalg/Gemm.cpp
+++ b/src/linalg/Gemm.cpp
@@ -74,7 +74,10 @@ namespace cytnx {
 
       if (c.is_empty()) return;
       if (px.shape()[1] == 0) {
-        c *= pb;
+        if (pb == Scalar(0.0))
+          c.storage().set_zeros();
+        else
+          c *= pb;
         return;
       }
 

--- a/src/linalg/Gemm.cpp
+++ b/src/linalg/Gemm.cpp
@@ -72,6 +72,12 @@ namespace cytnx {
       if (!py.is_contiguous()) py = py.contiguous();
       if (!c.is_contiguous()) c = c.contiguous();
 
+      if (c.is_empty()) return;
+      if (px.shape()[1] == 0) {
+        c *= pb;
+        return;
+      }
+
       if (x.device() == Device.cpu) {
         linalg_internal::lii.Gemm_ii[fin_dtype](c._impl->storage()._impl, px._impl->storage()._impl,
                                                 py._impl->storage()._impl, px.shape()[0],
@@ -125,6 +131,7 @@ namespace cytnx {
       if (!py.is_contiguous()) py = py.contiguous();
 
       Tensor out = zeros({px.shape()[0], py.shape()[1]}, fin_dtype, x.device());
+      if (out.is_empty() || px.shape()[1] == 0) return out;
 
       Scalar pb(1, fin_dtype);
 

--- a/src/linalg/Gemm_Batch.cpp
+++ b/src/linalg/Gemm_Batch.cpp
@@ -45,6 +45,7 @@ namespace cytnx {
       if (total_matrices == 0) return;
 
       const int device = a_tensors[0].device();
+      bool has_zero_extent = false;
 
       // Per-group scalar validation
       for (cytnx_int64 g = 0; g < group_count; g++) {
@@ -105,6 +106,8 @@ namespace cytnx {
         cytnx_error_msg(b_tensors[i].shape()[1] != c_tensors[i].shape()[1],
                         "[Gemm_Batch] error, b_tensors[%d],c_tensors[%d] dimension not match.%s", i,
                         i, "\n");
+        has_zero_extent = has_zero_extent || a_tensors[i].is_empty() || b_tensors[i].is_empty() ||
+                          c_tensors[i].is_empty();
       }
 
       // Within-group dimension consistency (MKL needs one m/n/k per group)
@@ -165,6 +168,19 @@ namespace cytnx {
           alpha_promoted[g] = alpha_array[g].astype(promoted_dtype);
         if (beta_array[g].dtype() != promoted_dtype)
           beta_promoted[g] = beta_array[g].astype(promoted_dtype);
+      }
+
+      // Batched BLAS interfaces do not consistently accept zero m/n/k. Fall back to the
+      // single-matrix wrapper, which implements the empty-output and k=0 semantics explicitly.
+      if (has_zero_extent) {
+        std::size_t idx = 0;
+        for (std::size_t g = 0; g < static_cast<std::size_t>(group_count); ++g) {
+          for (cytnx_int64 j = 0; j < group_size[g]; ++j, ++idx) {
+            Gemm_(alpha_promoted[g], a_promoted[idx], b_promoted[idx], beta_promoted[g],
+                  c_tensors[idx]);
+          }
+        }
+        return;
       }
 
       // Raw data pointer arrays

--- a/src/linalg/Ger.cpp
+++ b/src/linalg/Ger.cpp
@@ -33,6 +33,7 @@ namespace cytnx {
       Tensor py = y.astype(fin_dtype);
 
       Tensor out = zeros({x.shape()[0], y.shape()[0]}, fin_dtype, x.device());
+      if (out.is_empty()) return out;
 
       if (x.device() == Device.cpu) {
         linalg_internal::lii.ger_ii[fin_dtype](out.storage()._impl, px.storage()._impl,

--- a/src/linalg/Gesvd.cpp
+++ b/src/linalg/Gesvd.cpp
@@ -20,7 +20,7 @@ namespace cytnx {
       cytnx_error_msg(Tin.shape().size() != 2,
                       "[Gesvd] error, Gesvd can only operate on rank-2 Tensor.%s", "\n");
 
-      cytnx_uint64 n_singlu = std::max(cytnx_uint64(1), std::min(Tin.shape()[0], Tin.shape()[1]));
+      const cytnx_uint64 n_singlu = std::min(Tin.shape()[0], Tin.shape()[1]);
 
       Tensor in = Tin.contiguous();
       if (Tin.dtype() > Type.Float) in = in.astype(Type.Double);
@@ -36,6 +36,13 @@ namespace cytnx {
       if (is_vT) {
         vT.Init({n_singlu, in.shape()[1]}, in.dtype(), in.device());
         // vT.storage().set_zeros();
+      }
+
+      if (in.is_empty()) {
+        std::vector<Tensor> out{S};
+        if (is_U) out.push_back(U);
+        if (is_vT) out.push_back(vT);
+        return out;
       }
 
       if (Tin.device() == Device.cpu) {

--- a/src/linalg/Gesvd_truncate.cpp
+++ b/src/linalg/Gesvd_truncate.cpp
@@ -35,6 +35,16 @@ namespace cytnx {
       cytnx_error_msg(Tin.shape().size() != 2,
                       "[Gesvd_truncate] can only operate on rank-2 Tensor.%s", "\n");
 
+      if (Tin.is_empty()) {
+        std::vector<Tensor> out = Gesvd(Tin, is_U, is_vT);
+        if (return_err == 1) {
+          out.push_back(zeros({}, out[0].dtype(), out[0].device()));
+        } else if (return_err) {
+          out.push_back(zeros({0}, out[0].dtype(), out[0].device()));
+        }
+        return out;
+      }
+
       if (Tin.device() == Device.cpu) {
         std::vector<Tensor> outT = Gesvd(Tin, is_U, is_vT);
 

--- a/src/linalg/Inv.cpp
+++ b/src/linalg/Inv.cpp
@@ -18,6 +18,8 @@ namespace cytnx {
         out = Tin.clone();
       }
 
+      if (out.is_empty()) return out;
+
       if (Tin.device() == Device.cpu) {
         cytnx::linalg_internal::lii.Inv_inplace_ii[out.dtype()](
           out._impl->storage()._impl, out._impl->storage()._impl->size(), clip);

--- a/src/linalg/InvM.cpp
+++ b/src/linalg/InvM.cpp
@@ -22,6 +22,7 @@ namespace cytnx {
         out = Tin.clone();
 
       if (Tin.dtype() > 4) out = out.astype(Type.Double);
+      if (out.is_empty()) return out;
 
       if (Tin.device() == Device.cpu) {
         cytnx::linalg_internal::lii.InvM_inplace_ii[out.dtype()](out._impl->storage()._impl,

--- a/src/linalg/InvM_.cpp
+++ b/src/linalg/InvM_.cpp
@@ -15,6 +15,7 @@ namespace cytnx {
                       "[InvM] error, the size of last two rank should be the same.%s", "\n");
 
       if (Tin.dtype() > 4) Tin = Tin.contiguous().astype(Type.Double);
+      if (Tin.is_empty()) return;
 
       if (Tin.device() == Device.cpu) {
         cytnx::linalg_internal::lii.InvM_inplace_ii[Tin.dtype()](Tin._impl->storage()._impl,

--- a/src/linalg/Inv_.cpp
+++ b/src/linalg/Inv_.cpp
@@ -16,6 +16,8 @@ namespace cytnx {
         Tin = Tin.astype(Type.Double);
       }
 
+      if (Tin.is_empty()) return;
+
       if (Tin.device() == Device.cpu) {
         cytnx::linalg_internal::lii.Inv_inplace_ii[Tin.dtype()](
           Tin._impl->storage()._impl, Tin._impl->storage()._impl->size(), clip);

--- a/src/linalg/Kron.cpp
+++ b/src/linalg/Kron.cpp
@@ -67,6 +67,7 @@ namespace cytnx {
 
       Tensor out(new_shape, Type.type_promote(lhs_contiguous.dtype(), rhs_contiguous.dtype()),
                  lhs_contiguous.device());
+      if (out.is_empty()) return out;
 
       if (lhs_contiguous.device() == Device.cpu) {
         // Dispatch to the kernel based on the types of lhs and rhs.

--- a/src/linalg/Lstsq.cpp
+++ b/src/linalg/Lstsq.cpp
@@ -15,6 +15,10 @@ namespace cytnx {
 
       cytnx_error_msg(A.device() != b.device(),
                       "[Lsq] error, A and b should be on the same device!%s", "\n");
+      cytnx_error_msg(A.shape()[0] != b.shape()[0],
+                      "[Lsq] error, A and b must have the same number of rows.%s", "\n");
+      cytnx_error_msg(A.is_empty() || b.is_empty(),
+                      "[Lsq] error, Lstsq does not support zero-extent inputs.%s", "\n");
 
       cytnx_uint64 m = A.shape()[0];
       cytnx_uint64 n = A.shape()[1];

--- a/src/linalg/Matmul.cpp
+++ b/src/linalg/Matmul.cpp
@@ -35,16 +35,20 @@ namespace cytnx {
       // from both inputs (e.g. ComplexFloat x Double -> ComplexDouble), so
       // cast both operands; astype is a no-op when the dtype already matches.
       const unsigned int out_dtype = Type.type_promote(Tl.dtype(), Tr.dtype());
-      Tensor _tl = Tl.contiguous().astype(out_dtype);
-      Tensor _tr = Tr.contiguous().astype(out_dtype);
       Tensor out;
-      // the kernels fully overwrite the output, so skip zero-initialization
-      out.Init({Tl.shape()[0], Tr.shape()[1]}, out_dtype, Tl.device(), false);
+      const bool zero_inner_dimension = Tl.shape()[1] == 0;
+      // A zero inner dimension produces a nonempty zero matrix when both outer
+      // dimensions are nonzero. Other kernels fully overwrite their output.
+      out.Init({Tl.shape()[0], Tr.shape()[1]}, out_dtype, Tl.device(), zero_inner_dimension);
+      if (zero_inner_dimension || out.is_empty()) return out;
+
+      Tensor tl = Tl.contiguous().astype(out_dtype);
+      Tensor tr = Tr.contiguous().astype(out_dtype);
 
       if (Tl.device() == Device.cpu) {
         cytnx::linalg_internal::lii.Matmul_ii[out.dtype()](
-          out._impl->storage()._impl, _tl._impl->storage()._impl, _tr._impl->storage()._impl,
-          _tl.shape()[0], _tl.shape()[1], _tr.shape()[1]);
+          out._impl->storage()._impl, tl._impl->storage()._impl, tr._impl->storage()._impl,
+          tl.shape()[0], tl.shape()[1], tr.shape()[1]);
 
         return out;
 
@@ -52,8 +56,8 @@ namespace cytnx {
   #ifdef UNI_GPU
         checkCudaErrors(cudaSetDevice(Tl.device()));
         cytnx::linalg_internal::lii.cuMatmul_ii[out.dtype()](
-          out._impl->storage()._impl, _tl._impl->storage()._impl, _tr._impl->storage()._impl,
-          _tl.shape()[0], _tl.shape()[1], _tr.shape()[1]);
+          out._impl->storage()._impl, tl._impl->storage()._impl, tr._impl->storage()._impl,
+          tl.shape()[0], tl.shape()[1], tr.shape()[1]);
         return out;
   #else
         cytnx_error_msg(true, "[Matmul] fatal error,%s",

--- a/src/linalg/Matmul_dg.cpp
+++ b/src/linalg/Matmul_dg.cpp
@@ -44,16 +44,17 @@ namespace cytnx {
       // from both inputs (e.g. ComplexFloat x Double -> ComplexDouble), so
       // cast both operands; astype is a no-op when the dtype already matches.
       const unsigned int out_dtype = Type.type_promote(Tl.dtype(), Tr.dtype());
-      Tensor _tl = Tl.contiguous().astype(out_dtype);
-      Tensor _tr = Tr.contiguous().astype(out_dtype);
       Tensor out;
       out.Init({Tl.shape()[0], Tr.shape().back()}, out_dtype, Tl.device());
-      // out.storage().set_zeros();
+      if (out.is_empty()) return out;
+
+      Tensor tl = Tl.contiguous().astype(out_dtype);
+      Tensor tr = Tr.contiguous().astype(out_dtype);
 
       if (Tl.device() == Device.cpu) {
         cytnx::linalg_internal::lii.Matmul_dg_ii[out.dtype()](
-          out._impl->storage()._impl, _tl._impl->storage()._impl, _tr._impl->storage()._impl,
-          _tl.shape()[0], _tl.shape().back(), _tr.shape().back(), diag_L);
+          out._impl->storage()._impl, tl._impl->storage()._impl, tr._impl->storage()._impl,
+          tl.shape()[0], tl.shape().back(), tr.shape().back(), diag_L);
 
         // cytnx_error_msg(true,"[Developing][Matmul_dg][CPU]%s","\n");
 
@@ -63,8 +64,8 @@ namespace cytnx {
   #ifdef UNI_GPU
         checkCudaErrors(cudaSetDevice(Tl.device()));
         cytnx::linalg_internal::lii.cuMatmul_dg_ii[out.dtype()](
-          out._impl->storage()._impl, _tl._impl->storage()._impl, _tr._impl->storage()._impl,
-          _tl.shape()[0], _tl.shape().back(), _tr.shape().back(), diag_L);
+          out._impl->storage()._impl, tl._impl->storage()._impl, tr._impl->storage()._impl,
+          tl.shape()[0], tl.shape().back(), tr.shape().back(), diag_L);
         return out;
   #else
         cytnx_error_msg(true, "[Matmul] fatal error,%s",

--- a/src/linalg/Max.cpp
+++ b/src/linalg/Max.cpp
@@ -9,6 +9,7 @@ namespace cytnx {
   namespace linalg {
     Tensor Max(const Tensor &Tin) {
       cytnx_error_msg(Tin.dtype() == Type.Void, "[Cannot have void (Uninitialize) Tensor]%s", "\n");
+      cytnx_error_msg(Tin.is_empty(), "[Max] cannot reduce an empty Tensor.%s", "\n");
       Tensor out({}, Tin.dtype(), Tin.device());
 
       if (Tin.device() == Device.cpu) {

--- a/src/linalg/Min.cpp
+++ b/src/linalg/Min.cpp
@@ -10,6 +10,7 @@ namespace cytnx {
   namespace linalg {
     Tensor Min(const Tensor &Tin) {
       cytnx_error_msg(Tin.dtype() == Type.Void, "[Cannot have void (Uninitialize) Tensor]%s", "\n");
+      cytnx_error_msg(Tin.is_empty(), "[Min] cannot reduce an empty Tensor.%s", "\n");
       Tensor out({}, Tin.dtype(), Tin.device());
 
       if (Tin.device() == Device.cpu) {

--- a/src/linalg/Norm.cpp
+++ b/src/linalg/Norm.cpp
@@ -10,6 +10,7 @@
 namespace cytnx {
   namespace linalg {
     Tensor Norm(const Tensor& Tl) {
+      cytnx_error_msg(Tl.is_void(), "[Norm] cannot operate on an uninitialized Tensor.%s", "\n");
       // cytnx_error_msg(Tl.shape().size() != 1,"[Norm] error, tensor Tl ,Norm can only operate on
       // rank-1 Tensor.%s","\n"); cytnx_error_msg(!Tl.is_contiguous(), "[Norm] error tensor Tl must
       // be contiguous. Call Contiguous_() or Contiguous() first%s","\n");
@@ -33,6 +34,8 @@ namespace cytnx {
       } else {
         out.Init({}, _tl.dtype(), _tl.device());
       }
+
+      if (Tl.is_empty()) return out;
 
       if (Tl.device() == Device.cpu) {
         cytnx::linalg_internal::lii.Norm_ii[_tl.dtype()](out._impl->storage()._impl->data(),

--- a/src/linalg/Outer.cpp
+++ b/src/linalg/Outer.cpp
@@ -39,6 +39,7 @@ namespace cytnx {
       Tensor _Tr = Tr.astype(out_dtype);
 
       Tensor out(new_shape, out_dtype, Tl.device());
+      if (out.is_empty()) return out;
       cytnx_uint64 j1, j2;
       j1 = Tl.shape()[0];
       j2 = Tr.shape()[0];

--- a/src/linalg/Pow.cpp
+++ b/src/linalg/Pow.cpp
@@ -9,11 +9,14 @@
 namespace cytnx {
   namespace linalg {
     Tensor Pow(const Tensor &Tin, const double &p) {
+      cytnx_error_msg(Tin.is_void(), "[Pow] cannot operate on an uninitialized Tensor.%s", "\n");
       Tensor out;
       if (Tin.dtype() > 4)
         out = Tin.astype(Type.Double);
       else
         out = Tin.clone();
+
+      if (out.is_empty()) return out;
 
       if (Tin.device() == Device.cpu) {
         cytnx::linalg_internal::lii.Pow_ii[out.dtype()](out._impl->storage()._impl,
@@ -23,8 +26,8 @@ namespace cytnx {
   #ifdef UNI_GPU
         checkCudaErrors(cudaSetDevice(out.device()));
         cytnx::linalg_internal::lii.cuPow_ii[out.dtype()](out._impl->storage()._impl,
-                                                          Tin._impl->storage()._impl,
-                                                          Tin._impl->storage()._impl->size(), p);
+                                                          out._impl->storage()._impl,
+                                                          out._impl->storage()._impl->size(), p);
           // cytnx_error_msg(true,"[Pow][GPU] developing%s","\n");
   #else
         cytnx_error_msg(true, "[Pow] fatal error, the tensor is on GPU without CUDA support.%s",
@@ -36,11 +39,14 @@ namespace cytnx {
     }
 
     Tensor Pow(const Tensor &Tin, const Scalar &p) {
+      cytnx_error_msg(Tin.is_void(), "[Pow] cannot operate on an uninitialized Tensor.%s", "\n");
       Tensor out;
       if (Tin.dtype() > 4)
         out = Tin.astype(Type.Double);
       else
         out = Tin.clone();
+
+      if (out.is_empty()) return out;
 
       double dp = double(p);
 
@@ -52,8 +58,8 @@ namespace cytnx {
   #ifdef UNI_GPU
         checkCudaErrors(cudaSetDevice(out.device()));
         cytnx::linalg_internal::lii.cuPow_ii[out.dtype()](out._impl->storage()._impl,
-                                                          Tin._impl->storage()._impl,
-                                                          Tin._impl->storage()._impl->size(), dp);
+                                                          out._impl->storage()._impl,
+                                                          out._impl->storage()._impl->size(), dp);
           // cytnx_error_msg(true,"[Pow][GPU] developing%s","\n");
   #else
         cytnx_error_msg(true, "[Pow] fatal error, the tensor is on GPU without CUDA support.%s",

--- a/src/linalg/Pow_.cpp
+++ b/src/linalg/Pow_.cpp
@@ -9,7 +9,9 @@
 namespace cytnx {
   namespace linalg {
     void Pow_(Tensor &Tin, const double &p) {
+      cytnx_error_msg(Tin.is_void(), "[Pow_] cannot operate on an uninitialized Tensor.%s", "\n");
       if (Tin.dtype() > 4) Tin = Tin.astype(Type.Double);
+      if (Tin.is_empty()) return;
 
       if (Tin.device() == Device.cpu) {
         cytnx::linalg_internal::lii.Pow_ii[Tin.dtype()](Tin._impl->storage()._impl,
@@ -30,7 +32,9 @@ namespace cytnx {
     }
 
     void Pow_(Tensor &Tin, const Scalar &p) {
+      cytnx_error_msg(Tin.is_void(), "[Pow_] cannot operate on an uninitialized Tensor.%s", "\n");
       if (Tin.dtype() > 4) Tin = Tin.astype(Type.Double);
+      if (Tin.is_empty()) return;
       double dp = double(p);
 
       if (Tin.device() == Device.cpu) {

--- a/src/linalg/Qdr.cpp
+++ b/src/linalg/Qdr.cpp
@@ -17,7 +17,7 @@ namespace cytnx {
       cytnx_error_msg(Tin.shape().size() != 2,
                       "[Qdr] error, Qdr can only operate on rank-2 Tensor.%s", "\n");
 
-      cytnx_uint64 n_tau = std::max(cytnx_uint64(1), std::min(Tin.shape()[0], Tin.shape()[1]));
+      const cytnx_uint64 n_tau = std::min(Tin.shape()[0], Tin.shape()[1]);
 
       Tensor in = Tin.contiguous();
       if (Tin.dtype() > Type.Float) in = in.astype(Type.Double);
@@ -30,6 +30,13 @@ namespace cytnx {
       R.Init({n_tau, Tin.shape()[1]}, in.dtype(), in.device());
       R.storage().set_zeros();
       D = tau.clone();
+
+      if (in.is_empty()) {
+        Q.Init({Tin.shape()[0], n_tau}, in.dtype(), in.device());
+        std::vector<Tensor> out{Q, D, R};
+        if (is_tau) out.push_back(tau);
+        return out;
+      }
 
       if (Tin.device() == Device.cpu) {
         cytnx::linalg_internal::lii.QR_ii[in.dtype()](

--- a/src/linalg/Qr.cpp
+++ b/src/linalg/Qr.cpp
@@ -22,7 +22,7 @@ namespace cytnx {
       cytnx_error_msg(Tin.shape().size() != 2,
                       "[Qr] error, Qr can only operate on rank-2 Tensor.%s", "\n");
 
-      cytnx_uint64 n_tau = std::max(cytnx_uint64(1), std::min(Tin.shape()[0], Tin.shape()[1]));
+      const cytnx_uint64 n_tau = std::min(Tin.shape()[0], Tin.shape()[1]);
 
       Tensor in = Tin.contiguous();
       if (Tin.dtype() > Type.Float) in = in.astype(Type.Double);
@@ -32,6 +32,13 @@ namespace cytnx {
       tau.storage().set_zeros();
       R.Init({n_tau, Tin.shape()[1]}, in.dtype(), in.device());
       R.storage().set_zeros();
+
+      if (in.is_empty()) {
+        Q.Init({Tin.shape()[0], n_tau}, in.dtype(), in.device());
+        std::vector<Tensor> out{Q, R};
+        if (is_tau) out.push_back(tau);
+        return out;
+      }
 
       if (Tin.device() == Device.cpu) {
         Q.Init({Tin.shape()[0], Tin.shape()[1]}, in.dtype(), in.device());

--- a/src/linalg/Rand_isometry.cpp
+++ b/src/linalg/Rand_isometry.cpp
@@ -17,7 +17,13 @@ namespace cytnx {
     Tensor Rand_isometry(const Tensor &Tin, const cytnx_uint64 &keepdim,
                          const cytnx_uint64 &power_iteration, const unsigned int &seed) {
       std::vector<cytnx_uint64> shape = Tin.shape();
+      cytnx_error_msg(shape.size() != 2, "[Rand_isometry] can only operate on a rank-2 Tensor.%s",
+                      "\n");
       cytnx_int64 truncdim = std::min({keepdim, shape[0], shape[1]});
+      if (Tin.is_empty()) {
+        const unsigned int dtype = Tin.dtype() > Type.Float ? Type.Double : Tin.dtype();
+        return zeros({shape[0], static_cast<cytnx_uint64>(truncdim)}, dtype, Tin.device());
+      }
       shape[0] = shape[1];
       shape[1] = truncdim;
       Tensor randmat = random::normal(shape[0] * shape[1], 0., 1., Tin.device(), seed, Tin.dtype());

--- a/src/linalg/Rsvd.cpp
+++ b/src/linalg/Rsvd.cpp
@@ -436,10 +436,19 @@ namespace cytnx {
       cytnx_error_msg(return_err < 0, "[ERROR][Rsvd] return_err cannot be negative%s", "\n");
       //
       cytnx_error_msg(Tin.shape().size() != 2, "[Rsvd] can only operate on rank-2 Tensor.%s", "\n");
+      if (Tin.is_empty()) {
+        std::vector<Tensor> out = Gesvd(Tin, is_U, is_vT);
+        if (return_err == 1) {
+          out.push_back(zeros({}, out[0].dtype(), out[0].device()));
+        } else if (return_err) {
+          out.push_back(zeros({0}, out[0].dtype(), out[0].device()));
+        }
+        return out;
+      }
       cytnx_uint64 samplenum =
         (cytnx_uint64)((std::max(0., oversampling_factor) + 1.) * (double)keepdim) +
         oversampling_summand;
-      cytnx_uint64 n_singlu = std::max(cytnx_uint64(1), std::min(Tin.shape()[0], Tin.shape()[1]));
+      cytnx_uint64 n_singlu = std::min(Tin.shape()[0], Tin.shape()[1]);
       Tensor Q;
       if (Tin.device() == Device.cpu) {
         std::vector<Tensor> outT;

--- a/src/linalg/Sum.cpp
+++ b/src/linalg/Sum.cpp
@@ -9,6 +9,9 @@ namespace cytnx {
     Tensor Sum(const Tensor &Tin) {
       cytnx_error_msg(Tin.dtype() == Type.Void,
                       "[Cannot have void (uninitialized) Tensor as input]%s", "\n");
+      cytnx_error_msg(Tin.dtype() == Type.Bool,
+                      "[Sum] Bool tensors are not supported; cast to a numeric dtype first.%s",
+                      "\n");
       Tensor out({}, Tin.dtype(), Tin.device());
       if (Tin.is_empty()) return out;
 

--- a/src/linalg/Sum.cpp
+++ b/src/linalg/Sum.cpp
@@ -10,6 +10,7 @@ namespace cytnx {
       cytnx_error_msg(Tin.dtype() == Type.Void,
                       "[Cannot have void (uninitialized) Tensor as input]%s", "\n");
       Tensor out({}, Tin.dtype(), Tin.device());
+      if (Tin.is_empty()) return out;
 
       if (Tin.device() == Device.cpu) {
         cytnx::linalg_internal::lii.Sum_ii[out.dtype()](out._impl->storage()._impl,

--- a/src/linalg/Svd.cpp
+++ b/src/linalg/Svd.cpp
@@ -18,7 +18,7 @@ namespace cytnx {
       cytnx_error_msg(Tin.shape().size() != 2,
                       "[Svd] error, Svd can only operate on rank-2 Tensor.%s", "\n");
 
-      cytnx_uint64 n_singlu = std::max(cytnx_uint64(1), std::min(Tin.shape()[0], Tin.shape()[1]));
+      const cytnx_uint64 n_singlu = std::min(Tin.shape()[0], Tin.shape()[1]);
 
       Tensor in = Tin.contiguous();
       if (Tin.dtype() > Type.Float) in = in.astype(Type.Double);
@@ -34,6 +34,15 @@ namespace cytnx {
       if (is_UvT) {
         vT.Init({n_singlu, in.shape()[1]}, in.dtype(), in.device());
         // vT.storage().set_zeros();
+      }
+
+      if (in.is_empty()) {
+        std::vector<Tensor> out{S};
+        if (is_UvT) {
+          out.push_back(U);
+          out.push_back(vT);
+        }
+        return out;
       }
 
       if (Tin.device() == Device.cpu) {

--- a/src/linalg/Tensordot.cpp
+++ b/src/linalg/Tensordot.cpp
@@ -50,10 +50,16 @@ namespace cytnx {
 
       // calculate output shape:
       std::vector<cytnx_int64> new_shape(non_contract_l.size() + non_contract_r.size());
-      for (cytnx_uint64 i = 0; i < non_contract_l.size(); i++)
+      cytnx_int64 left_dim = 1;
+      cytnx_int64 right_dim = 1;
+      for (cytnx_uint64 i = 0; i < non_contract_l.size(); i++) {
         new_shape[i] = Tl.shape()[non_contract_l[i]];
-      for (cytnx_uint64 i = 0; i < non_contract_r.size(); i++)
+        left_dim *= new_shape[i];
+      }
+      for (cytnx_uint64 i = 0; i < non_contract_r.size(); i++) {
         new_shape[non_contract_l.size() + i] = Tr.shape()[non_contract_r[i]];
+        right_dim *= new_shape[non_contract_l.size() + i];
+      }
 
       Tensor tmpL = Tl;
       Tensor tmpR = Tr;
@@ -69,10 +75,10 @@ namespace cytnx {
         }
         tmpL.permute_(mapperL);
         oldshapeL = tmpL.shape();
-        tmpL.reshape_({-1, comm_dim});
+        tmpL.reshape_({left_dim, comm_dim});
 
       } else {
-        tmpL = Tl.permute(mapperL).reshape({-1, comm_dim});
+        tmpL = Tl.permute(mapperL).reshape({left_dim, comm_dim});
       }
       if (cacheR) {
         // calculate reverse mapper:
@@ -82,10 +88,10 @@ namespace cytnx {
         }
         tmpR.permute_(mapperR);
         oldshapeR = tmpR.shape();
-        tmpR.reshape_({comm_dim, -1});
+        tmpR.reshape_({comm_dim, right_dim});
 
       } else {
-        tmpR = Tr.permute(mapperR).reshape({comm_dim, -1});
+        tmpR = Tr.permute(mapperR).reshape({comm_dim, right_dim});
       }
 
       // permute!
@@ -184,7 +190,7 @@ namespace cytnx {
 
       Tensor out;
 
-      if (Tl.device() == Device.cpu) {
+      if (Tl.device() == Device.cpu || Tl.is_empty() || Tr.is_empty()) {
         _Tensordot_generic(out, Tl, Tr, idxl, idxr, cacheL, cacheR);
 
       } else {

--- a/src/linalg/Tensordot_dg.cpp
+++ b/src/linalg/Tensordot_dg.cpp
@@ -94,10 +94,16 @@ namespace cytnx {
 
       // calculate output shape:
       std::vector<cytnx_int64> new_shape(non_contract_l.size() + non_contract_r.size());
-      for (cytnx_uint64 i = 0; i < non_contract_l.size(); i++)
+      cytnx_int64 left_dim = 1;
+      cytnx_int64 right_dim = 1;
+      for (cytnx_uint64 i = 0; i < non_contract_l.size(); i++) {
         new_shape[i] = Tlshape[non_contract_l[i]];
-      for (cytnx_uint64 i = 0; i < non_contract_r.size(); i++)
+        left_dim *= new_shape[i];
+      }
+      for (cytnx_uint64 i = 0; i < non_contract_r.size(); i++) {
         new_shape[non_contract_l.size() + i] = Trshape[non_contract_r[i]];
+        right_dim *= new_shape[non_contract_l.size() + i];
+      }
 
       // permute!
       Tensor tmpL, tmpR, out, tmpout;
@@ -106,26 +112,27 @@ namespace cytnx {
         // Both bonds of Diag will be contracted.
         if (idxl.size() == 2) {
           tmpL = Tl;
-          tmpR = Tr.permute(mapperR).reshape({static_cast<cytnx_int64>(Tlshape[idxl[1]]), -1});
+          const cytnx_int64 diag_dim = Tlshape[idxl[1]];
+          tmpR = Tr.permute(mapperR).reshape({diag_dim, diag_dim * right_dim});
           tmpout = Matmul_dg(tmpL, tmpR);
           tmpout.reshape_({static_cast<cytnx_int64>(Tlshape[idxl[0]]),
-                           static_cast<cytnx_int64>(Tlshape[idxl[1]]), -1});
+                           static_cast<cytnx_int64>(Tlshape[idxl[1]]), right_dim});
           out = Trace(tmpout, 0, 1);
         } else {
           tmpL = Tl;
-          tmpR = Tr.permute(mapperR).reshape({comm_dim, -1});
+          tmpR = Tr.permute(mapperR).reshape({comm_dim, right_dim});
           out = Matmul_dg(tmpL, tmpR);
         }
       } else {
         if (idxr.size() == 2) {
-          tmpL = Tl.permute(mapperL).reshape({-1, comm_dim});
+          tmpL = Tl.permute(mapperL).reshape({left_dim, comm_dim});
           tmpR = Tr;
           tmpout = Matmul_dg(tmpL, tmpR);
-          tmpout.reshape_({-1, static_cast<cytnx_int64>(Tlshape[idxl[1]]),
+          tmpout.reshape_({left_dim, static_cast<cytnx_int64>(Tlshape[idxl[1]]),
                            static_cast<cytnx_int64>(Tlshape[idxl[0]])});
           out = Trace(tmpout, 1, 2);
         } else {
-          tmpL = Tl.permute(mapperL).reshape({-1, comm_dim});
+          tmpL = Tl.permute(mapperL).reshape({left_dim, comm_dim});
           tmpR = Tr;
           out = Matmul_dg(tmpL, tmpR);
         }

--- a/src/linalg/Tridiag.cpp
+++ b/src/linalg/Tridiag.cpp
@@ -25,6 +25,10 @@ namespace cytnx {
         "\n");
       cytnx_error_msg(Type.is_complex(Diag.dtype()) || Type.is_complex(Sub_diag.dtype()),
                       "[Tridiag] error, tri-diagonalize can only accept real vectors%s", "\n");
+      const cytnx_uint64 expected_subdiag_size = Diag.shape()[0] == 0 ? 0 : Diag.shape()[0] - 1;
+      cytnx_error_msg(Sub_diag.shape()[0] != expected_subdiag_size,
+                      "[Tridiag] error, Sub_diag must have max(Diag.size()-1, 0) elements.%s",
+                      "\n");
       // check prior type:
       unsigned int cType;
       if (Diag.dtype() < Sub_diag.dtype()) {
@@ -54,6 +58,16 @@ namespace cytnx {
         vT.Init({Diag.shape()[0], Diag.shape()[0]}, cType, Device.cpu);
       }
 
+      if (Diag.is_empty()) {
+        if (Diag.device() != Device.cpu) {
+          S.to_(Diag.device());
+          if (is_V) vT.to_(Diag.device());
+        }
+        std::vector<Tensor> out{S};
+        if (is_V) out.push_back(vT);
+        return out;
+      }
+
       if (Diag.device() == Device.cpu) {
         cytnx::linalg_internal::lii.Td_ii[cType](
           in_diag._impl->storage()._impl, s_diag._impl->storage()._impl, S._impl->storage()._impl,
@@ -79,7 +93,7 @@ namespace cytnx {
 
         // move result to GPU:
         S.to_(in_diag.device());
-        vT.to_(in_diag.device());
+        if (is_V) vT.to_(in_diag.device());
 
         std::vector<Tensor> out;
         out.push_back(S);

--- a/src/linalg/Vectordot.cpp
+++ b/src/linalg/Vectordot.cpp
@@ -10,6 +10,8 @@ namespace cytnx {
   namespace linalg {
     Tensor Vectordot(const Tensor &Tl, const Tensor &Tr, const bool &is_conj) {
       // checking:
+      cytnx_error_msg(Tl.is_void() || Tr.is_void(),
+                      "[Vectordot] cannot operate on an uninitialized Tensor.%s", "\n");
       cytnx_error_msg(Tl.device() != Tr.device(),
                       "[ERROR] Two tensors for Vectordot cannot be on different devices.%s", "\n");
       cytnx_error_msg(Tl.shape().size() != 1,
@@ -28,6 +30,7 @@ namespace cytnx {
       Tensor R = Tr.astype(out_dtype);
       Tensor out;
       out.Init({}, out_dtype, Tl.device());
+      if (Tl.is_empty()) return out;
 
       if (out.device() == Device.cpu) {
         cytnx::linalg_internal::lii.Vd_ii[out.dtype()](

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ add_executable(
   linalg_test/stride_view_test.cpp
   linalg_test/sum_test.cpp
   linalg_test/Vectordot_test.cpp
+  linalg_test/Zero_extent_test.cpp
   algo_test/Hsplit_test.cpp
   algo_test/Hstack_test.cpp
   algo_test/Vsplit_test.cpp

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(
   linalg_test/Trace_test.cpp
   linalg_test/linalg_test.cpp
   linalg_test/sum_test.cpp
+  linalg_test/Zero_extent_test.cpp
   algo_test/Hsplit_test.cpp
   algo_test/Hstack_test.cpp
   algo_test/Sort_test.cpp

--- a/tests/gpu/linalg_test/Zero_extent_test.cpp
+++ b/tests/gpu/linalg_test/Zero_extent_test.cpp
@@ -1,0 +1,107 @@
+#include "cytnx.hpp"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace cytnx {
+  namespace {
+
+    void ExpectGpuEmpty(const Tensor &tensor, const std::vector<cytnx_uint64> &shape,
+                        unsigned int dtype) {
+      EXPECT_TRUE(tensor.is_empty());
+      EXPECT_EQ(tensor.shape(), shape);
+      EXPECT_EQ(tensor.dtype(), dtype);
+      EXPECT_EQ(tensor.device(), Device.cuda);
+    }
+
+    void ExpectGpuAllEqual(const Tensor &tensor, double expected) {
+      Tensor flat = tensor.to(Device.cpu).reshape({static_cast<cytnx_int64>(tensor.size())});
+      for (cytnx_uint64 i = 0; i < flat.size(); ++i) {
+        EXPECT_DOUBLE_EQ(flat.at<double>({i}), expected);
+      }
+    }
+
+    TEST(ZeroExtentGpuLinalgTest, ElementwiseAndReductionsDoNotLaunchZeroBlockKernels) {
+      const std::vector<cytnx_uint64> shape{2, 0, 3};
+      Tensor lhs(shape, Type.Float, Device.cuda);
+      Tensor rhs(shape, Type.Double, Device.cuda);
+
+      ExpectGpuEmpty(linalg::Abs(Tensor(shape, Type.ComplexFloat, Device.cuda)), shape, Type.Float);
+      ExpectGpuEmpty(linalg::Conj(Tensor(shape, Type.ComplexFloat, Device.cuda)), shape,
+                     Type.ComplexFloat);
+      ExpectGpuEmpty(linalg::Exp(lhs), shape, Type.Double);
+      ExpectGpuEmpty(linalg::Inv(Tensor(shape, Type.Int64, Device.cuda)), shape, Type.Double);
+      ExpectGpuEmpty(linalg::Pow(Tensor(shape, Type.Int64, Device.cuda), 2.0), shape, Type.Double);
+      ExpectGpuEmpty(linalg::Mod(lhs, rhs), shape, Type.Double);
+      ExpectGpuEmpty(lhs == rhs, shape, Type.Bool);
+      ExpectGpuEmpty(linalg::Mod(lhs, 2.0), shape, Type.Double);
+      ExpectGpuEmpty(linalg::Cpr(lhs, 2.0), shape, Type.Bool);
+      EXPECT_THROW(linalg::Mod(Tensor(shape, Type.ComplexDouble, Device.cuda), rhs),
+                   std::logic_error);
+
+      EXPECT_DOUBLE_EQ(linalg::Sum(rhs).to(Device.cpu).at<double>({}), 0.0);
+      EXPECT_DOUBLE_EQ(linalg::Norm(rhs).to(Device.cpu).at<double>({}), 0.0);
+      EXPECT_THROW(linalg::Min(rhs), std::logic_error);
+      EXPECT_THROW(linalg::Max(rhs), std::logic_error);
+    }
+
+    TEST(ZeroExtentGpuLinalgTest, ProductsUseEmptyAndZeroInnerDimensionSemantics) {
+      Tensor product = linalg::Matmul(Tensor({2, 0}, Type.Float, Device.cuda),
+                                      Tensor({0, 3}, Type.Double, Device.cuda));
+      EXPECT_EQ(product.shape(), (std::vector<cytnx_uint64>{2, 3}));
+      EXPECT_EQ(product.dtype(), Type.Double);
+      ExpectGpuAllEqual(product, 0.0);
+
+      Tensor contracted = linalg::Tensordot(Tensor({2, 0, 3}, Type.Double, Device.cuda),
+                                            Tensor({4, 0, 5}, Type.Double, Device.cuda), {1}, {1});
+      EXPECT_EQ(contracted.shape(), (std::vector<cytnx_uint64>{2, 3, 4, 5}));
+      ExpectGpuAllEqual(contracted, 0.0);
+
+      Tensor c = ones({2, 3}, Type.Double, Device.cuda);
+      linalg::Gemm_(Scalar(3.0), Tensor({2, 0}, Type.Double, Device.cuda),
+                    Tensor({0, 3}, Type.Double, Device.cuda), Scalar(2.0), c);
+      ExpectGpuAllEqual(c, 2.0);
+
+      EXPECT_DOUBLE_EQ(linalg::Det(Tensor({0, 0}, Type.Double, Device.cuda)).at<double>({}), 1.0);
+    }
+
+    TEST(ZeroExtentGpuLinalgTest, ThinFactorizationsBypassGpuLibraries) {
+      Tensor matrix({3, 0}, Type.Float, Device.cuda);
+
+      std::vector<Tensor> svd = linalg::Svd(matrix);
+      ASSERT_EQ(svd.size(), 3);
+      ExpectGpuEmpty(svd[0], {0}, Type.Float);
+      ExpectGpuEmpty(svd[1], {3, 0}, Type.Float);
+      ExpectGpuEmpty(svd[2], {0, 0}, Type.Float);
+
+      std::vector<Tensor> qr = linalg::Qr(matrix, true);
+      ASSERT_EQ(qr.size(), 3);
+      ExpectGpuEmpty(qr[0], {3, 0}, Type.Float);
+      ExpectGpuEmpty(qr[1], {0, 0}, Type.Float);
+      ExpectGpuEmpty(qr[2], {0}, Type.Float);
+
+      std::vector<Tensor> eig = linalg::Eigh(Tensor({0, 0}, Type.Double, Device.cuda));
+      ASSERT_EQ(eig.size(), 2);
+      ExpectGpuEmpty(eig[0], {0}, Type.Double);
+      ExpectGpuEmpty(eig[1], {0, 0}, Type.Double);
+
+      std::vector<Tensor> tridiag = linalg::Tridiag(Tensor({0}, Type.Double, Device.cuda),
+                                                    Tensor({0}, Type.Double, Device.cuda));
+      ASSERT_EQ(tridiag.size(), 2);
+      ExpectGpuEmpty(tridiag[0], {0}, Type.Double);
+      ExpectGpuEmpty(tridiag[1], {0, 0}, Type.Double);
+    }
+
+    TEST(ZeroExtentGpuLinalgTest, IntegerPowReadsThePromotedBuffer) {
+      Tensor input = arange(1, 4, 1, Type.Int32, Device.cuda);
+      Tensor result = linalg::Pow(input, 2.0).to(Device.cpu);
+
+      ASSERT_EQ(result.dtype(), Type.Double);
+      EXPECT_DOUBLE_EQ(result.at<double>({0}), 1.0);
+      EXPECT_DOUBLE_EQ(result.at<double>({1}), 4.0);
+      EXPECT_DOUBLE_EQ(result.at<double>({2}), 9.0);
+    }
+
+  }  // namespace
+}  // namespace cytnx

--- a/tests/gpu/linalg_test/Zero_extent_test.cpp
+++ b/tests/gpu/linalg_test/Zero_extent_test.cpp
@@ -32,7 +32,7 @@ namespace cytnx {
       ExpectGpuEmpty(linalg::Abs(Tensor(shape, Type.ComplexFloat, Device.cuda)), shape, Type.Float);
       ExpectGpuEmpty(linalg::Conj(Tensor(shape, Type.ComplexFloat, Device.cuda)), shape,
                      Type.ComplexFloat);
-      ExpectGpuEmpty(linalg::Exp(lhs), shape, Type.Double);
+      ExpectGpuEmpty(linalg::Exp(rhs), shape, Type.Double);
       ExpectGpuEmpty(linalg::Inv(Tensor(shape, Type.Int64, Device.cuda)), shape, Type.Double);
       ExpectGpuEmpty(linalg::Pow(Tensor(shape, Type.Int64, Device.cuda), 2.0), shape, Type.Double);
       ExpectGpuEmpty(linalg::Mod(lhs, rhs), shape, Type.Double);

--- a/tests/gpu/linalg_test/Zero_extent_test.cpp
+++ b/tests/gpu/linalg_test/Zero_extent_test.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <vector>
 
 namespace cytnx {
@@ -27,6 +28,7 @@ namespace cytnx {
       Tensor lhs(shape, Type.Float, Device.cuda);
       Tensor rhs(shape, Type.Double, Device.cuda);
 
+      ExpectGpuEmpty(lhs.astype(Type.Double), shape, Type.Double);
       ExpectGpuEmpty(linalg::Abs(Tensor(shape, Type.ComplexFloat, Device.cuda)), shape, Type.Float);
       ExpectGpuEmpty(linalg::Conj(Tensor(shape, Type.ComplexFloat, Device.cuda)), shape,
                      Type.ComplexFloat);
@@ -41,6 +43,7 @@ namespace cytnx {
                    std::logic_error);
 
       EXPECT_DOUBLE_EQ(linalg::Sum(rhs).to(Device.cpu).at<double>({}), 0.0);
+      EXPECT_THROW(linalg::Sum(Tensor(shape, Type.Bool, Device.cuda)), std::logic_error);
       EXPECT_DOUBLE_EQ(linalg::Norm(rhs).to(Device.cpu).at<double>({}), 0.0);
       EXPECT_THROW(linalg::Min(rhs), std::logic_error);
       EXPECT_THROW(linalg::Max(rhs), std::logic_error);
@@ -62,6 +65,11 @@ namespace cytnx {
       linalg::Gemm_(Scalar(3.0), Tensor({2, 0}, Type.Double, Device.cuda),
                     Tensor({0, 3}, Type.Double, Device.cuda), Scalar(2.0), c);
       ExpectGpuAllEqual(c, 2.0);
+
+      c.fill(std::numeric_limits<double>::quiet_NaN());
+      linalg::Gemm_(Scalar(3.0), Tensor({2, 0}, Type.Double, Device.cuda),
+                    Tensor({0, 3}, Type.Double, Device.cuda), Scalar(0.0), c);
+      ExpectGpuAllEqual(c, 0.0);
 
       EXPECT_DOUBLE_EQ(linalg::Det(Tensor({0, 0}, Type.Double, Device.cuda)).at<double>({}), 1.0);
     }

--- a/tests/linalg_test/Zero_extent_test.cpp
+++ b/tests/linalg_test/Zero_extent_test.cpp
@@ -27,8 +27,8 @@ namespace cytnx {
 
       ExpectEmpty(linalg::Abs(Tensor(shape, Type.ComplexFloat)), shape, Type.Float);
       ExpectEmpty(linalg::Conj(Tensor(shape, Type.ComplexFloat)), shape, Type.ComplexFloat);
-      ExpectEmpty(linalg::Exp(Tensor(shape, Type.Float)), shape, Type.Double);
-      ExpectEmpty(linalg::Expf(Tensor(shape, Type.Double)), shape, Type.Float);
+      ExpectEmpty(linalg::Exp(Tensor(shape, Type.Double)), shape, Type.Double);
+      ExpectEmpty(linalg::Expf(Tensor(shape, Type.Float)), shape, Type.Float);
       ExpectEmpty(linalg::Inv(Tensor(shape, Type.Int64)), shape, Type.Double);
       ExpectEmpty(linalg::Pow(Tensor(shape, Type.Int64), 2.0), shape, Type.Double);
 
@@ -40,11 +40,11 @@ namespace cytnx {
       linalg::Conj_(value);
       ExpectEmpty(value, shape, Type.Float);
 
-      value = Tensor(shape, Type.Float);
+      value = Tensor(shape, Type.Double);
       linalg::Exp_(value);
       ExpectEmpty(value, shape, Type.Double);
 
-      value = Tensor(shape, Type.Double);
+      value = Tensor(shape, Type.Float);
       linalg::Expf_(value);
       ExpectEmpty(value, shape, Type.Float);
 

--- a/tests/linalg_test/Zero_extent_test.cpp
+++ b/tests/linalg_test/Zero_extent_test.cpp
@@ -1,0 +1,259 @@
+#include "cytnx.hpp"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace cytnx {
+  namespace {
+
+    void ExpectEmpty(const Tensor &tensor, const std::vector<cytnx_uint64> &shape,
+                     unsigned int dtype) {
+      EXPECT_TRUE(tensor.is_empty());
+      EXPECT_EQ(tensor.shape(), shape);
+      EXPECT_EQ(tensor.dtype(), dtype);
+    }
+
+    void ExpectAllEqual(const Tensor &tensor, double expected) {
+      Tensor flat = tensor.to(Device.cpu).reshape({static_cast<cytnx_int64>(tensor.size())});
+      for (cytnx_uint64 i = 0; i < flat.size(); ++i) {
+        EXPECT_DOUBLE_EQ(flat.at<double>({i}), expected);
+      }
+    }
+
+    TEST(ZeroExtentLinalgTest, UnaryOperationsPreserveShapeAndExpectedDtype) {
+      const std::vector<cytnx_uint64> shape{2, 0, 3};
+
+      ExpectEmpty(linalg::Abs(Tensor(shape, Type.ComplexFloat)), shape, Type.Float);
+      ExpectEmpty(linalg::Conj(Tensor(shape, Type.ComplexFloat)), shape, Type.ComplexFloat);
+      ExpectEmpty(linalg::Exp(Tensor(shape, Type.Float)), shape, Type.Double);
+      ExpectEmpty(linalg::Expf(Tensor(shape, Type.Double)), shape, Type.Float);
+      ExpectEmpty(linalg::Inv(Tensor(shape, Type.Int64)), shape, Type.Double);
+      ExpectEmpty(linalg::Pow(Tensor(shape, Type.Int64), 2.0), shape, Type.Double);
+
+      Tensor value(shape, Type.ComplexFloat);
+      linalg::Abs_(value);
+      ExpectEmpty(value, shape, Type.Float);
+
+      value = Tensor(shape, Type.Float);
+      linalg::Conj_(value);
+      ExpectEmpty(value, shape, Type.Float);
+
+      value = Tensor(shape, Type.Float);
+      linalg::Exp_(value);
+      ExpectEmpty(value, shape, Type.Double);
+
+      value = Tensor(shape, Type.Double);
+      linalg::Expf_(value);
+      ExpectEmpty(value, shape, Type.Float);
+
+      value = Tensor(shape, Type.Int64);
+      linalg::Inv_(value);
+      ExpectEmpty(value, shape, Type.Double);
+
+      value = Tensor(shape, Type.Int64);
+      linalg::Pow_(value, 2.0);
+      ExpectEmpty(value, shape, Type.Double);
+    }
+
+    TEST(ZeroExtentLinalgTest, BinaryOperationsDoNoWork) {
+      const std::vector<cytnx_uint64> shape{2, 0, 3};
+      Tensor lhs(shape, Type.Float);
+      Tensor rhs(shape, Type.Double);
+
+      ExpectEmpty(lhs + rhs, shape, Type.Double);
+      ExpectEmpty(lhs - rhs, shape, Type.Double);
+      ExpectEmpty(lhs * rhs, shape, Type.Double);
+      ExpectEmpty(lhs / rhs, shape, Type.Double);
+      ExpectEmpty(linalg::Mod(lhs, rhs), shape, Type.Double);
+      ExpectEmpty(lhs == rhs, shape, Type.Bool);
+
+      Tensor scalar({}, Type.Double);
+      scalar.at<double>({}) = 2.0;
+      ExpectEmpty(lhs + scalar, shape, Type.Double);
+      ExpectEmpty(linalg::Mod(lhs, scalar), shape, Type.Double);
+      ExpectEmpty(lhs == scalar, shape, Type.Bool);
+      ExpectEmpty(linalg::Mod(lhs, 2.0), shape, Type.Double);
+      ExpectEmpty(linalg::Cpr(lhs, 2.0), shape, Type.Bool);
+      EXPECT_THROW(linalg::Mod(Tensor(shape, Type.ComplexDouble), rhs), std::logic_error);
+
+      linalg::iAdd(lhs, rhs);
+      EXPECT_TRUE(lhs.is_empty());
+      linalg::iSub(lhs, rhs);
+      linalg::iMul(lhs, rhs);
+      linalg::iDiv(lhs, rhs);
+      EXPECT_EQ(lhs.shape(), shape);
+    }
+
+    TEST(ZeroExtentLinalgTest, ReductionsUseIdentitiesOrRejectUndefinedExtrema) {
+      Tensor real({2, 0, 3}, Type.Double);
+      Tensor complex({0}, Type.ComplexFloat);
+
+      EXPECT_DOUBLE_EQ(linalg::Sum(real).at<double>({}), 0.0);
+      EXPECT_FLOAT_EQ(linalg::Norm(complex).at<float>({}), 0.0f);
+      EXPECT_DOUBLE_EQ(
+        linalg::Vectordot(Tensor({0}, Type.Float), Tensor({0}, Type.Double)).at<double>({}), 0.0);
+      EXPECT_THROW(linalg::Min(real), std::logic_error);
+      EXPECT_THROW(linalg::Max(real), std::logic_error);
+
+      Tensor traced = linalg::Trace(Tensor({2, 0, 0, 3}, Type.Double), 1, 2);
+      EXPECT_EQ(traced.shape(), (std::vector<cytnx_uint64>{2, 3}));
+      ExpectAllEqual(traced, 0.0);
+    }
+
+    TEST(ZeroExtentLinalgTest, ProductsReturnEmptyOrAdditiveIdentity) {
+      Tensor zero_inner = linalg::Matmul(Tensor({2, 0}, Type.Float), Tensor({0, 3}, Type.Double));
+      EXPECT_EQ(zero_inner.shape(), (std::vector<cytnx_uint64>{2, 3}));
+      EXPECT_EQ(zero_inner.dtype(), Type.Double);
+      ExpectAllEqual(zero_inner, 0.0);
+
+      ExpectEmpty(linalg::Matmul(Tensor({0, 2}, Type.Double), Tensor({2, 3}, Type.Double)), {0, 3},
+                  Type.Double);
+      Tensor dot = linalg::Dot(Tensor({2, 0}, Type.Double), Tensor({0}, Type.Double));
+      EXPECT_EQ(dot.shape(), (std::vector<cytnx_uint64>{2}));
+      ExpectAllEqual(dot, 0.0);
+
+      ExpectEmpty(linalg::Diag(Tensor({0}, Type.Double)), {0, 0}, Type.Double);
+      ExpectEmpty(linalg::Diag(Tensor({0, 0}, Type.Double)), {0}, Type.Double);
+      ExpectEmpty(linalg::Outer(Tensor({0}, Type.Double), Tensor({3}, Type.Double)), {0, 3},
+                  Type.Double);
+      ExpectEmpty(linalg::Ger(Tensor({0}, Type.Double), Tensor({3}, Type.Double)), {0, 3},
+                  Type.Double);
+      ExpectEmpty(linalg::Kron(Tensor({0, 2}, Type.Double), Tensor({3, 4}, Type.Double)), {0, 8},
+                  Type.Double);
+      ExpectEmpty(linalg::Matmul_dg(Tensor({0}, Type.Double), Tensor({0, 3}, Type.Double)), {0, 3},
+                  Type.Double);
+
+      Tensor contracted =
+        linalg::Tensordot(Tensor({2, 0, 3}, Type.Double), Tensor({4, 0, 5}, Type.Double), {1}, {1});
+      EXPECT_EQ(contracted.shape(), (std::vector<cytnx_uint64>{2, 3, 4, 5}));
+      ExpectAllEqual(contracted, 0.0);
+
+      Tensor scalar =
+        linalg::Tensordot(Tensor({0}, Type.Double), Tensor({0}, Type.Double), {0}, {0});
+      EXPECT_TRUE(scalar.is_scalar());
+      EXPECT_DOUBLE_EQ(scalar.at<double>({}), 0.0);
+
+      Tensor weighted_trace = linalg::Tensordot_dg(
+        Tensor({0}, Type.Double), Tensor({0, 0, 2}, Type.Double), {0, 1}, {0, 1}, true);
+      EXPECT_EQ(weighted_trace.shape(), (std::vector<cytnx_uint64>{2}));
+      ExpectAllEqual(weighted_trace, 0.0);
+
+      ExpectEmpty(linalg::Directsum(Tensor({0, 2}, Type.Double), Tensor({0, 3}, Type.Double), {0}),
+                  {0, 5}, Type.Double);
+    }
+
+    TEST(ZeroExtentLinalgTest, MatrixFunctionsUseCanonicalEmptyResults) {
+      Tensor empty_matrix({0, 0}, Type.Double);
+      EXPECT_DOUBLE_EQ(linalg::Det(empty_matrix).at<double>({}), 1.0);
+      ExpectEmpty(linalg::InvM(empty_matrix), {0, 0}, Type.Double);
+      linalg::InvM_(empty_matrix);
+      ExpectEmpty(empty_matrix, {0, 0}, Type.Double);
+      ExpectEmpty(linalg::ExpH(empty_matrix), {0, 0}, Type.Double);
+      ExpectEmpty(linalg::ExpM(empty_matrix), {0, 0}, Type.ComplexDouble);
+
+      Tensor gemm =
+        linalg::Gemm(Scalar(3.0), Tensor({2, 0}, Type.Double), Tensor({0, 3}, Type.Double));
+      EXPECT_EQ(gemm.shape(), (std::vector<cytnx_uint64>{2, 3}));
+      ExpectAllEqual(gemm, 0.0);
+
+      Tensor c = ones({2, 3}, Type.Double);
+      linalg::Gemm_(Scalar(3.0), Tensor({2, 0}, Type.Double), Tensor({0, 3}, Type.Double),
+                    Scalar(2.0), c);
+      ExpectAllEqual(c, 2.0);
+    }
+
+    TEST(ZeroExtentLinalgTest, BatchedGemmFallsBackForZeroExtents) {
+      std::vector<Tensor> a{Tensor({2, 0}, Type.Double), eye(2, Type.Double)};
+      std::vector<Tensor> b{Tensor({0, 3}, Type.Double), eye(2, Type.Double)};
+      std::vector<Tensor> c{ones({2, 3}, Type.Double), ones({2, 2}, Type.Double)};
+
+      linalg::Gemm_Batch({Scalar(2.0), Scalar(3.0)}, a, b, {Scalar(4.0), Scalar(5.0)}, c, {1, 1});
+
+      ExpectAllEqual(c[0], 4.0);
+      EXPECT_DOUBLE_EQ(c[1].at<double>({0, 0}), 8.0);
+      EXPECT_DOUBLE_EQ(c[1].at<double>({0, 1}), 5.0);
+      EXPECT_DOUBLE_EQ(c[1].at<double>({1, 0}), 5.0);
+      EXPECT_DOUBLE_EQ(c[1].at<double>({1, 1}), 8.0);
+    }
+
+    TEST(ZeroExtentLinalgTest, ThinFactorizationsHaveZeroAuxiliaryDimension) {
+      Tensor matrix({3, 0}, Type.Float);
+
+      std::vector<Tensor> svd = linalg::Svd(matrix);
+      ASSERT_EQ(svd.size(), 3);
+      ExpectEmpty(svd[0], {0}, Type.Float);
+      ExpectEmpty(svd[1], {3, 0}, Type.Float);
+      ExpectEmpty(svd[2], {0, 0}, Type.Float);
+
+      std::vector<Tensor> gesvd = linalg::Gesvd(matrix);
+      ASSERT_EQ(gesvd.size(), 3);
+      ExpectEmpty(gesvd[0], {0}, Type.Float);
+      ExpectEmpty(gesvd[1], {3, 0}, Type.Float);
+      ExpectEmpty(gesvd[2], {0, 0}, Type.Float);
+
+      std::vector<Tensor> qr = linalg::Qr(matrix, true);
+      ASSERT_EQ(qr.size(), 3);
+      ExpectEmpty(qr[0], {3, 0}, Type.Float);
+      ExpectEmpty(qr[1], {0, 0}, Type.Float);
+      ExpectEmpty(qr[2], {0}, Type.Float);
+
+      std::vector<Tensor> qdr = linalg::Qdr(matrix, true);
+      ASSERT_EQ(qdr.size(), 4);
+      ExpectEmpty(qdr[0], {3, 0}, Type.Float);
+      ExpectEmpty(qdr[1], {0}, Type.Float);
+      ExpectEmpty(qdr[2], {0, 0}, Type.Float);
+      ExpectEmpty(qdr[3], {0}, Type.Float);
+
+      std::vector<Tensor> truncated = linalg::Svd_truncate(matrix, 2, 0.0, true, 2);
+      ASSERT_EQ(truncated.size(), 4);
+      ExpectEmpty(truncated[3], {0}, Type.Float);
+
+      std::vector<Tensor> gesvd_truncated = linalg::Gesvd_truncate(matrix, 2, 0.0, true, true, 2);
+      ASSERT_EQ(gesvd_truncated.size(), 4);
+      ExpectEmpty(gesvd_truncated[3], {0}, Type.Float);
+
+      std::vector<Tensor> randomized = linalg::Rsvd(matrix, 2, 0.0, true, true, 2);
+      ASSERT_EQ(randomized.size(), 4);
+      ExpectEmpty(randomized[0], {0}, Type.Float);
+      ExpectEmpty(randomized[3], {0}, Type.Float);
+
+      Tensor wide_matrix({0, 3}, Type.Float);
+      svd = linalg::Svd(wide_matrix);
+      ExpectEmpty(svd[0], {0}, Type.Float);
+      ExpectEmpty(svd[1], {0, 0}, Type.Float);
+      ExpectEmpty(svd[2], {0, 3}, Type.Float);
+
+      qr = linalg::Qr(wide_matrix);
+      ExpectEmpty(qr[0], {0, 0}, Type.Float);
+      ExpectEmpty(qr[1], {0, 3}, Type.Float);
+    }
+
+    TEST(ZeroExtentLinalgTest, EmptyEigenproblemsAndTridiagonalProblemReturnEmptyFactors) {
+      Tensor matrix({0, 0}, Type.Double);
+
+      std::vector<Tensor> eig = linalg::Eig(matrix);
+      ASSERT_EQ(eig.size(), 2);
+      ExpectEmpty(eig[0], {0}, Type.ComplexDouble);
+      ExpectEmpty(eig[1], {0, 0}, Type.ComplexDouble);
+
+      std::vector<Tensor> eigh = linalg::Eigh(matrix);
+      ASSERT_EQ(eigh.size(), 2);
+      ExpectEmpty(eigh[0], {0}, Type.Double);
+      ExpectEmpty(eigh[1], {0, 0}, Type.Double);
+
+      std::vector<Tensor> tridiag =
+        linalg::Tridiag(Tensor({0}, Type.Double), Tensor({0}, Type.Double));
+      ASSERT_EQ(tridiag.size(), 2);
+      ExpectEmpty(tridiag[0], {0}, Type.Double);
+      ExpectEmpty(tridiag[1], {0, 0}, Type.Double);
+      EXPECT_THROW(linalg::Tridiag(Tensor({2}, Type.Double), Tensor({0}, Type.Double)),
+                   std::logic_error);
+
+      ExpectEmpty(linalg::Rand_isometry(Tensor({3, 0}, Type.Float), 2), {3, 0}, Type.Float);
+      EXPECT_THROW(linalg::Lstsq(Tensor({0, 2}, Type.Double), Tensor({0, 1}, Type.Double)),
+                   std::logic_error);
+    }
+
+  }  // namespace
+}  // namespace cytnx

--- a/tests/linalg_test/Zero_extent_test.cpp
+++ b/tests/linalg_test/Zero_extent_test.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <vector>
 
 namespace cytnx {
@@ -90,6 +91,7 @@ namespace cytnx {
       Tensor complex({0}, Type.ComplexFloat);
 
       EXPECT_DOUBLE_EQ(linalg::Sum(real).at<double>({}), 0.0);
+      EXPECT_THROW(linalg::Sum(Tensor({0}, Type.Bool)), std::logic_error);
       EXPECT_FLOAT_EQ(linalg::Norm(complex).at<float>({}), 0.0f);
       EXPECT_DOUBLE_EQ(
         linalg::Vectordot(Tensor({0}, Type.Float), Tensor({0}, Type.Double)).at<double>({}), 0.0);
@@ -161,6 +163,11 @@ namespace cytnx {
       linalg::Gemm_(Scalar(3.0), Tensor({2, 0}, Type.Double), Tensor({0, 3}, Type.Double),
                     Scalar(2.0), c);
       ExpectAllEqual(c, 2.0);
+
+      c.fill(std::numeric_limits<double>::quiet_NaN());
+      linalg::Gemm_(Scalar(3.0), Tensor({2, 0}, Type.Double), Tensor({0, 3}, Type.Double),
+                    Scalar(0.0), c);
+      ExpectAllEqual(c, 0.0);
     }
 
     TEST(ZeroExtentLinalgTest, BatchedGemmFallsBackForZeroExtents) {


### PR DESCRIPTION
Harden error cases involving zero-extent tensors across elementwise, reduction, contraction, matrix, and thin-factorization APIs. Avoid zero-block CUDA launches and invalid BLAS/LAPACK calls, and add focused CPU and GPU regressions. Also drive-by fixes `Pow` CUDA dtype memory corruption bug.