### PR TITLE
refactor(Type): retire type_promote_gpu_t, promote GPU Kron via to_cuda_t (#1003)

### DIFF
--- a/include/Type.hpp
+++ b/include/Type.hpp
@@ -499,29 +499,6 @@ namespace cytnx {
     template <typename TL, typename TR>
     using type_promote_from_pointer_t = typename type_promote_from_pointer<TL, TR>::type;
 
-#ifdef UNI_GPU
-    // .. and we need a version where TL and TR are GPU device pointers
-    template <typename TL, typename TR>
-    using type_promote_gpu_t =
-      std::variant_alternative_t<Type_class::type_promote(variant_index_v<TL, Type_list_gpu>,
-                                                          variant_index_v<TR, Type_list_gpu>),
-                                 Type_list_gpu>;
-
-    template <typename TL, typename TR>
-    struct type_promote_from_gpu_pointer {
-      using type = void;
-    };
-
-    template <typename TL, typename TR>
-    struct type_promote_from_gpu_pointer<TL*, TR*> {
-      using type = type_promote_gpu_t<std::decay_t<TL>, std::decay_t<TR>>;
-    };
-
-    // helper typedef
-    template <typename TL, typename TR>
-    using type_promote_from_gpu_pointer_t = typename type_promote_from_gpu_pointer<TL, TR>::type;
-#endif
-
   };  // Type_class
   /// @endcond
 

--- a/src/linalg/Kron.cpp
+++ b/src/linalg/Kron.cpp
@@ -11,6 +11,7 @@
 
   #ifdef UNI_GPU
     #include "backend/linalg_internal_gpu/cuKron_internal.cuh"
+    #include "backend/linalg_internal_gpu/cuTypeCvt.hpp"
   #endif
 
 namespace cytnx {
@@ -84,16 +85,25 @@ namespace cytnx {
       } else {
   #ifdef UNI_GPU
         // checkCudaErrors(cudaSetDevice(lhs_contiguous.device()));
-        // Dispatch to the kernel based on the types of lhs and rhs.
+        // Dispatch to the kernel based on the types of lhs and rhs. This visits the
+        // ordinary Cytnx (host) value-type pointers and computes the promoted type with
+        // the same type_promote_from_pointer_t as the CPU path above, then maps to the
+        // CUDA-native kernel type with to_cuda_t at the launch boundary (#1013) -- there
+        // is no separate Type_list_gpu / type_promote_gpu_t promotion hierarchy.
         std::visit(
           [&](auto lhs_ptr, auto rhs_ptr) {
             using out_type =
-              Type_class::type_promote_from_gpu_pointer_t<decltype(lhs_ptr), decltype(rhs_ptr)>;
+              Type_class::type_promote_from_pointer_t<decltype(lhs_ptr), decltype(rhs_ptr)>;
             static_assert(!std::is_same_v<out_type, void>);
-            cytnx::linalg_internal::cuKron_general(out.gpu_ptr_as<out_type>(), lhs_ptr, rhs_ptr,
-                                                   lhs_padded_shape, rhs_padded_shape);
+            using TL = std::remove_const_t<std::remove_pointer_t<decltype(lhs_ptr)>>;
+            using TR = std::remove_const_t<std::remove_pointer_t<decltype(rhs_ptr)>>;
+            cytnx::linalg_internal::cuKron_general(
+              out.gpu_ptr_as<linalg_internal::to_cuda_t<out_type>>(),
+              reinterpret_cast<const linalg_internal::to_cuda_t<TL> *>(lhs_ptr),
+              reinterpret_cast<const linalg_internal::to_cuda_t<TR> *>(rhs_ptr), lhs_padded_shape,
+              rhs_padded_shape);
           },
-          lhs_contiguous.gpu_ptr(), rhs_contiguous.gpu_ptr());
+          lhs_contiguous.ptr(), rhs_contiguous.ptr());
   #else
         cytnx_error_msg(true, "[Kron] fatal error, the tensor is on GPU without CUDA support.%s",
                         "\n");

--- a/tests/Type_test.cpp
+++ b/tests/Type_test.cpp
@@ -41,12 +41,16 @@ namespace cytnx {
                     Type_class::ComplexFloat);
       static_assert(is_complex_v<cytnx_cuda_complex128>);
       static_assert(is_complex_v<cytnx_cuda_complex64>);
-      static_assert(
-        std::is_same_v<Type_class::type_promote_gpu_t<cytnx_cuda_complex64, cytnx_double>,
-                       cytnx_cuda_complex128>);
-      static_assert(
-        std::is_same_v<Type_class::type_promote_gpu_t<cytnx_double, cytnx_cuda_complex64>,
-                       cytnx_cuda_complex128>);
+      // GPU binary ops (e.g. Kron) promote via the shared, device-independent
+      // type_promote_t and map to the CUDA-native type with to_cuda_t at the launch
+      // boundary (#1013); the dedicated type_promote_gpu_t trait was retired. Since
+      // Type_list_gpu is Type_list with std::complex -> cuda::std::complex (index
+      // preserving, asserted above), the promotion is a host value-type property:
+      // ComplexFloat x Double -> ComplexDouble.
+      static_assert(std::is_same_v<Type_class::type_promote_t<cytnx_complex64, cytnx_double>,
+                                   cytnx_complex128>);
+      static_assert(std::is_same_v<Type_class::type_promote_t<cytnx_double, cytnx_complex64>,
+                                   cytnx_complex128>);
 #endif
 
       TEST(TypeTest, VariantContainsRecognizesSupportedTypes) {

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
   utils/getNconParameter.cpp
   linalg_test/Abs_test.cpp
   linalg_test/Add_test.cpp
+  linalg_test/Kron_test.cpp
   linalg_test/Cpr_test.cpp
   linalg_test/Div_test.cpp
   linalg_test/Mod_test.cpp

--- a/tests/gpu/linalg_test/Kron_test.cpp
+++ b/tests/gpu/linalg_test/Kron_test.cpp
@@ -1,0 +1,73 @@
+#include "gtest/gtest.h"
+
+#include "cytnx.hpp"
+#include "gpu_test_tools.h"
+
+// GPU Kron coverage. #1003 retired the Type_list_gpu / type_promote_gpu_t promotion
+// trait: Kron's GPU path now computes the promoted type with the shared host
+// type_promote_from_pointer_t and maps to the CUDA-native kernel type via to_cuda_t
+// at the launch boundary. These tests move CPU-built inputs to the GPU, run Kron
+// there, and check the result against independent hand-computed values -- especially
+// the ComplexFloat x Double -> ComplexDouble promotion, which exercises exactly that
+// path. Kron(a, b) for rank-1 a (len m) and b (len n) is a length-(m*n) vector with
+// element (i*n + j) = a_i * b_j.
+
+namespace cytnx {
+  namespace gpu_test {
+    namespace {
+
+      TEST(Kron, GpuRealValues) {
+        Tensor a = zeros({3}, Type.Double);
+        a.at<cytnx_double>({0}) = 1;
+        a.at<cytnx_double>({1}) = 2;
+        a.at<cytnx_double>({2}) = 3;
+        Tensor b = zeros({2}, Type.Double);
+        b.at<cytnx_double>({0}) = 4;
+        b.at<cytnx_double>({1}) = 5;
+
+        Tensor out = linalg::Kron(a.to(Device.cuda), b.to(Device.cuda)).to(Device.cpu);
+        ASSERT_EQ(out.shape(), std::vector<cytnx_uint64>({6}));
+        ASSERT_EQ(out.dtype(), Type.Double);
+        const double expect[6] = {4, 5, 8, 10, 12, 15};  // a_i * b_j, row-major (i, j)
+        for (cytnx_uint64 k = 0; k < 6; ++k) EXPECT_DOUBLE_EQ(out.at<cytnx_double>({k}), expect[k]);
+      }
+
+      TEST(Kron, GpuComplexFloatDoublePromotesToComplexDouble) {
+        // Exercises the retired-type_promote_gpu_t path: the promoted dtype differs
+        // from both operands and the wider complex output must hold full precision.
+        Tensor a = zeros({2}, Type.ComplexFloat);
+        a.at<cytnx_complex64>({0}) = cytnx_complex64(1, 1);
+        a.at<cytnx_complex64>({1}) = cytnx_complex64(2, 0);
+        Tensor b = zeros({2}, Type.Double);
+        b.at<cytnx_double>({0}) = 3;
+        b.at<cytnx_double>({1}) = 0.5;
+
+        Tensor out = linalg::Kron(a.to(Device.cuda), b.to(Device.cuda)).to(Device.cpu);
+        ASSERT_EQ(out.dtype(), Type.ComplexDouble);
+        ASSERT_EQ(out.shape(), std::vector<cytnx_uint64>({4}));
+        // (1+1i)*3, (1+1i)*0.5, (2+0i)*3, (2+0i)*0.5
+        const cytnx_complex128 expect[4] = {{3, 3}, {0.5, 0.5}, {6, 0}, {1, 0}};
+        for (cytnx_uint64 k = 0; k < 4; ++k) {
+          const cytnx_complex128 v = out.at<cytnx_complex128>({k});
+          EXPECT_DOUBLE_EQ(v.real(), expect[k].real());
+          EXPECT_DOUBLE_EQ(v.imag(), expect[k].imag());
+        }
+      }
+
+      TEST(Kron, GpuInt16Values) {
+        Tensor a = zeros({2}, Type.Int16);
+        a.at<cytnx_int16>({0}) = 3;
+        a.at<cytnx_int16>({1}) = -2;
+        Tensor b = zeros({2}, Type.Int16);
+        b.at<cytnx_int16>({0}) = 4;
+        b.at<cytnx_int16>({1}) = 5;
+
+        Tensor out = linalg::Kron(a.to(Device.cuda), b.to(Device.cuda)).to(Device.cpu);
+        ASSERT_EQ(out.dtype(), Type.Int16);
+        const cytnx_int16 expect[4] = {12, 15, -8, -10};
+        for (cytnx_uint64 k = 0; k < 4; ++k) EXPECT_EQ(out.at<cytnx_int16>({k}), expect[k]);
+      }
+
+    }  // namespace
+  }  // namespace gpu_test
+}  // namespace cytnx


### PR DESCRIPTION
## Problem
`type_promote_gpu_t` was a parallel GPU-side promotion trait — it promoted two `Type_list_gpu` (CUDA-native) types via `type_promote` on `Type_list_gpu` indices. The #1013 GPU arithmetic dispatch already retired this pattern for Add/Sub/Mul/Div/Cpr: it keeps the logical dispatch on the ordinary Cytnx **host** value types with the shared `type_promote_t` and confines the CUDA-native complex representation to the kernel-launch boundary via `to_cuda_t`. `Kron`'s GPU path was the **last functional user** of `type_promote_gpu_t` (via `type_promote_from_gpu_pointer_t`). This completes the retirement goal of #1101 (without the `Type_test.cpp` compile-break that PR was flagged for).

## Fix
- **`Kron` GPU dispatch** now visits the host value-type pointers (`Tensor::ptr()`, which has no device guard and views the managed storage), computes the promoted type with the same `type_promote_from_pointer_t` as the CPU path, and `reinterpret_cast`s to `to_cuda_t<…>` at the `cuKron_general` call. Since `Type_list_gpu` is `Type_list` with `std::complex → cuda::std::complex` (index-preserving), the resulting kernel types are **identical** to what `type_promote_gpu_t` produced — the `cuKron` kernels are unchanged.
- **Removed** `type_promote_gpu_t`, `type_promote_from_gpu_pointer`, `type_promote_from_gpu_pointer_t` from `Type.hpp`. `Type_list_gpu` / `cy_typeid_gpu_v` / `gpu_ptr` / `gpu_ptr_as` stay — still used to hand CUDA-native pointers to kernels.
- **`Type_test.cpp`**: replaced the two `type_promote_gpu_t` static-asserts with the equivalent device-independent `type_promote_t` asserts (the promotion is a host value-type property; `to_cuda_t` is index-preserving, asserted alongside).

## Testing
Added `tests/gpu/linalg_test/Kron_test.cpp` with independent hand-computed values — real, Int16, and the `ComplexFloat × Double → ComplexDouble` promotion that exercises the migrated path.
- **GPU** (`build_gpu` `gpu_test_main`, CUDA 13, RTX 4070 Ti): `Kron.*` all pass; the cytnx CUDA library compiles with the trait removed.
- **CUDA test build** (`test_main` under `USE_CUDA=ON`): compiles — the `#ifdef UNI_GPU` `Type_test.cpp` asserts are verified; `TypeTest.*` pass.
- **CPU** unaffected — every change is within `#ifdef UNI_GPU`.

Refs #1003. Completes the `type_promote_gpu_t` retirement goal of #1101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)