### PR TITLE
docs(install): document cuTENSOR/cuQuantum as required for CUDA builds

### DIFF
--- a/docs/source/adv_install.rst
+++ b/docs/source/adv_install.rst
@@ -132,7 +132,7 @@ There are two methods how you can set-up all the dependencies before starting th
         3. Make sure libblas=mkl (you can check using *$conda list | grep libblas*)
 
 
-3. In addition, if you want to have GPU support (compile with -DUSE_CUDA=on), then additional packages need to be installed:
+3. In addition, if you want to have GPU support (compile with ``-DUSE_CUDA=ON``), then additional packages need to be installed:
 
 .. .. code-block:: shell
 
@@ -140,19 +140,33 @@ There are two methods how you can set-up all the dependencies before starting th
 
 .. code-block:: shell
 
-    $conda install -c nvidia cuda
+    $conda install -c nvidia cuda cutensor cuquantum
 
-If cutensor shall be used as well (compile option -DUSE_CUTENSOR=ON), then further install the following:
+.. note::
 
-.. code-block:: shell
+    **A CUDA build needs cuTENSOR and cuQuantum as well, not just the CUDA toolkit.**
+    Every CUDA configuration Cytnx ships enables all three: the ``openblas-cuda`` preset
+    (and ``mkl-cuda`` / ``debug-openblas-cuda`` / ``debug-mkl-cuda``, which inherit it)
+    sets ``USE_CUDA``, ``USE_CUTENSOR`` and ``USE_CUQUANTUM`` to ``ON``, and so do the
+    GPU CI job and the published ``cytnx-cuda`` wheels.
 
-    $conda install -c nvidia cutensor
+    ``-DUSE_CUTENSOR=ON`` and ``-DUSE_CUQUANTUM=ON`` each additionally **require** the
+    corresponding install root to be set, either in the environment or on the command
+    line. Configuring without them fails with::
 
-Similarly, cuqauantum (compile option -DUSE_CUTENSOR=ON), requires:
+        Error: Cache variable 'CUTENSOR_ROOT' is required under dependency conditions
+        (USE_CUTENSOR) but its value is empty.
 
-.. code-block:: shell
+    With the conda packages above, both roots are your conda prefix:
 
-    $conda install -c nvidia cuquantum
+    .. code-block:: shell
+
+        $export CUTENSOR_ROOT=$CONDA_PREFIX
+        $export CUQUANTUM_ROOT=$CONDA_PREFIX
+
+    Each root is expected to contain ``include/`` and ``lib/`` subdirectories. cuTENSOR
+    2.x is required; ``lib/`` may either hold the libraries directly or use a
+    per-CUDA-major subdirectory (``lib/12``, ``lib/13``) — both layouts are searched.
 
 **Option B. Install dependencies via system package manager**
 
@@ -226,7 +240,7 @@ The following are the available compiling option flags that you can specify in *
 +------------------------+-------------------+------------------------------------+
 |       options          | default           |          description               |
 +------------------------+-------------------+------------------------------------+
-| -DCMAKE_INSTALL_PREFIX | /usr/local/cytnx  | Install destination of the library |
+| -DCMAKE_INSTALL_PREFIX | ~/.local/cytnx    | Install destination of the library |
 +------------------------+-------------------+------------------------------------+
 | -DBUILD_PYTHON         |   ON              | Compile and install Python API     |
 +------------------------+-------------------+------------------------------------+
@@ -241,6 +255,54 @@ The following are the available compiling option flags that you can specify in *
 | -DUSE_HPTT             |   OFF             | Accelerate tensor transpose with   |
 |                        |                   | hptt                               |
 +------------------------+-------------------+------------------------------------+
