### PR TITLE
docs(CLAUDE): drop stale cuKron-broken gotcha (#999 closed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,8 +167,6 @@ Green locally before opening a PR. CI enforces:
   non-contiguous tensor⊗tensor kernels that `cuAdd`/`cuSub` have — contiguous-ize
   first or results are silently wrong; a narrow LHS can OOB-write; a length-1
   scalar RHS must stay CPU-resident (#988).
-- **`cuKron` GPU compile is currently broken** under CUDA 13 (#999) — the CUDA
-  build is not green for that path.
 - **Raise errors via `cytnx_error_msg(cond, "fmt", …)`** (throws `cytnx::error`,
   surfaced in Python as `cytnx.CytnxError`); the function name comes from
   `CYTNX_FUNC_NAME`.


### PR DESCRIPTION
## Problem
The `CLAUDE.md` domain-gotchas list claimed:

> **`cuKron` GPU compile is currently broken** under CUDA 13 (#999) — the CUDA build is not green for that path.

But **#999 is closed** and `cuKron` compiles and runs fine under CUDA 13. A "gotcha" that flags a working path as broken actively misleads agents (e.g. it discouraged reusing the GPU `Kron` path — which #1105 and #1106 both do).

## Fix
Remove the stale gotcha bullet.

## Verification
`build_gpu` `gpu_test_main` (CUDA 13.0, RTX 4070 Ti) builds cleanly and the GPU `Kron` tests pass — this is the basis for #1105 (Outer via Kron) and #1106 (retire `type_promote_gpu_t`, which migrates the GPU Kron path). Issue #999 is `CLOSED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)