### PR TITLE
fix(ci): unblock the CUDA wheel build — CMAKE_PREFIX_PATH separator and Boost pin

### DIFF
--- a/tools/cibuildwheel_before_all.sh
+++ b/tools/cibuildwheel_before_all.sh
@@ -22,11 +22,18 @@ if command -v dnf >/dev/null 2>&1; then
       conda_subdir="linux-64"
     fi
     curl -fLs "https://micro.mamba.pm/api/micromamba/${conda_subdir}/latest" | tar -xj -C /usr/local bin/micromamba
+    # Boost >= 1.89 marks boost::intrusive_ptr's members constexpr. Every CUDA
+    # translation unit that reaches cytnx::intrusive_ptr_base through
+    # backend/Storage.hpp then crashes nvcc's cudafe++ frontend with
+    # "internal error: check_for_and_take_source_seq_entry: wrong entry"
+    # (issues #1124, #1063). g++ and clang++ accept the same code, and no nvcc
+    # flag avoids it, so the Boost version is the only lever here.
+    # TODO: lift this pin once a CUDA toolkit ships a fixed cudafe++.
     MAMBA_ROOT_PREFIX=/opt/micromamba /usr/local/bin/micromamba create -y -p "${CYTNX_DEPS_PREFIX}" -c conda-forge \
       "openblas=*=*openmp*" \
       liblapacke \
       "arpack=*=nompi*" \
-      libboost-headers
+      "libboost-headers<1.89"
 
 # musllinux_1_2 images are Alpine-based, so use apk there. conda-forge
 # publishes no musl builds, so arpack/boost still come from Alpine's own

--- a/tools/prepare_cuda_release.py
+++ b/tools/prepare_cuda_release.py
@@ -164,13 +164,16 @@ def rewrite_pyproject(doc: tomlkit.TOMLDocument) -> None:
         f"{CUDA_TOOLCHAIN_PREFIX} {toolchain_args}"
     )
 
-    # CMAKE_PREFIX_PATH may not be set yet on a checkout that predates the
-    # conda-forge dependency migration (#1057) -- append rather than assume
-    # it's there, so this keeps working regardless of merge order between
-    # that PR and this one.
+    # linux["environment"] may or may not already carry CMAKE_PREFIX_PATH --
+    # append to it if present, otherwise set it fresh.
+    #
+    # This table becomes environment variables inside the cibuildwheel
+    # container, where CMake reads CMAKE_PREFIX_PATH as a POSIX env-var path
+    # list: entries are ':'-separated. (';' only separates entries in a
+    # -DCMAKE_PREFIX_PATH= cache argument, not the env var.)
     existing_prefix_path = linux["environment"].get("CMAKE_PREFIX_PATH", "")
     new_prefix_path = (
-        f"{existing_prefix_path};{CUDA_TOOLCHAIN_ROOT}"
+        f"{existing_prefix_path}:{CUDA_TOOLCHAIN_ROOT}"
         if existing_prefix_path
         else CUDA_TOOLCHAIN_ROOT
     )


### PR DESCRIPTION
Two independent defects both had to be fixed before `Release CUDA wheels` could produce a wheel. The first stops CMake configuration; the second stops compilation a minute later.

Closes #1063. Refs #1124 — see "Issue status" below for why that one stays open.

## Problem 1 — `CMAKE_PREFIX_PATH` was joined with `;` instead of `:`

