### PR TITLE
test(cmake): make test targets MSVC-portable

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,9 +10,9 @@ else()
 # needs a config-mode install or CMake's FindGTest from 3.23+ -- so require the
 # gmock target explicitly and fail with actionable guidance when it is missing.
 find_package(GTest REQUIRED)
-if(NOT TARGET GTest::gmock)
+if(NOT TARGET GTest::gmock_main)
   message(FATAL_ERROR
-    "GoogleTest was found but the GTest::gmock target is missing, which the test "
+    "GoogleTest was found but the GTest::gmock_main target is missing, which the test "
     "suite links against. Install a GoogleTest that also provides GMock (it is not "
     "fetched automatically):\n"
     "  macOS:         brew install googletest\n"
@@ -99,14 +99,18 @@ target_include_directories(
 )
 target_link_libraries(
   test_main
-  GTest::gtest_main
-  GTest::gmock
-  GTest::gtest
+  GTest::gmock_main
 )
 target_link_libraries(test_main cytnx)
 
-add_compile_options(-fsanitize=address)
-add_link_options(-fsanitize=address)
+if(USE_DEBUG)
+  if(MSVC)
+    target_compile_options(test_main PRIVATE /fsanitize=address)
+  else()
+    target_compile_options(test_main PRIVATE -fsanitize=address)
+    target_link_options(test_main PRIVATE -fsanitize=address)
+  endif()
+endif()
 
 #target_link_libraries(test_main PUBLIC "-lgcov --coverage")
 include(GoogleTest)

--- a/tests/Tensor_test.cpp
+++ b/tests/Tensor_test.cpp
@@ -461,7 +461,7 @@ namespace cytnx {
         EXPECT_DOUBLE_EQ(scalar.item<double>(), 9.0);
 
         vector.set(std::vector<Accessor>{}, shape_one);
-        for (int i = 0; i < 3; ++i) EXPECT_DOUBLE_EQ(vector.at<double>({i}), 9.0);
+        for (std::size_t i = 0; i < 3; ++i) EXPECT_DOUBLE_EQ(vector.at<double>({i}), 9.0);
 
         Tensor shape_one_one({1, 1}, Type.Double);
         shape_one_one.at<double>({0, 0}) = 6.0;

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -57,9 +57,7 @@ target_include_directories(
 )
 target_link_libraries(
   gpu_test_main
-  GTest::gtest_main
-  GTest::gmock
-  GTest::gtest
+  GTest::gmock_main
 )
 target_link_libraries(gpu_test_main cytnx)
 #target_link_libraries(test_main PUBLIC "-lgcov --coverage")


### PR DESCRIPTION
## Problem

The test CMake files unconditionally pass GNU AddressSanitizer flags, link three overlapping GoogleTest targets, and contain a signed loop index that warns under MSVC. These test-only changes were previously mixed into #1110.

## Fix

- link `GTest::gmock_main` as the single canonical test entry point;
- apply AddressSanitizer only to debug test builds, with MSVC/GNU-specific flags;
- use `std::size_t` for the Tensor test index.

The Lanczos tolerance change from #1110 is intentionally excluded: numerical behavior needs separate evidence and human review. This PR is based directly on `master`, as requested in the #1110 review.

Part of #1114.

## Testing

- pinned pre-commit hooks: passed
- Linux/macOS CI: pending