### PR TITLE
refactor(linalg)!: consolidate Exp/Expf into one dtype-preserving Exp

### DIFF
--- a/include/linalg.hpp
+++ b/include/linalg.hpp
@@ -2261,50 +2261,47 @@ namespace cytnx {
     \f[
         T_{o}[i] = e^{T_{i}[i]}
     \f]
-    Note that it will cast to Double type or ComplexDouble type.
+    The output preserves the input's floating precision (Float stays Float, Double stays Double,
+    ComplexFloat/ComplexDouble preserved); integer/bool inputs promote to Double.
     @param[in] Tin a Tensor
-    @return
-        [Double Tensor] or [ComplexDouble Tensor]
+    @return a Tensor with the same floating dtype as \p Tin (Double for integer/bool input)
 
     */
     Tensor Exp(const Tensor &Tin);
 
     /**
-    @brief Exponential all the element in Tensor.
-    @details This function will perform Exponential on all the elements in Tensor \p Tin.
-    That is, the output will be:
-    \f[
-        T_{o}[i] = e^{T_{i}[i]}
-    \f]
-    Note that it will cast to Float type or ComplexFloat type.
+    @brief Exponential all the element in Tensor (deprecated).
+    @details This function will perform Exponential on all the elements in Tensor \p Tin,
+    casting to Float type or ComplexFloat type.
     @param[in] Tin a Tensor
     @return
         [Float Tensor] or [ComplexFloat Tensor]
-
+    @deprecated Use Exp() instead, which is dtype-preserving (a Float input already yields a
+    Float result); for the old float-precision-forcing behavior use Exp(Tin.astype(Type.Float)).
     */
-    Tensor Expf(const Tensor &Tin);
+    [[deprecated("use Exp() (dtype-preserving) instead")]] Tensor Expf(const Tensor &Tin);
 
     /**
     @brief inplace perform Exponential on all the element in Tensor.
     @details This function will perform Exponential on all the elements in Tensor \p Tin.
     Furthermore,
         1. on return, the elements in Tin will be modified to it's exponetial value.
-        2. For Real, if the type is not Double, change the type of the input tensor to Double.
-        3. For Complex, if input is ComplexFloat, promote to ComplexDouble.
+        2. the floating precision is preserved (Float stays Float, Double stays Double); only
+           integer/bool inputs are promoted to Double.
+        3. Complex inputs keep their precision (ComplexFloat stays ComplexFloat).
     @param[in] Tin, the input Tensor.
     */
     void Exp_(Tensor &Tin);
 
     /**
-    @brief inplace perform Exponential on all the element in Tensor.
-    @details This function will perform Exponential on all the elements in Tensor \p Tin.
-    Furthermore,
-        1. on return, the elements in Tin will be modified to it's exponetial value.
-        2. For Real, if the type is not Float, change the type of the input tensor to Float.
-        3. For Complex, if input is ComplexDouble, promote to ComplexFloat.
+    @brief inplace perform Exponential on all the element in Tensor (deprecated).
+    @details This function will perform Exponential on all the elements in Tensor \p Tin,
+    casting the input to Float / ComplexFloat in place.
     @param[in] Tin, the input Tensor.
+    @deprecated Use Exp_() instead, which is dtype-preserving; for the old float-precision-forcing
+    behavior cast first (Tin.astype_(Type.Float)) then call Exp_().
     */
-    void Expf_(Tensor &Tin);
+    [[deprecated("use Exp_() (dtype-preserving) instead")]] void Expf_(Tensor &Tin);
 
     // Pow:
     //==================================================

