### PR TITLE
fix(linalg): support non-contiguous tensor⊗tensor for GPU Mul/Div (#1003, #988)

### DIFF
--- a/src/linalg/Div.cpp
+++ b/src/linalg/Div.cpp
@@ -95,7 +95,7 @@ namespace cytnx {
           checkCudaErrors(cudaSetDevice(Rt.device()));
           linalg_internal::cuDiv_dispatch(out._impl->storage()._impl, left._impl->storage()._impl,
                                           right._impl->storage()._impl,
-                                          left._impl->storage()._impl->size(), left._impl->shape(),
+                                          out._impl->storage()._impl->size(), left._impl->shape(),
                                           left._impl->invmapper(), right._impl->invmapper());
   #else
           cytnx_error_msg(true, "[Div] fatal error, the tensor is on GPU without CUDA support.%s",

--- a/src/linalg/Div.cpp
+++ b/src/linalg/Div.cpp
@@ -88,10 +88,15 @@ namespace cytnx {
             Lt._impl->storage().as_storage_variant(), Rt._impl->storage().as_storage_variant());
         } else {
   #ifdef UNI_GPU
-          cytnx_error_msg(true,
-                          "[Div][on GPU/CUDA] error two tensors must be contiguous. Call "
-                          "Contiguous_() or Contiguous() first%s",
-                          "\n");
+          // Non-contiguous tensor(/)tensor on the GPU: the shared cuArithmeticDispatchGPU
+          // kernel applies the layout mappers (as Add/Sub already do), so pass the layout
+          // instead of forcing the caller to contiguous-ize first (#1003, #988). `out` is
+          // already allocated with the true-division (floating) dtype above.
+          checkCudaErrors(cudaSetDevice(Rt.device()));
+          linalg_internal::cuDiv_dispatch(out._impl->storage()._impl, left._impl->storage()._impl,
+                                          right._impl->storage()._impl,
+                                          left._impl->storage()._impl->size(), left._impl->shape(),
+                                          left._impl->invmapper(), right._impl->invmapper());
   #else
           cytnx_error_msg(true, "[Div] fatal error, the tensor is on GPU without CUDA support.%s",
                           "\n");

--- a/src/linalg/Mul.cpp
+++ b/src/linalg/Mul.cpp
@@ -76,7 +76,7 @@ namespace cytnx {
           checkCudaErrors(cudaSetDevice(Rt.device()));
           linalg_internal::cuMul_dispatch(out._impl->storage()._impl, left._impl->storage()._impl,
                                           right._impl->storage()._impl,
-                                          left._impl->storage()._impl->size(), left._impl->shape(),
+                                          out._impl->storage()._impl->size(), left._impl->shape(),
                                           left._impl->invmapper(), right._impl->invmapper());
   #else
           cytnx_error_msg(true, "[Mul] fatal error, the tensor is on GPU without CUDA support.%s",

--- a/src/linalg/Mul.cpp
+++ b/src/linalg/Mul.cpp
@@ -70,10 +70,14 @@ namespace cytnx {
             Lt._impl->storage().as_storage_variant(), Rt._impl->storage().as_storage_variant());
         } else {
   #ifdef UNI_GPU
-          cytnx_error_msg(true,
-                          "[Mul][on GPU/CUDA] error two tensors must be contiguous. Call "
-                          "Contiguous_() or Contiguous() first%s",
-                          "\n");
+          // Non-contiguous tensor(x)tensor on the GPU: the shared cuArithmeticDispatchGPU
+          // kernel applies the layout mappers (as Add/Sub already do), so pass the layout
+          // instead of forcing the caller to contiguous-ize first (#1003, #988).
+          checkCudaErrors(cudaSetDevice(Rt.device()));
+          linalg_internal::cuMul_dispatch(out._impl->storage()._impl, left._impl->storage()._impl,
+                                          right._impl->storage()._impl,
+                                          left._impl->storage()._impl->size(), left._impl->shape(),
+                                          left._impl->invmapper(), right._impl->invmapper());
   #else
           cytnx_error_msg(true, "[Mul] fatal error, the tensor is on GPU without CUDA support.%s",
                           "\n");

--- a/tests/gpu/linalg_test/Div_test.cpp
+++ b/tests/gpu/linalg_test/Div_test.cpp
@@ -238,6 +238,47 @@ namespace cytnx {
 
       INSTANTIATE_TEST_SUITE_P(DivTests, DivTestAllShapes, ::testing::ValuesIn(GetTestShapes()));
 
+      // Non-contiguous tensor(/)tensor on the GPU (#1003, #988): the GPU front end used to
+      // reject a non-contiguous operand ("must be contiguous"); it now feeds the layout to
+      // the shared dispatch kernel like Add/Sub. Both operands are permuted so both operand
+      // offsets are gathered through the inverse mappers. Div is true division (floating
+      // output). Nonzero denominators (arange from 1) avoid divide-by-zero. Compare against
+      // the independent CPU path across all dtypes.
+      TEST(DivNonContig, GpuNoncontiguousTensorTensorMatchesCpu) {
+        for (auto dtype : dtype_list) {
+          if (dtype == Type.Bool) continue;
+          SCOPED_TRACE("Div non-contiguous dtype=" + std::to_string(dtype));
+
+          Tensor gpu_l = arange(2, 8, 1, dtype).reshape({3, 2}).permute({1, 0}).to(Device.cuda);
+          Tensor gpu_r = arange(1, 7, 1, dtype).reshape({3, 2}).permute({1, 0}).to(Device.cuda);
+          ASSERT_FALSE(gpu_l.is_contiguous());
+          ASSERT_FALSE(gpu_r.is_contiguous());
+
+          Tensor gpu_out = linalg::Div(gpu_l, gpu_r);
+          Tensor cpu_out = linalg::Div(gpu_l.to(Device.cpu), gpu_r.to(Device.cpu));
+          EXPECT_EQ(gpu_out.dtype(), cpu_out.dtype());
+          EXPECT_TRUE(
+            AreNearlyEqTensor(gpu_out.to(Device.cpu), cpu_out, GetTolerance(gpu_out.dtype())));
+        }
+      }
+
+      // Independent hand-computed literal (NOT the CPU oracle) for the non-contiguous gather:
+      // l logical = [[2,4,6],[3,5,7]], r logical = [[1,3,5],[2,4,6]] (arange 3x2 permuted).
+      // Int64/Int64 is true division -> Double: l/r = [[2, 4/3, 6/5],[3/2, 5/4, 7/6]] --
+      // distinct per element, so a wrong multi-index decomposition is caught.
+      TEST(DivNonContig, GpuNoncontiguousLiteral) {
+        Tensor l = arange(2, 8, 1, Type.Int64).reshape({3, 2}).permute({1, 0}).to(Device.cuda);
+        Tensor r = arange(1, 7, 1, Type.Int64).reshape({3, 2}).permute({1, 0}).to(Device.cuda);
+        ASSERT_FALSE(l.is_contiguous());
+        Tensor got = linalg::Div(l, r).to(Device.cpu);
+        EXPECT_EQ(got.dtype(), Type.Double);
+        const cytnx_double expect[2][3] = {{2.0, 4.0 / 3.0, 6.0 / 5.0},
+                                           {3.0 / 2.0, 5.0 / 4.0, 7.0 / 6.0}};
+        for (cytnx_uint64 i = 0; i < 2; i++)
+          for (cytnx_uint64 j = 0; j < 3; j++)
+            EXPECT_NEAR(got.at<cytnx_double>({i, j}), expect[i][j], 1e-10);
+      }
+
     }  // namespace
   }  // namespace gpu_test
 }  // namespace cytnx

--- a/tests/gpu/linalg_test/Mul_test.cpp
+++ b/tests/gpu/linalg_test/Mul_test.cpp
@@ -236,6 +236,44 @@ namespace cytnx {
         return tolerance;
       }
 
+      // Non-contiguous tensor(x)tensor on the GPU (#1003, #988): the GPU front end used to
+      // reject a non-contiguous operand ("must be contiguous"); it now feeds the layout to
+      // the shared dispatch kernel like Add/Sub. Both operands are permuted so both operand
+      // offsets are gathered through the inverse mappers. Compare against the independent CPU
+      // path across all dtypes. Inputs are built with CPU arange then moved to the GPU.
+      TEST(MulNonContig, GpuNoncontiguousTensorTensorMatchesCpu) {
+        for (auto dtype : dtype_list) {
+          if (dtype == Type.Bool) continue;
+          SCOPED_TRACE("Mul non-contiguous dtype=" + std::to_string(dtype));
+
+          Tensor gpu_l = arange(1, 7, 1, dtype).reshape({3, 2}).permute({1, 0}).to(Device.cuda);
+          Tensor gpu_r = arange(2, 8, 1, dtype).reshape({3, 2}).permute({1, 0}).to(Device.cuda);
+          ASSERT_FALSE(gpu_l.is_contiguous());
+          ASSERT_FALSE(gpu_r.is_contiguous());
+
+          Tensor gpu_out = linalg::Mul(gpu_l, gpu_r);
+          Tensor cpu_out = linalg::Mul(gpu_l.to(Device.cpu), gpu_r.to(Device.cpu));
+          EXPECT_EQ(gpu_out.dtype(), cpu_out.dtype());
+          EXPECT_TRUE(
+            AreNearlyEqTensor(gpu_out.to(Device.cpu), cpu_out, GetTolerance(gpu_out.dtype())));
+        }
+      }
+
+      // Independent hand-computed literal (NOT the CPU oracle) for the non-contiguous gather:
+      // l logical = [[1,3,5],[2,4,6]], r logical = [[10,30,50],[20,40,60]] (arange 3x2
+      // permuted), so l*r = [[10,90,250],[40,160,360]] -- distinct per element, so a wrong
+      // multi-index decomposition (not just a wrong L/R pairing) is caught.
+      TEST(MulNonContig, GpuNoncontiguousLiteral) {
+        Tensor l = arange(1, 7, 1, Type.Int64).reshape({3, 2}).permute({1, 0}).to(Device.cuda);
+        Tensor r = arange(10, 70, 10, Type.Int64).reshape({3, 2}).permute({1, 0}).to(Device.cuda);
+        ASSERT_FALSE(l.is_contiguous());
+        Tensor got = linalg::Mul(l, r).to(Device.cpu);
+        EXPECT_EQ(got.dtype(), Type.Int64);
+        const cytnx_int64 expect[2][3] = {{10, 90, 250}, {40, 160, 360}};
+        for (cytnx_uint64 i = 0; i < 2; i++)
+          for (cytnx_uint64 j = 0; j < 3; j++) EXPECT_EQ(got.at<cytnx_int64>({i, j}), expect[i][j]);
+      }
+
     }  // namespace
   }  // namespace gpu_test
 }  // namespace cytnx


