### PR TITLE
build(release): prepare Windows CUDA wheel metadata

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -482,6 +482,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/f9/8163f9145012263743dee49333f3a39bf214b83dac0ede7b06bb9ff7287c/delvewheel-1.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/2a/f9697576603dae937727827505a6126a066affb227034e77e6f9068910da/pyelftools-0.33-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/e4/4f2d41881fae547f06ffa4c9748fa8ed13c4db5c830ff268b84175546b3c/pybind11_stubgen-2.5.5-py3-none-any.whl
@@ -646,6 +647,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/08/8f/890a96ea1ff615100296977cce23296052dcb8c114d4e451201ec39df9bf/nvidia_cublas-13.6.0.2-py3-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/f9/8163f9145012263743dee49333f3a39bf214b83dac0ede7b06bb9ff7287c/delvewheel-1.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/d3/b1afcd9c40ceca72022579215fcaf5318cd747fd896cb928d4a1de924ff8/nvidia_cuda_cccl-13.3.3.4.1-py3-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/2a/eb/63f7710fc84837e0118002bc29671542807921aef3a0c710da83a5e7e711/nvidia_curand-10.4.3.29-py3-none-win_amd64.whl
@@ -3359,6 +3361,11 @@ packages:
   - virtualenv>=20.17 ; python_full_version >= '3.10' and python_full_version < '3.14' and extra == 'virtualenv'
   - virtualenv>=20.31 ; python_full_version >= '3.14' and extra == 'virtualenv'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl
+  name: tomlkit
+  version: 0.15.1
+  sha256: 177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/13/f9/8163f9145012263743dee49333f3a39bf214b83dac0ede7b06bb9ff7287c/delvewheel-1.13.0-py3-none-any.whl
   name: delvewheel
   version: 1.13.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -67,6 +67,7 @@ python = "3.11.*"
 [feature.wheel.pypi-dependencies]
 cibuildwheel = "==3.3.0"
 delvewheel = "==1.13.0"
+tomlkit = ">=0.13,<1"
 
 [target.win-64.activation]
 scripts = ["tools/activate_windows.bat"]
@@ -75,7 +76,7 @@ scripts = ["tools/activate_windows.bat"]
 CMAKE_GENERATOR = "Ninja"
 CMAKE_GENERATOR_PLATFORM = ""
 CMAKE_GENERATOR_TOOLSET = ""
-CMAKE_ARGS = "-DUSE_HPTT=OFF -DHPTT_ENABLE_FINE_TUNE=OFF -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF"
+CMAKE_ARGS = "-DUSE_HPTT=OFF -DHPTT_ENABLE_FINE_TUNE=OFF"
 
 [tasks]
 setup = "git submodule update --init --recursive"
@@ -111,7 +112,7 @@ cutensor-cu13 = "~=2.7.0"
 
 [feature.cuda.activation.env]
 CMAKE_BUILD_PARALLEL_LEVEL = "2"
-CMAKE_ARGS = "-DUSE_HPTT=OFF -DHPTT_ENABLE_FINE_TUNE=OFF -DUSE_CUQUANTUM=OFF -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF"
+CMAKE_ARGS = "-DUSE_HPTT=OFF -DHPTT_ENABLE_FINE_TUNE=OFF -DUSE_CUQUANTUM=OFF"
 
 [feature.cuda.tasks]
 check-cuda-layout = "tools\\activate_windows.bat python tools/prepare_windows_import_libraries.py --cuda --check"