+| -DBACKEND_TORCH        |   OFF             | Use PyTorch as the tensor backend  |
+|                        |                   | instead of the native backend.     |
+|                        |                   | Forces USE_MKL/USE_HPTT/USE_CUDA   |
+|                        |                   | off.                               |
++------------------------+-------------------+------------------------------------+
+
+.. note::
+
+    The defaults above are what plain ``cmake`` uses. Building through a preset
+    (``cmake --preset openblas-cuda``, see ``CMakePresets.json``) overrides several of
+    them — in particular the CUDA presets turn ``USE_CUTENSOR`` and ``USE_CUQUANTUM``
+    on. ``cmake -L <build dir>`` shows the values actually in effect.
+
+Additional options for CUDA if -DUSE_CUDA=on:
+
++-------------------------+-------------------+------------------------------------+
+|       options           | default           |          description               |
++-------------------------+-------------------+------------------------------------+
+| -DUSE_CUTENSOR          |  OFF              | Accelerate tensor contraction with |
+|                         |                   | cuTENSOR (>= 2.0). Requires        |
+|                         |                   | CUTENSOR_ROOT. ON in every CUDA    |
+|                         |                   | preset.                            |
++-------------------------+-------------------+------------------------------------+
+| -DUSE_CUQUANTUM         |  OFF              | Enable cuQuantum (cuTensorNet /    |
+|                         |                   | cuStateVec). Requires              |
+|                         |                   | CUQUANTUM_ROOT. ON in every CUDA   |
+|                         |                   | preset. GPU QR is only available   |
+|                         |                   | with this on; Gesvd_truncate also  |
+|                         |                   | routes through cuTensorNet rather  |
+|                         |                   | than cuSOLVER.                     |
++-------------------------+-------------------+------------------------------------+
+| -DCUTENSOR_ROOT         |  (unset)          | Install root of cuTENSOR. Required |
+|                         |                   | when USE_CUTENSOR=ON. May also be  |
+|                         |                   | given as an environment variable.  |
++-------------------------+-------------------+------------------------------------+
+| -DCUQUANTUM_ROOT        |  (unset)          | Install root of cuQuantum.         |
+|                         |                   | Required when USE_CUQUANTUM=ON.    |
+|                         |                   | May also be given as an            |
+|                         |                   | environment variable.              |
++-------------------------+-------------------+------------------------------------+
+
+.. warning::
+
+    If ``CUTENSOR_ROOT`` or ``CUQUANTUM_ROOT`` is exported in your environment, that
+    value currently takes precedence over the ``-D`` flag on the command line, so an
+    explicit ``-DCUTENSOR_ROOT=...`` is silently ignored. Conda environments export
+    ``CUQUANTUM_ROOT`` by default. Until this is fixed (see issue #1129), either unset
+    the environment variable or set it to the path you intend to use.
 
 Additional options for HPTT if -DUSE_HPTT=on:
 


### PR DESCRIPTION
## Problem

`docs/source/adv_install.rst` presented cuTENSOR and cuQuantum as optional extras and
never mentioned `CUTENSOR_ROOT` / `CUQUANTUM_ROOT` at all. There was **no path from the
documentation to a working CUDA build**: follow the install steps, run a documented CUDA
preset, and configure fails with

```
Error: Cache variable 'CUTENSOR_ROOT' is required under dependency conditions
(USE_CUTENSOR) but its value is empty.
```

I hit exactly this on a machine that already had CUDA installed.

In practice both libraries are mandatory. Every CUDA configuration the project ships turns
them on:

| configuration | cuTENSOR | cuQuantum |
| --- | --- | --- |
| `openblas-cuda` preset (and `mkl-cuda`, `debug-openblas-cuda`, `debug-mkl-cuda`, which inherit it) | ON | ON |
| GPU CI (`ci-gpu_tests.yml:80`) | ON | ON |
| CUDA release wheels (`prepare_cuda_release.py` → `--preset=openblas-cuda`) | ON | ON |

## Fix

- **State the requirement up front** — a CUDA build needs cuTENSOR and cuQuantum, not just
  the CUDA toolkit — with the two root variables, a worked conda example, and the expected
  `include/` + `lib/` layout (including that both the flat and per-CUDA-major `lib/`
  layouts are searched, post-#993).
- **New CUDA options table** covering `USE_CUTENSOR`, `USE_CUQUANTUM`, `CUTENSOR_ROOT`,
  `CUQUANTUM_ROOT`.
- **`BACKEND_TORCH`** added to the main options table.
- **Default install prefix corrected**: `~/.local/cytnx`, not `/usr/local/cytnx`
  (`CMakeLists.txt:166` and the `default` preset).
- **Copy-paste bug fixed**: the cuQuantum paragraph gave `-DUSE_CUTENSOR=ON` as its compile
  option, and misspelled "cuqauantum".
- **Note that presets override** the plain-`cmake` defaults the table lists.
- **Warning about #1129** — an exported `CUTENSOR_ROOT`/`CUQUANTUM_ROOT` silently takes
  precedence over `-D`, which bites conda users because conda exports `CUQUANTUM_ROOT`.

## Testing

Documentation only; no build or code changes.

RST validated with docutils 0.23 against the file before and after: the three grid tables
parse and render (verified in the generated HTML), and the file gains **no new parse
errors** — the two reported are pre-existing `code-block` directives that plain docutils
does not implement (Sphinx-only) and are present on `master` too.

Every factual claim was checked against the tree: option defaults from `CMakeLists.txt`
(L166, L168–186), preset values from `CMakePresets.json`, CI flags from
`ci-gpu_tests.yml:80`, wheel flags from `tools/prepare_cuda_release.py`.

Addresses the install-docs gap tracked on #970 (Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
