### PR TITLE
fix(pybind): take const& in the non-in-place Expf binding (follow-up to #1047)

### DIFF
--- a/pybind/linalg_py.cpp
+++ b/pybind/linalg_py.cpp
@@ -256,7 +256,9 @@ void linalg_binding(py::module &m) {
     py::arg("Tio"));
   m_linalg.def(
     "Expf",
-    [](cytnx::Tensor &Tio) {
+    // Expf is non-in-place (returns a new Tensor); take const& so pybind11 also accepts
+    // const/temporary Tensors, matching how Exp is bound. Expf_ above stays non-const (in-place).
+    [](const cytnx::Tensor &Tio) {
       if (PyErr_WarnEx(PyExc_DeprecationWarning, "Expf() is deprecated, use Exp() instead.", 1) < 0)
         throw py::error_already_set();
       return cytnx::linalg::Expf(Tio);


### PR DESCRIPTION
## Problem

Follow-up to #1047 (merged). During review, @gemini-code-assist flagged (high priority) that the deprecated **non-in-place** `Expf` Python binding wraps `linalg::Expf` in a lambda taking a **non-const** reference:

```cpp
m_linalg.def("Expf", [](cytnx::Tensor &Tio) { ...; return cytnx::linalg::Expf(Tio); }, py::arg("Tio"));
```

`Expf` does not mutate its input (C++ sig `Tensor Expf(const Tensor&)`), so a non-const lvalue ref makes pybind11 reject const/temporary Tensors from Python. #1047 merged before the fix landed, so master still carries it.

## Fix

Take `const cytnx::Tensor &` in the `Expf` lambda, matching how `Exp` is bound. The in-place `Expf_` lambda stays non-const (it mutates — correct as-is).

## Testing

Rebuilt `openblas-cpu` and verified:
- `linalg.Expf(A + 0.0)` (a temporary expression) now succeeds — previously the target of the finding.
- `Expf` still emits `DeprecationWarning`.
- `Exp(Float)` stays `Float` (the #1047 dtype-preserving behavior is unaffected); `e^1 == 2.718282`.

Addresses the outstanding review comment on #1047.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
