### PR TITLE
fix(utils): honor non-unit step in GPU arange for real dtypes (#1070)

### DIFF
--- a/src/backend/utils_internal_gpu/cuSetArange_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuSetArange_gpu.cu
@@ -8,7 +8,7 @@ namespace cytnx {
                                        cytnx_uint64 Nelem) {
       if (blockIdx.x * blockDim.x + threadIdx.x < Nelem) {
         in[blockIdx.x * blockDim.x + threadIdx.x] =
-          start + step * blockIdx.x * blockDim.x + threadIdx.x;
+          start + step * (blockIdx.x * blockDim.x + threadIdx.x);
       }
     }
     __global__ void cuSetArange_kernel(cuDoubleComplex *in, cytnx_double start, cytnx_double step,

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(
   DenseUniTensor_test.cpp
   Accessor_test.cpp
   Tensor_test.cpp
+  arange_test.cpp
   utils_test/vec_concatenate.cpp
   utils_test/vec_unique.cpp
   utils/getNconParameter.cpp

--- a/tests/gpu/arange_test.cpp
+++ b/tests/gpu/arange_test.cpp
@@ -1,0 +1,40 @@
+#include "gtest/gtest.h"
+
+#include "gpu_test_tools.h"
+#include "cytnx.hpp"
+
+// Regression for the GPU arange step bug: cuSetArange_kernel dropped the parentheses
+// around the linear index, so `start + step * blockIdx.x * blockDim.x + threadIdx.x`
+// added the per-thread offset without scaling it by step. For arrays that fit in one
+// block this collapsed to `start + threadIdx.x` (step effectively 1); for larger
+// arrays the per-thread offset was still unscaled. Only real dtypes were affected;
+// the complex overloads already parenthesized the index.
+namespace ArangeTest {
+
+  using namespace cytnx;
+
+  // Independent literal check: arange(10, 40, 10) is [10, 20, 30] on the GPU.
+  TEST(GpuArangeTest, nonunit_step_literal) {
+    Tensor g = arange(10, 40, 10, Type.Int64, Device.cuda).to(Device.cpu);
+    ASSERT_EQ(g.shape()[0], static_cast<cytnx_uint64>(3));
+    EXPECT_EQ(g.at<cytnx_int64>({0}), 10);
+    EXPECT_EQ(g.at<cytnx_int64>({1}), 20);
+    EXPECT_EQ(g.at<cytnx_int64>({2}), 30);
+  }
+
+  // Real dtypes, single-block (n=3) and multi-block (n=1000 > blockDim) sizes, checked
+  // against the (correct, independent) CPU arange implementation.
+  TEST(GpuArangeTest, nonunit_step_real_dtypes) {
+    for (auto dt : {Type.Int64, Type.Int32, Type.Double, Type.Float}) {
+      for (cytnx_uint64 n : {static_cast<cytnx_uint64>(3), static_cast<cytnx_uint64>(1000)}) {
+        SCOPED_TRACE("dtype=" + std::to_string(dt) + " n=" + std::to_string(n));
+        const double end = 2.0 * static_cast<double>(n);
+        Tensor cpu = arange(0, end, 2, dt);
+        Tensor gpu = arange(0, end, 2, dt, Device.cuda).to(Device.cpu);
+        ASSERT_EQ(gpu.shape()[0], n);
+        EXPECT_TRUE(TestTools::AreNearlyEqTensor(gpu, cpu, 1e-6));
+      }
+    }
+  }
+
+}  // namespace ArangeTest


### PR DESCRIPTION
## Problem

`cytnx::arange(start, end, step)` on `Device.cuda` ignores `step` for real
(non-complex) dtypes. `arange(10, 40, 10, Type.Int64, Device.cuda)` produced
`[10, 11, 12]` instead of `[10, 20, 30]` (CPU is correct). See #1070.

## Fix

The generic real-type `cuSetArange_kernel` in
`src/backend/utils_internal_gpu/cuSetArange_gpu.cu` was missing parentheses around
the linear index:

```cpp
start + step * blockIdx.x * blockDim.x + threadIdx.x;   // = start + (step*blk*dim) + thread
```

so the per-thread offset `threadIdx.x` was added un-scaled by `step` (for a single
block this collapses to `start + threadIdx.x`). The complex-dtype overloads in the
same file already had the parentheses. Fixed to:

```cpp
start + step * (blockIdx.x * blockDim.x + threadIdx.x);
```

## Testing

Added `tests/gpu/arange_test.cpp`:
- **independent literal check** — `arange(10,40,10)` on the GPU is `[10,20,30]`;
- real dtypes (`Int64/Int32/Double/Float`) at single-block (n=3) and multi-block
  (n=1000) sizes, checked against the CPU `arange`.

Both pass on an RTX 4070 Ti SUPER (CUDA 13, sm_89). (Verified on the GPU branch
where the bug was found; the kernel and test are independent of that branch's
changes.) GPU tests don't run in CI (no GPU runners), so this was validated
locally.

Closes #1070.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
