### PR TITLE
test(linalg): GPU correctness coverage for Kron and Outer (#1003, confirms #999)

### DIFF
--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -19,8 +19,10 @@ add_executable(
   linalg_test/Add_test.cpp
   linalg_test/Cpr_test.cpp
   linalg_test/Div_test.cpp
+  linalg_test/Kron_test.cpp
   linalg_test/Mod_test.cpp
   linalg_test/Mul_test.cpp
+  linalg_test/Outer_test.cpp
   linalg_test/Sub_test.cpp
   linalg_test/InplacePromote_test.cpp
   linalg_test/Det_test.cpp

--- a/tests/gpu/linalg_test/Kron_test.cpp
+++ b/tests/gpu/linalg_test/Kron_test.cpp
@@ -1,0 +1,167 @@
+#include "gtest/gtest.h"
+
+#include "cytnx.hpp"
+#include "gpu_test_tools.h"
+
+// GPU Kron correctness. Every expected value here is computed independently
+// from the Kronecker-product definition
+//
+//     out[i, j] = A[i / bR, j / bC] * B[i % bR, j % bC]
+//
+// (A is aR x aC, B is bR x bC, out is (aR*bR) x (aC*bC)), written out as
+// literals or recomputed from the raw inputs -- never by comparing against
+// another Cytnx path that could share the same bug. The mixed
+// ComplexFloat x Double case is the #984/#999 promotion discriminator: the
+// output must be ComplexDouble (not the narrower ComplexFloat) and carry full
+// double precision.
+//
+// Inputs are built on the CPU and copied to the GPU with .to(Device.cuda) --
+// GPU arange ignores a non-unit step for real dtypes (#1070), so never build
+// GPU inputs with arange directly.
+namespace cytnx {
+  namespace gpu_test {
+    namespace {
+
+      // 2x2 Kron 2x2 -> 4x4, real. A = [[1,2],[3,4]], B = [[0,5],[6,7]].
+      // Kron(A,B) laid out by hand:
+      //   [ 0  5   0 10 ]
+      //   [ 6  7  12 14 ]
+      //   [ 0 15   0 20 ]
+      //   [18 21  24 28 ]
+      TEST(GpuKron, DoubleMatchesHandComputed) {
+        Tensor a = zeros({2, 2}, Type.Double);
+        a.at<cytnx_double>({0, 0}) = 1;
+        a.at<cytnx_double>({0, 1}) = 2;
+        a.at<cytnx_double>({1, 0}) = 3;
+        a.at<cytnx_double>({1, 1}) = 4;
+        Tensor b = zeros({2, 2}, Type.Double);
+        b.at<cytnx_double>({0, 0}) = 0;
+        b.at<cytnx_double>({0, 1}) = 5;
+        b.at<cytnx_double>({1, 0}) = 6;
+        b.at<cytnx_double>({1, 1}) = 7;
+
+        Tensor out = linalg::Kron(a.to(Device.cuda), b.to(Device.cuda)).to(Device.cpu);
+
+        ASSERT_EQ(out.dtype(), Type.Double);
+        ASSERT_EQ(out.shape(), (std::vector<cytnx_uint64>{4, 4}));
+        const double expected[4][4] = {
+          {0, 5, 0, 10}, {6, 7, 12, 14}, {0, 15, 0, 20}, {18, 21, 24, 28}};
+        for (cytnx_uint64 i = 0; i < 4; i++)
+          for (cytnx_uint64 j = 0; j < 4; j++)
+            EXPECT_DOUBLE_EQ(out.at<cytnx_double>({i, j}), expected[i][j])
+              << "at (" << i << "," << j << ")";
+      }
+
+      // Fractional and negative values, recomputed per-element from the raw
+      // inputs (independent of Kron's own layout).
+      TEST(GpuKron, DoubleFractionalNegative) {
+        Tensor a = zeros({3, 2}, Type.Double);
+        a.at<cytnx_double>({0, 0}) = -1.5;
+        a.at<cytnx_double>({0, 1}) = 0.25;
+        a.at<cytnx_double>({1, 0}) = 2.0;
+        a.at<cytnx_double>({1, 1}) = -3.5;
+        a.at<cytnx_double>({2, 0}) = 0.0;
+        a.at<cytnx_double>({2, 1}) = 4.75;
+        Tensor b = zeros({2, 3}, Type.Double);
+        b.at<cytnx_double>({0, 0}) = 1.0;
+        b.at<cytnx_double>({0, 1}) = -2.0;
+        b.at<cytnx_double>({0, 2}) = 0.5;
+        b.at<cytnx_double>({1, 0}) = -0.25;
+        b.at<cytnx_double>({1, 1}) = 3.0;
+        b.at<cytnx_double>({1, 2}) = -4.0;
+
+        Tensor out = linalg::Kron(a.to(Device.cuda), b.to(Device.cuda)).to(Device.cpu);
+
+        ASSERT_EQ(out.dtype(), Type.Double);
+        ASSERT_EQ(out.shape(), (std::vector<cytnx_uint64>{6, 6}));
+        const cytnx_uint64 bR = 2, bC = 3;
+        for (cytnx_uint64 i = 0; i < 6; i++)
+          for (cytnx_uint64 j = 0; j < 6; j++) {
+            const double expected =
+              a.at<cytnx_double>({i / bR, j / bC}) * b.at<cytnx_double>({i % bR, j % bC});
+            EXPECT_DOUBLE_EQ(out.at<cytnx_double>({i, j}), expected)
+              << "at (" << i << "," << j << ")";
+          }
+      }
+
+      // Complex x complex, hand-computed. A = [[1+1i, 2-1i]], B = [[0+1i],[3+0i]].
+      TEST(GpuKron, ComplexDoubleMatchesHandComputed) {
+        Tensor a = zeros({1, 2}, Type.ComplexDouble);
+        a.at<cytnx_complex128>({0, 0}) = cytnx_complex128(1, 1);
+        a.at<cytnx_complex128>({0, 1}) = cytnx_complex128(2, -1);
+        Tensor b = zeros({2, 1}, Type.ComplexDouble);
+        b.at<cytnx_complex128>({0, 0}) = cytnx_complex128(0, 1);
+        b.at<cytnx_complex128>({1, 0}) = cytnx_complex128(3, 0);
+
+        Tensor out = linalg::Kron(a.to(Device.cuda), b.to(Device.cuda)).to(Device.cpu);
+
+        ASSERT_EQ(out.dtype(), Type.ComplexDouble);
+        ASSERT_EQ(out.shape(), (std::vector<cytnx_uint64>{2, 2}));
+        // out[i,j] = a[0, j] * b[i, 0]
+        // (1+1i)*(0+1i) = -1+1i ; (2-1i)*(0+1i) = 1+2i
+        // (1+1i)*(3+0i) =  3+3i ; (2-1i)*(3+0i) = 6-3i
+        auto near = [&](cytnx_uint64 i, cytnx_uint64 j, double re, double im) {
+          auto v = out.at<cytnx_complex128>({i, j});
+          EXPECT_NEAR(v.real(), re, 1e-12) << "real at (" << i << "," << j << ")";
+          EXPECT_NEAR(v.imag(), im, 1e-12) << "imag at (" << i << "," << j << ")";
+        };
+        near(0, 0, -1, 1);
+        near(0, 1, 1, 2);
+        near(1, 0, 3, 3);
+        near(1, 1, 6, -3);
+      }
+
+      // The #984/#999 promotion discriminator: ComplexFloat (x) Double must
+      // produce ComplexDouble output (the higher-precision complex), with the
+      // product computed and stored through that output type.
+      TEST(GpuKron, MixedComplexFloatDoublePromotesToComplexDouble) {
+        Tensor a = zeros({2, 1}, Type.ComplexFloat);
+        a.at<cytnx_complex64>({0, 0}) = cytnx_complex64(1.5f, -2.5f);
+        a.at<cytnx_complex64>({1, 0}) = cytnx_complex64(0.0f, 4.0f);
+        Tensor b = zeros({1, 2}, Type.Double);
+        b.at<cytnx_double>({0, 0}) = 2.0;
+        b.at<cytnx_double>({0, 1}) = -0.5;
+
+        Tensor out = linalg::Kron(a.to(Device.cuda), b.to(Device.cuda)).to(Device.cpu);
+
+        ASSERT_EQ(out.dtype(), Type.ComplexDouble);
+        ASSERT_EQ(out.shape(), (std::vector<cytnx_uint64>{2, 2}));
+        // out[i,j] = a[i,0] * b[0,j]
+        auto near = [&](cytnx_uint64 i, cytnx_uint64 j, double re, double im) {
+          auto v = out.at<cytnx_complex128>({i, j});
+          EXPECT_NEAR(v.real(), re, 1e-6) << "real at (" << i << "," << j << ")";
+          EXPECT_NEAR(v.imag(), im, 1e-6) << "imag at (" << i << "," << j << ")";
+        };
+        near(0, 0, 3.0, -5.0);  // (1.5-2.5i)*2
+        near(0, 1, -0.75, 1.25);  // (1.5-2.5i)*-0.5
+        near(1, 0, 0.0, 8.0);  // (0+4i)*2
+        near(1, 1, 0.0, -2.0);  // (0+4i)*-0.5
+      }
+
+      // Broad cross-check: GPU Kron vs CPU Kron over every real/complex dtype
+      // and a few shapes. Secondary to the independent-value tests above.
+      TEST(GpuKron, GpuMatchesCpuAllDtypes) {
+        const std::vector<std::pair<std::vector<cytnx_uint64>, std::vector<cytnx_uint64>>> shapes =
+          {{{2, 3}, {3, 2}}, {{4, 1}, {2, 5}}, {{1, 1}, {3, 3}}};
+        for (auto dtype : dtype_list) {
+          if (dtype == Type.Bool) continue;  // Kron has no Bool kernel
+          // See Outer_test's note: ~1e6-magnitude complex-float products diverge
+          // from the CPU at the float32 ULP, so ComplexFloat gets a looser tol.
+          const cytnx_double tol = (dtype == Type.ComplexFloat) ? 0.1 : 1e-6;
+          for (const auto& s : shapes) {
+            SCOPED_TRACE("dtype " + std::to_string(dtype));
+            Tensor a(s.first, dtype);
+            Tensor b(s.second, dtype);
+            InitTensorUniform(a, /*seed=*/1);
+            InitTensorUniform(b, /*seed=*/2);
+            Tensor expected = linalg::Kron(a, b);
+            Tensor gpu = linalg::Kron(a.to(Device.cuda), b.to(Device.cuda)).to(Device.cpu);
+            EXPECT_EQ(gpu.dtype(), expected.dtype());
+            EXPECT_TRUE(AreNearlyEqTensor(gpu, expected, tol));
+          }
+        }
+      }
+
+    }  // namespace
+  }  // namespace gpu_test
+}  // namespace cytnx

--- a/tests/gpu/linalg_test/Outer_test.cpp
+++ b/tests/gpu/linalg_test/Outer_test.cpp
@@ -1,0 +1,113 @@
+#include "gtest/gtest.h"
+
+#include "cytnx.hpp"
+#include "gpu_test_tools.h"
+
+// GPU Outer correctness. Outer(a, b) for rank-1 a (len m) and rank-1 b (len n)
+// gives an m x n tensor with out[i, j] = a[i] * b[j]. Every expected value is
+// computed independently from that definition (literals or a per-element
+// recompute from the raw inputs), never by comparing against another Cytnx
+// path. The mixed ComplexFloat x Double case mirrors the CPU
+// DtypePromotion.OuterComplexfloatDouble regression: the result must be
+// ComplexDouble, computed and stored through that output type.
+//
+// Inputs are built on the CPU and moved with .to(Device.cuda) (GPU arange
+// ignores a non-unit step for real dtypes, #1070).
+namespace cytnx {
+  namespace gpu_test {
+    namespace {
+
+      TEST(GpuOuter, DoubleMatchesHandComputed) {
+        Tensor a = zeros({3}, Type.Double);
+        a.at<cytnx_double>({0}) = -1.5;
+        a.at<cytnx_double>({1}) = 0.0;
+        a.at<cytnx_double>({2}) = 2.25;
+        Tensor b = zeros({2}, Type.Double);
+        b.at<cytnx_double>({0}) = 4.0;
+        b.at<cytnx_double>({1}) = -0.5;
+
+        Tensor out = linalg::Outer(a.to(Device.cuda), b.to(Device.cuda)).to(Device.cpu);
+
+        ASSERT_EQ(out.dtype(), Type.Double);
+        ASSERT_EQ(out.shape(), (std::vector<cytnx_uint64>{3, 2}));
+        const double expected[3][2] = {{-6.0, 0.75}, {0.0, -0.0}, {9.0, -1.125}};
+        for (cytnx_uint64 i = 0; i < 3; i++)
+          for (cytnx_uint64 j = 0; j < 2; j++)
+            EXPECT_DOUBLE_EQ(out.at<cytnx_double>({i, j}), expected[i][j])
+              << "at (" << i << "," << j << ")";
+      }
+
+      TEST(GpuOuter, ComplexDoubleMatchesHandComputed) {
+        Tensor a = zeros({2}, Type.ComplexDouble);
+        a.at<cytnx_complex128>({0}) = cytnx_complex128(1, 2);
+        a.at<cytnx_complex128>({1}) = cytnx_complex128(-3, 1);
+        Tensor b = zeros({2}, Type.ComplexDouble);
+        b.at<cytnx_complex128>({0}) = cytnx_complex128(0, -1);
+        b.at<cytnx_complex128>({1}) = cytnx_complex128(2, 2);
+
+        Tensor out = linalg::Outer(a.to(Device.cuda), b.to(Device.cuda)).to(Device.cpu);
+
+        ASSERT_EQ(out.dtype(), Type.ComplexDouble);
+        ASSERT_EQ(out.shape(), (std::vector<cytnx_uint64>{2, 2}));
+        // (1+2i)*(0-1i) = 2-1i ; (1+2i)*(2+2i) = -2+6i
+        // (-3+1i)*(0-1i)= 1+3i ; (-3+1i)*(2+2i)= -8-4i
+        auto near = [&](cytnx_uint64 i, cytnx_uint64 j, double re, double im) {
+          auto v = out.at<cytnx_complex128>({i, j});
+          EXPECT_NEAR(v.real(), re, 1e-12) << "real at (" << i << "," << j << ")";
+          EXPECT_NEAR(v.imag(), im, 1e-12) << "imag at (" << i << "," << j << ")";
+        };
+        near(0, 0, 2, -1);
+        near(0, 1, -2, 6);
+        near(1, 0, 1, 3);
+        near(1, 1, -8, -4);
+      }
+
+      // The promotion discriminator (mirrors CPU DtypePromotion.OuterComplexfloatDouble):
+      // ComplexFloat (x) Double -> ComplexDouble, full double precision.
+      TEST(GpuOuter, MixedComplexFloatDoublePromotesToComplexDouble) {
+        Tensor a = zeros({2}, Type.ComplexFloat);
+        a.at<cytnx_complex64>({0}) = cytnx_complex64(1, 1);
+        a.at<cytnx_complex64>({1}) = cytnx_complex64(2, 0);
+        Tensor b = zeros({2}, Type.Double);
+        b.at<cytnx_double>({0}) = 3;
+        b.at<cytnx_double>({1}) = 0.5;
+
+        Tensor out = linalg::Outer(a.to(Device.cuda), b.to(Device.cuda)).to(Device.cpu);
+
+        ASSERT_EQ(out.dtype(), Type.ComplexDouble);
+        ASSERT_EQ(out.shape(), (std::vector<cytnx_uint64>{2, 2}));
+        auto near = [&](cytnx_uint64 i, cytnx_uint64 j, double re, double im) {
+          auto v = out.at<cytnx_complex128>({i, j});
+          EXPECT_NEAR(v.real(), re, 1e-6) << "real at (" << i << "," << j << ")";
+          EXPECT_NEAR(v.imag(), im, 1e-6) << "imag at (" << i << "," << j << ")";
+        };
+        near(0, 0, 3, 3);  // (1+1i)*3
+        near(0, 1, 0.5, 0.5);  // (1+1i)*0.5
+        near(1, 0, 6, 0);  // 2*3
+        near(1, 1, 1, 0);  // 2*0.5
+      }
+
+      // Broad cross-check: GPU Outer vs CPU Outer over every real/complex dtype.
+      // InitTensorUniform draws from [-1000, 1000], so products reach ~1e6; at
+      // that magnitude a complex-float multiply diverges from the CPU one at the
+      // float32 ULP (~0.06), hence the looser ComplexFloat tolerance (matches
+      // Mul_test's convention). A single real multiply is bit-identical.
+      TEST(GpuOuter, GpuMatchesCpuAllDtypes) {
+        for (auto dtype : dtype_list) {
+          if (dtype == Type.Bool) continue;  // Outer has no Bool kernel
+          SCOPED_TRACE("dtype " + std::to_string(dtype));
+          const cytnx_double tol = (dtype == Type.ComplexFloat) ? 0.1 : 1e-6;
+          Tensor a({5}, dtype);
+          Tensor b({7}, dtype);
+          InitTensorUniform(a, /*seed=*/3);
+          InitTensorUniform(b, /*seed=*/4);
+          Tensor expected = linalg::Outer(a, b);
+          Tensor gpu = linalg::Outer(a.to(Device.cuda), b.to(Device.cuda)).to(Device.cpu);
+          EXPECT_EQ(gpu.dtype(), expected.dtype());
+          EXPECT_TRUE(AreNearlyEqTensor(gpu, expected, tol));
+        }
+      }
+
+    }  // namespace
+  }  // namespace gpu_test
+}  // namespace cytnx


### PR DESCRIPTION
## Problem

`Kron` and `Outer` had **no GPU tests** — their CUDA paths (`cuKron_internal.cuh`, `cuOuter_internal.cu`) were entirely uncovered. This is the coverage the #1003 Outer/Kron typed-dispatch consolidation needs as a safety net, and it also confirms #999 is resolved.

## Fix

Add `tests/gpu/linalg_test/Kron_test.cpp` and `Outer_test.cpp`. Expected values are computed **independently** from the operation definition (literals or per-element recompute), not by comparing against another Cytnx path that could share the same bug:

- **Double / ComplexDouble** — hand-written literal results (Kron also covers fractional + negative values).
- **Mixed `ComplexFloat × Double → ComplexDouble`** — the promotion discriminator behind #999/#984: the product must be computed and stored through the promoted output type. Checks output **dtype and value**.
- **Broad GPU-vs-CPU cross-check** over every real/complex dtype as *secondary* coverage. `ComplexFloat` uses a looser tolerance because ~1e6-magnitude float32 complex products diverge from the CPU at the ULP; a single real multiply is bit-identical.

Inputs are built on the CPU and moved with `.to(Device.cuda)` (GPU `arange` ignores a non-unit step for real dtypes, #1070).

## Testing

All **9 tests pass** on an RTX 4070 Ti SUPER (CUDA 13.0, `sm_89`):

```
[  PASSED  ] 9 tests.   (GpuKron: 5, GpuOuter: 4)
```

Verified against a build with the parent commit's `Outer_ii` fix applied (the Outer cross-check's CPU reference needs the Int16/Uint16 dispatch rows). The `cuKron`/`cuOuter`/`Kron.cpp`/`Outer.cpp` sources under test are identical to `origin/master`.

## Notes

- **Stacked on** #1099 (the CPU `Outer` Int16/Uint16/Bool dispatch fix). The Outer GPU cross-check's CPU reference crashes without it. Will retarget to `master` once #1099 merges.
- No GPU CI runner exists, so these compile/run only under a local `USE_CUDA` build (as done here).

Part of #1003. Confirms #999.
