### PR TITLE
test(gpu): skip GpuBkFUtQr without cuQuantum instead of failing (#1127)

### DIFF
--- a/tests/gpu/linalg_test/linalg_test.cpp
+++ b/tests/gpu/linalg_test/linalg_test.cpp
@@ -409,6 +409,9 @@ namespace cytnx {
       }
 
       TEST_F(linalg_Test, GpuBkFUtQr) {
+#ifndef UNI_CUQUANTUM
+        GTEST_SKIP() << "QR decomposition is currently only supported if cuQuantum is available.";
+#else
         const double tol = 1e-10;
         UniTensor M = permute_with_signflips(make_rank4_hermitian());
         auto qr_gpu = linalg::Qr(M.to(Device.cuda));
@@ -416,6 +419,7 @@ namespace cytnx {
         expect_unitary(Q, "_aux_", tol);  // Q is an isometry
         UniTensor recon = Contract(Q, R).permute(M.labels());
         EXPECT_TRUE((recon.apply() - M.apply()).Norm().item() < tol);  // Q R == M
+#endif
       }
 
       TEST_F(linalg_Test, GpuBkFUtExpH) {


### PR DESCRIPTION
## Problem

`linalg_Test.GpuBkFUtQr` calls `linalg::Qr` on a GPU `UniTensor` without guarding on cuQuantum. In
a `USE_CUQUANTUM=OFF` build, `Qr` raises by design (`src/linalg/Qr.cpp:84`), the exception escapes
the test body, and the test **fails**:

```
[ RUN      ] linalg_Test.GpuBkFUtQr
unknown file: Failure
C++ exception with description "
# Cytnx error occur at std::vector<cytnx::Tensor> cytnx::linalg::Qr(const cytnx::Tensor&, const bool&)
# error: QR decomposition on GPU not implemented without cuQuantum support!
# file : src/linalg/Qr.cpp (84)" thrown in the test body.
[  FAILED  ] linalg_Test.GpuBkFUtQr (249 ms)
```

The library is behaving as designed — this is purely a test-side gap. Every other
cuQuantum-dependent GPU test `GTEST_SKIP()`s instead, including `GpuBkUtQr1` in the **same file**
with the **same fixture** (`tests/gpu/linalg_test/linalg_test.cpp:84`) and six tests in
`tests/gpu/linalg_test/Rsvd_test.cpp` (lines 54, 93, 111, 441, 537, 556). `GpuBkFUtQr` was the only
one of the eight missing the guard.

Because the GPU suite is not run in CI, this only surfaces when someone runs `gpu_test_main`
locally on a non-cuQuantum build, where it reads as a real regression rather than an unavailable
optional dependency.

## Fix

Wrap the body in the same `#ifndef UNI_CUQUANTUM` → `GTEST_SKIP()` guard the sibling test already
uses. Four added lines; the test body is untouched.

## Testing

Verified on both sides of the guard, on an RTX 4070 Ti SUPER (`sm_89`), CUDA 13.0:

- **`USE_CUQUANTUM=OFF`** (the failing configuration): `linalg_Test.GpuBkFUtQr` now reports
  `[  SKIPPED ]` with the explanatory message instead of `[  FAILED  ]`.
- **`USE_CUQUANTUM=ON`**: the `#else` branch — the actual test body, which the OFF build does not
  compile — builds and the test **passes**, so the guard does not quietly disable a working test.

`pre-commit` clean (clang-format v14).

Closes #1127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
