### PR TITLE
bench(linalg): compare GPU non-contiguous Mul against contiguous-first

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
   linalg/Svd_bm.cpp
   linalg/Svd_truncate_bm.cpp
   linalg/Trace_bm.cpp
+  linalg/Mul_noncontig_bm.cpp
   linalg/Vectordot_bm.cpp
   linalg/Lanczos_bm.cpp
   linalg/linalg_basic_bm.cpp

--- a/benchmarks/linalg/Mul_noncontig_bm.cpp
+++ b/benchmarks/linalg/Mul_noncontig_bm.cpp
@@ -1,0 +1,142 @@
+#include <benchmark/benchmark.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "cytnx.hpp"
+
+#ifdef UNI_GPU
+  #include <cuda_runtime.h>
+#endif
+
+// Which is faster on the GPU for a non-contiguous operand: letting Mul consume it directly
+// through the layout mappers (the path #1096 enables), or calling contiguous() on both operands
+// first and multiplying contiguous buffers?
+//
+// The direct path avoids two full device-to-device copies but makes every element access a
+// gather through the inverse mappers. The contiguous path pays for two materialised copies up
+// front and then runs a fully coalesced kernel. Which wins is an empirical question -- these
+// benchmarks answer it rather than reasoning about it.
+//
+// GPU kernel launches are asynchronous, so every timed region ends in cudaDeviceSynchronize().
+// Without it the loop measures launch overhead, not execution. (Note the other GPU benchmarks in
+// this directory do not synchronize, so their device numbers are not comparable to these.)
+namespace BMTest_MulNonContig {
+
+#ifdef UNI_GPU
+
+  using cytnx::cytnx_double;
+  using cytnx::Tensor;
+
+  namespace {
+
+    // A rank-3 cube permuted so that neither operand is contiguous, which is what forces the
+    // gather path. permute() alone only relabels the strides; no data moves.
+    Tensor MakeNonContiguousCube(cytnx::cytnx_uint64 n, unsigned int seed, unsigned int dtype) {
+      const cytnx_double kLow = -10.0;
+      const cytnx_double kHigh = 10.0;
+      Tensor t =
+        cytnx::random::random_tensor({n, n, n}, kLow, kHigh, cytnx::Device.cuda, seed, dtype);
+      return t.permute({2, 0, 1});
+    }
+
+    void SyncDevice() { cudaDeviceSynchronize(); }
+
+  }  // namespace
+
+  // Direct: Mul consumes both non-contiguous operands (the path enabled by #1096).
+  template <unsigned int dtype>
+  static void BM_GpuMul_NonContig_Direct(benchmark::State& state) {
+    const auto n = static_cast<cytnx::cytnx_uint64>(state.range(0));
+    const Tensor a = MakeNonContiguousCube(n, 0, dtype);
+    const Tensor b = MakeNonContiguousCube(n, 1, dtype);
+    SyncDevice();
+    for (auto _ : state) {
+      auto result = cytnx::linalg::Mul(a, b);
+      SyncDevice();
+      benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * n * n * n);
+  }
+
+  // Contiguous-first: materialise both operands, then multiply contiguous buffers. This is what
+  // callers had to do before #1096, and what Ian expects to be faster.
+  template <unsigned int dtype>
+  static void BM_GpuMul_NonContig_ContiguousFirst(benchmark::State& state) {
+    const auto n = static_cast<cytnx::cytnx_uint64>(state.range(0));
+    const Tensor a = MakeNonContiguousCube(n, 0, dtype);
+    const Tensor b = MakeNonContiguousCube(n, 1, dtype);
+    SyncDevice();
+    for (auto _ : state) {
+      auto result = cytnx::linalg::Mul(a.contiguous(), b.contiguous());
+      SyncDevice();
+      benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * n * n * n);
+  }
+
+  // Control: both operands already contiguous. Neither a gather nor a copy -- the floor that
+  // says how much of each number above is the multiply itself.
+  template <unsigned int dtype>
+  static void BM_GpuMul_Contig_Baseline(benchmark::State& state) {
+    const auto n = static_cast<cytnx::cytnx_uint64>(state.range(0));
+    const cytnx_double kLow = -10.0;
+    const cytnx_double kHigh = 10.0;
+    const Tensor a =
+      cytnx::random::random_tensor({n, n, n}, kLow, kHigh, cytnx::Device.cuda, 0, dtype);
+    const Tensor b =
+      cytnx::random::random_tensor({n, n, n}, kLow, kHigh, cytnx::Device.cuda, 1, dtype);
+    SyncDevice();
+    for (auto _ : state) {
+      auto result = cytnx::linalg::Mul(a, b);
+      SyncDevice();
+      benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * n * n * n);
+  }
+
+  // Isolates the copy half of the contiguous-first path, so a difference can be attributed to
+  // the copies rather than to the multiply.
+  template <unsigned int dtype>
+  static void BM_GpuContiguous_Only(benchmark::State& state) {
+    const auto n = static_cast<cytnx::cytnx_uint64>(state.range(0));
+    const Tensor a = MakeNonContiguousCube(n, 0, dtype);
+    SyncDevice();
+    for (auto _ : state) {
+      auto result = a.contiguous();
+      SyncDevice();
+      benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * n * n * n);
+  }
+
+  // 64^3 = 262k elements up to 384^3 = 56.6M, so the comparison covers both the
+  // launch-overhead-dominated end and the bandwidth-dominated end.
+  BENCHMARK(BM_GpuMul_NonContig_Direct<cytnx::Type.Double>)
+    ->Arg(64)
+    ->Arg(128)
+    ->Arg(256)
+    ->Arg(384)
+    ->Unit(benchmark::kMicrosecond);
+  BENCHMARK(BM_GpuMul_NonContig_ContiguousFirst<cytnx::Type.Double>)
+    ->Arg(64)
+    ->Arg(128)
+    ->Arg(256)
+    ->Arg(384)
+    ->Unit(benchmark::kMicrosecond);
+  BENCHMARK(BM_GpuMul_Contig_Baseline<cytnx::Type.Double>)
+    ->Arg(64)
+    ->Arg(128)
+    ->Arg(256)
+    ->Arg(384)
+    ->Unit(benchmark::kMicrosecond);
+  BENCHMARK(BM_GpuContiguous_Only<cytnx::Type.Double>)
+    ->Arg(64)
+    ->Arg(128)
+    ->Arg(256)
+    ->Arg(384)
+    ->Unit(benchmark::kMicrosecond);
+
+#endif  // UNI_GPU
+
+}  // namespace BMTest_MulNonContig


