### PR TITLE
refactor(linalg): constrain free Tensor/UniTensor scalar operators to scalar-like types (#1003)

### DIFF
--- a/include/Tensor.hpp
+++ b/include/Tensor.hpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include "utils/dynamic_arg_resolver.hpp"
 #include "Accessor.hpp"
+#include <type_traits>
 #include <utility>
 #include <vector>
 #include <initializer_list>
@@ -25,17 +26,11 @@ namespace cytnx {
 
   class Tensor;
 
-  ///@cond
-  // [Note] these are fwd from linalg.hpp
-  template <class T>
-  Tensor operator+(const Tensor &lhs, const T &rc);
-  template <class T>
-  Tensor operator-(const Tensor &lhs, const T &rhs);
-  template <class T>
-  Tensor operator*(const Tensor &lhs, const T &rhs);
-  template <class T>
-  Tensor operator/(const Tensor &lhs, const T &rhs);
-  ///@endcond
+  // [Note] The free `Tensor <op> T` operators declared in linalg.hpp are forward-declared below
+  // the class definition rather than here, because their constraint names Tensor::Tproxy, which
+  // is not available until Tensor is complete. Declaring them unconstrained here would defeat the
+  // constraint entirely: a differently-constrained declaration is a *distinct* template, so the
+  // unconstrained candidate would stay viable for every non-scalar T (#1003, Ian's review).
 
   /// @brief an tensor (multi-dimensional array)
   class Tensor {
@@ -1787,6 +1782,47 @@ namespace cytnx {
     Tensor Min() const;
 
   };  // class Tensor
+
+  // Scalar-like operand concepts for the free Tensor / UniTensor arithmetic and comparison
+  // operators. They live here, after the class, because cytnx_scalar_like names Tensor::Tproxy
+  // and so needs Tensor to be complete; linalg.hpp includes this header and reuses them.
+  //
+  // Each concept admits exactly the operand types the corresponding operators are instantiated
+  // for, so an unsupported operand is rejected at overload resolution instead of surviving to a
+  // link error. Widening one without adding the matching explicit instantiation reintroduces
+  // precisely that failure (#1003, operator hygiene -- Ian's review).
+
+  /// @cond
+  // Plain scalar values: the cytnx dtype scalars and cytnx::Scalar. This is the operand set of
+  // `operator%` (Tensor and UniTensor) and `operator==` (Tensor), which have no element-proxy
+  // instantiations -- see Mod.cpp and Cpr.cpp.
+  template <class T>
+  concept cytnx_scalar_value =
+    CytnxType<std::remove_cvref_t<T>> || std::is_same_v<std::remove_cvref_t<T>, Scalar>;
+
+  // Adds both element proxies: the operand set of the free Tensor `+ - * /` operators.
+  template <class T>
+  concept cytnx_scalar_like =
+    cytnx_scalar_value<T> || std::is_same_v<std::remove_cvref_t<T>, Tensor::Tproxy> ||
+    std::is_same_v<std::remove_cvref_t<T>, Scalar::Sproxy>;
+
+  // Adds only the Scalar proxy: the operand set of the free UniTensor `+ - * /` operators, which
+  // are instantiated for Scalar::Sproxy but never for Tensor::Tproxy -- see Add.cpp.
+  template <class T>
+  concept cytnx_unitensor_scalar_like =
+    cytnx_scalar_value<T> || std::is_same_v<std::remove_cvref_t<T>, Scalar::Sproxy>;
+
+  // [Note] these are fwd from linalg.hpp; the constraint must match linalg.hpp exactly, or the
+  // two declarations become distinct overloads and the unconstrained one stays viable.
+  template <cytnx_scalar_like T>
+  Tensor operator+(const Tensor &lhs, const T &rc);
+  template <cytnx_scalar_like T>
+  Tensor operator-(const Tensor &lhs, const T &rhs);
+  template <cytnx_scalar_like T>
+  Tensor operator*(const Tensor &lhs, const T &rhs);
+  template <cytnx_scalar_like T>
+  Tensor operator/(const Tensor &lhs, const T &rhs);
+  /// @endcond
 
   Tensor operator+(const Tensor &lhs, const Tensor::Tproxy &rhs);
   Tensor operator-(const Tensor &lhs, const Tensor::Tproxy &rhs);

--- a/include/linalg.hpp
+++ b/include/linalg.hpp
@@ -12,6 +12,7 @@
 #else
 
   #include <functional>
+  #include <type_traits>
 
   #include "backend/Scalar.hpp"
   #include "backend/Storage.hpp"

--- a/include/linalg.hpp
+++ b/include/linalg.hpp
@@ -19,16 +19,12 @@
 
 namespace cytnx {
 
-  // A scalar-like operand for the free Tensor / UniTensor arithmetic and comparison operators
-  // (`+ - * / % ==`). It admits exactly the types those operators are specialized for: the cytnx
-  // dtype scalars (CytnxType), cytnx::Scalar, and the Tensor / Scalar element proxies. Constraining
-  // the operators keeps arbitrary std / user-defined types from silently becoming viable Cytnx
-  // arithmetic operands through implicit conversion (#1003, operator hygiene -- Ian's note).
-  template <class T>
-  concept cytnx_scalar_like =
-    CytnxType<std::remove_cvref_t<T>> || std::is_same_v<std::remove_cvref_t<T>, Scalar> ||
-    std::is_same_v<std::remove_cvref_t<T>, Tensor::Tproxy> ||
-    std::is_same_v<std::remove_cvref_t<T>, Scalar::Sproxy>;
+  // The scalar-like operand concepts (cytnx_scalar_value, cytnx_scalar_like,
+  // cytnx_unitensor_scalar_like) are defined in Tensor.hpp, which this header includes. They must
+  // be declared there because cytnx_scalar_like names Tensor::Tproxy, and because Tensor.hpp
+  // forward-declares the constrained `Tensor <op> T` operators -- those forward declarations have
+  // to carry the identical constraint or they form a distinct, unconstrained overload set
+  // (#1003, operator hygiene -- Ian's note).
 
   /**
    * @brief The addition operator between two UniTensor.
@@ -65,7 +61,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the addition.
    * @see linalg::Add(const T &lc, const cytnx::UniTensor &Rt)
    */
-  template <cytnx_scalar_like T>
+  template <cytnx_unitensor_scalar_like T>
   cytnx::UniTensor operator+(const T &lc, const cytnx::UniTensor &Rt);
 
   /**
@@ -77,7 +73,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the addition.
    * @see linalg::Add(const cytnx::UniTensor &Lt, const T &rc)
    */
-  template <cytnx_scalar_like T>
+  template <cytnx_unitensor_scalar_like T>
   cytnx::UniTensor operator+(const cytnx::UniTensor &Lt, const T &rc);
 
   /**
@@ -104,7 +100,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the subtraction.
    * @see linalg::Sub(const T &lc, const cytnx::UniTensor &Rt)
    */
-  template <cytnx_scalar_like T>
+  template <cytnx_unitensor_scalar_like T>
   cytnx::UniTensor operator-(const T &lc, const cytnx::UniTensor &Rt);
 
   /**
@@ -116,7 +112,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the subtraction.
    * @see linalg::Sub(const cytnx::UniTensor &Lt, const T &rc)
    */
-  template <cytnx_scalar_like T>
+  template <cytnx_unitensor_scalar_like T>
   cytnx::UniTensor operator-(const cytnx::UniTensor &Lt, const T &rc);
 
   /**
@@ -143,7 +139,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the multiplication.
    * @see linalg::Mul(const T &lc, const cytnx::UniTensor &Rt)
    */
-  template <cytnx_scalar_like T>
+  template <cytnx_unitensor_scalar_like T>
   cytnx::UniTensor operator*(const T &lc, const cytnx::UniTensor &Rt);
 
   /**
@@ -155,7 +151,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the multiplication.
    * @see linalg::Mul(const cytnx::UniTensor &Lt, const T &rc)
    */
-  template <cytnx_scalar_like T>
+  template <cytnx_unitensor_scalar_like T>
   cytnx::UniTensor operator*(const cytnx::UniTensor &Lt, const T &rc);
 
   /**
@@ -182,7 +178,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the division.
    * @see linalg::Div(const T &lc, const cytnx::UniTensor &Rt)
    */
-  template <cytnx_scalar_like T>
+  template <cytnx_unitensor_scalar_like T>
   cytnx::UniTensor operator/(const T &lc, const cytnx::UniTensor &Rt);
 
   /**
@@ -194,7 +190,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the division.
    * @see linalg::Div(const cytnx::UniTensor &Lt, const T &rc)
    */
-  template <cytnx_scalar_like T>
+  template <cytnx_unitensor_scalar_like T>
   cytnx::UniTensor operator/(const cytnx::UniTensor &Lt, const T &rc);
 
   /**
@@ -218,7 +214,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the modulo.
    * @see linalg::Mod(const T &lc, const cytnx::UniTensor &Rt)
    */
-  template <cytnx_scalar_like T>
+  template <cytnx_scalar_value T>
   cytnx::UniTensor operator%(const T &lc, const cytnx::UniTensor &Rt);
 
   /**
@@ -230,7 +226,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the modulo.
    * @see linalg::Mod(const cytnx::UniTensor &Lt, const T &rc)
    */
-  template <cytnx_scalar_like T>
+  template <cytnx_scalar_value T>
   cytnx::UniTensor operator%(const cytnx::UniTensor &Lt, const T &rc);
 
   /**
@@ -3340,7 +3336,7 @@ namespace cytnx {
    * @return [Tensor] the result of mode.
    * @see linalg::Mod(const T &lc, const Tensor &Rt)
    */
-  template <cytnx_scalar_like T>
+  template <cytnx_scalar_value T>
   Tensor operator%(const T &lc, const Tensor &Rt);
 
   /**
@@ -3352,7 +3348,7 @@ namespace cytnx {
    * @return [Tensor] the result of mode.
    * @see linalg::Mod(const Tensor &Lt, const T &rc)
    */
-  template <cytnx_scalar_like T>
+  template <cytnx_scalar_value T>
   Tensor operator%(const Tensor &Lt, const T &rc);
 
   //----------------------------------
@@ -3376,7 +3372,7 @@ namespace cytnx {
    * @return [Tensor] the result of comparison.
    * @see linalg::Cpr(const T &lc, const Tensor &Rt)
    */
-  template <cytnx_scalar_like T>
+  template <cytnx_scalar_value T>
   Tensor operator==(const T &lc, const Tensor &Rt);
 
   /**
@@ -3388,7 +3384,7 @@ namespace cytnx {
    * @return [Tensor] the result of comparison.
    * @see linalg::Cpr(const Tensor &Lt, const T &rc)
    */
-  template <cytnx_scalar_like T>
+  template <cytnx_scalar_value T>
   Tensor operator==(const Tensor &Lt, const T &rc);
 
 }  // namespace cytnx

--- a/include/linalg.hpp
+++ b/include/linalg.hpp
@@ -18,6 +18,17 @@
 
 namespace cytnx {
 
+  // A scalar-like operand for the free Tensor / UniTensor arithmetic and comparison operators
+  // (`+ - * / % ==`). It admits exactly the types those operators are specialized for: the cytnx
+  // dtype scalars (CytnxType), cytnx::Scalar, and the Tensor / Scalar element proxies. Constraining
+  // the operators keeps arbitrary std / user-defined types from silently becoming viable Cytnx
+  // arithmetic operands through implicit conversion (#1003, operator hygiene -- Ian's note).
+  template <class T>
+  concept cytnx_scalar_like =
+    CytnxType<std::remove_cvref_t<T>> || std::is_same_v<std::remove_cvref_t<T>, Scalar> ||
+    std::is_same_v<std::remove_cvref_t<T>, Tensor::Tproxy> ||
+    std::is_same_v<std::remove_cvref_t<T>, Scalar::Sproxy>;
+
   /**
    * @brief The addition operator between two UniTensor.
    * @details This is the addition function for UniTensor. It will call the
@@ -53,7 +64,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the addition.
    * @see linalg::Add(const T &lc, const cytnx::UniTensor &Rt)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator+(const T &lc, const cytnx::UniTensor &Rt);
 
   /**
@@ -65,7 +76,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the addition.
    * @see linalg::Add(const cytnx::UniTensor &Lt, const T &rc)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator+(const cytnx::UniTensor &Lt, const T &rc);
 
   /**
@@ -92,7 +103,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the subtraction.
    * @see linalg::Sub(const T &lc, const cytnx::UniTensor &Rt)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator-(const T &lc, const cytnx::UniTensor &Rt);
 
   /**
@@ -104,7 +115,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the subtraction.
    * @see linalg::Sub(const cytnx::UniTensor &Lt, const T &rc)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator-(const cytnx::UniTensor &Lt, const T &rc);
 
   /**
@@ -131,7 +142,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the multiplication.
    * @see linalg::Mul(const T &lc, const cytnx::UniTensor &Rt)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator*(const T &lc, const cytnx::UniTensor &Rt);
 
   /**
@@ -143,7 +154,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the multiplication.
    * @see linalg::Mul(const cytnx::UniTensor &Lt, const T &rc)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator*(const cytnx::UniTensor &Lt, const T &rc);
 
   /**
@@ -170,7 +181,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the division.
    * @see linalg::Div(const T &lc, const cytnx::UniTensor &Rt)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator/(const T &lc, const cytnx::UniTensor &Rt);
 
   /**
@@ -182,7 +193,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the division.
    * @see linalg::Div(const cytnx::UniTensor &Lt, const T &rc)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator/(const cytnx::UniTensor &Lt, const T &rc);
 
   /**
@@ -206,7 +217,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the modulo.
    * @see linalg::Mod(const T &lc, const cytnx::UniTensor &Rt)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator%(const T &lc, const cytnx::UniTensor &Rt);
 
   /**
@@ -218,7 +229,7 @@ namespace cytnx {
    * @return [UniTensor] The result of the modulo.
    * @see linalg::Mod(const cytnx::UniTensor &Lt, const T &rc)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator%(const cytnx::UniTensor &Lt, const T &rc);
 
   /**
@@ -3176,7 +3187,7 @@ namespace cytnx {
    * @return [Tensor] the result of addition.
    * @see linalg::Add(const T &lc, const Tensor &Rt)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   Tensor operator+(const T &lc, const Tensor &Rt);
 
   /**
@@ -3188,7 +3199,7 @@ namespace cytnx {
    * @return [Tensor] the result of addition.
    * @see linalg::Add(const Tensor &Lt, const T &rc)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   Tensor operator+(const Tensor &Lt, const T &rc);
 
   //------------------------------------
@@ -3213,7 +3224,7 @@ namespace cytnx {
    * @return [Tensor] the result of subtraction.
    * @see linalg::Sub(const T &lc, const Tensor &Rt)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   Tensor operator-(const T &lc, const Tensor &Rt);
 
   /**
@@ -3225,7 +3236,7 @@ namespace cytnx {
    * @return [Tensor] the result of subtraction.
    * @see linalg::Sub(const Tensor &Lt, const T &rc)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   Tensor operator-(const Tensor &Lt, const T &rc);
 
   //-----------------------------------
@@ -3250,7 +3261,7 @@ namespace cytnx {
    * @return [Tensor] the result of multiplication.
    * @see linalg::Mul(const T &lc, const Tensor &Rt)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   Tensor operator*(const T &lc, const Tensor &Rt);
 
   /**
@@ -3262,7 +3273,7 @@ namespace cytnx {
    * @return [Tensor] the result of multiplication.
    * @see linalg::Mul(const Tensor &Lt, const T &rc)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   Tensor operator*(const Tensor &Lt, const T &rc);
 
   //----------------------------------
@@ -3290,7 +3301,7 @@ namespace cytnx {
    * @see linalg::Div(const T &lc, const Tensor &Rt)
    * @pre The divisor cannot be zero.
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   Tensor operator/(const T &lc, const Tensor &Rt);
 
   /**
@@ -3303,7 +3314,7 @@ namespace cytnx {
    * @see linalg::Div(const Tensor &Lt, const T &rc)
    * @pre The divisor cannot be zero.
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   Tensor operator/(const Tensor &Lt, const T &rc);
 
   //----------------------------------
@@ -3328,7 +3339,7 @@ namespace cytnx {
    * @return [Tensor] the result of mode.
    * @see linalg::Mod(const T &lc, const Tensor &Rt)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   Tensor operator%(const T &lc, const Tensor &Rt);
 
   /**
@@ -3340,7 +3351,7 @@ namespace cytnx {
    * @return [Tensor] the result of mode.
    * @see linalg::Mod(const Tensor &Lt, const T &rc)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   Tensor operator%(const Tensor &Lt, const T &rc);
 
   //----------------------------------
@@ -3364,7 +3375,7 @@ namespace cytnx {
    * @return [Tensor] the result of comparison.
    * @see linalg::Cpr(const T &lc, const Tensor &Rt)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   Tensor operator==(const T &lc, const Tensor &Rt);
 
   /**
@@ -3376,7 +3387,7 @@ namespace cytnx {
    * @return [Tensor] the result of comparison.
    * @see linalg::Cpr(const Tensor &Lt, const T &rc)
    */
-  template <class T>
+  template <cytnx_scalar_like T>
   Tensor operator==(const Tensor &Lt, const T &rc);
 
 }  // namespace cytnx

--- a/src/linalg/Add.cpp
+++ b/src/linalg/Add.cpp
@@ -438,7 +438,7 @@ namespace cytnx {
     return cytnx::linalg::Add(Lt, Rt);
   }
 
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator+(const T &lc, const cytnx::UniTensor &Rt) {
     return cytnx::linalg::Add(lc, Rt);
   }

--- a/src/linalg/Add.cpp
+++ b/src/linalg/Add.cpp
@@ -438,7 +438,7 @@ namespace cytnx {
     return cytnx::linalg::Add(Lt, Rt);
   }
 
-  template <cytnx_scalar_like T>
+  template <cytnx_unitensor_scalar_like T>
   cytnx::UniTensor operator+(const T &lc, const cytnx::UniTensor &Rt) {
     return cytnx::linalg::Add(lc, Rt);
   }

--- a/src/linalg/Div.cpp
+++ b/src/linalg/Div.cpp
@@ -1196,7 +1196,7 @@ namespace cytnx {
     return cytnx::linalg::Div(Lt, Rt);
   }
 
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator/(const T &lc, const cytnx::UniTensor &Rt) {
     return cytnx::linalg::Div(lc, Rt);
   }
@@ -1228,7 +1228,7 @@ namespace cytnx {
   template cytnx::UniTensor operator/<cytnx_bool>(const cytnx_bool &lc, const cytnx::UniTensor &Rt);
   template cytnx::UniTensor operator/<Scalar>(const Scalar &lc, const cytnx::UniTensor &Rt);
 
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator/(const cytnx::UniTensor &Lt, const T &rc) {
     return cytnx::linalg::Div(Lt, rc);
   }

--- a/src/linalg/Div.cpp
+++ b/src/linalg/Div.cpp
@@ -1196,7 +1196,7 @@ namespace cytnx {
     return cytnx::linalg::Div(Lt, Rt);
   }
 
-  template <cytnx_scalar_like T>
+  template <cytnx_unitensor_scalar_like T>
   cytnx::UniTensor operator/(const T &lc, const cytnx::UniTensor &Rt) {
     return cytnx::linalg::Div(lc, Rt);
   }
@@ -1228,7 +1228,7 @@ namespace cytnx {
   template cytnx::UniTensor operator/<cytnx_bool>(const cytnx_bool &lc, const cytnx::UniTensor &Rt);
   template cytnx::UniTensor operator/<Scalar>(const Scalar &lc, const cytnx::UniTensor &Rt);
 
-  template <cytnx_scalar_like T>
+  template <cytnx_unitensor_scalar_like T>
   cytnx::UniTensor operator/(const cytnx::UniTensor &Lt, const T &rc) {
     return cytnx::linalg::Div(Lt, rc);
   }

--- a/src/linalg/Mod.cpp
+++ b/src/linalg/Mod.cpp
@@ -1153,7 +1153,7 @@ namespace cytnx {
     return cytnx::linalg::Mod(Lt, Rt);
   }
 
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator%(const T &lc, const cytnx::UniTensor &Rt) {
     return cytnx::linalg::Mod(lc, Rt);
   }
@@ -1180,7 +1180,7 @@ namespace cytnx {
     <cytnx_uint16>(const cytnx_uint16 &lc, const cytnx::UniTensor &Rt);
   template cytnx::UniTensor operator%<cytnx_bool>(const cytnx_bool &lc, const cytnx::UniTensor &Rt);
 
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator%(const cytnx::UniTensor &Lt, const T &rc) {
     return cytnx::linalg::Mod(Lt, rc);
   }

--- a/src/linalg/Mod.cpp
+++ b/src/linalg/Mod.cpp
@@ -1153,7 +1153,7 @@ namespace cytnx {
     return cytnx::linalg::Mod(Lt, Rt);
   }
 
-  template <cytnx_scalar_like T>
+  template <cytnx_scalar_value T>
   cytnx::UniTensor operator%(const T &lc, const cytnx::UniTensor &Rt) {
     return cytnx::linalg::Mod(lc, Rt);
   }
@@ -1180,7 +1180,7 @@ namespace cytnx {
     <cytnx_uint16>(const cytnx_uint16 &lc, const cytnx::UniTensor &Rt);
   template cytnx::UniTensor operator%<cytnx_bool>(const cytnx_bool &lc, const cytnx::UniTensor &Rt);
 
-  template <cytnx_scalar_like T>
+  template <cytnx_scalar_value T>
   cytnx::UniTensor operator%(const cytnx::UniTensor &Lt, const T &rc) {
     return cytnx::linalg::Mod(Lt, rc);
   }

--- a/src/linalg/Mul.cpp
+++ b/src/linalg/Mul.cpp
@@ -855,7 +855,7 @@ namespace cytnx {
   //-------------------------------------------
   UniTensor operator*(const UniTensor &Lt, const UniTensor &Rt) { return linalg::Mul(Lt, Rt); }
 
-  template <class T>
+  template <cytnx_scalar_like T>
   UniTensor operator*(const T &lc, const UniTensor &Rt) {
     return linalg::Mul(lc, Rt);
   }

--- a/src/linalg/Mul.cpp
+++ b/src/linalg/Mul.cpp
@@ -855,7 +855,7 @@ namespace cytnx {
   //-------------------------------------------
   UniTensor operator*(const UniTensor &Lt, const UniTensor &Rt) { return linalg::Mul(Lt, Rt); }
 
-  template <cytnx_scalar_like T>
+  template <cytnx_unitensor_scalar_like T>
   UniTensor operator*(const T &lc, const UniTensor &Rt) {
     return linalg::Mul(lc, Rt);
   }

--- a/src/linalg/Sub.cpp
+++ b/src/linalg/Sub.cpp
@@ -1164,7 +1164,7 @@ namespace cytnx {
     return cytnx::linalg::Sub(Lt, Rt);
   }
 
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator-(const T &lc, const cytnx::UniTensor &Rt) {
     return cytnx::linalg::Sub(lc, Rt);
   }
@@ -1196,7 +1196,7 @@ namespace cytnx {
   template cytnx::UniTensor operator-<cytnx_bool>(const cytnx_bool &lc, const cytnx::UniTensor &Rt);
   template cytnx::UniTensor operator-<Scalar>(const Scalar &lc, const cytnx::UniTensor &Rt);
 
-  template <class T>
+  template <cytnx_scalar_like T>
   cytnx::UniTensor operator-(const cytnx::UniTensor &Lt, const T &rc) {
     return cytnx::linalg::Sub(Lt, rc);
   }

--- a/src/linalg/Sub.cpp
+++ b/src/linalg/Sub.cpp
@@ -1164,7 +1164,7 @@ namespace cytnx {
     return cytnx::linalg::Sub(Lt, Rt);
   }
 
-  template <cytnx_scalar_like T>
+  template <cytnx_unitensor_scalar_like T>
   cytnx::UniTensor operator-(const T &lc, const cytnx::UniTensor &Rt) {
     return cytnx::linalg::Sub(lc, Rt);
   }
@@ -1196,7 +1196,7 @@ namespace cytnx {
   template cytnx::UniTensor operator-<cytnx_bool>(const cytnx_bool &lc, const cytnx::UniTensor &Rt);
   template cytnx::UniTensor operator-<Scalar>(const Scalar &lc, const cytnx::UniTensor &Rt);
 
-  template <cytnx_scalar_like T>
+  template <cytnx_unitensor_scalar_like T>
   cytnx::UniTensor operator-(const cytnx::UniTensor &Lt, const T &rc) {
     return cytnx::linalg::Sub(Lt, rc);
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(
   Type_test.cpp
   cytnx_error_test.cpp
   include_order_canary_test.cpp
+  operator_constraint_test.cpp
   Tensor_strides_test.cpp
   Storage_test.cpp
   Scalar_test.cpp

--- a/tests/operator_constraint_test.cpp
+++ b/tests/operator_constraint_test.cpp
@@ -1,0 +1,79 @@
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "cytnx.hpp"
+
+// Guard for #1003 (Ian's item 3): the free Tensor/UniTensor arithmetic and comparison operators
+// (`+ - * / % ==`) are constrained to scalar-like operands via the `cytnx_scalar_like` concept, so
+// arbitrary std / user-defined types are no longer viable Cytnx arithmetic operands through
+// implicit conversion. These are primarily COMPILE-TIME guards; if the constraint is dropped, the
+// `static_assert`s (and the whole TU) fail.
+using namespace cytnx;
+
+// The concept admits exactly the operator support surface: cytnx dtype scalars + Scalar + proxies.
+static_assert(cytnx_scalar_like<cytnx_double>);
+static_assert(cytnx_scalar_like<cytnx_complex128>);
+static_assert(cytnx_scalar_like<cytnx_float>);
+static_assert(cytnx_scalar_like<cytnx_int64>);
+static_assert(cytnx_scalar_like<cytnx_bool>);
+static_assert(cytnx_scalar_like<int>);  // == cytnx_int32
+static_assert(cytnx_scalar_like<Scalar>);
+
+// ...and rejects everything else.
+static_assert(!cytnx_scalar_like<std::string>);
+static_assert(!cytnx_scalar_like<Tensor>);
+static_assert(!cytnx_scalar_like<UniTensor>);
+static_assert(!cytnx_scalar_like<std::vector<double>>);
+static_assert(!cytnx_scalar_like<const char*>);
+
+// A type with no conversion to Tensor / UniTensor / any scalar-like type, so it can only reach the
+// arithmetic operators through the (now constrained) `template <class T>` overloads. (std::string
+// and containers are unsuitable here: Tensor has implicit constructors that would let them bind to
+// the non-template Tensor <op> Tensor overloads instead.)
+namespace {
+  struct NotScalar {};
+}  // namespace
+
+// Named helper concepts so each operator-viability check is a proper (SFINAE) requires context.
+template <class L, class R>
+concept cy_addable = requires(L l, R r) {
+  l + r;
+};
+template <class L, class R>
+concept cy_mulable = requires(L l, R r) {
+  l* r;
+};
+template <class L, class R>
+concept cy_eqable = requires(L l, R r) {
+  l == r;
+};
+
+// The scalar-on-the-left free operators (`scalar <op> Tensor/UniTensor`) can only be the free
+// namespace-scope operators this PR constrains -- a scalar left operand cannot bind a member
+// operator. They are no longer viable for a non-scalar operand (they were before #1003)...
+static_assert(!cy_addable<NotScalar, Tensor>);
+static_assert(!cy_mulable<NotScalar, Tensor>);
+static_assert(!cy_eqable<NotScalar, Tensor>);
+static_assert(!cy_addable<NotScalar, UniTensor>);
+static_assert(!cy_mulable<NotScalar, UniTensor>);
+// ...but remain viable for scalar operands.
+static_assert(cy_addable<double, Tensor>);
+static_assert(cy_mulable<double, Tensor>);
+static_assert(cy_addable<Scalar, Tensor>);
+static_assert(cy_mulable<double, UniTensor>);
+
+TEST(OperatorConstraint, scalar_operators_still_work) {
+  Tensor a = arange(0, 4, 1, Type.Double);  // [0,1,2,3]
+  Tensor b = a + 1.0;
+  EXPECT_DOUBLE_EQ(b.at<cytnx_double>({0}), 1.0);
+  EXPECT_DOUBLE_EQ(b.at<cytnx_double>({3}), 4.0);
+
+  Tensor c = 2.0 * a;
+  EXPECT_DOUBLE_EQ(c.at<cytnx_double>({3}), 6.0);
+
+  // Tensor <op> Tensor uses the non-template overloads and is unaffected.
+  Tensor d = a + a;
+  EXPECT_DOUBLE_EQ(d.at<cytnx_double>({3}), 6.0);
+}

--- a/tests/operator_constraint_test.cpp
+++ b/tests/operator_constraint_test.cpp
@@ -64,6 +64,14 @@ static_assert(cy_mulable<double, Tensor>);
 static_assert(cy_addable<Scalar, Tensor>);
 static_assert(cy_mulable<double, UniTensor>);
 
+// NOTE (Codex #1093): the scalar-on-the-RIGHT direction (`Tensor <op> non_scalar`) is NOT yet
+// rejected. Tensor.hpp still forward-declares the free operators unconstrained, so `Tensor +
+// NotScalar` binds that (undefined) overload and compiles. Those forward declarations are
+// load-bearing for Tensor's inline member templates (e.g. `Tensor Mul(const T&) { return *this *
+// rhs; }` -- operator* has no member form), and they cannot be constrained in place because
+// cytnx_scalar_like depends on the not-yet-complete Tensor::Tproxy at that point in the header.
+// Closing this gap needs a concept/header reorganization -- tracked as a follow-up.
+
 TEST(OperatorConstraint, scalar_operators_still_work) {
   Tensor a = arange(0, 4, 1, Type.Double);  // [0,1,2,3]
   Tensor b = a + 1.0;

--- a/tests/operator_constraint_test.cpp
+++ b/tests/operator_constraint_test.cpp
@@ -28,6 +28,30 @@ static_assert(!cytnx_scalar_like<UniTensor>);
 static_assert(!cytnx_scalar_like<std::vector<double>>);
 static_assert(!cytnx_scalar_like<const char*>);
 
+// Each concept must admit exactly the operand set its operators are instantiated for, otherwise an
+// accepted operand still dies at link time -- the failure mode this whole change exists to remove.
+// Widening any of these without adding the matching explicit instantiation reintroduces it.
+
+// `+ - * /` on Tensor are instantiated for both element proxies (Add.cpp instantiates
+// operator+<Tensor::Tproxy> and operator+<Scalar::Sproxy>).
+static_assert(cytnx_scalar_like<Tensor::Tproxy>);
+static_assert(cytnx_scalar_like<Scalar::Sproxy>);
+
+// `+ - * /` on UniTensor are instantiated for Scalar::Sproxy but never for Tensor::Tproxy.
+static_assert(cytnx_unitensor_scalar_like<Scalar::Sproxy>);
+static_assert(!cytnx_unitensor_scalar_like<Tensor::Tproxy>);
+static_assert(cytnx_unitensor_scalar_like<cytnx_double>);
+static_assert(cytnx_unitensor_scalar_like<Scalar>);
+static_assert(!cytnx_unitensor_scalar_like<std::string>);
+
+// `%` (Tensor and UniTensor) and `==` (Tensor) have no proxy instantiations at all -- see Mod.cpp
+// and Cpr.cpp, which specialize only the dtype scalars and Scalar.
+static_assert(cytnx_scalar_value<cytnx_double>);
+static_assert(cytnx_scalar_value<Scalar>);
+static_assert(!cytnx_scalar_value<Tensor::Tproxy>);
+static_assert(!cytnx_scalar_value<Scalar::Sproxy>);
+static_assert(!cytnx_scalar_value<std::string>);
+
 // A type with no conversion to Tensor / UniTensor / any scalar-like type, so it can only reach the
 // arithmetic operators through the (now constrained) `template <class T>` overloads. (std::string
 // and containers are unsuitable here: Tensor has implicit constructors that would let them bind to
@@ -44,6 +68,14 @@ concept cy_addable = requires(L l, R r) {
 template <class L, class R>
 concept cy_mulable = requires(L l, R r) {
   l* r;
+};
+template <class L, class R>
+concept cy_subable = requires(L l, R r) {
+  l - r;
+};
+template <class L, class R>
+concept cy_divable = requires(L l, R r) {
+  l / r;
 };
 template <class L, class R>
 concept cy_eqable = requires(L l, R r) {
@@ -64,13 +96,29 @@ static_assert(cy_mulable<double, Tensor>);
 static_assert(cy_addable<Scalar, Tensor>);
 static_assert(cy_mulable<double, UniTensor>);
 
-// NOTE (Codex #1093): the scalar-on-the-RIGHT direction (`Tensor <op> non_scalar`) is NOT yet
-// rejected. Tensor.hpp still forward-declares the free operators unconstrained, so `Tensor +
-// NotScalar` binds that (undefined) overload and compiles. Those forward declarations are
-// load-bearing for Tensor's inline member templates (e.g. `Tensor Mul(const T&) { return *this *
-// rhs; }` -- operator* has no member form), and they cannot be constrained in place because
-// cytnx_scalar_like depends on the not-yet-complete Tensor::Tproxy at that point in the header.
-// Closing this gap needs a concept/header reorganization -- tracked as a follow-up.
+// The scalar-on-the-RIGHT direction (`Tensor <op> non_scalar`) -- Ian's review item on #1093, and
+// the gap that made the constraint above cosmetic. Tensor.hpp forward-declares these same free
+// operators; while those forward declarations were unconstrained they formed a *distinct*,
+// unconstrained template, which stayed viable for every non-scalar T and reintroduced exactly the
+// undefined-reference failure the constraint was meant to turn into an overload-resolution
+// failure. The forward declarations now carry the identical constraint, so this direction is
+// rejected too. (They are load-bearing: Tensor's inline member templates call the free operators,
+// e.g. `Tensor Mul(const T&) { return *this * rhs; }` -- operator* has no member form. Because
+// `*this * rhs` is a dependent expression it binds by ADL at the point of instantiation, so the
+// declarations work equally well below the class, which is where cytnx_scalar_like can name the
+// now-complete Tensor::Tproxy.)
+static_assert(!cy_addable<Tensor, NotScalar>);
+static_assert(!cy_mulable<Tensor, NotScalar>);
+static_assert(!cy_subable<Tensor, NotScalar>);
+static_assert(!cy_divable<Tensor, NotScalar>);
+static_assert(!cy_addable<UniTensor, NotScalar>);
+static_assert(!cy_mulable<UniTensor, NotScalar>);
+// ...while scalar right-operands stay viable in the same direction.
+static_assert(cy_addable<Tensor, double>);
+static_assert(cy_mulable<Tensor, double>);
+static_assert(cy_subable<Tensor, Scalar>);
+static_assert(cy_divable<Tensor, cytnx_int64>);
+static_assert(cy_addable<UniTensor, double>);
 
 TEST(OperatorConstraint, scalar_operators_still_work) {
   Tensor a = arange(0, 4, 1, Type.Double);  // [0,1,2,3]


### PR DESCRIPTION
## Problem

Ian's **item 3** from the #1003 review. The free namespace-scope arithmetic/comparison operators for `Tensor` and `UniTensor` (`+ - * / % ==` paired with a scalar) were declared as unconstrained `template <class T>`:

```cpp
template <class T> Tensor operator+(const T&, const Tensor&);
template <class T> cytnx::UniTensor operator*(const T&, const cytnx::UniTensor&);
template <class T> Tensor operator==(const Tensor&, const T&);
```

So an arbitrary `std` / user-defined type could be deduced as `T` and made the operator a viable candidate in overload resolution (e.g. under `using namespace cytnx`), even though the operators are only ever specialized/instantiated for the cytnx scalar surface.

## Fix

Add a `cytnx_scalar_like` concept in `linalg.hpp` admitting exactly that surface — the cytnx dtype scalars (reusing the existing `CytnxType` concept), `cytnx::Scalar`, and the `Tensor::Tproxy` / `Scalar::Sproxy` element proxies — and constrain the **22 free operator primary declarations** with it.

- The `Tensor` operators are **full specializations**, so constraining the primary declaration suffices (no `.cpp` change).
- The `UniTensor` operators are **generic templates**, so their **8 generic definitions** in `Add/Sub/Mul/Div/Mod.cpp` get the matching constraint (a constrained declaration needs a constrained definition).

`linalg::Add/Sub/Mul/Div/Mod/Cpr` (explicitly named — not an overload-resolution pollution vector; pybind uses these with explicit scalar casts) and the `ExpH/ExpM` templates are intentionally left unconstrained.

**Not a breaking change for valid use:** every builtin scalar literal deduces to a cytnx alias (`int` → `cytnx_int32`, `1.0` → `cytnx_double`, …); a non-scalar operand that "compiled" before only ever failed at link (no instantiation exists) and now fails with a clear overload error instead.

Adds `tests/operator_constraint_test.cpp`: compile-time guards that `cytnx_scalar_like` admits the scalars/proxies and rejects other types, that `scalar-on-the-left <op> Tensor/UniTensor` is viable for scalars but **not** for a non-scalar struct (these fail on pre-fix code), plus a runtime check that scalar operators and `Tensor<op>Tensor` still work.

## Testing

CPU (openblas): library + `test_main` build clean (the full library build confirmed no other call site relied on the loose operators); `OperatorConstraint` passes; `pybind/tensor_py.cpp` and `unitensor_py.cpp` compile clean. clang-format-14 clean.

Advances #1003 (Ian's operator-hygiene fold-in, item 3). Independent of the sibling #1003 branches (#1091 GPU in-place, #1092 complex_arithmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)