### PR TITLE
perf(backend): cache the cuTENSOR handle per device instead of per call (#1132)

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(
   Tensor_bm.cpp
   UniTensor_bm.cpp
   cublas_handle_bm.cpp
+  cutensor_handle_bm.cpp
   search_tree_bm.cpp
   algo/Vsplit_bm.cpp
   algo/Vstack_bm.cpp

--- a/benchmarks/cutensor_handle_bm.cpp
+++ b/benchmarks/cutensor_handle_bm.cpp
@@ -1,0 +1,99 @@
+#include <benchmark/benchmark.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "cytnx.hpp"
+
+#ifdef UNI_GPU
+  #include <cuda_runtime.h>
+#endif
+
+// Cytnx used to call cutensorCreate() and cutensorDestroy() around every single cuTENSOR
+// operation. cutensorCreate costs ~3.4 ms flat -- it initialises the library context and its
+// plan cache -- and that cost is independent of tensor size, so on small tensors it was the
+// entire runtime (#1132).
+//
+// Two live paths pay it. With UNI_CUTENSOR defined, every float/complex GPU Movemem goes through
+// cuMovemem_cutensor_gpu, so contiguous() and permute() pay it; and Tensordot pays it. (Integer
+// dtypes take the general kernel instead and are unaffected -- hence the Double dtype here.)
+//
+// These benchmarks are deliberately weighted towards small tensors, where a flat per-call cost
+// dominates and the regression is visible; at large n the real work swamps it and the two
+// revisions should converge. That convergence is itself the check that the handle cache changes
+// only overhead and not the work being done.
+//
+// GPU kernel launches are asynchronous, so every timed region ends in cudaDeviceSynchronize().
+// Without it the loop measures launch overhead rather than execution.
+namespace BMTest_CutensorHandle {
+
+#ifdef UNI_GPU
+
+  using cytnx::cytnx_double;
+  using cytnx::cytnx_uint64;
+  using cytnx::Tensor;
+
+  namespace {
+
+    void SyncDevice() { cudaDeviceSynchronize(); }
+
+    // A rank-3 cube permuted so the result is non-contiguous. permute() only relabels strides;
+    // no data moves until contiguous() is called, which is what routes into Movemem.
+    Tensor MakeNonContiguousCube(cytnx_uint64 n, unsigned int seed) {
+      const cytnx_double kLow = -10.0;
+      const cytnx_double kHigh = 10.0;
+      Tensor t = cytnx::random::random_tensor({n, n, n}, kLow, kHigh, cytnx::Device.cuda, seed,
+                                              cytnx::Type.Double);
+      return t.permute({2, 0, 1});
+    }
+
+  }  // namespace
+
+  // contiguous() on a non-contiguous GPU tensor -> cuMovemem_cutensor_gpu.
+  static void BM_GpuContiguous(benchmark::State& state) {
+    const auto n = static_cast<cytnx_uint64>(state.range(0));
+    const Tensor a = MakeNonContiguousCube(n, 0);
+    SyncDevice();
+    for (auto _ : state) {
+      auto result = a.contiguous();
+      SyncDevice();
+      benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * n * n * n);
+  }
+  BENCHMARK(BM_GpuContiguous)
+    ->Arg(8)
+    ->Arg(16)
+    ->Arg(32)
+    ->Arg(64)
+    ->Arg(128)
+    ->Unit(benchmark::kMicrosecond);
+
+  // Tensordot over one contracted index -> cuTensordot_internal.
+  static void BM_GpuTensordot(benchmark::State& state) {
+    const auto n = static_cast<cytnx_uint64>(state.range(0));
+    const cytnx_double kLow = -10.0;
+    const cytnx_double kHigh = 10.0;
+    const Tensor a =
+      cytnx::random::random_tensor({n, n}, kLow, kHigh, cytnx::Device.cuda, 0, cytnx::Type.Double);
+    const Tensor b =
+      cytnx::random::random_tensor({n, n}, kLow, kHigh, cytnx::Device.cuda, 1, cytnx::Type.Double);
+    SyncDevice();
+    for (auto _ : state) {
+      auto result = cytnx::linalg::Tensordot(a, b, {1}, {0});
+      SyncDevice();
+      benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * n * n);
+  }
+  BENCHMARK(BM_GpuTensordot)
+    ->Arg(8)
+    ->Arg(16)
+    ->Arg(32)
+    ->Arg(64)
+    ->Arg(128)
+    ->Unit(benchmark::kMicrosecond);
+
+#endif  // UNI_GPU
+
+}  // namespace BMTest_CutensorHandle

--- a/src/backend/linalg_internal_gpu/cuTensordot_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTensordot_internal.cu
@@ -104,7 +104,7 @@ namespace cytnx {
 
       // Shared per-device handle (#1132): cutensorCreate costs ~3.4 ms
       // per call and its plan cache dies with the handle.
-      cutensorHandle_t handle = utils_internal::GetCutensorHandle();
+      cutensorHandle_t handle = utils_internal::get_cutensor_handle();
 
       /**********************
        * Create Tensor Descriptors

--- a/src/backend/linalg_internal_gpu/cuTensordot_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTensordot_internal.cu
@@ -3,6 +3,7 @@
   #include "cytnx_error.hpp"
   #include "Type.hpp"
   #include "backend/lapack_wrapper.hpp"
+  #include "backend/utils_internal_gpu/cuTensorHandle_gpu.hpp"
   #include <cutensor.h>
 
   #define HANDLE_ERROR(x)                                                        \
@@ -101,8 +102,9 @@ namespace cytnx {
        * cuTENSOR
        *************************/
 
-      cutensorHandle_t handle;
-      HANDLE_ERROR(cutensorCreate(&handle));
+      // Shared per-device handle (#1132): cutensorCreate costs ~3.4 ms
+      // per call and its plan cache dies with the handle.
+      cutensorHandle_t handle = utils_internal::GetCutensorHandle();
 
       /**********************
        * Create Tensor Descriptors
@@ -183,7 +185,6 @@ namespace cytnx {
       HANDLE_ERROR(cutensorDestroyTensorDescriptor(descOut));
       HANDLE_ERROR(cutensorDestroyPlanPreference(planPref));
       HANDLE_ERROR(cutensorDestroyPlan(plan));
-      HANDLE_ERROR(cutensorDestroy(handle));
     }
 
     void cuTensordot_internal_cd(Tensor &out, const Tensor &Lin, const Tensor &Rin,

--- a/src/backend/utils_internal_gpu/CMakeLists.txt
+++ b/src/backend/utils_internal_gpu/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(cytnx
     cuLibraryHandle_gpu.hpp
     cuMovemem_gpu.hpp
     cuScopedResource_gpu.hpp
+    cuTensorHandle_gpu.hpp
     cuSetArange_gpu.hpp
     cuSetElems_gpu.hpp
     cuSetElems_contiguous_gpu.hpp
@@ -22,6 +23,7 @@ target_sources(cytnx
     cuGetElems_contiguous_gpu.cu
     cuLibraryHandle_gpu.cu
     cuMovemem_gpu.cu
+    cuTensorHandle_gpu.cu
     cuSetArange_gpu.cu
     cuSetElems_gpu.cu
     cuSetElems_contiguous_gpu.cu

--- a/src/backend/utils_internal_gpu/cuMovemem_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuMovemem_gpu.cu
@@ -234,7 +234,7 @@ namespace cytnx {
 
       // Shared per-device handle (#1132): cutensorCreate costs ~3.4 ms
       // per call and its plan cache dies with the handle.
-      cutensorHandle_t handle = GetCutensorHandle();
+      cutensorHandle_t handle = get_cutensor_handle();
 
       // This is the default alignment of cudaMalloc() and may also be the default alignment of
       // cudaMallocManaged()

--- a/src/backend/utils_internal_gpu/cuMovemem_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuMovemem_gpu.cu
@@ -9,6 +9,7 @@
 
 #include "backend/Storage.hpp"
 #include "cuAlloc_gpu.hpp"
+#include "cuTensorHandle_gpu.hpp"
 #include "Type.hpp"
 
 #ifdef UNI_GPU
@@ -231,8 +232,9 @@ namespace cytnx {
         one = 1;
       }
 
-      cutensorHandle_t handle;
-      checkCudaErrors(cutensorCreate(&handle));
+      // Shared per-device handle (#1132): cutensorCreate costs ~3.4 ms
+      // per call and its plan cache dies with the handle.
+      cutensorHandle_t handle = GetCutensorHandle();
 
       // This is the default alignment of cudaMalloc() and may also be the default alignment of
       // cudaMallocManaged()
@@ -268,7 +270,6 @@ namespace cytnx {
       checkCudaErrors(cutensorDestroyTensorDescriptor(descC));
       checkCudaErrors(cutensorDestroyPlanPreference(planPref));
       checkCudaErrors(cutensorDestroyPlan(plan));
-      checkCudaErrors(cutensorDestroy(handle));
 
       boost::intrusive_ptr<Storage_base> out = __SII.USIInit[dtype_T]();
       if (is_inplace) {

--- a/src/backend/utils_internal_gpu/cuTensorHandle_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuTensorHandle_gpu.cu
@@ -10,7 +10,7 @@
 namespace cytnx {
   namespace utils_internal {
 
-    cutensorHandle_t GetCutensorHandle() {
+    cutensorHandle_t get_cutensor_handle() {
       int device = -1;
       checkCudaErrors(cudaGetDevice(&device));
 

--- a/src/backend/utils_internal_gpu/cuTensorHandle_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuTensorHandle_gpu.cu
@@ -1,0 +1,37 @@
+#include "cuTensorHandle_gpu.hpp"
+
+#if defined(UNI_GPU) && defined(UNI_CUTENSOR)
+
+  #include <mutex>
+  #include <unordered_map>
+
+  #include "cuda_runtime_api.h"
+
+namespace cytnx {
+  namespace utils_internal {
+
+    cutensorHandle_t GetCutensorHandle() {
+      int device = -1;
+      checkCudaErrors(cudaGetDevice(&device));
+
+      // Never destroyed by design -- see the note on the declaration. Function-local statics also
+      // keep initialization lazy, so a CPU-only run never creates a CUDA context here.
+      static std::mutex mutex;
+      static auto* handles = new std::unordered_map<int, cutensorHandle_t>();
+
+      std::lock_guard<std::mutex> lock(mutex);
+      auto found = handles->find(device);
+      if (found != handles->end()) {
+        return found->second;
+      }
+
+      cutensorHandle_t handle;
+      checkCudaErrors(cutensorCreate(&handle));
+      handles->emplace(device, handle);
+      return handle;
+    }
+
+  }  // namespace utils_internal
+}  // namespace cytnx
+
+#endif

--- a/src/backend/utils_internal_gpu/cuTensorHandle_gpu.hpp
+++ b/src/backend/utils_internal_gpu/cuTensorHandle_gpu.hpp
@@ -44,7 +44,7 @@ namespace cytnx {
      * torn down the context that owns them, making `cutensorDestroy` undefined behaviour. The
      * cost is bounded -- one handle per device actually used.
      */
-    cutensorHandle_t GetCutensorHandle();
+    cutensorHandle_t get_cutensor_handle();
 
 #endif
 

--- a/src/backend/utils_internal_gpu/cuTensorHandle_gpu.hpp
+++ b/src/backend/utils_internal_gpu/cuTensorHandle_gpu.hpp
@@ -1,0 +1,54 @@
+#ifndef CYTNX_BACKEND_UTILS_INTERNAL_GPU_CUTENSORHANDLE_GPU_H_
+#define CYTNX_BACKEND_UTILS_INTERNAL_GPU_CUTENSORHANDLE_GPU_H_
+
+#include "Type.hpp"
+#include "cytnx_error.hpp"
+
+#if defined(UNI_GPU) && defined(UNI_CUTENSOR)
+  #include <cutensor.h>
+#endif
+
+namespace cytnx {
+  namespace utils_internal {
+
+#if defined(UNI_GPU) && defined(UNI_CUTENSOR)
+
+    /**
+     * @brief The shared cuTENSOR handle for the CUDA device that is current at the time of the
+     * call, creating it on first use.
+     *
+     * `cutensorCreate` costs roughly 3.4 ms -- flat, regardless of tensor size -- because it
+     * initializes the library context and its plan cache. Cytnx used to pay that on *every*
+     * `contiguous()`, `permute()`, and `Tensordot`, which made an 8-element permute take 3.5 ms
+     * (#1132). Handles are meant to be created once and reused, so they are cached here.
+     *
+     * Keyed by device, not global: cuTENSOR binds a handle to whichever device was current when
+     * `cutensorCreate` ran, and documents that it stays bound. Using one handle across devices
+     * would silently drive the wrong GPU. Callers therefore get the handle for the current
+     * device, which preserves each call site's existing device selection exactly.
+     *
+     * Reusing the handle also restores its 64-entry plan cache, which previously died with the
+     * handle after a single use -- repeated permutes of the same shape now reuse a plan.
+     *
+     * Sharing one handle across threads is sanctioned by cuTENSOR, not merely assumed: every
+     * entry point Cytnx calls (`cutensorPermute`, `cutensorContract`, `cutensorCreatePlan`,
+     * `cutensorCreateTensorDescriptor`, `cutensorCreatePlanPreference`,
+     * `cutensorEstimateWorkspaceSize`, `cutensorPlanGetAttribute`) is documented
+     * "no reentrant, and thread-safe", and the plan cache "can be shared across different threads
+     * in a thread-safe manner". The one non-thread-safe call, `cutensorHandleResizePlanCache`,
+     * is never used here -- the cache stays at its default capacity.
+     *
+     * This accessor is itself thread-safe. The handles intentionally live for the whole process
+     * and are never destroyed:
+     * a static destructor would run after main, by which point the CUDA runtime may already have
+     * torn down the context that owns them, making `cutensorDestroy` undefined behaviour. The
+     * cost is bounded -- one handle per device actually used.
+     */
+    cutensorHandle_t GetCutensorHandle();
+
+#endif
+
+  }  // namespace utils_internal
+}  // namespace cytnx
+
+#endif  // CYTNX_BACKEND_UTILS_INTERNAL_GPU_CUTENSORHANDLE_GPU_H_


### PR DESCRIPTION
Closes #1132.

## Problem

Cytnx wrapped every cuTENSOR operation in `cutensorCreate` / `cutensorDestroy`. `cutensorCreate` costs **~3.4 ms flat** — it initialises the library context and its plan cache — and that cost does not scale with tensor size, so on small tensors it *was* the runtime. I measured it in isolation while investigating #1096: `cutensorCreate`+`cutensorDestroy` = 3446.6 µs, against 24.4 µs for the `cudaMallocManaged`+`free` in the same function.

Handles are meant to be created once and reused.

## Scope: 2 sites

I originally filed this against `cuMovemem_gpu.cu` alone, then corrected it to 13 sites. The accurate number is **2**. The other 11 are in `cuTNPerm_gpu.cu`, which is orphaned source — absent from every CMakeLists, never compiled, and its header does not even parse (trailing comma in all four declarations). Filed separately as #1142; this PR leaves that file alone, since edits to a never-compiled file cannot be compile-checked.

| file | affects |
|---|---|
| `cuMovemem_gpu.cu` | `contiguous()`, `permute()` |
| `cuTensordot_internal.cu` | `Tensordot` |

Two sites, but not a narrow case. With `UNI_CUTENSOR` defined — which every CUDA preset does — *every* float/complex GPU `Movemem` takes the cuTENSOR path:

```cpp
if constexpr (is_complex_v<DType> || std::is_floating_point_v<DType>) {
#if defined(UNI_CUTENSOR)
    return cuMovemem_cutensor_gpu<DType>(...);
```

So this was paid on every `contiguous()` and every `permute()` of a real- or complex-typed GPU tensor, which is on the hot path of essentially any contraction. Integer dtypes take the general kernel and are unaffected.

## Fix

`utils_internal::GetCutensorHandle()` creates a handle on first use and caches it. Descriptors, plan preferences and plans are still created and destroyed per call — only the handle persists.

Three decisions worth review:

**Keyed by device, not global.** cuTENSOR binds a handle to whichever device was current at `cutensorCreate` and documents that it stays bound, so one process-wide handle would silently drive the wrong GPU in a multi-device process. Callers get the handle for the *current* device, preserving each site's existing device selection exactly.

**Shared across threads — sanctioned, not assumed.** This is the real behaviour change: calls used to get a private handle and now share one. Every entry point Cytnx calls (`cutensorPermute`, `cutensorContract`, `cutensorCreatePlan`, `cutensorCreateTensorDescriptor`, `cutensorCreatePlanPreference`, `cutensorEstimateWorkspaceSize`, `cutensorPlanGetAttribute`) is documented in `cutensor.h` as "no reentrant, and thread-safe", and the plan cache "can be shared across different threads in a thread-safe manner". The one non-thread-safe call, `cutensorHandleResizePlanCache`, is never used in this repo. The accessor itself is mutex-guarded.

**Never destroyed, deliberately.** A static destructor would run after `main`, by which point the CUDA runtime may already have torn down the context that owns the handle, making `cutensorDestroy` undefined behaviour. Bounded at one handle per device actually used.

Reusing the handle also restores its 64-entry plan cache, which previously died after a single use, so repeated same-shape operations now reuse a plan.

## Measurements

Both columns on the same machine and session, RTX 4070 Ti SUPER, mean of 5 repetitions, µs. Base = `a1ce3a58` (benchmark only), tip = `916abfd0` (benchmark + fix). The benchmark is committed *before* the fix so both revisions run identical code.

| benchmark | base | tip | speedup | **delta** |
|---|---|---|---|---|
| `BM_GpuContiguous/8` | 3,323 | 17.1 | **194.3×** | 3,306 |
| `BM_GpuContiguous/16` | 3,303 | 17.2 | **192.0×** | 3,286 |
| `BM_GpuContiguous/32` | 3,294 | 17.4 | **189.3×** | 3,277 |
| `BM_GpuContiguous/64` | 3,691 | 288.0 | **12.8×** | 3,403 |
| `BM_GpuContiguous/128` | 5,654 | 2,005.0 | **2.8×** | 3,649 |
| `BM_GpuTensordot/8` | 3,431 | 86.1 | **39.8×** | 3,345 |
| `BM_GpuTensordot/16` | 3,404 | 79.3 | **42.9×** | 3,325 |
| `BM_GpuTensordot/32` | 3,326 | 39.3 | **84.6×** | 3,287 |
| `BM_GpuTensordot/64` | 3,342 | 46.5 | **71.9×** | 3,296 |
| `BM_GpuTensordot/128` | 3,370 | 60.9 | **55.3×** | 3,309 |
**The delta column is the actual result.** Across 10 measurements, two different operations, and volumes spanning 8³ to 128³, the absolute saving is constant at ~3.3 ms — exactly one `cutensorCreate`. That is the evidence the change removes a flat per-call cost and nothing else. The speedup column varies only because that same constant is being compared against different amounts of real work: 194× when there is almost no work to do, 2.8× at 128³ where the copy itself costs 2 ms.

Two methodology notes:

- **Warmup is required, and not for the usual reason.** The *first* `cutensorCreate` in a process costs ~195 ms, not 3.4 ms, because it loads and initialises the cuTENSOR library. Without warmup that one-time cost dominates and hides the effect entirely. Both columns use `--benchmark_min_warmup_time`.
- Run on GPU 1 while an unrelated job held GPU 0; load average 2.0–2.2 throughout, identical for both columns. Worst-case CV was 4.5% (base) and 0.86% (tip).

## Testing

Full GPU suite, run by the #1044 GPU CI job on this exact commit (`916abfd0`) — [run 30479043950](https://github.com/Cytnx-dev/Cytnx/actions/runs/30479043950):

```
100% tests passed, 0 tests failed out of 817
Total Test time (real) = 1657.89 sec
```

`ctest -L gpu`, no exclusions, no parallelism. Because a shared long-lived handle introduces cross-call state where there was none, the whole suite is the right check rather than only the permute and contraction tests.

## Out of scope, noted while here

- **`cuTNPerm_gpu.cu` should be deleted** — #1142.
- **The cuTENSOR paths in `cuTNPerm_gpu.cu` never call `cudaSetDevice`** while the non-cuTENSOR paths in the same file do. Moot while that file is dead, but it should not be resurrected without fixing it.
- **cuBLAS and cuSOLVER handles are created per call** throughout `linalg_internal_gpu/` (`cuGer_internal.cu`, `cuDet_internal.cu`, `cuGeSvd_internal.cu`, `cuGemm_internal.cu`, …). Same anti-pattern, smaller constant. Worth its own issue.
