### PR TITLE
refactor(linalg): pass cuCpr non-contiguous layout by value (#1003)

### DIFF
--- a/src/backend/linalg_internal_gpu/cuCpr_dispatch.cu
+++ b/src/backend/linalg_internal_gpu/cuCpr_dispatch.cu
@@ -64,12 +64,10 @@ namespace cytnx {
       __global__ void cuCpr_dispatch_tn_kernel_nonconti(
         cytnx_bool *out, const TL *lhs, const cytnx_uint64 n, const TR *rhs,
         const gpu_layout::GpuNonContigLayout layout) {
-        extern __shared__ cytnx_uint64 tmpv[];
-
         const cytnx_uint64 idx = blockIdx.x * blockDim.x + threadIdx.x;
         if (idx < n) {
           cytnx_uint64 Lidx, Ridx;
-          gpu_layout::ComputeGpuNonContigIndices(idx, tmpv, layout, Lidx, Ridx);
+          gpu_layout::compute_gpu_non_contig_indices(idx, layout, Lidx, Ridx);
           out[idx] = CuCprDispatchOp<TO>(lhs[Lidx], rhs[Ridx]);
         }
       }
@@ -103,10 +101,8 @@ namespace cytnx {
             cuCpr_dispatch_tn_kernel<TO><<<NBlocks, 512>>>(_out, _Lin, len, _Rin);
           } else {
             const gpu_layout::GpuNonContigLayout layout =
-              gpu_layout::MakeGpuNonContigLayout(shape, invmapper_L, invmapper_R);
-            cuCpr_dispatch_tn_kernel_nonconti<TO>
-              <<<NBlocks, 512, 512 * shape.size() * sizeof(cytnx_uint64)>>>(_out, _Lin, len, _Rin,
-                                                                            layout);
+              gpu_layout::make_gpu_non_contig_layout(shape, invmapper_L, invmapper_R);
+            cuCpr_dispatch_tn_kernel_nonconti<TO><<<NBlocks, 512>>>(_out, _Lin, len, _Rin, layout);
           }
         }
       }

--- a/src/backend/linalg_internal_gpu/cuCpr_dispatch.cu
+++ b/src/backend/linalg_internal_gpu/cuCpr_dispatch.cu
@@ -4,6 +4,7 @@
 
 #include "backend/Storage.hpp"
 #include "backend/utils_internal_interface.hpp"
+#include "cuNonContigLayout.cuh"
 #include "cuTypeCvt.hpp"
 
 // Typed GPU dispatch for out-of-place comparison (==). Unlike the arithmetic ops