--- a/pixi.toml
+++ b/pixi.toml
@@ -91,7 +91,7 @@ build = { cmd = "tools\\activate_windows.bat cmake --build build/windows-mkl-cpu
 # to retain one initialized native runtime and keep local test runs practical.
 test-cpp = { cmd = "..\\tools\\activate_windows.bat ..\\build\\windows-mkl-cpu\\tests\\test_main.exe", cwd = "tests", depends-on = ["build"] }
 
-install-python = { cmd = "tools\\activate_windows.bat python -m pip install --editable . --no-deps --no-build-isolation --verbose --config-settings=build-dir=build/windows-mkl-cpu-editable --config-settings=cmake.args=--preset=mkl-cpu", depends-on = ["setup", "prepare-windows"] }
+install-python = { cmd = "tools\\activate_windows.bat python -m pip install --editable . --no-deps --no-build-isolation --verbose --config-settings=build-dir=build/windows-mkl-cpu-editable --config-settings=cmake.args=--preset=mkl-cpu --config-settings=cmake.args=-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF", depends-on = ["setup", "prepare-windows"] }
 test-python = { cmd = "tools\\activate_windows.bat python -m pytest pytests --doctest-modules", depends-on = ["install-python"] }
 format = "tools\\activate_windows.bat pre-commit run --all-files"
 
@@ -122,7 +122,7 @@ cuda-doctor = { cmd = "tools\\activate_windows.bat --cuda-doctor", depends-on = 
 configure-cuda = { cmd = "tools\\activate_windows.bat cmake --preset mkl-cuda -B build/windows-mkl-cuda -DUSE_HPTT=OFF -DHPTT_ENABLE_FINE_TUNE=OFF -DUSE_CUQUANTUM=OFF -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF", depends-on = ["setup", "prepare-cuda"] }
 build-cuda = { cmd = "tools\\activate_windows.bat cmake --build build/windows-mkl-cuda --parallel 2", depends-on = ["configure-cuda"] }
 
-install-python-cuda = { cmd = "tools\\activate_windows.bat python -m pip install --editable . --no-deps --no-build-isolation --verbose --config-settings=build-dir=build/windows-mkl-cuda-editable --config-settings=cmake.args=--preset=mkl-cuda", depends-on = ["setup", "prepare-cuda"] }
+install-python-cuda = { cmd = "tools\\activate_windows.bat python -m pip install --editable . --no-deps --no-build-isolation --verbose --config-settings=build-dir=build/windows-mkl-cuda-editable --config-settings=cmake.args=--preset=mkl-cuda --config-settings=cmake.args=-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF", depends-on = ["setup", "prepare-cuda"] }
 
 [environments]
 default = { features = ["python310", "mkl"], solve-group = "windows-mkl" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ viz = [
 test = [
     "pytest",
     "pytest-cov",
+    # Exercises the release-manifest rewrite tests without making tomlkit a
+    # runtime dependency of either cytnx distribution.
+    "tomlkit",
 ]
 # Tooling for collecting C++ coverage from the build directory. Pure
 # Python and works against any GCC/Clang-produced .gcno/.gcda pair.

--- a/pytests/prepare_cuda_release_test.py
+++ b/pytests/prepare_cuda_release_test.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+tomlkit = pytest.importorskip("tomlkit")
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import prepare_cuda_release as release  # noqa: E402
+
+
+def _manifest():
+    return tomlkit.parse((REPO_ROOT / "pyproject.toml").read_text())
+
+
+def test_linux_cuda_release_rewrite_preserves_runpath_pipeline():
+    document = _manifest()
+    original_before_all = document["tool"]["cibuildwheel"]["linux"]["before-all"]
+
+    release.rewrite_pyproject(document, target_platform="linux")
+
+    assert document["project"]["name"] == "cytnx-cuda"
+    assert document["tool"]["scikit-build"]["cmake"]["args"] == [
+        "--preset=openblas-cuda",
+        f"-DCMAKE_INSTALL_RPATH={release.CUDA_INSTALL_RPATH}",
+    ]
+    linux = document["tool"]["cibuildwheel"]["linux"]
+    assert linux["before-all"].startswith(original_before_all + " && ")
+    assert "cibuildwheel_before_all_cuda.sh" in linux["before-all"]
+    assert "auditwheel repair" in linux["repair-wheel-command"]
+
+
+def test_windows_cuda_release_rewrite_uses_external_pypi_dlls():
+    document = _manifest()
+    original_linux = tomlkit.dumps(document["tool"]["cibuildwheel"]["linux"])
+
+    release.rewrite_pyproject(document, target_platform="windows")
+
+    assert document["project"]["name"] == "cytnx-cuda"
+    dependencies = document["project"]["dependencies"]
+    assert all(
+        "sys_platform == 'win32'" in dependency
+        for dependency in dependencies
+        if dependency.split()[0] in {
+            "nvidia-cuda-runtime",
+            "nvidia-cublas",
+            "nvidia-cusparse",
+            "nvidia-curand",
+            "nvidia-cusolver",
+            "cutensor-cu13",
+        }
+    )
+    assert all(
+        "sys_platform == 'linux'" in dependency
+        and "win32" not in dependency
+        for dependency in dependencies
+        if dependency.split()[0] in {"cutensornet-cu13", "custatevec-cu13"}
+    )
+    assert document["tool"]["scikit-build"]["cmake"]["args"] == [
+        "--preset=openblas-cuda",
+        "-DUSE_CUQUANTUM=OFF",
+        "-DUSE_HPTT=OFF",
+        "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON",
+    ]
+    assert (
+        document["tool"]["cibuildwheel"]["windows"]["repair-wheel-command"]
+        == "python {project}/tools/repair_windows_wheel.py --wheel {wheel} "
+        "--dest-dir {dest_dir}"
+    )
+    assert tomlkit.dumps(document["tool"]["cibuildwheel"]["linux"]) == original_linux
+
+
+def test_cuda_release_rewrite_rejects_unknown_platform():
+    with pytest.raises(ValueError, match="unsupported CUDA wheel platform"):
+        release.rewrite_pyproject(_manifest(), target_platform="plan9")

--- a/pytests/prepare_cuda_release_test.py
+++ b/pytests/prepare_cuda_release_test.py
@@ -63,7 +63,7 @@ def test_windows_cuda_release_rewrite_uses_external_pypi_dlls():
         "--preset=openblas-cuda",
         "-DUSE_CUQUANTUM=OFF",
         "-DUSE_HPTT=OFF",
-        "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON",
+        "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF",
     ]
     assert (
         document["tool"]["cibuildwheel"]["windows"]["repair-wheel-command"]

--- a/tools/prepare_cuda_release.py
+++ b/tools/prepare_cuda_release.py
@@ -20,15 +20,15 @@ The script
      deliberately NOT depended on: it pulls in cudensitymat/cupauliprop/
      custabilizer, none of which cytnx links;
   3. switches `[tool.scikit-build].cmake.args` to the `openblas-cuda`
-     preset and sets `CMAKE_INSTALL_RPATH` to an $ORIGIN-relative RUNPATH
-     (see CUDA_INSTALL_RPATH) so the installed extension finds those
-     libraries in their sibling pip packages at runtime without
-     LD_LIBRARY_PATH;
-  4. overrides `[tool.cibuildwheel.linux].repair-wheel-command` to
+     preset. On Linux it also sets an $ORIGIN-relative RUNPATH (see
+     CUDA_INSTALL_RPATH); Windows instead disables unavailable cuQuantum
+     support and relies on the package's pre-import `os.add_dll_directory`
+     bootstrap;
+  4. on Linux, overrides `[tool.cibuildwheel.linux].repair-wheel-command` to
      exclude those same libraries from `auditwheel repair`'s vendoring,
      so the wheel stays small and relies on the pip dependencies (found
      via the RUNPATH from step 3) instead; and
-  5. chains tools/cibuildwheel_before_all_cuda.sh onto
+  5. on Linux, chains tools/cibuildwheel_before_all_cuda.sh onto
      `[tool.cibuildwheel.linux].before-all` and points CMAKE_CUDA_COMPILER/
      CUTENSOR_ROOT/CUQUANTUM_ROOT/PATH/CMAKE_PREFIX_PATH at the toolchain it
      installs, so the build step can compile CUDA/cuTENSOR/cuQuantum code
@@ -43,6 +43,7 @@ dependency-group) so the rewrite preserves comments and formatting on
 round-trip.
 """
 
+import argparse
 import pathlib
 import shlex
 
@@ -65,13 +66,19 @@ CUDA_TOOLCHAIN_ROOT = f"{CUDA_TOOLCHAIN_PREFIX}/nvidia/cu13"
 # same minor version are allowed to satisfy the dependency, anything
 # outside it is not (see the module docstring for why only these, not
 # their transitive NVIDIA/cuTENSOR dependencies, need listing).
+CUDA_COMMON_RUNTIME_SPECS = [
+    "nvidia-cuda-runtime ~=13.3.29",
+    "nvidia-cublas ~=13.6.0.2",
+    "nvidia-cusparse ~=12.8.2.51",
+    "nvidia-curand ~=10.4.3.29",
+    "nvidia-cusolver ~=12.2.6.9",
+    "cutensor-cu13 ~=2.7.0",
+]
 CUDA_RUNTIME_DEPENDENCIES = [
-    "nvidia-cuda-runtime ~=13.3.29 ; sys_platform == 'linux'",
-    "nvidia-cublas ~=13.6.0.2 ; sys_platform == 'linux'",
-    "nvidia-cusparse ~=12.8.2.51 ; sys_platform == 'linux'",
-    "nvidia-curand ~=10.4.3.29 ; sys_platform == 'linux'",
-    "nvidia-cusolver ~=12.2.6.9 ; sys_platform == 'linux'",
-    "cutensor-cu13 ~=2.7.0 ; sys_platform == 'linux'",
+    f"{spec} ; sys_platform == 'linux' or sys_platform == 'win32'"
+    for spec in CUDA_COMMON_RUNTIME_SPECS
+] + [
+    # NVIDIA does not publish these cuQuantum runtime wheels for Windows.
     "cutensornet-cu13 ~=2.13.0 ; sys_platform == 'linux'",
     "custatevec-cu13 ~=1.14.0 ; sys_platform == 'linux'",
 ]
@@ -131,7 +138,11 @@ EXCLUDED_SONAMES = [
 ]
 
 
-def rewrite_pyproject(doc: tomlkit.TOMLDocument) -> None:
+def rewrite_pyproject(
+    doc: tomlkit.TOMLDocument, *, target_platform: str = "linux"
+) -> None:
+    if target_platform not in {"linux", "windows"}:
+        raise ValueError(f"unsupported CUDA wheel platform: {target_platform}")
     project = doc["project"]
     project["name"] = "cytnx-cuda"
 
@@ -146,10 +157,30 @@ def rewrite_pyproject(doc: tomlkit.TOMLDocument) -> None:
             "--preset=openblas-cpu before this rewrite; pyproject.toml's "
             "structure may have changed"
         )
-    skb["cmake"]["args"] = [
-        "--preset=openblas-cuda",
-        f"-DCMAKE_INSTALL_RPATH={CUDA_INSTALL_RPATH}",
-    ]
+    if target_platform == "linux":
+        skb["cmake"]["args"] = [
+            "--preset=openblas-cuda",
+            f"-DCMAKE_INSTALL_RPATH={CUDA_INSTALL_RPATH}",
+        ]
+    else:
+        # The activated Pixi environment supplies Ninja, MSVC, OpenBLAS,
+        # ARPACK, CUDA, and cuTENSOR. cuQuantum remains Linux-only because its
+        # runtime PyPI wheels do not support Windows.
+        skb["cmake"]["args"] = [
+            "--preset=openblas-cuda",
+            "-DUSE_CUQUANTUM=OFF",
+            "-DUSE_HPTT=OFF",
+            "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON",
+        ]
+
+    if target_platform == "windows":
+        windows = doc["tool"]["cibuildwheel"].get("windows")
+        if not windows or "repair-wheel-command" not in windows:
+            raise SystemExit(
+                "expected [tool.cibuildwheel.windows].repair-wheel-command "
+                "for the Windows CUDA wheel"
+            )
+        return
 
     exclude_flags = " ".join(f"--exclude {name}" for name in EXCLUDED_SONAMES)
     linux = doc["tool"]["cibuildwheel"]["linux"]
@@ -190,13 +221,20 @@ def rewrite_pyproject(doc: tomlkit.TOMLDocument) -> None:
     env["CUQUANTUM_ROOT"] = f"{CUDA_TOOLCHAIN_PREFIX}/cuquantum"
     linux["environment"] = env
 
-    PYPROJECT.write_text(tomlkit.dumps(doc))
-
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--platform",
+        choices=("linux", "windows"),
+        default="linux",
+        help="target wheel platform (default: linux, preserving the existing CI path)",
+    )
+    args = parser.parse_args()
     doc = tomlkit.parse(PYPROJECT.read_text())
-    rewrite_pyproject(doc)
-    print("stamped pyproject.toml for cytnx-cuda")
+    rewrite_pyproject(doc, target_platform=args.platform)
+    PYPROJECT.write_text(tomlkit.dumps(doc))
+    print(f"stamped pyproject.toml for cytnx-cuda ({args.platform})")
 
 
 if __name__ == "__main__":

--- a/tools/prepare_cuda_release.py
+++ b/tools/prepare_cuda_release.py
@@ -170,7 +170,10 @@ def rewrite_pyproject(
             "--preset=openblas-cuda",
             "-DUSE_CUQUANTUM=OFF",
             "-DUSE_HPTT=OFF",
-            "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON",
+            # Device LTO reaches nvlink but cannot load the LTO backend from
+            # NVIDIA's Windows PyPI layout. Keep IPO disabled on Windows;
+            # Linux retains its existing release/LTO pipeline above.
+            "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF",
         ]
 
     if target_platform == "windows":


### PR DESCRIPTION
## Stack

`master → #1110 → codex/windows-msvc-cuda-stack (#1116 patch) → #1117 → #1118 → #1119 → #1113`

Depends on #1118 and is the final implementation layer before workflow-only #1113.

## Summary

- teach the CUDA release-manifest rewrite to emit Windows PyPI runtime dependencies and disable unavailable cuQuantum packages;
- preserve the existing Linux RUNPATH/auditwheel rewrite;
- add platform-specific release-manifest tests and the release-only tomlkit dependency;
- keep IPO enabled in the existing Linux release pipeline;
- disable IPO for Windows CUDA release wheels because CUDA 13 device LTO cannot find the NVVM runtime reliably in the split PyPI toolkit layout;
- explicitly keep IPO off in both CPU and CUDA editable-install commands so iterative builds remain incremental.

## Compatibility

Windows metadata uses compatible-release pins for CUDA 13 and cuTENSOR. The Python loader then locates those declared distributions directly; it does not scan arbitrary system SDK roots.

## Validation

- `pytests/prepare_cuda_release_test.py`: 3 passed;
- both editable Pixi tasks explicitly pass `-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF`; 
- Linux release metadata retains its prior LTO setting;
- repository-pinned pre-commit hooks pass.

Part of #1114.