### PR DESCRIPTION
## Problem

#1096's review raised a performance objection that nothing in the tree could answer:

> OK, but noting that the current implementation is very slow; much slower than making it contiguous (assuming the algorithm for making it contiguous is effiicient -- I didn't check that)

There was no benchmark covering GPU elementwise arithmetic on non-contiguous operands, so the choice between "consume the non-contiguous operand directly" and "make it contiguous first" rested on intuition. `CLAUDE.md` requires performance claims to be measured, and a measurement is only auditable if the harness is in the tree.

## Fix

Adds `benchmarks/linalg/Mul_noncontig_bm.cpp` with four cases over `Double` cubes at n = 64/128/256/384 (262 k → 56.6 M elements), each operand permuted `{2,0,1}` so neither is contiguous:

| case | measures |
|---|---|
| `BM_GpuMul_NonContig_Direct` | `Mul(a_perm, b_perm)` — the path #1096 enables |
| `BM_GpuMul_NonContig_ContiguousFirst` | `Mul(a.contiguous(), b.contiguous())` |
| `BM_GpuMul_Contig_Baseline` | both already contiguous — the floor |
| `BM_GpuContiguous_Only` | `a.contiguous()` alone — isolates the copy cost |

The last two exist for attribution: without them a gap between the first two tells you *that* one is slower, not *why*.

**Every timed region ends in `cudaDeviceSynchronize()`.** CUDA launches are asynchronous; without it the loop times kernel *launches* rather than execution, and the two cases collapse to indistinguishable and meaninglessly fast. Note that the pre-existing GPU benchmarks in this directory do **not** synchronize, so their device-side numbers are not comparable to these — worth fixing separately.

## Testing

Built and run on RTX 4070 Ti SUPER (sm_89), CUDA 13.0, cuTENSOR 2.4.1, `Release`, `USE_CUTENSOR=ON USE_CUQUANTUM=ON`. Mean of 5 repetitions, µs:

| n (cube) | elements | Direct | contiguous-first | contiguous floor | `contiguous()` alone |
|---:|---:|---:|---:|---:|---:|
| 64  | 262 144    | **313**    | 7 315   | 287    | 3 588 |
| 128 | 2 097 152  | **2 180**  | 11 084  | 2 043  | 5 478 |
| 256 | 16 777 216 | **18 169** | 56 036  | 17 011 | 21 647 |
| 384 | 56 623 104 | **61 768** | 173 608 | 56 579 | 61 078 |

The direct path wins by 2.8×–23×, and sits within 6.7–9.2% of the already-contiguous floor. Full analysis, correctness cross-check, and caveats in https://github.com/Cytnx-dev/Cytnx/pull/1096#issuecomment-5109867027; the fixed-cost finding it turned up is filed as #1132.

`pre-commit run --files` passes (clang-format v14 clean). `RUN_BENCHMARKS` defaults `OFF` and is `OFF` in every preset, and no workflow enables it, so this adds nothing to CI build or run time.

## History

Originally opened stacked on `fix/1003-gpu-mul-div-noncontig`, because before #1096 landed `Mul` on two non-contiguous GPU operands raised

```
[Mul][on GPU/CUDA] error two tensors must be contiguous. Call Contiguous_() or Contiguous() first
```

and `BM_GpuMul_NonContig_Direct` would have aborted the benchmark binary. #1096 has since merged (`cf539f07`), so this is now rebased onto `master` as a single commit and every case runs there.

One consequence worth recording: the usual "land the benchmark first, then compare across revisions" ordering was never available here. The pre-#1096 revision doesn't do *less* work, it refuses to run — so there is no fair earlier baseline to set beside these numbers. The `Contig_Baseline` and `Contiguous_Only` cases serve that role instead; they are what make the direct-vs-contiguous-first gap interpretable rather than an unanchored ratio.

Refs #1096, #1003, #988.
