### PR TITLE
fix(linalg): register missing Int16/Uint16/Bool rows in CPU Outer dispatch (fixes segfault)

### DIFF
--- a/src/backend/linalg_internal_interface.cpp
+++ b/src/backend/linalg_internal_interface.cpp
@@ -324,6 +324,47 @@ namespace cytnx {
       Outer_ii[Type.Uint32][Type.Int16] = Outer_internal_u32ti16;
       Outer_ii[Type.Uint32][Type.Bool] = Outer_internal_u32tb;
 
+      // The Int16/Uint16/Bool source rows were omitted from this table, so
+      // Outer_ii[Int16/Uint16/Bool][...] were null; linalg::Outer with such a
+      // left operand dereferenced a null function pointer and crashed. The
+      // Outer_internal_{i16,u16,b}t* implementations already exist -- register
+      // them here so every dtype pair dispatches. (cuOuter_ii already had them.)
+      Outer_ii[Type.Int16][Type.ComplexDouble] = Outer_internal_i16tcd;
+      Outer_ii[Type.Int16][Type.ComplexFloat] = Outer_internal_i16tcf;
+      Outer_ii[Type.Int16][Type.Double] = Outer_internal_i16td;
+      Outer_ii[Type.Int16][Type.Float] = Outer_internal_i16tf;
+      Outer_ii[Type.Int16][Type.Int64] = Outer_internal_i16ti64;
+      Outer_ii[Type.Int16][Type.Uint64] = Outer_internal_i16tu64;
+      Outer_ii[Type.Int16][Type.Int32] = Outer_internal_i16ti32;
+      Outer_ii[Type.Int16][Type.Uint32] = Outer_internal_i16tu32;
+      Outer_ii[Type.Int16][Type.Uint16] = Outer_internal_i16tu16;
+      Outer_ii[Type.Int16][Type.Int16] = Outer_internal_i16ti16;
+      Outer_ii[Type.Int16][Type.Bool] = Outer_internal_i16tb;
+
+      Outer_ii[Type.Uint16][Type.ComplexDouble] = Outer_internal_u16tcd;
+      Outer_ii[Type.Uint16][Type.ComplexFloat] = Outer_internal_u16tcf;
+      Outer_ii[Type.Uint16][Type.Double] = Outer_internal_u16td;
+      Outer_ii[Type.Uint16][Type.Float] = Outer_internal_u16tf;
+      Outer_ii[Type.Uint16][Type.Int64] = Outer_internal_u16ti64;
+      Outer_ii[Type.Uint16][Type.Uint64] = Outer_internal_u16tu64;
+      Outer_ii[Type.Uint16][Type.Int32] = Outer_internal_u16ti32;
+      Outer_ii[Type.Uint16][Type.Uint32] = Outer_internal_u16tu32;
+      Outer_ii[Type.Uint16][Type.Uint16] = Outer_internal_u16tu16;
+      Outer_ii[Type.Uint16][Type.Int16] = Outer_internal_u16ti16;
+      Outer_ii[Type.Uint16][Type.Bool] = Outer_internal_u16tb;
+
+      Outer_ii[Type.Bool][Type.ComplexDouble] = Outer_internal_btcd;
+      Outer_ii[Type.Bool][Type.ComplexFloat] = Outer_internal_btcf;
+      Outer_ii[Type.Bool][Type.Double] = Outer_internal_btd;
+      Outer_ii[Type.Bool][Type.Float] = Outer_internal_btf;
+      Outer_ii[Type.Bool][Type.Int64] = Outer_internal_bti64;
+      Outer_ii[Type.Bool][Type.Uint64] = Outer_internal_btu64;
+      Outer_ii[Type.Bool][Type.Int32] = Outer_internal_bti32;
+      Outer_ii[Type.Bool][Type.Uint32] = Outer_internal_btu32;
+      Outer_ii[Type.Bool][Type.Uint16] = Outer_internal_btu16;
+      Outer_ii[Type.Bool][Type.Int16] = Outer_internal_bti16;
+      Outer_ii[Type.Bool][Type.Bool] = Outer_internal_btb;
+
       //================
 
       Lstsq_ii = std::vector<Lstsqfunc_oii>(5);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,7 @@ add_executable(
   linalg_test/Gesvd_truncate_test.cpp
   linalg_test/Rsvd_test.cpp
   linalg_test/DtypePromotion_test.cpp
+  linalg_test/Outer_test.cpp
   linalg_test/TypedArithmeticCoverage_test.cpp
   linalg_test/Gemm_Batch_test.cpp
   linalg_test/Trace_test.cpp

--- a/tests/linalg_test/Outer_test.cpp
+++ b/tests/linalg_test/Outer_test.cpp
@@ -1,0 +1,108 @@
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "Device.hpp"
+#include "Generator.hpp"
+#include "linalg.hpp"
+#include "Type.hpp"
+
+// Regression coverage for linalg::Outer over the small-integer and Bool
+// dtypes. The CPU Outer_ii dispatch table was missing every Int16, Uint16, and
+// Bool *source* row, so linalg::Outer with such a left operand dereferenced a
+// null function pointer and segfaulted. These tests exercise exactly those
+// dtypes (out_dtype == Int16/Uint16/Bool) and check independently hand-computed
+// values, so they crash on the pre-fix binary and pass once the rows are
+// registered. Outer(a, b) gives out[i, j] = a[i] * b[j].
+namespace cytnx {
+  namespace test {
+    namespace {
+
+      // Int16 x Int16 -> Int16, with negative values. Products stay within
+      // int16 range so the expected values are exact.
+      TEST(OuterDtypeCoverage, Int16) {
+        Tensor a = zeros({3}, Type.Int16, Device.cpu);
+        a.at<cytnx_int16>({0}) = 2;
+        a.at<cytnx_int16>({1}) = -3;
+        a.at<cytnx_int16>({2}) = 4;
+        Tensor b = zeros({2}, Type.Int16, Device.cpu);
+        b.at<cytnx_int16>({0}) = 5;
+        b.at<cytnx_int16>({1}) = -6;
+
+        Tensor out = linalg::Outer(a, b);
+
+        ASSERT_EQ(out.dtype(), Type.Int16);
+        ASSERT_EQ(out.shape(), (std::vector<cytnx_uint64>{3, 2}));
+        const cytnx_int16 expected[3][2] = {{10, -12}, {-15, 18}, {20, -24}};
+        for (cytnx_uint64 i = 0; i < 3; i++)
+          for (cytnx_uint64 j = 0; j < 2; j++)
+            EXPECT_EQ(out.at<cytnx_int16>({i, j}), expected[i][j])
+              << "at (" << i << "," << j << ")";
+      }
+
+      // Uint16 x Uint16 -> Uint16.
+      TEST(OuterDtypeCoverage, Uint16) {
+        Tensor a = zeros({2}, Type.Uint16, Device.cpu);
+        a.at<cytnx_uint16>({0}) = 2;
+        a.at<cytnx_uint16>({1}) = 3;
+        Tensor b = zeros({3}, Type.Uint16, Device.cpu);
+        b.at<cytnx_uint16>({0}) = 4;
+        b.at<cytnx_uint16>({1}) = 5;
+        b.at<cytnx_uint16>({2}) = 6;
+
+        Tensor out = linalg::Outer(a, b);
+
+        ASSERT_EQ(out.dtype(), Type.Uint16);
+        ASSERT_EQ(out.shape(), (std::vector<cytnx_uint64>{2, 3}));
+        const cytnx_uint16 expected[2][3] = {{8, 10, 12}, {12, 15, 18}};
+        for (cytnx_uint64 i = 0; i < 2; i++)
+          for (cytnx_uint64 j = 0; j < 3; j++)
+            EXPECT_EQ(out.at<cytnx_uint16>({i, j}), expected[i][j])
+              << "at (" << i << "," << j << ")";
+      }
+
+      // Bool x Bool -> Bool. The outer product of two boolean vectors is the
+      // logical AND (product) of their entries.
+      TEST(OuterDtypeCoverage, Bool) {
+        Tensor a = zeros({2}, Type.Bool, Device.cpu);
+        a.at<cytnx_bool>({0}) = true;
+        a.at<cytnx_bool>({1}) = false;
+        Tensor b = zeros({3}, Type.Bool, Device.cpu);
+        b.at<cytnx_bool>({0}) = true;
+        b.at<cytnx_bool>({1}) = true;
+        b.at<cytnx_bool>({2}) = false;
+
+        Tensor out = linalg::Outer(a, b);
+
+        ASSERT_EQ(out.dtype(), Type.Bool);
+        ASSERT_EQ(out.shape(), (std::vector<cytnx_uint64>{2, 3}));
+        const bool expected[2][3] = {{true, true, false}, {false, false, false}};
+        for (cytnx_uint64 i = 0; i < 2; i++)
+          for (cytnx_uint64 j = 0; j < 3; j++)
+            EXPECT_EQ(out.at<cytnx_bool>({i, j}), expected[i][j]) << "at (" << i << "," << j << ")";
+      }
+
+      // Int16 x Bool -> Int16 (Bool promotes to Int16): exercises the Int16
+      // source row against a different second dtype.
+      TEST(OuterDtypeCoverage, Int16TimesBool) {
+        Tensor a = zeros({2}, Type.Int16, Device.cpu);
+        a.at<cytnx_int16>({0}) = 7;
+        a.at<cytnx_int16>({1}) = -9;
+        Tensor b = zeros({2}, Type.Bool, Device.cpu);
+        b.at<cytnx_bool>({0}) = true;
+        b.at<cytnx_bool>({1}) = false;
+
+        Tensor out = linalg::Outer(a, b);
+
+        ASSERT_EQ(out.dtype(), Type.Int16);
+        ASSERT_EQ(out.shape(), (std::vector<cytnx_uint64>{2, 2}));
+        const cytnx_int16 expected[2][2] = {{7, 0}, {-9, 0}};
+        for (cytnx_uint64 i = 0; i < 2; i++)
+          for (cytnx_uint64 j = 0; j < 2; j++)
+            EXPECT_EQ(out.at<cytnx_int16>({i, j}), expected[i][j])
+              << "at (" << i << "," << j << ")";
+      }
+
+    }  // namespace
+  }  // namespace test
+}  // namespace cytnx


### PR DESCRIPTION
## Problem

`linalg::Outer` **segfaults** for `Int16`, `Uint16`, or `Bool` inputs on the CPU.

`Outer.cpp` promotes both operands to a common dtype and dispatches through
`Outer_ii[out_dtype][out_dtype]`. The CPU `Outer_ii` dispatch table in
`linalg_internal_interface.cpp` was never populated with the **Int16, Uint16,
or Bool source rows** — every other source dtype has a full 11-entry row, but
these three had none. So when the promoted dtype is `Int16`/`Uint16`/`Bool`,
`Outer_ii[out_dtype][out_dtype]` is a null function pointer, and the call jumps
to address `0`:

```
AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x000000000000 ...)
    #1 ... TestBody tests/linalg_test/Outer_test.cpp:32   // the linalg::Outer(a, b) call
```

Every sibling dispatch table in the same constructor — `MM_ii`, `Sum_ii`,
`Diag_ii`, `Matmul_ii`, `Matvec_ii`, and even the GPU `cuOuter_ii` — already
registers these dtypes, so the omission is an oversight, not intent. (The GPU
path works; this is CPU-only.)

Reproduces on `master` (86cb96c2). Minimal repro:

```python
import cytnx
a = cytnx.zeros([5], cytnx.Type.Int16); b = cytnx.zeros([7], cytnx.Type.Int16)
cytnx.linalg.Outer(a, b)   # SIGSEGV
```

## Fix

Register the 33 missing rows (`Int16`, `Uint16`, `Bool` sources × 11 target
dtypes). The `Outer_internal_{i16,u16,b}t*` implementations already exist and
are declared — **this is registration only, no kernel or algorithm change.**

## Testing

- New `tests/linalg_test/Outer_test.cpp` (`OuterDtypeCoverage`: `Int16`,
  `Uint16`, `Bool`, `Int16xBool`) checks independently hand-computed values
  (dtype **and** value, with negative and boolean cases).
- **Regression discipline:** on the pre-fix binary these crash with the ASan
  SEGV above at the `linalg::Outer` call site; post-fix all four pass.
- Existing `DtypePromotion.OuterComplexfloatDouble` and `LinalgKronTest` tests
  still pass. `clang-format` (v14) clean.