--- a/pybind/linalg_py.cpp
+++ b/pybind/linalg_py.cpp
@@ -235,8 +235,36 @@ void linalg_binding(py::module &m) {
 
   m_linalg.def("Exp", &cytnx::linalg::Exp, py::arg("Tin"));
   m_linalg.def("Exp_", &cytnx::linalg::Exp_, py::arg("Tio"));
-  m_linalg.def("Expf_", &cytnx::linalg::Expf_, py::arg("Tio"));
-  m_linalg.def("Expf", &cytnx::linalg::Expf, py::arg("Tio"));
+  // Expf/Expf_ are deprecated: Exp/Exp_ are now dtype-preserving (a Float input already yields a
+  // Float result), so the float-precision variants are redundant. The -Wdeprecated-declarations
+  // warning from calling the [[deprecated]] cytnx::linalg::Expf/Expf_ is suppressed around these
+  // standalone binding statements (legal at statement scope, unlike inside a .def() chain).
+  #if defined(__GNUC__) || defined(__clang__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  #endif
+  m_linalg.def(
+    "Expf_",
+    [](cytnx::Tensor &Tio) {
+      // PyErr_WarnEx returns -1 when the warning is turned into an exception (e.g. under
+      // -W error::DeprecationWarning); propagate it instead of continuing.
+      if (PyErr_WarnEx(PyExc_DeprecationWarning, "Expf_() is deprecated, use Exp_() instead.", 1) <
+          0)
+        throw py::error_already_set();
+      cytnx::linalg::Expf_(Tio);
+    },
+    py::arg("Tio"));
+  m_linalg.def(
+    "Expf",
+    [](cytnx::Tensor &Tio) {
+      if (PyErr_WarnEx(PyExc_DeprecationWarning, "Expf() is deprecated, use Exp() instead.", 1) < 0)
+        throw py::error_already_set();
+      return cytnx::linalg::Expf(Tio);
+    },
+    py::arg("Tio"));
+  #if defined(__GNUC__) || defined(__clang__)
+    #pragma GCC diagnostic pop
+  #endif
 
   // UT, [Note] no bool type!
   m_linalg.def(

--- a/src/linalg/Exp.cpp
+++ b/src/linalg/Exp.cpp
@@ -8,13 +8,13 @@ namespace cytnx {
   namespace linalg {
     Tensor Exp(const Tensor &Tin) {
       Tensor out;
-      if ((Tin.dtype() == Type.ComplexDouble) || (Tin.dtype() == Type.Double))
+      // dtype-preserving: a floating/complex input keeps its own precision (Float stays Float,
+      // ComplexFloat stays ComplexFloat), so Exp subsumes the former Expf(); only integer/bool
+      // inputs, which have no floating exp kernel, promote to Double.
+      if ((Tin.dtype() == Type.ComplexDouble) || (Tin.dtype() == Type.Double) ||
+          (Tin.dtype() == Type.ComplexFloat) || (Tin.dtype() == Type.Float))
         out = Tin.clone();
-      else if (Tin.dtype() == Type.ComplexFloat)
-        out = Tin.astype(Type.ComplexDouble);
       else if (Tin.dtype() > 4)
-        out = Tin.astype(Type.Double);
-      else if (Tin.dtype() == Type.Float)
         out = Tin.astype(Type.Double);
       else
         cytnx_error_msg(true, "[Cannot have void (Uninitialize) Tensor]%s", "\n");

--- a/src/linalg/Exp_.cpp
+++ b/src/linalg/Exp_.cpp
@@ -7,13 +7,13 @@
 namespace cytnx {
   namespace linalg {
     void Exp_(Tensor &Tin) {
-      if ((Tin.dtype() == Type.ComplexDouble) || (Tin.dtype() == Type.Double)) {
+      // dtype-preserving: a floating/complex input keeps its own precision in place (Float stays
+      // Float, ComplexFloat stays ComplexFloat), so Exp_ subsumes the former Expf_(); only
+      // integer/bool inputs, which have no floating exp kernel, promote to Double.
+      if ((Tin.dtype() == Type.ComplexDouble) || (Tin.dtype() == Type.Double) ||
+          (Tin.dtype() == Type.ComplexFloat) || (Tin.dtype() == Type.Float)) {
         ;
-      } else if (Tin.dtype() == Type.ComplexFloat)
-        Tin = Tin.astype(Type.ComplexDouble);
-      else if (Tin.dtype() > 4)
-        Tin = Tin.astype(Type.Double);
-      else if (Tin.dtype() == Type.Float)
+      } else if (Tin.dtype() > 4)
         Tin = Tin.astype(Type.Double);
       else
         cytnx_error_msg(true, "[Cannot have void (Uninitialize) Tensor]%s", "\n");

--- a/tests/linalg_test/DtypePromotion_test.cpp
+++ b/tests/linalg_test/DtypePromotion_test.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -276,21 +277,52 @@ namespace cytnx {
     ExpectComplexNear(out, {1, 1}, 1, 0);  // 2 * 0.5
   }
 
-  TEST(DtypePromotion, Exp_complexfloat_promotes_to_complexdouble) {
-    Tensor a = zeros({1}, Type.ComplexFloat, Device.cpu);  // exp(0) = 1
+  // Exp() is dtype-preserving: a ComplexFloat input keeps ComplexFloat (it no longer promotes to
+  // ComplexDouble). exp(1+i) = e*(cos 1 + i sin 1).
+  TEST(DtypePromotion, Exp_complexfloat_preserves_complexfloat) {
+    Tensor a = zeros({1}, Type.ComplexFloat, Device.cpu);
+    a.storage().at<cytnx_complex64>(0) = cytnx_complex64(1.0f, 1.0f);
     Tensor out = linalg::Exp(a);
-    ASSERT_EQ(out.dtype(), Type.ComplexDouble);
-    ExpectComplexNear(out, {0}, 1, 0);
+    ASSERT_EQ(out.dtype(), Type.ComplexFloat);
+    auto v = out.at<cytnx_complex64>({0});
+    EXPECT_NEAR(v.real(), std::exp(1.0f) * std::cos(1.0f), 1e-5);
+    EXPECT_NEAR(v.imag(), std::exp(1.0f) * std::sin(1.0f), 1e-5);
   }
 
-  TEST(DtypePromotion, Exp_float_reads_correct_buffer_width) {
-    // Old dispatch fed the float storage to the Double kernel, reinterpreting
-    // float bits as double. Nonzero input makes the corruption visible.
+  // Exp() is dtype-preserving: a Float input keeps Float and reads its own buffer width. A
+  // fractional, negative value exercises both the value and the (formerly mis-sized) read.
+  TEST(DtypePromotion, Exp_float_preserves_float) {
     Tensor a = zeros({1}, Type.Float, Device.cpu);
-    a.storage().at<cytnx_float>(0) = 1.0f;
+    a.storage().at<cytnx_float>(0) = -0.5f;
     Tensor out = linalg::Exp(a);
-    ASSERT_EQ(out.dtype(), Type.Double);
-    EXPECT_NEAR(out.at<cytnx_double>({0}), 2.718281828459045, 1e-6);
+    ASSERT_EQ(out.dtype(), Type.Float);
+    EXPECT_NEAR(out.at<cytnx_float>({0}), std::exp(-0.5f), 1e-6f);
+  }
+
+  // Double stays Double; integer promotes to Double (no floating exp kernel for ints).
+  TEST(DtypePromotion, Exp_double_and_int_dtypes) {
+    Tensor d = zeros({2}, Type.Double, Device.cpu);
+    d.at<cytnx_double>({0}) = 1.5;
+    d.at<cytnx_double>({1}) = -2.0;
+    Tensor od = linalg::Exp(d);
+    ASSERT_EQ(od.dtype(), Type.Double);
+    EXPECT_NEAR(od.at<cytnx_double>({0}), std::exp(1.5), 1e-12);
+    EXPECT_NEAR(od.at<cytnx_double>({1}), std::exp(-2.0), 1e-12);
+
+    Tensor i = zeros({1}, Type.Int64, Device.cpu);
+    i.at<cytnx_int64>({0}) = 2;
+    Tensor oi = linalg::Exp(i);
+    ASSERT_EQ(oi.dtype(), Type.Double);
+    EXPECT_NEAR(oi.at<cytnx_double>({0}), std::exp(2.0), 1e-12);
+  }
+
+  // Exp_() (in-place) preserves the input dtype as well.
+  TEST(DtypePromotion, Exp_inplace_preserves_dtype) {
+    Tensor f = zeros({1}, Type.Float, Device.cpu);
+    f.storage().at<cytnx_float>(0) = 0.25f;
+    linalg::Exp_(f);
+    ASSERT_EQ(f.dtype(), Type.Float);
+    EXPECT_NEAR(f.at<cytnx_float>({0}), std::exp(0.25f), 1e-6f);
   }
 
   TEST(DtypePromotion, Concatenate_complexfloat_double) {

--- a/tests/linalg_test/Zero_extent_test.cpp
+++ b/tests/linalg_test/Zero_extent_test.cpp
@@ -28,7 +28,7 @@ namespace cytnx {
       ExpectEmpty(linalg::Abs(Tensor(shape, Type.ComplexFloat)), shape, Type.Float);
       ExpectEmpty(linalg::Conj(Tensor(shape, Type.ComplexFloat)), shape, Type.ComplexFloat);
       ExpectEmpty(linalg::Exp(Tensor(shape, Type.Double)), shape, Type.Double);
-      ExpectEmpty(linalg::Expf(Tensor(shape, Type.Float)), shape, Type.Float);
+      ExpectEmpty(linalg::Exp(Tensor(shape, Type.Float)), shape, Type.Float);
       ExpectEmpty(linalg::Inv(Tensor(shape, Type.Int64)), shape, Type.Double);
       ExpectEmpty(linalg::Pow(Tensor(shape, Type.Int64), 2.0), shape, Type.Double);
 
@@ -45,7 +45,7 @@ namespace cytnx {
       ExpectEmpty(value, shape, Type.Double);
 
       value = Tensor(shape, Type.Float);
-      linalg::Expf_(value);
+      linalg::Exp_(value);
       ExpectEmpty(value, shape, Type.Float);
 
       value = Tensor(shape, Type.Int64);


### PR DESCRIPTION
## Problem
`Exp` and `Expf` are the same element-wise operation at two fixed precisions — `Exp` always computes in ≥ double (Float→Double, ComplexFloat→ComplexDouble), `Expf` always in float (Double→Float, ComplexDouble→ComplexFloat). Having two functions for one operation is redundant and easy to misuse.

## Fix
Make **`Exp`/`Exp_` dtype-preserving**: a floating/complex input keeps its own precision (Float→Float, Double→Double, ComplexFloat/ComplexDouble preserved); only integer/bool inputs, which have no floating exp kernel, promote to Double. This subsumes `Expf` — you get the precision of your input.

**`Expf`/`Expf_` are deprecated** (`[[deprecated]]` in C++, bodies unchanged as one-release shims). Their Python bindings now emit a `DeprecationWarning` and propagate it correctly under `-W error` (the lambdas check `PyErr_WarnEx`'s return before continuing, avoiding a `SystemError: returned a result with an exception set`).

⚠️ **BREAKING (flagged per CLAUDE.md — type-promotion change):** `Exp(Float)` now returns `Float` (was `Double`) and `Exp(ComplexFloat)` returns `ComplexFloat` (was `ComplexDouble`). `ExpM`/`ExpH` with the default `double` scalar are unaffected (their `Exp` input is already ≥ double); only explicit float-scalar instantiations shift precision, which is the more correct behavior. Migration for the old always-float behavior: `Exp(x.astype(Type.Float))`.

## Testing
- Updated the two intentional dtype tests (`Exp_complexfloat_*`, `Exp_float_*`) and added dtype **and** value coverage — Float, ComplexFloat (fractional/complex), Double, Int64→Double, and in-place `Exp_` — plus migrated the zero-extent `Expf`/`Expf_` cases to `Exp`/`Exp_`.
- **Full CPU `test_main`: 1219 passed / 11 skipped (unrelated `StoragePutValue`) / 0 failed.**
- Python (`pycytnx` built under GCC 13.3): `Exp(Float)→Float` / `Exp(Double)→Double` confirmed; `Expf` still computes (legacy float precision), emits `DeprecationWarning`, and raises cleanly under `-W error::DeprecationWarning`.
- clang-format v14 clean.

Note: user-facing API-doc prose (docs site) is deferred to a later docs pass; only the inline Doxygen inseparable from the behavior/deprecation change is updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