[`Release CUDA wheels` failed](https://github.com/Cytnx-dev/Cytnx/actions/runs/30100470055/job/89509289253) at CMake configuration:

```
CMake Error at .../FindBoost.cmake:2437 (find_package_handle_standard_args):
  Could NOT find Boost (missing: Boost_INCLUDE_DIR)
Call Stack (most recent call first):
  CMakeLists.txt:346 (find_package)
```

`tools/prepare_cuda_release.py` appended the CUDA toolchain root onto the existing `CMAKE_PREFIX_PATH` with a semicolon. That table becomes environment variables inside the cibuildwheel container, and CMake parses the `CMAKE_PREFIX_PATH` *environment variable* as a POSIX path list — `:`-separated. `;` is only a separator for a `-DCMAKE_PREFIX_PATH=` cache argument. The joined value was therefore read as a single nonexistent directory, so neither `/opt/cytnx-deps` (where #1057 moved Boost/OpenBLAS/arpack) nor the CUDA toolchain prefix was searched.

Before #1057 no `CMAKE_PREFIX_PATH` was set, so the append never ran and the bug stayed dormant. The non-CUDA `Release wheels` workflow is unaffected — it only ever sets a single-entry value.

**Fix:** join with `:`, matching how `ci-cmake_tests.yml` already extends `CMAKE_PREFIX_PATH`.

## Problem 2 — Boost ≥ 1.89 crashes nvcc's frontend

With configuration fixed, the build reaches compilation and aborts on the first CUDA object:

```
Storage.hpp(767): internal error: check_for_and_take_source_seq_entry: wrong entry
1 catastrophic error detected in the compilation of "src/linalg/Kron.cpp"
```

Boost 1.89 added `boost/smart_ptr/detail/sp_cxx20_constexpr.hpp` and applied `BOOST_SP_CXX20_CONSTEXPR` to `boost::intrusive_ptr`, making its members `constexpr` whenever the compiler advertises `__cpp_constexpr_dynamic_alloc`. nvcc's `cudafe++` frontend crashes on the resulting `constexpr intrusive_ptr` in every CUDA translation unit that reaches `cytnx::intrusive_ptr_base` through `backend/Storage.hpp`. `Kron.cpp` is simply the first such object in build order — `cuComplexmem_gpu.cu`, `cuCast_gpu.cu`, `cuTrace_internal.cu`, `cuSum_internal.cu` and `cuMovemem_gpu.cu` fail identically.

Evidence that Boost's `constexpr` is the trigger, all against nvcc 13.3.73:

| libboost-headers | 1.86 | 1.88 | 1.89 | 1.90 | 1.91 |
|---|---|---|---|---|---|
| `Kron.cpp` | ✅ clean | ✅ clean | 💥 crash | 💥 crash | 💥 crash |

Patching Boost 1.89's `sp_cxx20_constexpr.hpp` to take its *non*-`constexpr` branch makes the same source compile cleanly — that one `constexpr` is the whole delta. g++ 15.2 and clang++ accept the same code, and `--expt-relaxed-constexpr` does not avoid the crash, so the Boost version is the only lever available in the wheel build.

**Fix:** constrain the conda-forge install in `tools/cibuildwheel_before_all.sh` to `libboost-headers<1.89`, with a `TODO` to lift it once a CUDA toolkit ships a fixed `cudafe++`. This also removes an unpinned build dependency, so the wheel build no longer shifts when conda-forge publishes a new Boost.

## Issue status

#1063 and #1124 are the same nvcc defect seen from two directions — #1063 from a local `debug-openblas-cuda` build, #1124 from the release workflow.

**#1063 is closed by this PR.** Its suggested cause — the C++20 concept-constrained `template <CytnxType T>` members — turns out not to be required: a minimal reproducer with the concept removed still crashes, while removing Boost's `constexpr` fixes it. The root cause is now identified and the release path is unblocked.

**#1124 stays open** as the tracking issue for managing system dependencies with pixi. This PR pins the Boost version inside the wheel-build script, which fixes CI and released wheels but leaves a local `debug-openblas-cuda` build against a developer's own Boost ≥ 1.89 still crashing. Pixi-managed dependencies would give every build — CI, wheel, and local — one pinned toolchain instead of a constraint that only applies to one of them.

A version-pin-free alternative exists if it is ever wanted: defining `BOOST_SMART_PTR_DETAIL_SP_CXX20_CONSTEXPR_HPP_INCLUDED` / `BOOST_SP_CXX20_CONSTEXPR=` / `BOOST_SP_NO_CXX20_CONSTEXPR` as target compile definitions suppresses Boost's `constexpr` opt-in. I verified that lets Boost 1.91 compile all six affected translation units cleanly with identical refcount behaviour, but it depends on a Boost-internal macro name and needs a full CUDA build plus ODR review, so it is deliberately not in this PR.

## Scope note

This PR carries two logically distinct fixes rather than being split, because both are required for `Release CUDA wheels` to go green and a red CI blocks review of either one.

## Testing

- Ran `tools/prepare_cuda_release.py` and confirmed the stamped environment now reads `CMAKE_PREFIX_PATH = "/opt/cytnx-deps:/opt/cuda-toolchain/nvidia/cu13"`.
- Reproduced the ICE locally with the exact CI toolchain (conda-forge `cuda-nvcc` 13.3.73), bisected `libboost-headers` 1.86→1.91 as tabulated above, and confirmed 1.88 — the version this pin resolves to — compiles `src/linalg/Kron.cpp` cleanly.
- `bash -n tools/cibuildwheel_before_all.sh` and `pre-commit run --files …` both pass.
- Full end-to-end verification is CI's: `Release CUDA wheels` must now get past both failure points and produce wheels.
