### PR TITLE
fix(arange): correct CPU length calc + GPU step scaling (#1076)

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -4,6 +4,8 @@
 
 #include "linalg.hpp"
 #include <cfloat>
+#include <cmath>
+#include <limits>
 #include <iostream>
 
 #ifdef BACKEND_TORCH
@@ -41,22 +43,34 @@ namespace cytnx {
   //-----------------
   Tensor arange(cytnx_double start, cytnx_double end, cytnx_double step, unsigned int dtype,
                 int device) {
-    cytnx_error_msg((end - start) / step <= 0,
-                    "[ERROR] arange(start=%f,end=%f,step=%f) "
-                    "No values in the specified range.\n",
+    cytnx_error_msg(step == 0, "[ERROR] arange(start=%f,end=%f,step=%f): step cannot be zero.\n",
                     start, end, step);
-    cytnx_uint64 Nelem;
-    Tensor out;
-    if (start < end) {
-      Nelem = (end - start) / step;
-      if (fmod((end - start), step) > 1.0e-14) Nelem += 1;
-    } else {
-      Nelem = (start - end) / (-step);
-      if (fmod((start - end), (-step)) > 1.0e-14) Nelem += 1;
+    cytnx_error_msg(
+      !std::isfinite(start) || !std::isfinite(end) || !std::isfinite(step),
+      "[ERROR] arange(start=%f,end=%f,step=%f): start, end, and step must all be finite.\n", start,
+      end, step);
+
+    // The range is half-open [start, end): the element count is ceil((end - start) / step).
+    // A non-positive count is an empty or direction-mismatched range and yields a zero-extent
+    // tensor rather than an error (zero-extent tensors are supported). This replaces the old
+    // integer-truncation + `fmod(...) > 1e-14` test, which was neither a reliable ceil nor a
+    // stable half-open test -- it could include the endpoint (fmod(1.0, 0.1) ~= 0.1, not 0) and
+    // its fixed absolute threshold miscounted at small scales. See #1076.
+    const cytnx_double count = (end - start) / step;
+    cytnx_uint64 Nelem = 0;
+    if (count > 0) {
+      const cytnx_double nelem = std::ceil(count);
+      cytnx_error_msg(
+        nelem > static_cast<cytnx_double>(std::numeric_limits<cytnx_uint64>::max()),
+        "[ERROR] arange(start=%f,end=%f,step=%f): the requested number of elements exceeds the "
+        "maximum representable size.\n",
+        start, end, step);
+      Nelem = static_cast<cytnx_uint64>(nelem);
     }
-    cytnx_error_msg(Nelem == 0, "[ERROR] arange(start,end,step)%s",
-                    "Nelem cannot be zero! check the range!\n");
+
+    Tensor out;
     out.Init({Nelem}, dtype, device);
+    if (Nelem == 0) return out;  // zero-extent range: nothing to fill
 
     if (device == Device.cpu) {
       utils_internal::uii.SetArange_ii[dtype](out._impl->storage()._impl, start, end, step, Nelem);
@@ -74,7 +88,10 @@ namespace cytnx {
     return out;
   }
   Tensor arange(cytnx_int64 Nelem) {
-    cytnx_error_msg(Nelem <= 0, "[ERROR] arange(Nelem) , %s", "Nelem must be integer > 0");
+    cytnx_error_msg(Nelem < 0, "[ERROR] arange(Nelem): Nelem must be a non-negative integer.%s",
+                    "\n");
+    // Nelem == 0 yields a zero-extent tensor (consistent with the empty-range case of the
+    // start/end/step overload).
     return arange(0, Nelem, 1);
   }
 

--- a/src/backend/utils_internal_gpu/cuSetArange_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuSetArange_gpu.cu
@@ -3,26 +3,30 @@
 namespace cytnx {
   namespace utils_internal {
 
+    // The linear index is computed once in 64-bit: `blockIdx.x * blockDim.x` is 32-bit and
+    // overflows past 2^32 elements. The value is `start + step * idx` -- the earlier generic
+    // kernel dropped the parentheses (`start + step * blk * dim + thread`), so the intra-block
+    // offset was added un-scaled by step and non-unit steps were ignored (#1070/#1076).
     template <class T>
     __global__ void cuSetArange_kernel(T *in, cytnx_double start, cytnx_double step,
                                        cytnx_uint64 Nelem) {
-      if (blockIdx.x * blockDim.x + threadIdx.x < Nelem) {
-        in[blockIdx.x * blockDim.x + threadIdx.x] =
-          start + step * blockIdx.x * blockDim.x + threadIdx.x;
+      const uint64_t idx = static_cast<uint64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+      if (idx < Nelem) {
+        in[idx] = start + step * idx;
       }
     }
     __global__ void cuSetArange_kernel(cuDoubleComplex *in, cytnx_double start, cytnx_double step,
                                        cytnx_uint64 Nelem) {
-      if (blockIdx.x * blockDim.x + threadIdx.x < Nelem) {
-        in[blockIdx.x * blockDim.x + threadIdx.x] =
-          make_cuDoubleComplex(start + step * (blockIdx.x * blockDim.x + threadIdx.x), 0);
+      const uint64_t idx = static_cast<uint64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+      if (idx < Nelem) {
+        in[idx] = make_cuDoubleComplex(start + step * idx, 0);
       }
     }
     __global__ void cuSetArange_kernel(cuFloatComplex *in, cytnx_double start, cytnx_double step,
                                        cytnx_uint64 Nelem) {
-      if (blockIdx.x * blockDim.x + threadIdx.x < Nelem) {
-        in[blockIdx.x * blockDim.x + threadIdx.x] =
-          make_cuFloatComplex(start + step * (blockIdx.x * blockDim.x + threadIdx.x), 0);
+      const uint64_t idx = static_cast<uint64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+      if (idx < Nelem) {
+        in[idx] = make_cuFloatComplex(start + step * idx, 0);
       }
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(
   DenseUniTensor_test.cpp
   Accessor_test.cpp
   Tensor_test.cpp
+  arange_test.cpp
   Type_test.cpp
   cytnx_error_test.cpp
   include_order_canary_test.cpp

--- a/tests/DenseUniTensor_test.cpp
+++ b/tests/DenseUniTensor_test.cpp
@@ -5626,11 +5626,15 @@ TEST_F(DenseUniTensorTest, arange) {
 }
 
 /*=====test info=====
-describe:test arange_step_error, start < end but step < 0
+describe:a direction-mismatched range (start < end but step < 0) is empty and yields a
+zero-extent tensor rather than throwing (#1076)
 ====================*/
-TEST_F(DenseUniTensorTest, arange_step_error) {
+TEST_F(DenseUniTensorTest, arange_direction_mismatch_is_empty) {
   const double start = 0.1, end = 0.7, step = -0.11;
-  EXPECT_THROW(UniTensor::arange(start, end, step), std::logic_error);
+  UniTensor ut;
+  EXPECT_NO_THROW(ut = UniTensor::arange(start, end, step));
+  EXPECT_EQ(ut.rank(), 1);
+  EXPECT_EQ(ut.shape()[0], 0u);
 }
 
 /*=====test info=====

--- a/tests/arange_test.cpp
+++ b/tests/arange_test.cpp
@@ -1,0 +1,113 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "Generator.hpp"
+#include "Tensor.hpp"
+#include "Type.hpp"
+
+// Independent (hand-computed) expected values for cytnx::arange(start, end, step).
+// The contract is a half-open range [start, end): values start, start+step, ... strictly
+// on the `start` side of `end`. See #1076. Values are read from contiguous storage.
+
+using cytnx::Device;
+using cytnx::Type;
+
+namespace {
+
+  TEST(Arange, HalfOpenIntegerStep) {
+    // 40 is the exclusive endpoint, so it is NOT included.
+    auto t = cytnx::arange(10, 40, 10, Type.Int64);
+    ASSERT_EQ(t.shape().size(), 1u);
+    ASSERT_EQ(t.shape()[0], 3u);
+    EXPECT_EQ(t.dtype(), Type.Int64);
+    EXPECT_EQ(t.storage().at<cytnx::cytnx_int64>(0), 10);
+    EXPECT_EQ(t.storage().at<cytnx::cytnx_int64>(1), 20);
+    EXPECT_EQ(t.storage().at<cytnx::cytnx_int64>(2), 30);
+  }
+
+  TEST(Arange, EndpointExcludedWhenExactlyOnGrid) {
+    // end lands exactly on start + 3*step; half-open excludes it -> 3 elements, not 4.
+    auto t = cytnx::arange(0, 3, 1, Type.Int64);
+    ASSERT_EQ(t.shape()[0], 3u);
+    EXPECT_EQ(t.storage().at<cytnx::cytnx_int64>(0), 0);
+    EXPECT_EQ(t.storage().at<cytnx::cytnx_int64>(1), 1);
+    EXPECT_EQ(t.storage().at<cytnx::cytnx_int64>(2), 2);
+  }
+
+  TEST(Arange, FractionalStep) {
+    // [0, 0.25, 0.5, 0.75]; 1.0 is the exclusive endpoint.
+    auto t = cytnx::arange(0, 1, 0.25, Type.Double);
+    ASSERT_EQ(t.shape()[0], 4u);
+    EXPECT_DOUBLE_EQ(t.storage().at<cytnx::cytnx_double>(0), 0.0);
+    EXPECT_DOUBLE_EQ(t.storage().at<cytnx::cytnx_double>(1), 0.25);
+    EXPECT_DOUBLE_EQ(t.storage().at<cytnx::cytnx_double>(2), 0.5);
+    EXPECT_DOUBLE_EQ(t.storage().at<cytnx::cytnx_double>(3), 0.75);
+  }
+
+  TEST(Arange, NegativeStep) {
+    // Descending: [5, 4, 3, 2, 1]; 0 is the exclusive endpoint.
+    auto t = cytnx::arange(5, 0, -1, Type.Int64);
+    ASSERT_EQ(t.shape()[0], 5u);
+    EXPECT_EQ(t.storage().at<cytnx::cytnx_int64>(0), 5);
+    EXPECT_EQ(t.storage().at<cytnx::cytnx_int64>(4), 1);
+  }
+
+  TEST(Arange, SmallScaleSingleElement) {
+    // #1076: count = 1e-15 / 2e-15 = 0.5 -> ceil -> 1 element [0.0].
+    // The old fixed-1e-14 fmod threshold computed 0 elements here and threw.
+    auto t = cytnx::arange(0.0, 1e-15, 2e-15, Type.Double);
+    ASSERT_EQ(t.shape()[0], 1u);
+    EXPECT_DOUBLE_EQ(t.storage().at<cytnx::cytnx_double>(0), 0.0);
+  }
+
+  TEST(Arange, EmptyRangesAreZeroExtent) {
+    // Empty / direction-mismatched ranges are a zero-extent tensor, not an error (#1076).
+    for (auto t : {cytnx::arange(5, 5, 1, Type.Int64),  // start == end
+                   cytnx::arange(10, 0, 1, Type.Int64),  // positive step, end < start
+                   cytnx::arange(0, 10, -1, Type.Int64)}) {  // negative step, end > start
+      ASSERT_EQ(t.shape().size(), 1u);
+      EXPECT_EQ(t.shape()[0], 0u);
+      EXPECT_EQ(t.dtype(), Type.Int64);
+    }
+  }
+
+  TEST(Arange, UlpBoundaryEndpoint) {
+    // Push the endpoint one ULP past an integer grid point: end just ABOVE 3 now
+    // includes 3 (count = 3.0000...4 -> ceil 4), so [0, 1, 2, 3].
+    auto above = cytnx::arange(0.0, std::nextafter(3.0, INFINITY), 1.0, Type.Double);
+    ASSERT_EQ(above.shape()[0], 4u);
+    EXPECT_DOUBLE_EQ(above.storage().at<cytnx::cytnx_double>(3), 3.0);
+
+    // end just BELOW 3 excludes 3 (count = 2.9999...6 -> ceil 3), so [0, 1, 2].
+    auto below = cytnx::arange(0.0, std::nextafter(3.0, -INFINITY), 1.0, Type.Double);
+    ASSERT_EQ(below.shape()[0], 3u);
+    EXPECT_DOUBLE_EQ(below.storage().at<cytnx::cytnx_double>(2), 2.0);
+  }
+
+  TEST(Arange, StepZeroThrows) {
+    EXPECT_THROW(cytnx::arange(0, 10, 0, Type.Double), std::logic_error);
+  }
+
+  TEST(Arange, NonFiniteThrows) {
+    EXPECT_THROW(cytnx::arange(0.0, INFINITY, 1.0, Type.Double), std::logic_error);
+    EXPECT_THROW(cytnx::arange(0.0, 10.0, NAN, Type.Double), std::logic_error);
+  }
+
+  TEST(Arange, CountOverloadHalfOpen) {
+    // arange(N) == arange(0, N, 1): [0, 1, ..., N-1], default dtype Double.
+    auto t = cytnx::arange(6);
+    ASSERT_EQ(t.shape()[0], 6u);
+    EXPECT_EQ(t.dtype(), Type.Double);
+    EXPECT_DOUBLE_EQ(t.storage().at<cytnx::cytnx_double>(0), 0.0);
+    EXPECT_DOUBLE_EQ(t.storage().at<cytnx::cytnx_double>(5), 5.0);
+  }
+
+  TEST(Arange, CountOverloadZeroIsEmptyNegativeThrows) {
+    auto t = cytnx::arange(0);  // consistent with the empty-range case
+    EXPECT_EQ(t.shape().size(), 1u);
+    EXPECT_EQ(t.shape()[0], 0u);
+    EXPECT_THROW(cytnx::arange(-1), std::logic_error);
+  }
+
+}  // namespace

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(
   DenseUniTensor_test.cpp
   Accessor_test.cpp
   Tensor_test.cpp
+  arange_test.cpp
   utils_test/vec_concatenate.cpp
   utils_test/vec_unique.cpp
   utils/getNconParameter.cpp

--- a/tests/gpu/arange_test.cpp
+++ b/tests/gpu/arange_test.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+
+#include "Device.hpp"
+#include "Generator.hpp"
+#include "Tensor.hpp"
+#include "Type.hpp"
+
+// GPU arange: independent (hand-computed) expected values, NOT compared against the CPU
+// arange -- the CPU front-end has had its own bugs (#1076), so it is not a trusted oracle.
+// Covers the #1070 fix (per-thread offset must be scaled by step) and the >512-element
+// multi-block linear index. Values are read back by copying to the host.
+
+using cytnx::Device;
+using cytnx::Type;
+
+namespace {
+
+  // arange(10, 40, 10) on the GPU must be [10, 20, 30] -- the pre-#1070 kernel dropped the
+  // parentheses and produced [10, 11, 12] for a single block.
+  template <typename T>
+  void ExpectNonUnitStep(unsigned int dtype) {
+    auto host = cytnx::arange(10, 40, 10, dtype, Device.cuda).to(Device.cpu);
+    ASSERT_EQ(host.shape()[0], 3u);
+    EXPECT_EQ(host.storage().template at<T>(0), static_cast<T>(10));
+    EXPECT_EQ(host.storage().template at<T>(1), static_cast<T>(20));
+    EXPECT_EQ(host.storage().template at<T>(2), static_cast<T>(30));
+  }
+
+  TEST(GpuArange, NonUnitStepRealDtypes) {
+    ExpectNonUnitStep<cytnx::cytnx_int64>(Type.Int64);
+    ExpectNonUnitStep<cytnx::cytnx_int32>(Type.Int32);
+    ExpectNonUnitStep<cytnx::cytnx_double>(Type.Double);
+    ExpectNonUnitStep<cytnx::cytnx_float>(Type.Float);
+  }
+
+  TEST(GpuArange, MultiBlockStepScaling) {
+    // 1000 elements span more than one 512-thread block, so the block-boundary indices
+    // (511 -> 512) exercise the full linear index. value[i] == 3*i (hand-computed).
+    const cytnx::cytnx_uint64 n = 1000;
+    auto host = cytnx::arange(0, 3000, 3, Type.Int64, Device.cuda).to(Device.cpu);
+    ASSERT_EQ(host.shape()[0], n);
+    EXPECT_EQ(host.storage().at<cytnx::cytnx_int64>(0), 0);
+    EXPECT_EQ(host.storage().at<cytnx::cytnx_int64>(511), 1533);  // last of block 0
+    EXPECT_EQ(host.storage().at<cytnx::cytnx_int64>(512), 1536);  // first of block 1
+    EXPECT_EQ(host.storage().at<cytnx::cytnx_int64>(999), 2997);
+  }
+
+  TEST(GpuArange, FractionalStepDouble) {
+    auto host = cytnx::arange(0, 1, 0.25, Type.Double, Device.cuda).to(Device.cpu);
+    ASSERT_EQ(host.shape()[0], 4u);
+    EXPECT_DOUBLE_EQ(host.storage().at<cytnx::cytnx_double>(0), 0.0);
+    EXPECT_DOUBLE_EQ(host.storage().at<cytnx::cytnx_double>(1), 0.25);
+    EXPECT_DOUBLE_EQ(host.storage().at<cytnx::cytnx_double>(2), 0.5);
+    EXPECT_DOUBLE_EQ(host.storage().at<cytnx::cytnx_double>(3), 0.75);
+  }
+
+  TEST(GpuArange, EmptyRangeZeroExtent) {
+    auto g = cytnx::arange(5, 5, 1, Type.Int64, Device.cuda);
+    ASSERT_EQ(g.shape().size(), 1u);
+    EXPECT_EQ(g.shape()[0], 0u);
+    EXPECT_EQ(g.device(), Device.cuda);
+  }
+
+}  // namespace


### PR DESCRIPTION
## Problem

`arange` correctness needed a coordinated CPU + GPU fix (#1076). Two independent bugs, sharing one broken length calculation:

1. **CPU front-end (`src/Generator.cpp::arange`)** — computed the element count as integer truncation of `(end-start)/step` plus a `fmod(...) > 1.0e-14` bump. Per @ianmccul's #1071 review this was "neither a reliable ceil nor a stable half-open test": `fmod(1.0, 0.1) ≈ 0.1` (not 0) so decimal steps included the endpoint; the fixed `1e-14` absolute threshold miscounted at small scales (`arange(0, 1e-15, 2e-15)` computed 0 elements and threw instead of yielding `[0]`); and empty/direction-mismatched ranges threw despite zero-extent tensors being supported.
2. **GPU kernel (`cuSetArange_gpu.cu`)** — the generic real-dtype kernel dropped the parentheses (`start + step * blk * dim + thread`), so the per-thread offset was added un-scaled by `step`; `arange(10, 40, 10)` on `Device.cuda` gave `[10, 11, 12]` instead of `[10, 20, 30]` (#1070). The linear index was also 32-bit and overflows past 2^32 elements.

The front-end computes the count once and feeds it to **both** backends, so the CPU length bug propagated to the GPU path too.

## Fix

- **CPU:** `Nelem = ceil((end - start) / step)`, clamped to 0 for an empty/direction-mismatched range (returns a zero-extent tensor). Guards added for zero step, non-finite `start`/`end`/`step`, and overflow of the `double → uint64` count. `arange(Nelem)` made consistent (`0` → empty, negative → error).
- **GPU:** compute the linear index once as 64-bit and use `start + step * idx` in all real and complex kernels.

## ⚠️ Behavior change (please review)

This changes **user-visible numeric behavior**, as #1076 intended:
- half-open `[start, end)` endpoint handling now via ceil-of-count;
- small-scale ranges count correctly (e.g. `arange(0, 1e-15, 2e-15)` → `[0]`);
- empty / direction-mismatched ranges return a **zero-extent** tensor instead of throwing.

One existing test (`DenseUniTensorTest.arange_step_error`) asserted the old throw-on-direction-mismatch; it's updated to expect a zero-extent result and renamed.

## Testing

- **CPU** (`tests/arange_test.cpp`, new): independent hand-computed values — half-open integer/fractional/negative-step, the `1e-15` small-scale case, ULP boundaries via `nextafter(end, ±inf)`, zero-extent empties, and the step/finite guards. Bug-targeting cases were confirmed to **fail on the pre-fix code**. Full CPU suite: **1801 passed, 0 failed**.
- **GPU** (`tests/gpu/arange_test.cpp`, new): independent literal values (not the CPU path as oracle, per Ian) — non-unit step across Int64/Int32/Double/Float, a >512-element multi-block case exercising the block-boundary index (`value[i] == 3*i`), fractional step, zero-extent empty. Run locally on an RTX 4070 Ti SUPER (CUDA 13, sm_89). GPU tests don't run in CI (no GPU runner).

Not in scope: the remaining #1076 items (e.g. the `<cuda/std/complex>` install/PUBLIC-propagation for GPU consumers) belong to #1067.

Closes #1076. Fixes the GPU half of #1070.