@@ -62,25 +63,13 @@ namespace cytnx {
       template <typename TO, typename TL, typename TR>
       __global__ void cuCpr_dispatch_tn_kernel_nonconti(
         cytnx_bool *out, const TL *lhs, const cytnx_uint64 n, const TR *rhs,
-        const cytnx_uint64 *accu_shape, const cytnx_uint64 *old_accu_shapeL,
-        const cytnx_uint64 *old_accu_shapeR, const cytnx_uint64 *invmapper_L,
-        const cytnx_uint64 *invmapper_R, const cytnx_uint64 shapesize) {
+        const gpu_layout::GpuNonContigLayout layout) {
         extern __shared__ cytnx_uint64 tmpv[];
 
         const cytnx_uint64 idx = blockIdx.x * blockDim.x + threadIdx.x;
         if (idx < n) {
-          cytnx_uint64 tmp = idx;
-          const cytnx_uint64 offset = threadIdx.x * shapesize;
-          cytnx_uint64 Lidx = 0, Ridx = 0;
-
-          for (cytnx_uint64 j = 0; j < shapesize; j++) {
-            tmpv[offset + j] = tmp / accu_shape[j];
-            tmp = tmp % accu_shape[j];
-          }
-          for (cytnx_uint64 j = 0; j < shapesize; j++) {
-            Lidx += tmpv[offset + invmapper_L[j]] * old_accu_shapeL[j];
-            Ridx += tmpv[offset + invmapper_R[j]] * old_accu_shapeR[j];
-          }
+          cytnx_uint64 Lidx, Ridx;
+          gpu_layout::ComputeGpuNonContigIndices(idx, tmpv, layout, Lidx, Ridx);
           out[idx] = CuCprDispatchOp<TO>(lhs[Lidx], rhs[Ridx]);
         }
       }
@@ -113,46 +102,11 @@ namespace cytnx {
           if (shape.size() == 0) {
             cuCpr_dispatch_tn_kernel<TO><<<NBlocks, 512>>>(_out, _Lin, len, _Rin);
           } else {
-            cytnx_uint64 *m_accu_shape = reinterpret_cast<cytnx_uint64 *>(
-              utils_internal::cuCalloc_gpu(shape.size(), sizeof(cytnx_uint64)));
-            cytnx_uint64 *m_old_accu_shapeL = reinterpret_cast<cytnx_uint64 *>(
-              utils_internal::cuCalloc_gpu(shape.size(), sizeof(cytnx_uint64)));
-            cytnx_uint64 *m_old_accu_shapeR = reinterpret_cast<cytnx_uint64 *>(
-              utils_internal::cuCalloc_gpu(shape.size(), sizeof(cytnx_uint64)));
-            cytnx_uint64 *m_invmapper_L = reinterpret_cast<cytnx_uint64 *>(
-              utils_internal::cuMalloc_gpu(invmapper_L.size() * sizeof(cytnx_uint64)));
-            cytnx_uint64 *m_invmapper_R = reinterpret_cast<cytnx_uint64 *>(
-              utils_internal::cuMalloc_gpu(invmapper_R.size() * sizeof(cytnx_uint64)));
-
-            checkCudaErrors(cudaMemcpy(m_invmapper_L, &invmapper_L[0],
-                                       sizeof(cytnx_uint64) * invmapper_L.size(),
-                                       cudaMemcpyHostToDevice));
-            checkCudaErrors(cudaMemcpy(m_invmapper_R, &invmapper_R[0],
-                                       sizeof(cytnx_uint64) * invmapper_R.size(),
-                                       cudaMemcpyHostToDevice));
-
-            cytnx_uint64 tmp1 = 1, tmp2 = 1, tmp3 = 1;
-            for (cytnx_uint64 i = 0; i < shape.size(); i++) {
-              m_accu_shape[shape.size() - 1 - i] = tmp1;
-              tmp1 *= shape[shape.size() - 1 - i];
-
-              m_old_accu_shapeL[shape.size() - 1 - i] = tmp2;
-              tmp2 *= shape[invmapper_L[shape.size() - 1 - i]];
-
-              m_old_accu_shapeR[shape.size() - 1 - i] = tmp3;
-              tmp3 *= shape[invmapper_R[shape.size() - 1 - i]];
-            }
-
+            const gpu_layout::GpuNonContigLayout layout =
+              gpu_layout::MakeGpuNonContigLayout(shape, invmapper_L, invmapper_R);
             cuCpr_dispatch_tn_kernel_nonconti<TO>
-              <<<NBlocks, 512, 512 * shape.size() * sizeof(cytnx_uint64)>>>(
-                _out, _Lin, len, _Rin, m_accu_shape, m_old_accu_shapeL, m_old_accu_shapeR,
-                m_invmapper_L, m_invmapper_R, shape.size());
-
-            checkCudaErrors(cudaFree(m_accu_shape));
-            checkCudaErrors(cudaFree(m_old_accu_shapeL));
-            checkCudaErrors(cudaFree(m_old_accu_shapeR));
-            checkCudaErrors(cudaFree(m_invmapper_L));
-            checkCudaErrors(cudaFree(m_invmapper_R));
+              <<<NBlocks, 512, 512 * shape.size() * sizeof(cytnx_uint64)>>>(_out, _Lin, len, _Rin,
+                                                                            layout);
           }
         }
       }