### PR DESCRIPTION
Part of #1003; closes the GPU non-contiguous gap tracked in #988 for Mul/Div.

## Problem
The GPU out-of-place **Mul** and **Div** front ends rejected a non-contiguous operand with `two tensors must be contiguous. Call Contiguous_() or Contiguous() first` — forcing the caller to contiguous-ize first, even though **Add/Sub accept it** and the **CPU path handles it**. This was a leftover from the pre-#1013 era when `cuMul`/`cuDiv` had no working non-contiguous kernel (#988).

## Fix
#1013 unified all four arithmetic ops onto the shared `cuArithmeticDispatchGPU` kernel, which already applies the layout mappers. `Mul.cpp`/`Div.cpp` now pass the layout (`shape` + inverse mappers) to `cuMul_dispatch`/`cuDiv_dispatch` in the non-contiguous branch — **exactly as `Add.cpp`/`Sub.cpp` already do** — instead of erroring. Div's output is already allocated with the true-division (floating) dtype before the branch.

⚠️ **Behavior change (flagged):** GPU `Mul`/`Div` now **accept** a non-contiguous operand and return the correct result (matching CPU and Add/Sub) rather than throwing. This removes a restriction; it does not change any result that previously succeeded.

## Testing
New non-contiguous `tensor(op)tensor` cases in `Mul_test.cpp` and `Div_test.cpp`:
- **GPU-vs-CPU** across all dtypes (both operands permuted, so both offsets are gathered through the inverse mappers);
- **independent hand-computed literals** with *distinct per-element* results, so a wrong multi-index decomposition is caught, not just a wrong L/R pairing.

Both new tests **fail on the pre-fix code** (which threw "must be contiguous"). On an RTX 4070 Ti (CUDA 13, sm_89): `gpu_test_main` builds clean; the new tests pass; the full **Mul/Div GPU suites (148 tests) are green**. clang-format-14 clean.

Composes with (and is independent of) #1095 — when both land, this newly-live non-contiguous path uses the by-value layout instead of per-call device allocation.

Note: GPU results are from the local RTX 4070 Ti — there is no GPU CI runner. `Cpr` still rejects non-contiguous operands (separate Bool-output kernel); left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)