### PR TITLE
fix(cmake): search all cuTENSOR per-CUDA-major lib dirs, not just the host's

### DIFF
--- a/cmake/Modules/FindCUTENSOR.cmake
+++ b/cmake/Modules/FindCUTENSOR.cmake
@@ -27,15 +27,26 @@ else()
 endif()
 
 message(STATUS " cudaver: ${CUDAToolkit_VERSION_MAJOR}" )
-# Search both cuTENSOR library layouts: 2.x tarballs place the libraries
-# directly under lib/, while older tarballs and apt use a per-CUDA-major
-# subdir (lib/<cuda-major>, e.g. lib/11, lib/12, lib/13). Listing both as
-# find_library PATH_SUFFIXES resolves either layout for any CUDA major. The
-# older minor-specific lib/10.2 and lib/11.0 special-cases were removed; the
-# generic lib/<major> covers them (apt multiarch paths remain, issue #946).
-# The CUDA-version floor is a separate policy decision (issue #962), enforced
-# in CMakeLists.txt rather than gated here, so this finder stays policy-free.
+# Search every cuTENSOR library layout: 2.x tarballs place the libraries
+# directly under lib/, while older tarballs and apt use a per-CUDA-major subdir
+# (lib/<cuda-major>, e.g. lib/11, lib/12, lib/13). The older minor-specific
+# lib/10.2 and lib/11.0 special-cases were removed; the generic lib/<major>
+# covers them (apt multiarch paths remain, issue #946). The CUDA-version floor
+# is a separate policy decision (issue #962), enforced in CMakeLists.txt rather
+# than gated here, so this finder stays policy-free.
+#
+# The per-major directory records which CUDA major the libraries were *built*
+# for, which need not equal the host toolkit's major: a cuTENSOR built for CUDA
+# 12 ships lib/12 and is usable from a CUDA 13 host. Searching only
+# lib/${CUDAToolkit_VERSION_MAJOR} therefore misses valid installs, so glob for
+# the per-major directories this install actually has and append them, highest
+# first. lib/ and the host major stay at the front so an exact match still wins.
 set(CUTNLIB_DIR lib lib/${CUDAToolkit_VERSION_MAJOR})
+file(GLOB _cutensor_major_dirs RELATIVE "${CUTENSOR_ROOT}" "${CUTENSOR_ROOT}/lib/[0-9]*")
+list(SORT _cutensor_major_dirs COMPARE NATURAL ORDER DESCENDING)
+list(APPEND CUTNLIB_DIR ${_cutensor_major_dirs})
+list(REMOVE_DUPLICATES CUTNLIB_DIR)
+message(STATUS "cuTENSOR library search suffixes: ${CUTNLIB_DIR}")
 
 set(CUTENSOR_INCLUDE_DIRS ${CUTENSOR_ROOT}/include)
 


### PR DESCRIPTION
## Problem

**GPU CI is currently red on `master` for every PR**, failing at the configure step:

```
CMake Error at FindPackageHandleStandardArgs.cmake:227 (message):
  Could NOT find CUTENSOR (missing: CUTENSOR_LIB) (found version "2.4")
Call Stack (most recent call first):
  cmake/Modules/FindCUTENSOR.cmake:119 (find_package_handle_standard_args)
  CytnxBKNDCMakeLists.cmake:306 (find_package)
```

This is a regression from #993 (merged as `1820911d`), and it is my fault — I verified that
PR against conda (flat `lib/`) and synthetic `lib/13` fixtures, but never against the
runner's actual layout, and reported "regresses none" on that basis.

**Root cause.** The self-hosted runner's cuTENSOR is a **CUDA-12 build used from a CUDA 13
toolkit**:

```
/home/…/cutensor-cu13/lib/12/libcutensor.so     # cuTENSOR 2.4.1, built for CUDA 12
$ nvcc --version                                 # CUDA 13.0
```

#993 changed two things that combine badly here:

1. the hardcoded `lib/12` suffix became `lib/${CUDAToolkit_VERSION_MAJOR}` → `lib/13`, which
   does not exist in that install;
2. `CUTENSOR_FOUND` became honest, so the resulting miss is now a hard configure failure
   instead of a silent `-NOTFOUND` on the link line.

Neither change is wrong — old `master` matched `lib/12` purely by luck, and the honesty fix is
what surfaced the latent problem. But the assumption that the per-major directory equals the
*host* CUDA major is incorrect: it records which CUDA major the libraries were **built** for,
and a cuTENSOR built for CUDA 12 is usable from a CUDA 13 host.

## Fix

Glob the per-major directories the install actually has and append them to the search
suffixes, highest first, keeping `lib/` and the host major at the front so an exact match
still wins. Also log the resolved suffix list — "which directories did it look in" was not
visible in the configure output before.

This preserves everything #993 added (honest `*_FOUND`, the `>= 2.0` version gate, flat-`lib/`
support); it only widens where libraries may be found.

## Testing

All on the GPU runner host itself (CUDA 13.0, sm_89):

**1. The exact `ci-gpu_tests.yml` configure line**, with the runner's roots — the command that
is currently failing on `master`:

```
-- cuTENSOR library search suffixes: lib;lib/13;lib/12
-- Found CUTENSOR: /home/…/cutensor-cu13/lib/12/libcutensor.so (found version "2.4")
-- Build with CuTensor: YES
-- Found CUQUANTUM: /home/…/cuquantum-cu13/lib/libcutensornet.so
-- Configuring done / Generating done          # exit 0
```

**2. Finder probe across four layouts**, module directory swapped, nothing else varied:

| layout | before this PR | after |
| --- | --- | --- |
| runner `lib/12` on CUDA 13 | ❌ `CUTENSOR_LIB-NOTFOUND` | ✅ `lib/12/libcutensor.so` |
| flat `lib/` (2.x tarball) | ✅ | ✅ |
| `lib/13` | ✅ | ✅ |
| conda prefix | ✅ | ✅ |

**3. Negative control** — a root with headers but no libraries still fails to configure, so
#993's honest-failure behaviour is intact and this is not a silent-success regression.

**4.** `gpu_test_main` builds from that configure and the GPU suite runs. (Result appended
below once the build finishes.)

## Note

The runner's install is arguably itself mismatched — a directory named `cutensor-cu13`
containing only `lib/12`. Aligning it would also unbreak CI. Fixing the finder is the better
answer: the same mismatch will occur on any user's machine, and #946 already tracks that these
finders are too rigid about layout.

Fixes the GPU CI breakage introduced by #993. Related: #946, #1129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
