### PR TITLE
fix(backend): null-represent empty GPU storage to fix cudaFree crash (#1089)

### DIFF
--- a/src/backend/StorageImplementation.cpp
+++ b/src/backend/StorageImplementation.cpp
@@ -187,6 +187,23 @@ namespace cytnx {
                         "[ERROR] try to move from cpu(Host) to gpu without CUDA support.");
 #endif
       }
+      // An empty storage owns no elements, but start_ may still hold a
+      // device-specific empty buffer (e.g. host malloc(0) on CPU). Switching
+      // device_ alone would leave the destructor freeing that buffer with the
+      // wrong deallocator -- cudaFree on a host pointer -> cudaErrorInvalidValue
+      // (#1089). Release it with the current device's deallocator and represent
+      // the empty storage as null, which the destructor's null guard skips.
+      if (this->device_ != device && this->start_ != nullptr) {
+#ifdef UNI_GPU
+        if (this->device_ == Device.cpu)
+          free(this->start_);
+        else
+          checkCudaErrors(cudaFree(this->start_));
+#else
+        free(this->start_);
+#endif
+        this->start_ = nullptr;
+      }
       this->device_ = device;
       return;
     }

--- a/src/backend/utils_internal_gpu/cuAlloc_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuAlloc_gpu.cu
@@ -6,13 +6,22 @@ namespace cytnx {
     // void* Calloc_cpu(const cytnx_uint64 &N, const cytnx_uint64 &perelem_bytes){
     //     return calloc(M,perelem_bytes);
     // }
+    // An empty (zero-byte) buffer is represented by a null pointer, matching the
+    // Storage destructor's `data() != nullptr` free guard. cudaMallocManaged(0)
+    // is not guaranteed to return a pointer that cudaFree later accepts (unlike
+    // glibc malloc(0), which the CPU path relies on), so a zero-length request
+    // that reached the driver would crash on destruction with
+    // cudaErrorInvalidValue (#1089). Return nullptr instead; every caller copies
+    // via cudaMemcpy*(..., 0) (a no-op) and frees with cudaFree(nullptr) (valid).
     void* cuCalloc_gpu(const cytnx_uint64& N, const cytnx_uint64& perelem_bytes) {
+      if (N == 0 || perelem_bytes == 0) return nullptr;
       void* ptr;
       checkCudaErrors(cudaMallocManaged((void**)&ptr, perelem_bytes * N));
       checkCudaErrors(cudaMemset(ptr, 0, perelem_bytes * N));
       return ptr;
     }
     void* cuMalloc_gpu(const cytnx_uint64& bytes) {
+      if (bytes == 0) return nullptr;
       void* ptr;
       checkCudaErrors(cudaMallocManaged(&ptr, bytes));
       return ptr;


### PR DESCRIPTION
## Problem

Destroying a zero-element GPU `Storage` aborts with:

```
CUDA error at src/backend/StorageImplementation.cpp:873 code=1(cudaErrorInvalidValue) "cudaFree(this->data())"
```

Surfaced by `ZeroExtentGpuLinalgTest.GpuThinFactorizationsBypassGpuLibraries` (reported in **#1089**). Two independent paths hand the destructor a non-freeable device pointer for an empty storage:

1. **`StorageImplementation::Init`** routes `size_ == 0` straight to `cuCalloc_gpu → cudaMallocManaged(&ptr, 0)`. Unlike glibc `malloc(0)`, a zero-byte managed allocation is not guaranteed to return a pointer that `cudaFree` later accepts (driver/version-dependent).
2. **`StorageImplementation::to_`** special-cases `size_ == 0` by flipping `device_` **without touching `start_`**. Moving an empty CPU storage to the GPU therefore leaves a host `malloc(0)` pointer tagged as a GPU buffer, and the destructor calls `cudaFree` on host memory.

The destructor already guards `data() != nullptr` — i.e. an empty storage is meant to own *no* buffer.

## Fix

Make both paths honor that contract (empty ⇒ null on GPU):

- `cuCalloc_gpu` / `cuMalloc_gpu` return `nullptr` for a zero-byte request. This single chokepoint covers `Init`, in-place `to_`, `resize`, and the out-of-place `to()`. Every caller then copies via `cudaMemcpy*(…, 0)` (a no-op) and frees with `cudaFree(nullptr)` (valid).
- `to_`'s `size_ == 0` branch releases the existing empty buffer with the **current** device's deallocator before switching `device_`, then leaves `start_` null.

CPU behavior is unchanged: a non-moved empty CPU storage keeps its `free()`-able `malloc(0)` pointer.

## Testing

On an RTX 4070 Ti SUPER (CUDA 13) `gpu_test_main` build:

- `ZeroExtentGpuLinalgTest.GpuThinFactorizationsBypassGpuLibraries` (crashed before) and the rest of `ZeroExtentGpuLinalgTest` now **pass** (4/4).
- Storage and device-transfer GPU suites pass (23/23).
- Full `gpu_test_main`: 812/813 pass; the single failure is `GpuBkFUtQr` failing with *"QR … not implemented without cuQuantum support"*, a limitation of the local `USE_CUTENSOR=OFF` build — unrelated to this change and green under the cuQuantum CI build.
- A standalone repro confirmed the direct-construct and `to_(cuda)` empty paths independently (the former exercises fix point 1, the latter fix point 2).

The existing `ZeroExtentGpuLinalgTest.GpuThinFactorizationsBypassGpuLibraries` is the regression guard — it fails on pre-fix code (in CI and locally) and passes after.

Closes #1089.

🤖 Generated with [Claude Code](https://claude.com/claude-code)