### PR TITLE
fix(pybind)!: guard UniTensor//UniTensor floor-division (closes #934 hole from #997)

### DIFF
--- a/pybind/unitensor_py.cpp
+++ b/pybind/unitensor_py.cpp
@@ -1764,7 +1764,14 @@ void unitensor_binding(py::module &m) {
     .def("__itruediv__", [](UniTensor &self, const cytnx::Scalar &rhs) { return self.Div_(rhs); })
 
     // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
-    .def("__floordiv__", [](UniTensor &self, const UniTensor &rhs) { return linalg::Div(self, rhs); })
+    // Python '//' maps to __floordiv__, a distinct dunder from '/'. It must mirror __truediv__:
+    // UniTensor//UniTensor is the same removed elementwise (Hadamard) division (#934), so it raises
+    // rather than silently routing to linalg::Div -- otherwise 'a // b' is a back-door for the
+    // quotient that 'a / b' rejects. Scalar floordiv ('ut // 2.0') stays, matching scalar '/'.
+    .def("__floordiv__",
+         [](UniTensor &self, const UniTensor &rhs) -> UniTensor {
+           raise_unitensor_elementwise_removed(" // ", kUniTensorDivRemovedGuidance);
+         })
     .def("__floordiv__",
          [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
            return linalg::Div(self, static_cast<cytnx::cytnx_float>(rhs));
@@ -1859,8 +1866,12 @@ void unitensor_binding(py::module &m) {
     .def("__rfloordiv__", [](UniTensor &self, const cytnx::Scalar &lhs) { return linalg::Div(lhs, self); })
 
     // keep-set; registration ORDER matters -- see "KEEP-SET ORDERING" in pybind/pyint_dispatch.hpp.
+    // '//=' maps to __ifloordiv__; mirror __itruediv__ -- UniTensor//=UniTensor is the removed
+    // in-place elementwise division (#934), so it raises instead of routing to Div_.
     .def("__ifloordiv__",
-         [](UniTensor &self, const UniTensor &rhs) { return self.Div_(rhs); })
+         [](UniTensor &self, const UniTensor &rhs) -> UniTensor & {
+           raise_unitensor_elementwise_removed(" //= ", kUniTensorDivRemovedGuidance);
+         })
     .def("__ifloordiv__",
          [](UniTensor &self, const py::numpy_scalar<float> &rhs) {
            return self.Div_(static_cast<cytnx::cytnx_float>(rhs));

--- a/pytests/binding_unitensor_elementwise_test.py
+++ b/pytests/binding_unitensor_elementwise_test.py
@@ -13,7 +13,11 @@ well defined:
     TypeError instead.
   * ``*`` ``/`` ``*=`` ``/=`` are REMOVED: the elementwise (Hadamard)
     product/quotient of two UniTensors is basis-dependent and has no
-    tensor-network meaning. They raise TypeError with guidance.
+    tensor-network meaning. They raise TypeError with guidance. Python's
+    floor-division ``//`` / ``//=`` map to the distinct ``__floordiv__`` /
+    ``__ifloordiv__`` dunders but route to the same removed elementwise
+    division, so they must raise too (otherwise ``a // b`` back-doors the
+    quotient that ``a / b`` rejects).
 
 The C++ ``operator+``/``operator-`` on UniTensor (declared in
 include/linalg.hpp) is unchanged: src/linalg/Lanczos_Gnd_Ut.cpp and
@@ -139,6 +143,20 @@ def test_itruediv_unitensor_unitensor_raises():
         ut1 /= ut2
 
 
+def test_floordiv_unitensor_unitensor_raises():
+    # '//' (__floordiv__) is a distinct dunder from '/' but routes to the same
+    # removed elementwise division -- it must not back-door the quotient.
+    ut1, ut2 = _pair()
+    with pytest.raises(TypeError, match=r"(?s)934.*get_block"):
+        ut1 // ut2
+
+
+def test_ifloordiv_unitensor_unitensor_raises():
+    ut1, ut2 = _pair()
+    with pytest.raises(TypeError, match=r"(?s)934.*get_block"):
+        ut1 //= ut2
+
+
 # ---------------------------------------------------------------------------
 # Kept: scalar (+) UniTensor / UniTensor (+) scalar in both directions,
 # out-of-place and in-place.
@@ -175,6 +193,17 @@ def test_scalar_truediv_unitensor_still_works():
     r2 = 4.0 / ut
     assert r1.get_block()[0, 0].item() == 0.5
     assert r2.get_block()[0, 0].item() == 4.0
+
+
+def test_scalar_floordiv_unitensor_still_works():
+    # scope boundary: only the two-UniTensor '//' overload is removed; scalar
+    # floor division stays, mirroring scalar '/'. (It routes to linalg::Div, so
+    # 'ut // 2.0' matches 'ut / 2.0' rather than performing an integer floor.)
+    ut = cytnx.UniTensor(cytnx.ones([2, 2]))
+    r1 = ut // 2.0
+    assert r1.get_block()[0, 0].item() == 0.5
+    ut //= 2.0
+    assert ut.get_block()[0, 0].item() == 0.5
 
 
 def test_iadd_scalar_still_works():


### PR DESCRIPTION
## Problem

#997 removed elementwise `UniTensor ⊘ UniTensor` division from the Python surface — but only for the **true-division** dunders. Python's `/` maps to `__truediv__`, which #997 correctly guarded (raises `TypeError`). Python's **floor-division** `//` maps to a *distinct* dunder, `__floordiv__`, and the `UniTensor⊗UniTensor` overloads there were left routing straight to `linalg::Div` / `Div_`:

```python
ut1 / ut2    # TypeError  (removed, as #997 intended)
ut1 // ut2   # silently ran linalg::Div(ut1, ut2)   ← back-door
ut1 //= ut2  # silently ran ut1.Div_(ut2)           ← back-door
```

So `//` and `//=` were a silent back-door for the exact basis-dependent Hadamard quotient that `/` was made to reject (#934 — no well-defined tensor-network meaning, typically produces inf/nan). The floor-division path had **no test coverage** in `binding_unitensor_elementwise_test.py`, which is why the gap slipped through #997.

(There is no floor-**multiply** operator, so the `*` removal has no analogous hole — this is division-only.)

## Fix

The two `UniTensor⊗UniTensor` floordiv overloads now `raise_unitensor_elementwise_removed`, mirroring their `__truediv__` / `__itruediv__` siblings exactly and reusing the same `kUniTensorDivRemovedGuidance` message:

- `pybind/unitensor_py.cpp` `__floordiv__(UniTensor, UniTensor)` → raises `TypeError` (` // `)
- `pybind/unitensor_py.cpp` `__ifloordiv__(UniTensor, UniTensor)` → raises `TypeError` (` //= `)

**Scalar floordiv is retained** (`ut // 2.0`, `ut //= 2.0`), matching how scalar `/` is kept — only the two-UniTensor overloads change.

## Testing

`pytests/binding_unitensor_elementwise_test.py` — added:
- `test_floordiv_unitensor_unitensor_raises` — `ut1 // ut2` raises `TypeError`
- `test_ifloordiv_unitensor_unitensor_raises` — `ut1 //= ut2` raises `TypeError`
- `test_scalar_floordiv_unitensor_still_works` — pins the scope boundary (scalar `//` still works)

Rebuilt `openblas-cpu` and ran the suite: **23 passed** (was 20).

## Breaking change

`ut1 // ut2` and `ut1 //= ut2` now raise `TypeError` instead of performing elementwise division — this completes the removal announced as a BREAKING CHANGE in #997.

Closes the floor-division gap in #934 / #997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