--- a/src/linalg/Cpr.cpp
+++ b/src/linalg/Cpr.cpp
@@ -76,7 +76,7 @@ namespace cytnx {
           checkCudaErrors(cudaSetDevice(Rt.device()));
           cytnx::linalg_internal::cuCpr_dispatch(
             out._impl->storage()._impl, left._impl->storage()._impl, right._impl->storage()._impl,
-            left._impl->storage()._impl->size(), left._impl->shape(), left._impl->invmapper(),
+            out._impl->storage()._impl->size(), left._impl->shape(), left._impl->invmapper(),
             right._impl->invmapper());
   #else
           cytnx_error_msg(true, "[Cpr] fatal error, the tensor is on GPU without CUDA support.%s",

--- a/src/linalg/Cpr.cpp
+++ b/src/linalg/Cpr.cpp
@@ -70,10 +70,14 @@ namespace cytnx {
             Lt._impl->storage().as_storage_variant(), Rt._impl->storage().as_storage_variant());
         } else {
   #ifdef UNI_GPU
-          cytnx_error_msg(true,
-                          "[Cpr][on GPU/CUDA] error two tensors must be contiguous. Call "
-                          "Contiguous_() or Contiguous() first%s",
-                          "\n");
+          // Non-contiguous tensor(==)tensor on the GPU: cuCpr_dispatch's non-contiguous kernel
+          // applies the layout mappers (as Add/Sub/Mul/Div already do), so pass the layout
+          // instead of forcing the caller to contiguous-ize first (#1003, #988).
+          checkCudaErrors(cudaSetDevice(Rt.device()));
+          cytnx::linalg_internal::cuCpr_dispatch(
+            out._impl->storage()._impl, left._impl->storage()._impl, right._impl->storage()._impl,
+            left._impl->storage()._impl->size(), left._impl->shape(), left._impl->invmapper(),
+            right._impl->invmapper());
   #else
           cytnx_error_msg(true, "[Cpr] fatal error, the tensor is on GPU without CUDA support.%s",
                           "\n");

--- a/tests/gpu/linalg_test/Cpr_test.cpp
+++ b/tests/gpu/linalg_test/Cpr_test.cpp
@@ -216,6 +216,52 @@ namespace cytnx {
 
       INSTANTIATE_TEST_SUITE_P(CprTests, CprTestAllShapes, ::testing::ValuesIn(GetTestShapes()));
 
+      // Non-contiguous tensor(==)tensor on the GPU (#1003, #988): the GPU front end used to
+      // reject a non-contiguous operand ("must be contiguous"); it now feeds the layout to
+      // cuCpr_dispatch's non-contiguous kernel like the arithmetic ops. a[i][j]=3j+i (permuted)
+      // vs b[i][j]=3i+j (contiguous) are equal iff i==j, so the Bool result is the 3x3 identity
+      // -- a mix a wrong gather would break. Both operand orders are covered so each inverse
+      // mapper is exercised. Compared exactly against the independent CPU path.
+      TEST(CprNonContig, GpuNoncontiguousMatchesCpu) {
+        for (auto dtype : dtype_list) {
+          if (dtype == Type.Bool) continue;
+          SCOPED_TRACE("Cpr non-contiguous dtype=" + std::to_string(dtype));
+
+          Tensor permuted = arange(0, 9, 1, dtype).reshape({3, 3}).permute({1, 0}).to(Device.cuda);
+          Tensor contig = arange(0, 9, 1, dtype).reshape({3, 3}).to(Device.cuda);
+          ASSERT_FALSE(permuted.is_contiguous());
+
+          // permuted LHS (exercises invmapper_L), contiguous RHS
+          {
+            Tensor gpu_out = linalg::Cpr(permuted, contig);
+            Tensor cpu_out = linalg::Cpr(permuted.to(Device.cpu), contig.to(Device.cpu));
+            EXPECT_EQ(gpu_out.dtype(), Type.Bool);
+            EXPECT_TRUE(AreEqTensor(gpu_out.to(Device.cpu), cpu_out));
+          }
+          // contiguous LHS, permuted RHS (exercises invmapper_R)
+          {
+            Tensor gpu_out = linalg::Cpr(contig, permuted);
+            Tensor cpu_out = linalg::Cpr(contig.to(Device.cpu), permuted.to(Device.cpu));
+            EXPECT_EQ(gpu_out.dtype(), Type.Bool);
+            EXPECT_TRUE(AreEqTensor(gpu_out.to(Device.cpu), cpu_out));
+          }
+        }
+      }
+
+      // Independent hand-computed literal for the non-contiguous comparison gather:
+      // a[i][j]=3j+i (permuted) vs b[i][j]=3i+j (contiguous) -> equal iff i==j.
+      TEST(CprNonContig, GpuNoncontiguousLiteral) {
+        Tensor permuted =
+          arange(0, 9, 1, Type.Int64).reshape({3, 3}).permute({1, 0}).to(Device.cuda);
+        Tensor contig = arange(0, 9, 1, Type.Int64).reshape({3, 3}).to(Device.cuda);
+        ASSERT_FALSE(permuted.is_contiguous());
+        Tensor got = linalg::Cpr(permuted, contig).to(Device.cpu);
+        EXPECT_EQ(got.dtype(), Type.Bool);
+        for (cytnx_uint64 i = 0; i < 3; i++)
+          for (cytnx_uint64 j = 0; j < 3; j++)
+            EXPECT_EQ(got.at<cytnx_bool>({i, j}), (i == j)) << "at (" << i << "," << j << ")";
+      }
+
     }  // namespace
   }  // namespace gpu_test
 }  // namespace cytnx


### PR DESCRIPTION
Stacked follow-up completing #1003 step 4 for the comparison path.

**Depends on #1095** (shared `cuNonContigLayout.cuh`) **and #1097** (which makes the GPU Cpr non-contiguous path live and provides its test coverage). The base of this PR is #1095's branch; the `Cpr.cpp` / `Cpr_test.cpp` changes shown in the diff are #1097. Once #1095 and #1097 merge to `master`, this reduces to just the `cuCpr_dispatch.cu` change.

## What
#1095 gave the arithmetic non-contiguous kernels a by-value layout (no per-call `cuMalloc_gpu`/`memcpy`/`free`) but deliberately skipped `cuCpr` because its non-contiguous path was then unreachable. #1097 made that path live (GPU `Cpr` now accepts non-contiguous operands). This PR applies the same by-value treatment to `cuCpr_dispatch`'s non-contiguous kernel: it reuses the shared `GpuNonContigLayout` / `MakeGpuNonContigLayout` / `ComputeGpuNonContigIndices` instead of allocating five device arrays per call (net −46 lines in `cuCpr_dispatch.cu`).

With this, **all** GPU elementwise non-contiguous kernels (Add/Sub/Mul/Div and Cpr) are free of per-call device allocation.

## Testing
The `CprNonContig` tests (added in #1097) now exercise the by-value `cuCpr` kernel: permuted-vs-contiguous in both operand orders (each inverse mapper), GPU-vs-CPU across all dtypes, and a hand-computed identity-pattern literal. On an RTX 4070 Ti (CUDA 13, sm_89): `gpu_test_main` builds clean, `CprNonContig` passes, and the full **Cpr GPU suite (82 tests) is green**. clang-format-14 clean.

Note: GPU results are from the local RTX 4070 Ti — there is no GPU CI runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
