### PR TITLE
fix(linalg): scope GPU cuSOLVER resources so error paths cannot leak (#1145, #1146)

### DIFF
--- a/src/backend/linalg_internal_gpu/cuDet_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuDet_internal.cu
@@ -17,9 +17,8 @@ namespace cytnx {
       cytnx_complex128* od = (cytnx_complex128*)out;  // result on cpu!
       // Scoped resources (#1146): the info check below throws, so ownership -- not a cleanup block
       // at the tail of the function -- is what keeps these from leaking.
-      auto _in = utils_internal::DeviceBuffer<cuDoubleComplex>::adopt(
-        (cuDoubleComplex*)utils_internal::cuMalloc_gpu(in->size() *
-                                                       sizeof(cuDoubleComplex)));  // unify mem.
+      // Managed (unified) memory: the diagonal is read from the host below.
+      auto _in = utils_internal::DeviceBuffer<cuDoubleComplex>::managed(in->size());
       checkCudaErrors(cudaMemcpy(_in.get(), in->data(), sizeof(cytnx_complex128) * in->size(),
                                  cudaMemcpyDeviceToDevice));
 
@@ -57,9 +56,8 @@ namespace cytnx {
     void cuDet_internal_cf(void* out, const boost::intrusive_ptr<Storage_base>& in,
                            const cytnx_uint64& L) {
       cytnx_complex64* od = (cytnx_complex64*)out;  // result on cpu!
-      auto _in = utils_internal::DeviceBuffer<cuFloatComplex>::adopt(
-        (cuFloatComplex*)utils_internal::cuMalloc_gpu(in->size() *
-                                                      sizeof(cuFloatComplex)));  // unify mem.
+      // Managed (unified) memory: the diagonal is read from the host below.
+      auto _in = utils_internal::DeviceBuffer<cuFloatComplex>::managed(in->size());
       checkCudaErrors(cudaMemcpy(_in.get(), in->data(), sizeof(cytnx_complex64) * in->size(),
                                  cudaMemcpyDeviceToDevice));
 
@@ -97,9 +95,8 @@ namespace cytnx {
     void cuDet_internal_d(void* out, const boost::intrusive_ptr<Storage_base>& in,
                           const cytnx_uint64& L) {
       cytnx_double* od = (cytnx_double*)out;  // result on cpu!
-      auto _in = utils_internal::DeviceBuffer<cytnx_double>::adopt(
-        (cytnx_double*)utils_internal::cuMalloc_gpu(in->size() *
-                                                    sizeof(cytnx_double)));  // unify mem.
+      // Managed (unified) memory: the diagonal is read from the host below.
+      auto _in = utils_internal::DeviceBuffer<cytnx_double>::managed(in->size());
       checkCudaErrors(cudaMemcpy(_in.get(), in->data(), sizeof(cytnx_double) * in->size(),
                                  cudaMemcpyDeviceToDevice));
 
@@ -137,8 +134,8 @@ namespace cytnx {
     void cuDet_internal_f(void* out, const boost::intrusive_ptr<Storage_base>& in,
                           const cytnx_uint64& L) {
       cytnx_float* od = (cytnx_float*)out;  // result on cpu!
-      auto _in = utils_internal::DeviceBuffer<cytnx_float>::adopt((
-        cytnx_float*)utils_internal::cuMalloc_gpu(in->size() * sizeof(cytnx_float)));  // unify mem.
+      // Managed (unified) memory: the diagonal is read from the host below.
+      auto _in = utils_internal::DeviceBuffer<cytnx_float>::managed(in->size());
       checkCudaErrors(cudaMemcpy(_in.get(), in->data(), sizeof(cytnx_float) * in->size(),
                                  cudaMemcpyDeviceToDevice));
 

--- a/src/backend/linalg_internal_gpu/cuDet_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuDet_internal.cu
@@ -4,6 +4,9 @@
 #include "backend/lapack_wrapper.hpp"
 
 #include "backend/utils_internal_gpu/cuAlloc_gpu.hpp"
+#include "backend/utils_internal_gpu/cuScopedResource_gpu.hpp"
+
+#include <vector>
 
 namespace cytnx {
 
@@ -12,28 +15,28 @@ namespace cytnx {
     void cuDet_internal_cd(void* out, const boost::intrusive_ptr<Storage_base>& in,
                            const cytnx_uint64& L) {
       cytnx_complex128* od = (cytnx_complex128*)out;  // result on cpu!
-      cuDoubleComplex* _in = (cuDoubleComplex*)utils_internal::cuMalloc_gpu(
-        in->size() * sizeof(cuDoubleComplex));  // unify mem.
-      checkCudaErrors(cudaMemcpy(_in, in->data(), sizeof(cytnx_complex128) * in->size(),
+      // Scoped resources (#1146): the info check below throws, so ownership -- not a cleanup block
+      // at the tail of the function -- is what keeps these from leaking.
+      auto _in = utils_internal::DeviceBuffer<cuDoubleComplex>::adopt(
+        (cuDoubleComplex*)utils_internal::cuMalloc_gpu(in->size() *
+                                                       sizeof(cuDoubleComplex)));  // unify mem.
+      checkCudaErrors(cudaMemcpy(_in.get(), in->data(), sizeof(cytnx_complex128) * in->size(),
                                  cudaMemcpyDeviceToDevice));
 
-      cusolverDnHandle_t cusolverH;
-      cusolverDnCreate(&cusolverH);
+      utils_internal::CusolverDnHandle cusolverH;
 
-      int* devIpiv;
-      int* devInfo;
-      checkCudaErrors(cudaMalloc((void**)&devIpiv, L * sizeof(int)));
-      checkCudaErrors(cudaMalloc((void**)&devInfo, sizeof(int)));
+      utils_internal::DeviceBuffer<int> devIpiv(L);
+      utils_internal::DeviceBuffer<int> devInfo(1);
 
       int workspace_size = 0;
-      cuDoubleComplex* workspace = nullptr;
-      cusolverDnZgetrf_bufferSize(cusolverH, L, L, _in, L, &workspace_size);
-      checkCudaErrors(cudaMalloc((void**)&workspace, workspace_size * sizeof(cuDoubleComplex)));
+      cusolverDnZgetrf_bufferSize(cusolverH.get(), L, L, _in.get(), L, &workspace_size);
+      utils_internal::DeviceBuffer<cuDoubleComplex> workspace(workspace_size);
 
-      cusolverDnZgetrf(cusolverH, L, L, _in, L, workspace, devIpiv, devInfo);
+      cusolverDnZgetrf(cusolverH.get(), L, L, _in.get(), L, workspace.get(), devIpiv.get(),
+                       devInfo.get());
 
       int info;
-      checkCudaErrors(cudaMemcpy(&info, devInfo, sizeof(int), cudaMemcpyDeviceToHost));
+      checkCudaErrors(cudaMemcpy(&info, devInfo.get(), sizeof(int), cudaMemcpyDeviceToHost));
       cytnx_error_msg(info < 0, "[ERROR] cusolverDnZgetrf fail with info= %d\n", info);
       // TODO: info > 0 means U[info - 1, info - 1] is zero, which implies the determinant is
       // zero. The steps below can be skipped.
@@ -41,46 +44,39 @@ namespace cytnx {
       // since we do unify mem, direct access element is possible:
       od[0] = 1;
       bool neg = 0;
-      int* ipiv = new int[L];
-      checkCudaErrors(cudaMemcpy(ipiv, devIpiv, L * sizeof(int), cudaMemcpyDeviceToHost));
-      for (int i = 0; i < L; i++) {
-        od[0] *= ((cytnx_complex128*)_in)[i * L + i];
-        if (ipiv[i] != (i + 1)) neg = !neg;
+      std::vector<int> ipiv(L);
+      checkCudaErrors(
+        cudaMemcpy(ipiv.data(), devIpiv.get(), L * sizeof(int), cudaMemcpyDeviceToHost));
+      for (cytnx_uint64 i = 0; i < L; i++) {
+        od[0] *= ((cytnx_complex128*)_in.get())[i * L + i];
+        if (ipiv[i] != static_cast<int>(i + 1)) neg = !neg;
       }
-      delete[] ipiv;
-      cudaFree(devIpiv);
-      cudaFree(devInfo);
-      cudaFree(workspace);
-      cudaFree(_in);
-      cusolverDnDestroy(cusolverH);
       if (neg) od[0] *= -1;
     }
 
     void cuDet_internal_cf(void* out, const boost::intrusive_ptr<Storage_base>& in,
                            const cytnx_uint64& L) {
       cytnx_complex64* od = (cytnx_complex64*)out;  // result on cpu!
-      cuFloatComplex* _in = (cuFloatComplex*)utils_internal::cuMalloc_gpu(
-        in->size() * sizeof(cuFloatComplex));  // unify mem.
-      checkCudaErrors(cudaMemcpy(_in, in->data(), sizeof(cytnx_complex64) * in->size(),
+      auto _in = utils_internal::DeviceBuffer<cuFloatComplex>::adopt(
+        (cuFloatComplex*)utils_internal::cuMalloc_gpu(in->size() *
+                                                      sizeof(cuFloatComplex)));  // unify mem.
+      checkCudaErrors(cudaMemcpy(_in.get(), in->data(), sizeof(cytnx_complex64) * in->size(),
                                  cudaMemcpyDeviceToDevice));
 
-      cusolverDnHandle_t cusolverH;
-      cusolverDnCreate(&cusolverH);
+      utils_internal::CusolverDnHandle cusolverH;
 
-      int* devIpiv;
-      int* devInfo;
-      checkCudaErrors(cudaMalloc((void**)&devIpiv, L * sizeof(int)));
-      checkCudaErrors(cudaMalloc((void**)&devInfo, sizeof(int)));
+      utils_internal::DeviceBuffer<int> devIpiv(L);
+      utils_internal::DeviceBuffer<int> devInfo(1);
 
       int workspace_size = 0;
-      cuFloatComplex* workspace = nullptr;
-      cusolverDnCgetrf_bufferSize(cusolverH, L, L, _in, L, &workspace_size);
-      checkCudaErrors(cudaMalloc((void**)&workspace, workspace_size * sizeof(cuFloatComplex)));
+      cusolverDnCgetrf_bufferSize(cusolverH.get(), L, L, _in.get(), L, &workspace_size);
+      utils_internal::DeviceBuffer<cuFloatComplex> workspace(workspace_size);
 
-      cusolverDnCgetrf(cusolverH, L, L, _in, L, workspace, devIpiv, devInfo);
+      cusolverDnCgetrf(cusolverH.get(), L, L, _in.get(), L, workspace.get(), devIpiv.get(),
+                       devInfo.get());
 
       int info;
-      checkCudaErrors(cudaMemcpy(&info, devInfo, sizeof(int), cudaMemcpyDeviceToHost));
+      checkCudaErrors(cudaMemcpy(&info, devInfo.get(), sizeof(int), cudaMemcpyDeviceToHost));
       cytnx_error_msg(info < 0, "[ERROR] cusolverDnCgetrf fail with info= %d\n", info);
       // TODO: info > 0 means U[info - 1, info - 1] is zero, which implies the determinant is
       // zero. The steps below can be skipped.
@@ -88,46 +84,39 @@ namespace cytnx {
       // since we do unify mem, direct access element is possible:
       od[0] = 1;
       bool neg = 0;
-      int* ipiv = new int[L];
-      checkCudaErrors(cudaMemcpy(ipiv, devIpiv, L * sizeof(int), cudaMemcpyDeviceToHost));
-      for (int i = 0; i < L; i++) {
-        od[0] *= ((cytnx_complex64*)_in)[i * L + i];
-        if (ipiv[i] != (i + 1)) neg = !neg;
+      std::vector<int> ipiv(L);
+      checkCudaErrors(
+        cudaMemcpy(ipiv.data(), devIpiv.get(), L * sizeof(int), cudaMemcpyDeviceToHost));
+      for (cytnx_uint64 i = 0; i < L; i++) {
+        od[0] *= ((cytnx_complex64*)_in.get())[i * L + i];
+        if (ipiv[i] != static_cast<int>(i + 1)) neg = !neg;
       }
-      delete[] ipiv;
-      cudaFree(devIpiv);
-      cudaFree(devInfo);
-      cudaFree(workspace);
-      cudaFree(_in);
-      cusolverDnDestroy(cusolverH);
       if (neg) od[0] *= -1;
     }
 
     void cuDet_internal_d(void* out, const boost::intrusive_ptr<Storage_base>& in,
                           const cytnx_uint64& L) {
       cytnx_double* od = (cytnx_double*)out;  // result on cpu!
-      cytnx_double* _in = (cytnx_double*)utils_internal::cuMalloc_gpu(
-        in->size() * sizeof(cytnx_double));  // unify mem.
-      checkCudaErrors(
-        cudaMemcpy(_in, in->data(), sizeof(cytnx_double) * in->size(), cudaMemcpyDeviceToDevice));
+      auto _in = utils_internal::DeviceBuffer<cytnx_double>::adopt(
+        (cytnx_double*)utils_internal::cuMalloc_gpu(in->size() *
+                                                    sizeof(cytnx_double)));  // unify mem.
+      checkCudaErrors(cudaMemcpy(_in.get(), in->data(), sizeof(cytnx_double) * in->size(),
+                                 cudaMemcpyDeviceToDevice));
 
-      cusolverDnHandle_t cusolverH;
-      cusolverDnCreate(&cusolverH);
+      utils_internal::CusolverDnHandle cusolverH;
 
-      int* devIpiv;
-      int* devInfo;
-      checkCudaErrors(cudaMalloc((void**)&devIpiv, L * sizeof(int)));
-      checkCudaErrors(cudaMalloc((void**)&devInfo, sizeof(int)));
+      utils_internal::DeviceBuffer<int> devIpiv(L);
+      utils_internal::DeviceBuffer<int> devInfo(1);
 
       int workspace_size = 0;
-      cytnx_double* workspace = nullptr;
-      cusolverDnDgetrf_bufferSize(cusolverH, L, L, _in, L, &workspace_size);
-      checkCudaErrors(cudaMalloc((void**)&workspace, workspace_size * sizeof(cytnx_double)));
+      cusolverDnDgetrf_bufferSize(cusolverH.get(), L, L, _in.get(), L, &workspace_size);
+      utils_internal::DeviceBuffer<cytnx_double> workspace(workspace_size);
 
-      cusolverDnDgetrf(cusolverH, L, L, _in, L, workspace, devIpiv, devInfo);
+      cusolverDnDgetrf(cusolverH.get(), L, L, _in.get(), L, workspace.get(), devIpiv.get(),
+                       devInfo.get());
 
       int info;
-      checkCudaErrors(cudaMemcpy(&info, devInfo, sizeof(int), cudaMemcpyDeviceToHost));
+      checkCudaErrors(cudaMemcpy(&info, devInfo.get(), sizeof(int), cudaMemcpyDeviceToHost));
       cytnx_error_msg(info < 0, "[ERROR] cusolverDnDgetrf fail with info= %d\n", info);
       // TODO: info > 0 means U[info - 1, info - 1] is zero, which implies the determinant is
       // zero. The steps below can be skipped.
@@ -135,46 +124,38 @@ namespace cytnx {
       // since we do unify mem, direct access element is possible:
       od[0] = 1;
       bool neg = 0;
-      int* ipiv = new int[L];
-      checkCudaErrors(cudaMemcpy(ipiv, devIpiv, L * sizeof(int), cudaMemcpyDeviceToHost));
-      for (int i = 0; i < L; i++) {
-        od[0] *= _in[i * L + i];
-        if (ipiv[i] != (i + 1)) neg = !neg;
+      std::vector<int> ipiv(L);
+      checkCudaErrors(
+        cudaMemcpy(ipiv.data(), devIpiv.get(), L * sizeof(int), cudaMemcpyDeviceToHost));
+      for (cytnx_uint64 i = 0; i < L; i++) {
+        od[0] *= _in.get()[i * L + i];
+        if (ipiv[i] != static_cast<int>(i + 1)) neg = !neg;
       }
-      delete[] ipiv;
-      cudaFree(devIpiv);
-      cudaFree(devInfo);
-      cudaFree(workspace);
-      cudaFree(_in);
-      cusolverDnDestroy(cusolverH);
       if (neg) od[0] *= -1;
     }
 
     void cuDet_internal_f(void* out, const boost::intrusive_ptr<Storage_base>& in,
                           const cytnx_uint64& L) {
       cytnx_float* od = (cytnx_float*)out;  // result on cpu!
-      cytnx_float* _in =
-        (cytnx_float*)utils_internal::cuMalloc_gpu(in->size() * sizeof(cytnx_float));  // unify mem.
-      checkCudaErrors(
-        cudaMemcpy(_in, in->data(), sizeof(cytnx_float) * in->size(), cudaMemcpyDeviceToDevice));
+      auto _in = utils_internal::DeviceBuffer<cytnx_float>::adopt((
+        cytnx_float*)utils_internal::cuMalloc_gpu(in->size() * sizeof(cytnx_float)));  // unify mem.
+      checkCudaErrors(cudaMemcpy(_in.get(), in->data(), sizeof(cytnx_float) * in->size(),
+                                 cudaMemcpyDeviceToDevice));
 
-      cusolverDnHandle_t cusolverH;
-      cusolverDnCreate(&cusolverH);
+      utils_internal::CusolverDnHandle cusolverH;
 
-      int* devIpiv;
-      int* devInfo;
-      checkCudaErrors(cudaMalloc((void**)&devIpiv, L * sizeof(int)));
-      checkCudaErrors(cudaMalloc((void**)&devInfo, sizeof(int)));
+      utils_internal::DeviceBuffer<int> devIpiv(L);
+      utils_internal::DeviceBuffer<int> devInfo(1);
 
       int workspace_size = 0;
-      cytnx_float* workspace = nullptr;
-      cusolverDnSgetrf_bufferSize(cusolverH, L, L, _in, L, &workspace_size);
-      checkCudaErrors(cudaMalloc((void**)&workspace, workspace_size * sizeof(cytnx_float)));
+      cusolverDnSgetrf_bufferSize(cusolverH.get(), L, L, _in.get(), L, &workspace_size);
+      utils_internal::DeviceBuffer<cytnx_float> workspace(workspace_size);
 
-      cusolverDnSgetrf(cusolverH, L, L, _in, L, workspace, devIpiv, devInfo);
+      cusolverDnSgetrf(cusolverH.get(), L, L, _in.get(), L, workspace.get(), devIpiv.get(),
+                       devInfo.get());
 
       int info;
-      checkCudaErrors(cudaMemcpy(&info, devInfo, sizeof(int), cudaMemcpyDeviceToHost));
+      checkCudaErrors(cudaMemcpy(&info, devInfo.get(), sizeof(int), cudaMemcpyDeviceToHost));
       cytnx_error_msg(info < 0, "[ERROR] cusolverDnSgetrf fail with info= %d\n", info);
       // TODO: info > 0 means U[info - 1, info - 1] is zero, which implies the determinant is
       // zero. The steps below can be skipped.
@@ -182,18 +163,13 @@ namespace cytnx {
       // since we do unify mem, direct access element is possible:
       od[0] = 1;
       bool neg = 0;
-      int* ipiv = new int[L];
-      checkCudaErrors(cudaMemcpy(ipiv, devIpiv, L * sizeof(int), cudaMemcpyDeviceToHost));
-      for (int i = 0; i < L; i++) {
-        od[0] *= _in[i * L + i];
-        if (ipiv[i] != (i + 1)) neg = !neg;
+      std::vector<int> ipiv(L);
+      checkCudaErrors(
+        cudaMemcpy(ipiv.data(), devIpiv.get(), L * sizeof(int), cudaMemcpyDeviceToHost));
+      for (cytnx_uint64 i = 0; i < L; i++) {
+        od[0] *= _in.get()[i * L + i];
+        if (ipiv[i] != static_cast<int>(i + 1)) neg = !neg;
       }
-      delete[] ipiv;
-      cudaFree(devIpiv);
-      cudaFree(devInfo);
-      cudaFree(workspace);
-      cudaFree(_in);
-      cusolverDnDestroy(cusolverH);
       if (neg) od[0] *= -1;
     }
 

--- a/src/backend/linalg_internal_gpu/cuEigh_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuEigh_internal.cu
@@ -21,17 +21,17 @@ namespace cytnx {
       utils_internal::CusolverDnHandle cusolverH;
 
       // `tA` aliases v's storage when eigenvectors are wanted and is a temporary otherwise;
-      // `owned_tA` is non-empty only in the second case, matching the old conditional cudaFree.
+      // `owned_ta` is non-empty only in the second case, matching the old conditional cudaFree.
       cytnx_complex128 *tA;
-      utils_internal::DeviceBuffer<cytnx_complex128> owned_tA;
+      utils_internal::DeviceBuffer<cytnx_complex128> owned_ta;
       if (v->dtype() != Type.Void) {
         tA = (cytnx_complex128 *)v->data();
         checkCudaErrors(cudaMemcpy(v->data(), in->data(),
                                    sizeof(cytnx_complex128) * cytnx_uint64(L) * L,
                                    cudaMemcpyDeviceToDevice));
       } else {
-        owned_tA = utils_internal::DeviceBuffer<cytnx_complex128>(cytnx_uint64(L) * L);
-        tA = owned_tA.get();
+        owned_ta = utils_internal::DeviceBuffer<cytnx_complex128>(cytnx_uint64(L) * L);
+        tA = owned_ta.get();
         checkCudaErrors(cudaMemcpy(tA, in->data(), sizeof(cytnx_complex128) * cytnx_uint64(L) * L,
                                    cudaMemcpyDeviceToDevice));
       }
@@ -70,15 +70,15 @@ namespace cytnx {
       utils_internal::CusolverDnHandle cusolverH;
 
       cytnx_complex64 *tA;
-      utils_internal::DeviceBuffer<cytnx_complex64> owned_tA;
+      utils_internal::DeviceBuffer<cytnx_complex64> owned_ta;
       if (v->dtype() != Type.Void) {
         tA = (cytnx_complex64 *)v->data();
         checkCudaErrors(cudaMemcpy(v->data(), in->data(),
                                    sizeof(cytnx_complex64) * cytnx_uint64(L) * L,
                                    cudaMemcpyDeviceToDevice));
       } else {
-        owned_tA = utils_internal::DeviceBuffer<cytnx_complex64>(cytnx_uint64(L) * L);
-        tA = owned_tA.get();
+        owned_ta = utils_internal::DeviceBuffer<cytnx_complex64>(cytnx_uint64(L) * L);
+        tA = owned_ta.get();
         checkCudaErrors(cudaMemcpy(tA, in->data(), sizeof(cytnx_complex64) * cytnx_uint64(L) * L,
                                    cudaMemcpyDeviceToDevice));
       }
@@ -117,15 +117,15 @@ namespace cytnx {
       utils_internal::CusolverDnHandle cusolverH;
 
       cytnx_double *tA;
-      utils_internal::DeviceBuffer<cytnx_double> owned_tA;
+      utils_internal::DeviceBuffer<cytnx_double> owned_ta;
       if (v->dtype() != Type.Void) {
         tA = (cytnx_double *)v->data();
         checkCudaErrors(cudaMemcpy(v->data(), in->data(),
                                    sizeof(cytnx_double) * cytnx_uint64(L) * L,
                                    cudaMemcpyDeviceToDevice));
       } else {
-        owned_tA = utils_internal::DeviceBuffer<cytnx_double>(cytnx_uint64(L) * L);
-        tA = owned_tA.get();
+        owned_ta = utils_internal::DeviceBuffer<cytnx_double>(cytnx_uint64(L) * L);
+        tA = owned_ta.get();
         checkCudaErrors(cudaMemcpy(tA, in->data(), sizeof(cytnx_double) * cytnx_uint64(L) * L,
                                    cudaMemcpyDeviceToDevice));
       }
@@ -164,14 +164,14 @@ namespace cytnx {
       utils_internal::CusolverDnHandle cusolverH;
 
       cytnx_float *tA;
-      utils_internal::DeviceBuffer<cytnx_float> owned_tA;
+      utils_internal::DeviceBuffer<cytnx_float> owned_ta;
       if (v->dtype() != Type.Void) {
         tA = (cytnx_float *)v->data();
         checkCudaErrors(cudaMemcpy(v->data(), in->data(), sizeof(cytnx_float) * cytnx_uint64(L) * L,
                                    cudaMemcpyDeviceToDevice));
       } else {
-        owned_tA = utils_internal::DeviceBuffer<cytnx_float>(cytnx_uint64(L) * L);
-        tA = owned_tA.get();
+        owned_ta = utils_internal::DeviceBuffer<cytnx_float>(cytnx_uint64(L) * L);
+        tA = owned_ta.get();
         checkCudaErrors(cudaMemcpy(tA, in->data(), sizeof(cytnx_float) * cytnx_uint64(L) * L,
                                    cudaMemcpyDeviceToDevice));
       }

--- a/src/backend/linalg_internal_gpu/cuEigh_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuEigh_internal.cu
@@ -2,6 +2,7 @@
 #include "cytnx_error.hpp"
 #include "Type.hpp"
 #include "backend/lapack_wrapper.hpp"
+#include "backend/utils_internal_gpu/cuScopedResource_gpu.hpp"
 
 namespace cytnx {
 
@@ -15,17 +16,22 @@ namespace cytnx {
       if (v->dtype() == Type.Void) jobz = CUSOLVER_EIG_MODE_NOVECTOR;
 
       // create handles:
-      cusolverDnHandle_t cusolverH = nullptr;
-      checkCudaErrors(cusolverDnCreate(&cusolverH));
+      // Scoped resources (#1146): the info check below throws, so ownership -- not the cleanup
+      // block that used to sit at the tail of this function -- is what prevents a leak.
+      utils_internal::CusolverDnHandle cusolverH;
 
+      // `tA` aliases v's storage when eigenvectors are wanted and is a temporary otherwise;
+      // `owned_tA` is non-empty only in the second case, matching the old conditional cudaFree.
       cytnx_complex128 *tA;
+      utils_internal::DeviceBuffer<cytnx_complex128> owned_tA;
       if (v->dtype() != Type.Void) {
         tA = (cytnx_complex128 *)v->data();
         checkCudaErrors(cudaMemcpy(v->data(), in->data(),
                                    sizeof(cytnx_complex128) * cytnx_uint64(L) * L,
                                    cudaMemcpyDeviceToDevice));
       } else {
-        checkCudaErrors(cudaMalloc((void **)&tA, cytnx_uint64(L) * L * sizeof(cytnx_complex128)));
+        owned_tA = utils_internal::DeviceBuffer<cytnx_complex128>(cytnx_uint64(L) * L);
+        tA = owned_tA.get();
         checkCudaErrors(cudaMemcpy(tA, in->data(), sizeof(cytnx_complex128) * cytnx_uint64(L) * L,
                                    cudaMemcpyDeviceToDevice));
       }
@@ -33,33 +39,26 @@ namespace cytnx {
       // query buffer:
       cytnx_int32 lwork = 0;
       cytnx_int32 b32L = L;
-      checkCudaErrors(cusolverDnZheevd_bufferSize(cusolverH, jobz, CUBLAS_FILL_MODE_UPPER, b32L,
-                                                  (cuDoubleComplex *)tA, b32L,
+      checkCudaErrors(cusolverDnZheevd_bufferSize(cusolverH.get(), jobz, CUBLAS_FILL_MODE_UPPER,
+                                                  b32L, (cuDoubleComplex *)tA, b32L,
                                                   (cytnx_double *)e->data(), &lwork));
 
       // allocate working space:
-      cytnx_complex128 *work;
-      checkCudaErrors(cudaMalloc((void **)&work, sizeof(cytnx_complex128) * lwork));
+      utils_internal::DeviceBuffer<cytnx_complex128> work(lwork);
 
       // call :
       cytnx_int32 info;
-      cytnx_int32 *devinfo;
-      checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
-      checkCudaErrors(cusolverDnZheevd(cusolverH, jobz, CUBLAS_FILL_MODE_UPPER, b32L,
+      utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
+      checkCudaErrors(cusolverDnZheevd(cusolverH.get(), jobz, CUBLAS_FILL_MODE_UPPER, b32L,
                                        (cuDoubleComplex *)tA, b32L, (cytnx_double *)e->data(),
-                                       (cuDoubleComplex *)work, lwork, devinfo));
+                                       (cuDoubleComplex *)work.get(), lwork, devinfo.get()));
 
       // get info
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_error_msg(info != 0, "%s %d",
                       "Error in cuBlas function 'cusolverDnZheevd': cuBlas INFO = ", info);
-
-      cudaFree(work);
-      if (v->dtype() == Type.Void) cudaFree(tA);
-
-      cudaFree(devinfo);
-      cusolverDnDestroy(cusolverH);
     }
     void cuEigh_internal_cf(const boost::intrusive_ptr<Storage_base> &in,
                             boost::intrusive_ptr<Storage_base> &e,
@@ -68,17 +67,18 @@ namespace cytnx {
       if (v->dtype() == Type.Void) jobz = CUSOLVER_EIG_MODE_NOVECTOR;
 
       // create handles:
-      cusolverDnHandle_t cusolverH = nullptr;
-      checkCudaErrors(cusolverDnCreate(&cusolverH));
+      utils_internal::CusolverDnHandle cusolverH;
 
       cytnx_complex64 *tA;
+      utils_internal::DeviceBuffer<cytnx_complex64> owned_tA;
       if (v->dtype() != Type.Void) {
         tA = (cytnx_complex64 *)v->data();
         checkCudaErrors(cudaMemcpy(v->data(), in->data(),
                                    sizeof(cytnx_complex64) * cytnx_uint64(L) * L,
                                    cudaMemcpyDeviceToDevice));
       } else {
-        checkCudaErrors(cudaMalloc((void **)&tA, cytnx_uint64(L) * L * sizeof(cytnx_complex64)));
+        owned_tA = utils_internal::DeviceBuffer<cytnx_complex64>(cytnx_uint64(L) * L);
+        tA = owned_tA.get();
         checkCudaErrors(cudaMemcpy(tA, in->data(), sizeof(cytnx_complex64) * cytnx_uint64(L) * L,
                                    cudaMemcpyDeviceToDevice));
       }
@@ -86,33 +86,26 @@ namespace cytnx {
       // query buffer:
       cytnx_int32 lwork = 0;
       cytnx_int32 b32L = L;
-      checkCudaErrors(cusolverDnCheevd_bufferSize(cusolverH, jobz, CUBLAS_FILL_MODE_UPPER, b32L,
-                                                  (cuFloatComplex *)tA, b32L,
+      checkCudaErrors(cusolverDnCheevd_bufferSize(cusolverH.get(), jobz, CUBLAS_FILL_MODE_UPPER,
+                                                  b32L, (cuFloatComplex *)tA, b32L,
                                                   (cytnx_float *)e->data(), &lwork));
 
       // allocate working space:
-      cytnx_complex64 *work;
-      checkCudaErrors(cudaMalloc((void **)&work, sizeof(cytnx_complex64) * lwork));
+      utils_internal::DeviceBuffer<cytnx_complex64> work(lwork);
 
       // call :
       cytnx_int32 info;
-      cytnx_int32 *devinfo;
-      checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
-      checkCudaErrors(cusolverDnCheevd(cusolverH, jobz, CUBLAS_FILL_MODE_UPPER, b32L,
+      utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
+      checkCudaErrors(cusolverDnCheevd(cusolverH.get(), jobz, CUBLAS_FILL_MODE_UPPER, b32L,
                                        (cuFloatComplex *)tA, b32L, (cytnx_float *)e->data(),
-                                       (cuFloatComplex *)work, lwork, devinfo));
+                                       (cuFloatComplex *)work.get(), lwork, devinfo.get()));
 
       // get info
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_error_msg(info != 0, "%s %d",
                       "Error in cuBlas function 'cusolverDnZheevd': cuBlas INFO = ", info);
-
-      cudaFree(work);
-      if (v->dtype() == Type.Void) cudaFree(tA);
-
-      cudaFree(devinfo);
-      cusolverDnDestroy(cusolverH);
     }
     void cuEigh_internal_d(const boost::intrusive_ptr<Storage_base> &in,
                            boost::intrusive_ptr<Storage_base> &e,
@@ -121,17 +114,18 @@ namespace cytnx {
       if (v->dtype() == Type.Void) jobz = CUSOLVER_EIG_MODE_NOVECTOR;
 
       // create handles:
-      cusolverDnHandle_t cusolverH = nullptr;
-      checkCudaErrors(cusolverDnCreate(&cusolverH));
+      utils_internal::CusolverDnHandle cusolverH;
 
       cytnx_double *tA;
+      utils_internal::DeviceBuffer<cytnx_double> owned_tA;
       if (v->dtype() != Type.Void) {
         tA = (cytnx_double *)v->data();
         checkCudaErrors(cudaMemcpy(v->data(), in->data(),
                                    sizeof(cytnx_double) * cytnx_uint64(L) * L,
                                    cudaMemcpyDeviceToDevice));
       } else {
-        checkCudaErrors(cudaMalloc((void **)&tA, cytnx_uint64(L) * L * sizeof(cytnx_double)));
+        owned_tA = utils_internal::DeviceBuffer<cytnx_double>(cytnx_uint64(L) * L);
+        tA = owned_tA.get();
         checkCudaErrors(cudaMemcpy(tA, in->data(), sizeof(cytnx_double) * cytnx_uint64(L) * L,
                                    cudaMemcpyDeviceToDevice));
       }
@@ -139,31 +133,26 @@ namespace cytnx {
       // query buffer:
       cytnx_int32 lwork = 0;
       cytnx_int32 b32L = L;
-      checkCudaErrors(cusolverDnDsyevd_bufferSize(cusolverH, jobz, CUBLAS_FILL_MODE_UPPER, b32L, tA,
-                                                  b32L, (cytnx_double *)e->data(), &lwork));
+      checkCudaErrors(cusolverDnDsyevd_bufferSize(cusolverH.get(), jobz, CUBLAS_FILL_MODE_UPPER,
+                                                  b32L, tA, b32L, (cytnx_double *)e->data(),
+                                                  &lwork));
 
       // allocate working space:
-      cytnx_double *work;
-      checkCudaErrors(cudaMalloc((void **)&work, sizeof(cytnx_double) * lwork));
+      utils_internal::DeviceBuffer<cytnx_double> work(lwork);
 
       // call :
       cytnx_int32 info;
-      cytnx_int32 *devinfo;
-      checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
-      checkCudaErrors(cusolverDnDsyevd(cusolverH, jobz, CUBLAS_FILL_MODE_UPPER, b32L, tA, b32L,
-                                       (cytnx_double *)e->data(), work, lwork, devinfo));
+      utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
+      checkCudaErrors(cusolverDnDsyevd(cusolverH.get(), jobz, CUBLAS_FILL_MODE_UPPER, b32L, tA,
+                                       b32L, (cytnx_double *)e->data(), work.get(), lwork,
+                                       devinfo.get()));
 
       // get info
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_error_msg(info != 0, "%s %d",
                       "Error in cuBlas function 'cusolverDnDsysevd': cuBlas INFO = ", info);
-
-      cudaFree(work);
-      if (v->dtype() == Type.Void) cudaFree(tA);
-
-      cudaFree(devinfo);
-      cusolverDnDestroy(cusolverH);
     }
     void cuEigh_internal_f(const boost::intrusive_ptr<Storage_base> &in,
                            boost::intrusive_ptr<Storage_base> &e,
@@ -172,16 +161,17 @@ namespace cytnx {
       if (v->dtype() == Type.Void) jobz = CUSOLVER_EIG_MODE_NOVECTOR;
 
       // create handles:
-      cusolverDnHandle_t cusolverH = nullptr;
-      checkCudaErrors(cusolverDnCreate(&cusolverH));
+      utils_internal::CusolverDnHandle cusolverH;
 
       cytnx_float *tA;
+      utils_internal::DeviceBuffer<cytnx_float> owned_tA;
       if (v->dtype() != Type.Void) {
         tA = (cytnx_float *)v->data();
         checkCudaErrors(cudaMemcpy(v->data(), in->data(), sizeof(cytnx_float) * cytnx_uint64(L) * L,
                                    cudaMemcpyDeviceToDevice));
       } else {
-        checkCudaErrors(cudaMalloc((void **)&tA, cytnx_uint64(L) * L * sizeof(cytnx_float)));
+        owned_tA = utils_internal::DeviceBuffer<cytnx_float>(cytnx_uint64(L) * L);
+        tA = owned_tA.get();
         checkCudaErrors(cudaMemcpy(tA, in->data(), sizeof(cytnx_float) * cytnx_uint64(L) * L,
                                    cudaMemcpyDeviceToDevice));
       }
@@ -189,30 +179,25 @@ namespace cytnx {
       // query buffer:
       cytnx_int32 lwork = 0;
       cytnx_int32 b32L = L;
-      checkCudaErrors(cusolverDnSsyevd_bufferSize(cusolverH, jobz, CUBLAS_FILL_MODE_UPPER, b32L, tA,
-                                                  b32L, (cytnx_float *)e->data(), &lwork));
+      checkCudaErrors(cusolverDnSsyevd_bufferSize(cusolverH.get(), jobz, CUBLAS_FILL_MODE_UPPER,
+                                                  b32L, tA, b32L, (cytnx_float *)e->data(),
+                                                  &lwork));
 
       // allocate working space:
-      cytnx_float *work;
-      checkCudaErrors(cudaMalloc((void **)&work, sizeof(cytnx_float) * lwork));
+      utils_internal::DeviceBuffer<cytnx_float> work(lwork);
 
       // call :
       cytnx_int32 info;
-      cytnx_int32 *devinfo;
-      checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
-      checkCudaErrors(cusolverDnSsyevd(cusolverH, jobz, CUBLAS_FILL_MODE_UPPER, b32L, tA, b32L,
-                                       (cytnx_float *)e->data(), work, lwork, devinfo));
+      utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
+      checkCudaErrors(cusolverDnSsyevd(cusolverH.get(), jobz, CUBLAS_FILL_MODE_UPPER, b32L, tA,
+                                       b32L, (cytnx_float *)e->data(), work.get(), lwork,
+                                       devinfo.get()));
 
       // get info
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
       cytnx_error_msg(info != 0, "%s %d",
                       "Error in cuBlas function 'cusolverDnDsysevd': cuBlas INFO = ", info);
-
-      cudaFree(work);
-      if (v->dtype() == Type.Void) cudaFree(tA);
-
-      cudaFree(devinfo);
-      cusolverDnDestroy(cusolverH);
     }
 
   }  // namespace linalg_internal

--- a/src/backend/linalg_internal_gpu/cuGeSvd_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuGeSvd_internal.cu
@@ -1,5 +1,6 @@
 #include "cuGeSvd_internal.hpp"
 #include "cuConj_inplace_internal.hpp"
+#include "backend/utils_internal_gpu/cuScopedResource_gpu.hpp"
 
 namespace cytnx {
 
@@ -22,54 +23,59 @@ namespace cytnx {
       cytnx_int32 econ = 1; /* i.e. 'S' in gesvd  */
 
       // create handles:
-      cusolverDnHandle_t cusolverH = nullptr;
-      checkCudaErrors(cusolverDnCreate(&cusolverH));
+      // Scoped resources (#1145, #1146): the info check below throws, so ownership -- not the
+      // cleanup block that used to sit at the tail of this function -- is what prevents a leak.
+      utils_internal::CusolverDnHandle cusolverH;
 
-      cuDoubleComplex *Mij;
-      checkCudaErrors(cudaMalloc((void **)&Mij, M * N * sizeof(data_type)));
+      utils_internal::DeviceBuffer<data_type> Mij(M * N);
       checkCudaErrors(
-        cudaMemcpy(Mij, in->data(), sizeof(data_type) * M * N, cudaMemcpyDeviceToDevice));
+        cudaMemcpy(Mij.get(), in->data(), sizeof(data_type) * M * N, cudaMemcpyDeviceToDevice));
 
       cytnx_int64 min = std::min(M, N);
       cytnx_int64 max = std::max(M, N);
       cytnx_int64 ldA = N, ldu = N, ldvT = M;
 
+      // UMem/vTMem alias U's and vT's storage when it exists and are temporaries otherwise; the
+      // owned_* buffers are non-empty only in the temporary case, matching the old conditional
+      // cudaFree on `dtype() == Type.Void`.
       void *UMem = nullptr, *vTMem = nullptr;
+      utils_internal::DeviceBuffer<data_type> owned_UMem, owned_vTMem;
       if (U->data()) {
         UMem = U->data();
       } else {
-        if (jobz == CUSOLVER_EIG_MODE_VECTOR)
-          checkCudaErrors(cudaMalloc(&UMem, max * max * sizeof(data_type)));
+        if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
+          owned_UMem = utils_internal::DeviceBuffer<data_type>(max * max);
+          UMem = owned_UMem.get();
+        }
       }
       if (vT->data()) {
         vTMem = vT->data();
       } else {
-        if (jobz == CUSOLVER_EIG_MODE_VECTOR)
-          checkCudaErrors(cudaMalloc(&vTMem, max * max * sizeof(data_type)));
+        if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
+          owned_vTMem = utils_internal::DeviceBuffer<data_type>(max * max);
+          vTMem = owned_vTMem.get();
+        }
       }
-      gesvdjInfo_t gesvdj_params = nullptr;
       // const double tol = 1.e-14;
       // const int max_sweeps = 100;
-      checkCudaErrors(cusolverDnCreateGesvdjInfo(&gesvdj_params));
+      utils_internal::GesvdjInfo gesvdj_params;
       // checkCudaErrors(cusolverDnXgesvdjSetTolerance(gesvdj_params, tol));
       // checkCudaErrors(cusolverDnXgesvdjSetMaxSweeps(gesvdj_params, max_sweeps));
 
       cytnx_int32 lwork = 0;
-      void *d_work = nullptr;
       checkCudaErrors(cusolverDnZgesvdj_bufferSize(
-        cusolverH, jobz, econ, N, M, (d_data_type *)Mij, ldA, (cytnx_double *)S->data(),
-        (d_data_type *)vTMem, ldu, (d_data_type *)UMem, ldvT, &lwork, gesvdj_params));
+        cusolverH.get(), jobz, econ, N, M, (d_data_type *)Mij.get(), ldA, (cytnx_double *)S->data(),
+        (d_data_type *)vTMem, ldu, (d_data_type *)UMem, ldvT, &lwork, gesvdj_params.get()));
 
-      checkCudaErrors(cudaMalloc(reinterpret_cast<void **>(&d_work), sizeof(data_type) * lwork));
+      utils_internal::DeviceBuffer<data_type> d_work(lwork);
 
-      cytnx_int32 *devinfo;
-      checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
-      checkCudaErrors(cudaMemset(devinfo, 0, sizeof(cytnx_int32)));
+      utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
+      checkCudaErrors(cudaMemset(devinfo.get(), 0, sizeof(cytnx_int32)));
 
-      checkCudaErrors(cusolverDnZgesvdj(cusolverH, jobz, econ, N, M, (d_data_type *)Mij, ldA,
-                                        (cytnx_double *)S->data(), (d_data_type *)vTMem, ldu,
-                                        (d_data_type *)UMem, ldvT, (d_data_type *)d_work, lwork,
-                                        devinfo, gesvdj_params));
+      checkCudaErrors(cusolverDnZgesvdj(cusolverH.get(), jobz, econ, N, M, (d_data_type *)Mij.get(),
+                                        ldA, (cytnx_double *)S->data(), (d_data_type *)vTMem, ldu,
+                                        (d_data_type *)UMem, ldvT, (d_data_type *)d_work.get(),
+                                        lwork, devinfo.get(), gesvdj_params.get()));
       if (U->data() and jobz == CUSOLVER_EIG_MODE_VECTOR) {
         U->Move_memory_({(cytnx_uint64)min, (cytnx_uint64)M}, {1, 0}, {1, 0});
         linalg_internal::cuConj_inplace_internal_cd(U, M * min);
@@ -77,22 +83,12 @@ namespace cytnx {
 
       cytnx_int32 info;
       // get info
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_error_msg(
         info != 0, "%s %d %s", "Error in cuBlas function 'cusolverDnZgesvdj': cuBlas INFO = ", info,
         "If info>0, possibly svd not converge, if info<0, see cusolver manual for more info.");
-
-      checkCudaErrors(cudaFree(d_work));
-      checkCudaErrors(cudaFree(Mij));
-      if (UMem != nullptr and U->dtype() == Type.Void) {
-        checkCudaErrors(cudaFree(UMem));
-      }
-      if (vTMem != nullptr and vT->dtype() == Type.Void) {
-        checkCudaErrors(cudaFree(vTMem));
-      }
-      checkCudaErrors(cudaFree(devinfo));
-      checkCudaErrors(cusolverDnDestroy(cusolverH));
     }
     void cuGeSvd_internal_cf(const boost::intrusive_ptr<Storage_base> &in,
                              boost::intrusive_ptr<Storage_base> &U,
@@ -110,54 +106,59 @@ namespace cytnx {
       cytnx_int32 econ = 1; /* i.e. 'S' in gesvd  */
 
       // create handles:
-      cusolverDnHandle_t cusolverH = nullptr;
-      checkCudaErrors(cusolverDnCreate(&cusolverH));
+      // Scoped resources (#1145, #1146): the info check below throws, so ownership -- not the
+      // cleanup block that used to sit at the tail of this function -- is what prevents a leak.
+      utils_internal::CusolverDnHandle cusolverH;
 
-      cuDoubleComplex *Mij;
-      checkCudaErrors(cudaMalloc((void **)&Mij, M * N * sizeof(data_type)));
+      utils_internal::DeviceBuffer<data_type> Mij(M * N);
       checkCudaErrors(
-        cudaMemcpy(Mij, in->data(), sizeof(data_type) * M * N, cudaMemcpyDeviceToDevice));
+        cudaMemcpy(Mij.get(), in->data(), sizeof(data_type) * M * N, cudaMemcpyDeviceToDevice));
 
       cytnx_int64 min = std::min(M, N);
       cytnx_int64 max = std::max(M, N);
       cytnx_int64 ldA = N, ldu = N, ldvT = M;
 
+      // UMem/vTMem alias U's and vT's storage when it exists and are temporaries otherwise; the
+      // owned_* buffers are non-empty only in the temporary case, matching the old conditional
+      // cudaFree on `dtype() == Type.Void`.
       void *UMem = nullptr, *vTMem = nullptr;
+      utils_internal::DeviceBuffer<data_type> owned_UMem, owned_vTMem;
       if (U->data()) {
         UMem = U->data();
       } else {
-        if (jobz == CUSOLVER_EIG_MODE_VECTOR)
-          checkCudaErrors(cudaMalloc(&UMem, max * max * sizeof(data_type)));
+        if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
+          owned_UMem = utils_internal::DeviceBuffer<data_type>(max * max);
+          UMem = owned_UMem.get();
+        }
       }
       if (vT->data()) {
         vTMem = vT->data();
       } else {
-        if (jobz == CUSOLVER_EIG_MODE_VECTOR)
-          checkCudaErrors(cudaMalloc(&vTMem, max * max * sizeof(data_type)));
+        if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
+          owned_vTMem = utils_internal::DeviceBuffer<data_type>(max * max);
+          vTMem = owned_vTMem.get();
+        }
       }
-      gesvdjInfo_t gesvdj_params = nullptr;
       // const double tol = 1.e-14;
       // const int max_sweeps = 100;
-      checkCudaErrors(cusolverDnCreateGesvdjInfo(&gesvdj_params));
+      utils_internal::GesvdjInfo gesvdj_params;
       // checkCudaErrors(cusolverDnXgesvdjSetTolerance(gesvdj_params, tol));
       // checkCudaErrors(cusolverDnXgesvdjSetMaxSweeps(gesvdj_params, max_sweeps));
 
       cytnx_int32 lwork = 0;
-      void *d_work = nullptr;
       checkCudaErrors(cusolverDnCgesvdj_bufferSize(
-        cusolverH, jobz, econ, N, M, (d_data_type *)Mij, ldA, (cytnx_float *)S->data(),
-        (d_data_type *)vTMem, ldu, (d_data_type *)UMem, ldvT, &lwork, gesvdj_params));
+        cusolverH.get(), jobz, econ, N, M, (d_data_type *)Mij.get(), ldA, (cytnx_float *)S->data(),
+        (d_data_type *)vTMem, ldu, (d_data_type *)UMem, ldvT, &lwork, gesvdj_params.get()));
 
-      checkCudaErrors(cudaMalloc(reinterpret_cast<void **>(&d_work), sizeof(data_type) * lwork));
+      utils_internal::DeviceBuffer<data_type> d_work(lwork);
 
-      cytnx_int32 *devinfo;
-      checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
-      checkCudaErrors(cudaMemset(devinfo, 0, sizeof(cytnx_int32)));
+      utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
+      checkCudaErrors(cudaMemset(devinfo.get(), 0, sizeof(cytnx_int32)));
 
-      checkCudaErrors(cusolverDnCgesvdj(cusolverH, jobz, econ, N, M, (d_data_type *)Mij, ldA,
-                                        (cytnx_float *)S->data(), (d_data_type *)vTMem, ldu,
-                                        (d_data_type *)UMem, ldvT, (d_data_type *)d_work, lwork,
-                                        devinfo, gesvdj_params));
+      checkCudaErrors(cusolverDnCgesvdj(cusolverH.get(), jobz, econ, N, M, (d_data_type *)Mij.get(),
+                                        ldA, (cytnx_float *)S->data(), (d_data_type *)vTMem, ldu,
+                                        (d_data_type *)UMem, ldvT, (d_data_type *)d_work.get(),
+                                        lwork, devinfo.get(), gesvdj_params.get()));
       if (U->data() and jobz == CUSOLVER_EIG_MODE_VECTOR) {
         U->Move_memory_({(cytnx_uint64)min, (cytnx_uint64)M}, {1, 0}, {1, 0});
         linalg_internal::cuConj_inplace_internal_cf(U, M * min);
@@ -165,22 +166,12 @@ namespace cytnx {
 
       cytnx_int32 info;
       // get info
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_error_msg(
         info != 0, "%s %d %s", "Error in cuBlas function 'cusolverDnCgesvdj': cuBlas INFO = ", info,
         "If info>0, possibly svd not converge, if info<0, see cusolver manual for more info.");
-
-      checkCudaErrors(cudaFree(d_work));
-      checkCudaErrors(cudaFree(Mij));
-      if (UMem != nullptr and U->dtype() == Type.Void) {
-        checkCudaErrors(cudaFree(UMem));
-      }
-      if (vTMem != nullptr and vT->dtype() == Type.Void) {
-        checkCudaErrors(cudaFree(vTMem));
-      }
-      checkCudaErrors(cudaFree(devinfo));
-      checkCudaErrors(cusolverDnDestroy(cusolverH));
     }
     void cuGeSvd_internal_d(const boost::intrusive_ptr<Storage_base> &in,
                             boost::intrusive_ptr<Storage_base> &U,
@@ -197,76 +188,71 @@ namespace cytnx {
       cytnx_int32 econ = 1; /* i.e. 'S' in gesvd  */
 
       // create handles:
-      cusolverDnHandle_t cusolverH = nullptr;
-      checkCudaErrors(cusolverDnCreate(&cusolverH));
+      // Scoped resources (#1145, #1146): the info check below throws, so ownership -- not the
+      // cleanup block that used to sit at the tail of this function -- is what prevents a leak.
+      utils_internal::CusolverDnHandle cusolverH;
 
-      cuDoubleComplex *Mij;
-      checkCudaErrors(cudaMalloc((void **)&Mij, M * N * sizeof(data_type)));
+      utils_internal::DeviceBuffer<data_type> Mij(M * N);
       checkCudaErrors(
-        cudaMemcpy(Mij, in->data(), sizeof(data_type) * M * N, cudaMemcpyDeviceToDevice));
+        cudaMemcpy(Mij.get(), in->data(), sizeof(data_type) * M * N, cudaMemcpyDeviceToDevice));
 
       cytnx_int64 min = std::min(M, N);
       cytnx_int64 max = std::max(M, N);
       cytnx_int64 ldA = N, ldu = N, ldvT = M;
 
+      // UMem/vTMem alias U's and vT's storage when it exists and are temporaries otherwise; the
+      // owned_* buffers are non-empty only in the temporary case, matching the old conditional
+      // cudaFree on `dtype() == Type.Void`.
       void *UMem = nullptr, *vTMem = nullptr;
+      utils_internal::DeviceBuffer<data_type> owned_UMem, owned_vTMem;
       if (U->data()) {
         UMem = U->data();
       } else {
-        if (jobz == CUSOLVER_EIG_MODE_VECTOR)
-          checkCudaErrors(cudaMalloc(&UMem, max * max * sizeof(data_type)));
+        if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
+          owned_UMem = utils_internal::DeviceBuffer<data_type>(max * max);
+          UMem = owned_UMem.get();
+        }
       }
       if (vT->data()) {
         vTMem = vT->data();
       } else {
-        if (jobz == CUSOLVER_EIG_MODE_VECTOR)
-          checkCudaErrors(cudaMalloc(&vTMem, max * max * sizeof(data_type)));
+        if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
+          owned_vTMem = utils_internal::DeviceBuffer<data_type>(max * max);
+          vTMem = owned_vTMem.get();
+        }
       }
-      gesvdjInfo_t gesvdj_params = nullptr;
       // const double tol = 1.e-14;
       // const int max_sweeps = 100;
-      checkCudaErrors(cusolverDnCreateGesvdjInfo(&gesvdj_params));
+      utils_internal::GesvdjInfo gesvdj_params;
       // checkCudaErrors(cusolverDnXgesvdjSetTolerance(gesvdj_params, tol));
       // checkCudaErrors(cusolverDnXgesvdjSetMaxSweeps(gesvdj_params, max_sweeps));
 
       cytnx_int32 lwork = 0;
-      void *d_work = nullptr;
       checkCudaErrors(cusolverDnDgesvdj_bufferSize(
-        cusolverH, jobz, econ, N, M, (data_type *)Mij, ldA, (data_type *)S->data(),
-        (data_type *)vTMem, ldu, (data_type *)UMem, ldvT, &lwork, gesvdj_params));
+        cusolverH.get(), jobz, econ, N, M, (data_type *)Mij.get(), ldA, (data_type *)S->data(),
+        (data_type *)vTMem, ldu, (data_type *)UMem, ldvT, &lwork, gesvdj_params.get()));
 
-      checkCudaErrors(cudaMalloc(reinterpret_cast<void **>(&d_work), sizeof(data_type) * lwork));
+      utils_internal::DeviceBuffer<data_type> d_work(lwork);
 
-      cytnx_int32 *devinfo;
-      checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
-      checkCudaErrors(cudaMemset(devinfo, 0, sizeof(cytnx_int32)));
+      utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
+      checkCudaErrors(cudaMemset(devinfo.get(), 0, sizeof(cytnx_int32)));
 
-      checkCudaErrors(cusolverDnDgesvdj(cusolverH, jobz, econ, N, M, (data_type *)Mij, ldA,
-                                        (data_type *)S->data(), (data_type *)vTMem, ldu,
-                                        (data_type *)UMem, ldvT, (data_type *)d_work, lwork,
-                                        devinfo, gesvdj_params));
+      checkCudaErrors(cusolverDnDgesvdj(cusolverH.get(), jobz, econ, N, M, (data_type *)Mij.get(),
+                                        ldA, (data_type *)S->data(), (data_type *)vTMem, ldu,
+                                        (data_type *)UMem, ldvT, (data_type *)d_work.get(), lwork,
+                                        devinfo.get(), gesvdj_params.get()));
       if (U->data() and jobz == CUSOLVER_EIG_MODE_VECTOR) {
         U->Move_memory_({(cytnx_uint64)min, (cytnx_uint64)M}, {1, 0}, {1, 0});
       }
 
       cytnx_int32 info;
       // get info
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_error_msg(
         info != 0, "%s %d %s", "Error in cuBlas function 'cusolverDnDgesvdj': cuBlas INFO = ", info,
         "If info>0, possibly svd not converge, if info<0, see cusolver manual for more info.");
-
-      checkCudaErrors(cudaFree(d_work));
-      checkCudaErrors(cudaFree(Mij));
-      if (UMem != nullptr and U->dtype() == Type.Void) {
-        checkCudaErrors(cudaFree(UMem));
-      }
-      if (vTMem != nullptr and vT->dtype() == Type.Void) {
-        checkCudaErrors(cudaFree(vTMem));
-      }
-      checkCudaErrors(cudaFree(devinfo));
-      checkCudaErrors(cusolverDnDestroy(cusolverH));
     }
     void cuGeSvd_internal_f(const boost::intrusive_ptr<Storage_base> &in,
                             boost::intrusive_ptr<Storage_base> &U,
@@ -283,76 +269,71 @@ namespace cytnx {
       cytnx_int32 econ = 1; /* i.e. 'S' in gesvd  */
 
       // create handles:
-      cusolverDnHandle_t cusolverH = nullptr;
-      checkCudaErrors(cusolverDnCreate(&cusolverH));
+      // Scoped resources (#1145, #1146): the info check below throws, so ownership -- not the
+      // cleanup block that used to sit at the tail of this function -- is what prevents a leak.
+      utils_internal::CusolverDnHandle cusolverH;
 
-      cuDoubleComplex *Mij;
-      checkCudaErrors(cudaMalloc((void **)&Mij, M * N * sizeof(data_type)));
+      utils_internal::DeviceBuffer<data_type> Mij(M * N);
       checkCudaErrors(
-        cudaMemcpy(Mij, in->data(), sizeof(data_type) * M * N, cudaMemcpyDeviceToDevice));
+        cudaMemcpy(Mij.get(), in->data(), sizeof(data_type) * M * N, cudaMemcpyDeviceToDevice));
 
       cytnx_int64 min = std::min(M, N);
       cytnx_int64 max = std::max(M, N);
       cytnx_int64 ldA = N, ldu = N, ldvT = M;
 
+      // UMem/vTMem alias U's and vT's storage when it exists and are temporaries otherwise; the
+      // owned_* buffers are non-empty only in the temporary case, matching the old conditional
+      // cudaFree on `dtype() == Type.Void`.
       void *UMem = nullptr, *vTMem = nullptr;
+      utils_internal::DeviceBuffer<data_type> owned_UMem, owned_vTMem;
       if (U->data()) {
         UMem = U->data();
       } else {
-        if (jobz == CUSOLVER_EIG_MODE_VECTOR)
-          checkCudaErrors(cudaMalloc(&UMem, max * max * sizeof(data_type)));
+        if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
+          owned_UMem = utils_internal::DeviceBuffer<data_type>(max * max);
+          UMem = owned_UMem.get();
+        }
       }
       if (vT->data()) {
         vTMem = vT->data();
       } else {
-        if (jobz == CUSOLVER_EIG_MODE_VECTOR)
-          checkCudaErrors(cudaMalloc(&vTMem, max * max * sizeof(data_type)));
+        if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
+          owned_vTMem = utils_internal::DeviceBuffer<data_type>(max * max);
+          vTMem = owned_vTMem.get();
+        }
       }
-      gesvdjInfo_t gesvdj_params = nullptr;
       // const double tol = 1.e-14;
       // const int max_sweeps = 100;
-      checkCudaErrors(cusolverDnCreateGesvdjInfo(&gesvdj_params));
+      utils_internal::GesvdjInfo gesvdj_params;
       // checkCudaErrors(cusolverDnXgesvdjSetTolerance(gesvdj_params, tol));
       // checkCudaErrors(cusolverDnXgesvdjSetMaxSweeps(gesvdj_params, max_sweeps));
 
       cytnx_int32 lwork = 0;
-      void *d_work = nullptr;
       checkCudaErrors(cusolverDnSgesvdj_bufferSize(
-        cusolverH, jobz, econ, N, M, (data_type *)Mij, ldA, (data_type *)S->data(),
-        (data_type *)vTMem, ldu, (data_type *)UMem, ldvT, &lwork, gesvdj_params));
+        cusolverH.get(), jobz, econ, N, M, (data_type *)Mij.get(), ldA, (data_type *)S->data(),
+        (data_type *)vTMem, ldu, (data_type *)UMem, ldvT, &lwork, gesvdj_params.get()));
 
-      checkCudaErrors(cudaMalloc(reinterpret_cast<void **>(&d_work), sizeof(data_type) * lwork));
+      utils_internal::DeviceBuffer<data_type> d_work(lwork);
 
-      cytnx_int32 *devinfo;
-      checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
-      checkCudaErrors(cudaMemset(devinfo, 0, sizeof(cytnx_int32)));
+      utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
+      checkCudaErrors(cudaMemset(devinfo.get(), 0, sizeof(cytnx_int32)));
 
-      checkCudaErrors(cusolverDnSgesvdj(cusolverH, jobz, econ, N, M, (data_type *)Mij, ldA,
-                                        (data_type *)S->data(), (data_type *)vTMem, ldu,
-                                        (data_type *)UMem, ldvT, (data_type *)d_work, lwork,
-                                        devinfo, gesvdj_params));
+      checkCudaErrors(cusolverDnSgesvdj(cusolverH.get(), jobz, econ, N, M, (data_type *)Mij.get(),
+                                        ldA, (data_type *)S->data(), (data_type *)vTMem, ldu,
+                                        (data_type *)UMem, ldvT, (data_type *)d_work.get(), lwork,
+                                        devinfo.get(), gesvdj_params.get()));
       if (U->data() and jobz == CUSOLVER_EIG_MODE_VECTOR) {
         U->Move_memory_({(cytnx_uint64)min, (cytnx_uint64)M}, {1, 0}, {1, 0});
       }
 
       cytnx_int32 info;
       // get info
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_error_msg(
         info != 0, "%s %d %s", "Error in cuBlas function 'cusolverDnSgesvdj': cuBlas INFO = ", info,
         "If info>0, possibly svd not converge, if info<0, see cusolver manual for more info.");
-
-      checkCudaErrors(cudaFree(d_work));
-      checkCudaErrors(cudaFree(Mij));
-      if (UMem != nullptr and U->dtype() == Type.Void) {
-        checkCudaErrors(cudaFree(UMem));
-      }
-      if (vTMem != nullptr and vT->dtype() == Type.Void) {
-        checkCudaErrors(cudaFree(vTMem));
-      }
-      checkCudaErrors(cudaFree(devinfo));
-      checkCudaErrors(cusolverDnDestroy(cusolverH));
     }
 
   }  // namespace linalg_internal

--- a/src/backend/linalg_internal_gpu/cuGeSvd_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuGeSvd_internal.cu
@@ -39,21 +39,21 @@ namespace cytnx {
       // owned_* buffers are non-empty only in the temporary case, matching the old conditional
       // cudaFree on `dtype() == Type.Void`.
       void *UMem = nullptr, *vTMem = nullptr;
-      utils_internal::DeviceBuffer<data_type> owned_UMem, owned_vTMem;
+      utils_internal::DeviceBuffer<data_type> owned_u_mem, owned_vt_mem;
       if (U->data()) {
         UMem = U->data();
       } else {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
-          owned_UMem = utils_internal::DeviceBuffer<data_type>(max * max);
-          UMem = owned_UMem.get();
+          owned_u_mem = utils_internal::DeviceBuffer<data_type>(max * max);
+          UMem = owned_u_mem.get();
         }
       }
       if (vT->data()) {
         vTMem = vT->data();
       } else {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
-          owned_vTMem = utils_internal::DeviceBuffer<data_type>(max * max);
-          vTMem = owned_vTMem.get();
+          owned_vt_mem = utils_internal::DeviceBuffer<data_type>(max * max);
+          vTMem = owned_vt_mem.get();
         }
       }
       // const double tol = 1.e-14;
@@ -122,21 +122,21 @@ namespace cytnx {
       // owned_* buffers are non-empty only in the temporary case, matching the old conditional
       // cudaFree on `dtype() == Type.Void`.
       void *UMem = nullptr, *vTMem = nullptr;
-      utils_internal::DeviceBuffer<data_type> owned_UMem, owned_vTMem;
+      utils_internal::DeviceBuffer<data_type> owned_u_mem, owned_vt_mem;
       if (U->data()) {
         UMem = U->data();
       } else {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
-          owned_UMem = utils_internal::DeviceBuffer<data_type>(max * max);
-          UMem = owned_UMem.get();
+          owned_u_mem = utils_internal::DeviceBuffer<data_type>(max * max);
+          UMem = owned_u_mem.get();
         }
       }
       if (vT->data()) {
         vTMem = vT->data();
       } else {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
-          owned_vTMem = utils_internal::DeviceBuffer<data_type>(max * max);
-          vTMem = owned_vTMem.get();
+          owned_vt_mem = utils_internal::DeviceBuffer<data_type>(max * max);
+          vTMem = owned_vt_mem.get();
         }
       }
       // const double tol = 1.e-14;
@@ -204,21 +204,21 @@ namespace cytnx {
       // owned_* buffers are non-empty only in the temporary case, matching the old conditional
       // cudaFree on `dtype() == Type.Void`.
       void *UMem = nullptr, *vTMem = nullptr;
-      utils_internal::DeviceBuffer<data_type> owned_UMem, owned_vTMem;
+      utils_internal::DeviceBuffer<data_type> owned_u_mem, owned_vt_mem;
       if (U->data()) {
         UMem = U->data();
       } else {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
-          owned_UMem = utils_internal::DeviceBuffer<data_type>(max * max);
-          UMem = owned_UMem.get();
+          owned_u_mem = utils_internal::DeviceBuffer<data_type>(max * max);
+          UMem = owned_u_mem.get();
         }
       }
       if (vT->data()) {
         vTMem = vT->data();
       } else {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
-          owned_vTMem = utils_internal::DeviceBuffer<data_type>(max * max);
-          vTMem = owned_vTMem.get();
+          owned_vt_mem = utils_internal::DeviceBuffer<data_type>(max * max);
+          vTMem = owned_vt_mem.get();
         }
       }
       // const double tol = 1.e-14;
@@ -285,21 +285,21 @@ namespace cytnx {
       // owned_* buffers are non-empty only in the temporary case, matching the old conditional
       // cudaFree on `dtype() == Type.Void`.
       void *UMem = nullptr, *vTMem = nullptr;
-      utils_internal::DeviceBuffer<data_type> owned_UMem, owned_vTMem;
+      utils_internal::DeviceBuffer<data_type> owned_u_mem, owned_vt_mem;
       if (U->data()) {
         UMem = U->data();
       } else {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
-          owned_UMem = utils_internal::DeviceBuffer<data_type>(max * max);
-          UMem = owned_UMem.get();
+          owned_u_mem = utils_internal::DeviceBuffer<data_type>(max * max);
+          UMem = owned_u_mem.get();
         }
       }
       if (vT->data()) {
         vTMem = vT->data();
       } else {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
-          owned_vTMem = utils_internal::DeviceBuffer<data_type>(max * max);
-          vTMem = owned_vTMem.get();
+          owned_vt_mem = utils_internal::DeviceBuffer<data_type>(max * max);
+          vTMem = owned_vt_mem.get();
         }
       }
       // const double tol = 1.e-14;

--- a/src/backend/linalg_internal_gpu/cuInvM_inplace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuInvM_inplace_internal.cu
@@ -2,212 +2,177 @@
 #include "cytnx_error.hpp"
 #include "Type.hpp"
 #include "backend/lapack_wrapper.hpp"
+#include "backend/utils_internal_gpu/cuScopedResource_gpu.hpp"
+
+#include <vector>
 
 namespace cytnx {
   namespace linalg_internal {
 
     void cuInvM_inplace_internal_d(boost::intrusive_ptr<Storage_base> &ten, const cytnx_int64 &L) {
-      // create handles:
-      cusolverDnHandle_t cusolverH = nullptr;
-      checkCudaErrors(cusolverDnCreate(&cusolverH));
+      // Scoped resources (#1146): the info checks below throw, so ownership -- not a cleanup block
+      // at the tail of the function -- is what keeps these from leaking.
+      utils_internal::CusolverDnHandle cusolverH;
 
-      cytnx_int32 *ipiv;
       cytnx_int32 info;
       cytnx_int32 lwork = 0;
-      cytnx_double *d_work = nullptr;
-      cytnx_int32 *devinfo;
-      checkCudaErrors(cudaMalloc((void **)&ipiv, (L + 1) * sizeof(cytnx_int32)));
-      checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
+      utils_internal::DeviceBuffer<cytnx_int32> ipiv(L + 1);
+      utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
       // trf:
       checkCudaErrors(
-        cusolverDnDgetrf_bufferSize(cusolverH, L, L, (cytnx_double *)ten->data(), L, &lwork));
-      checkCudaErrors(cudaMalloc((void **)&d_work, sizeof(cytnx_double) * lwork));
+        cusolverDnDgetrf_bufferSize(cusolverH.get(), L, L, (cytnx_double *)ten->data(), L, &lwork));
+      utils_internal::DeviceBuffer<cytnx_double> d_work(lwork);
 
+      checkCudaErrors(cusolverDnDgetrf(cusolverH.get(), L, L, (cytnx_double *)ten->data(), L,
+                                       d_work.get(), ipiv.get(), devinfo.get()));
       checkCudaErrors(
-        cusolverDnDgetrf(cusolverH, L, L, (cytnx_double *)ten->data(), L, d_work, ipiv, devinfo));
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_error_msg(info != 0, "%s %d",
                       "ERROR in cuSolver function 'cusolverDnDgetrf': cuBlas INFO = ", info);
 
       // trs AX = B with B = I
-      lwork = 0;
-      cytnx_double *d_I;
-      checkCudaErrors(cudaMalloc((void **)&d_I, sizeof(cytnx_double) * L * L));
-      cytnx_double *h_I = (cytnx_double *)calloc(L * L, sizeof(cytnx_double));
-      for (auto i = 0; i < L; i++) h_I[i * L + i] = 1;
+      utils_internal::DeviceBuffer<cytnx_double> d_I(L * L);
+      std::vector<cytnx_double> h_I(L * L, 0);
+      for (cytnx_int64 i = 0; i < L; i++) h_I[i * L + i] = 1;
 
-      checkCudaErrors(cudaMemcpy(d_I, h_I, sizeof(cytnx_double) * L * L, cudaMemcpyHostToDevice));
+      checkCudaErrors(
+        cudaMemcpy(d_I.get(), h_I.data(), sizeof(cytnx_double) * L * L, cudaMemcpyHostToDevice));
 
-      checkCudaErrors(cusolverDnDgetrs(cusolverH, CUBLAS_OP_N, L, L, (cytnx_double *)ten->data(), L,
-                                       ipiv, d_I, L, devinfo));
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(cusolverDnDgetrs(cusolverH.get(), CUBLAS_OP_N, L, L,
+                                       (cytnx_double *)ten->data(), L, ipiv.get(), d_I.get(), L,
+                                       devinfo.get()));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_error_msg(info != 0, "%s %d",
                       "ERROR in cuSolver function 'cusolverDnDgetrs': cuBlas INFO = ", info);
 
       checkCudaErrors(
-        cudaMemcpy(ten->data(), d_I, sizeof(cytnx_double) * L * L, cudaMemcpyDeviceToDevice));
-
-      cudaFree(d_I);
-      cudaFree(d_work);
-      cudaFree(devinfo);
-      cudaFree(ipiv);
-      free(h_I);
-      cusolverDnDestroy(cusolverH);
+        cudaMemcpy(ten->data(), d_I.get(), sizeof(cytnx_double) * L * L, cudaMemcpyDeviceToDevice));
     }
-    void cuInvM_inplace_internal_f(boost::intrusive_ptr<Storage_base> &ten, const cytnx_int64 &L) {
-      // create handles:
-      cusolverDnHandle_t cusolverH = nullptr;
-      checkCudaErrors(cusolverDnCreate(&cusolverH));
 
-      cytnx_int32 *ipiv;
+    void cuInvM_inplace_internal_f(boost::intrusive_ptr<Storage_base> &ten, const cytnx_int64 &L) {
+      utils_internal::CusolverDnHandle cusolverH;
+
       cytnx_int32 info;
       cytnx_int32 lwork = 0;
-      cytnx_float *d_work = nullptr;
-      cytnx_int32 *devinfo;
-      checkCudaErrors(cudaMalloc((void **)&ipiv, (L + 1) * sizeof(cytnx_int32)));
-      checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
+      utils_internal::DeviceBuffer<cytnx_int32> ipiv(L + 1);
+      utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
       // trf:
       checkCudaErrors(
-        cusolverDnSgetrf_bufferSize(cusolverH, L, L, (cytnx_float *)ten->data(), L, &lwork));
-      checkCudaErrors(cudaMalloc((void **)&d_work, sizeof(cytnx_float) * lwork));
+        cusolverDnSgetrf_bufferSize(cusolverH.get(), L, L, (cytnx_float *)ten->data(), L, &lwork));
+      utils_internal::DeviceBuffer<cytnx_float> d_work(lwork);
 
+      checkCudaErrors(cusolverDnSgetrf(cusolverH.get(), L, L, (cytnx_float *)ten->data(), L,
+                                       d_work.get(), ipiv.get(), devinfo.get()));
       checkCudaErrors(
-        cusolverDnSgetrf(cusolverH, L, L, (cytnx_float *)ten->data(), L, d_work, ipiv, devinfo));
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_error_msg(info != 0, "%s %d",
                       "ERROR in cuSolver function 'cusolverDnSgetrf': cuBlas INFO = ", info);
 
       // trs AX = B with B = I
-      lwork = 0;
-      cytnx_float *d_I;
-      checkCudaErrors(cudaMalloc((void **)&d_I, sizeof(cytnx_float) * L * L));
-      cytnx_float *h_I = (cytnx_float *)calloc(L * L, sizeof(cytnx_float));
-      for (auto i = 0; i < L; i++) h_I[i * L + i] = 1;
+      utils_internal::DeviceBuffer<cytnx_float> d_I(L * L);
+      std::vector<cytnx_float> h_I(L * L, 0);
+      for (cytnx_int64 i = 0; i < L; i++) h_I[i * L + i] = 1;
 
-      checkCudaErrors(cudaMemcpy(d_I, h_I, sizeof(cytnx_float) * L * L, cudaMemcpyHostToDevice));
+      checkCudaErrors(
+        cudaMemcpy(d_I.get(), h_I.data(), sizeof(cytnx_float) * L * L, cudaMemcpyHostToDevice));
 
-      checkCudaErrors(cusolverDnSgetrs(cusolverH, CUBLAS_OP_N, L, L, (cytnx_float *)ten->data(), L,
-                                       ipiv, d_I, L, devinfo));
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(cusolverDnSgetrs(cusolverH.get(), CUBLAS_OP_N, L, L,
+                                       (cytnx_float *)ten->data(), L, ipiv.get(), d_I.get(), L,
+                                       devinfo.get()));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_error_msg(info != 0, "%s %d",
                       "ERROR in cuSolver function 'cusolverDnSgetrs': cuBlas INFO = ", info);
 
       checkCudaErrors(
-        cudaMemcpy(ten->data(), d_I, sizeof(cytnx_float) * L * L, cudaMemcpyDeviceToDevice));
-
-      cudaFree(d_I);
-      cudaFree(d_work);
-      cudaFree(devinfo);
-      cudaFree(ipiv);
-      free(h_I);
-      cusolverDnDestroy(cusolverH);
+        cudaMemcpy(ten->data(), d_I.get(), sizeof(cytnx_float) * L * L, cudaMemcpyDeviceToDevice));
     }
-    void cuInvM_inplace_internal_cd(boost::intrusive_ptr<Storage_base> &ten, const cytnx_int64 &L) {
-      // create handles:
-      cusolverDnHandle_t cusolverH = nullptr;
-      checkCudaErrors(cusolverDnCreate(&cusolverH));
 
-      cytnx_int32 *ipiv;
+    void cuInvM_inplace_internal_cd(boost::intrusive_ptr<Storage_base> &ten, const cytnx_int64 &L) {
+      utils_internal::CusolverDnHandle cusolverH;
+
       cytnx_int32 info;
       cytnx_int32 lwork = 0;
-      cytnx_complex128 *d_work = nullptr;
-      cytnx_int32 *devinfo;
-      checkCudaErrors(cudaMalloc((void **)&ipiv, (L + 1) * sizeof(cytnx_int32)));
-      checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
+      utils_internal::DeviceBuffer<cytnx_int32> ipiv(L + 1);
+      utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
       // trf:
-      checkCudaErrors(
-        cusolverDnZgetrf_bufferSize(cusolverH, L, L, (cuDoubleComplex *)ten->data(), L, &lwork));
-      checkCudaErrors(cudaMalloc((void **)&d_work, sizeof(cytnx_complex128) * lwork));
+      checkCudaErrors(cusolverDnZgetrf_bufferSize(cusolverH.get(), L, L,
+                                                  (cuDoubleComplex *)ten->data(), L, &lwork));
+      utils_internal::DeviceBuffer<cytnx_complex128> d_work(lwork);
 
-      checkCudaErrors(cusolverDnZgetrf(cusolverH, L, L, (cuDoubleComplex *)ten->data(), L,
-                                       (cuDoubleComplex *)d_work, ipiv, devinfo));
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(cusolverDnZgetrf(cusolverH.get(), L, L, (cuDoubleComplex *)ten->data(), L,
+                                       (cuDoubleComplex *)d_work.get(), ipiv.get(), devinfo.get()));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_error_msg(info != 0, "%s %d",
                       "ERROR in cuSolver function 'cusolverDnZgetrf': cuBlas INFO = ", info);
 
       // trs AX = B with B = I
-      lwork = 0;
-      cytnx_complex128 *d_I;
-      checkCudaErrors(cudaMalloc((void **)&d_I, sizeof(cytnx_complex128) * L * L));
-      cytnx_complex128 *h_I = (cytnx_complex128 *)calloc(L * L, sizeof(cytnx_complex128));
-      for (auto i = 0; i < L; i++) h_I[i * L + i] = cytnx_complex128(1, 0);
+      utils_internal::DeviceBuffer<cytnx_complex128> d_I(L * L);
+      std::vector<cytnx_complex128> h_I(L * L, 0);
+      for (cytnx_int64 i = 0; i < L; i++) h_I[i * L + i] = cytnx_complex128(1, 0);
 
+      checkCudaErrors(cudaMemcpy(d_I.get(), h_I.data(), sizeof(cytnx_complex128) * L * L,
+                                 cudaMemcpyHostToDevice));
+
+      checkCudaErrors(cusolverDnZgetrs(cusolverH.get(), CUBLAS_OP_N, L, L,
+                                       (cuDoubleComplex *)ten->data(), L, ipiv.get(),
+                                       (cuDoubleComplex *)d_I.get(), L, devinfo.get()));
       checkCudaErrors(
-        cudaMemcpy(d_I, h_I, sizeof(cytnx_complex128) * L * L, cudaMemcpyHostToDevice));
-
-      checkCudaErrors(cusolverDnZgetrs(cusolverH, CUBLAS_OP_N, L, L, (cuDoubleComplex *)ten->data(),
-                                       L, ipiv, (cuDoubleComplex *)d_I, L, devinfo));
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_error_msg(info != 0, "%s %d",
                       "ERROR in cuSolver function 'cusolverDnZgetrs': cuBlas INFO = ", info);
 
-      checkCudaErrors(
-        cudaMemcpy(ten->data(), d_I, sizeof(cytnx_complex128) * L * L, cudaMemcpyDeviceToDevice));
-
-      cudaFree(d_I);
-      cudaFree(d_work);
-      cudaFree(devinfo);
-      cudaFree(ipiv);
-      free(h_I);
-      cusolverDnDestroy(cusolverH);
+      checkCudaErrors(cudaMemcpy(ten->data(), d_I.get(), sizeof(cytnx_complex128) * L * L,
+                                 cudaMemcpyDeviceToDevice));
     }
 
     void cuInvM_inplace_internal_cf(boost::intrusive_ptr<Storage_base> &ten, const cytnx_int64 &L) {
-      // create handles:
-      cusolverDnHandle_t cusolverH = nullptr;
-      checkCudaErrors(cusolverDnCreate(&cusolverH));
+      utils_internal::CusolverDnHandle cusolverH;
 
-      cytnx_int32 *ipiv;
       cytnx_int32 info;
       cytnx_int32 lwork = 0;
-      cytnx_complex64 *d_work = nullptr;
-      cytnx_int32 *devinfo;
-      checkCudaErrors(cudaMalloc((void **)&ipiv, (L + 1) * sizeof(cytnx_int32)));
-      checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
+      utils_internal::DeviceBuffer<cytnx_int32> ipiv(L + 1);
+      utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
       // trf:
-      checkCudaErrors(
-        cusolverDnCgetrf_bufferSize(cusolverH, L, L, (cuFloatComplex *)ten->data(), L, &lwork));
-      checkCudaErrors(cudaMalloc((void **)&d_work, sizeof(cytnx_complex64) * lwork));
+      checkCudaErrors(cusolverDnCgetrf_bufferSize(cusolverH.get(), L, L,
+                                                  (cuFloatComplex *)ten->data(), L, &lwork));
+      utils_internal::DeviceBuffer<cytnx_complex64> d_work(lwork);
 
-      checkCudaErrors(cusolverDnCgetrf(cusolverH, L, L, (cuFloatComplex *)ten->data(), L,
-                                       (cuFloatComplex *)d_work, ipiv, devinfo));
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(cusolverDnCgetrf(cusolverH.get(), L, L, (cuFloatComplex *)ten->data(), L,
+                                       (cuFloatComplex *)d_work.get(), ipiv.get(), devinfo.get()));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_error_msg(info != 0, "%s %d",
                       "ERROR in cuSolver function 'cusolverDnCgetrf': cuBlas INFO = ", info);
 
       // trs AX = B with B = I
-      lwork = 0;
-      cytnx_complex64 *d_I;
-      checkCudaErrors(cudaMalloc((void **)&d_I, sizeof(cytnx_complex64) * L * L));
-      cytnx_complex64 *h_I = (cytnx_complex64 *)calloc(L * L, sizeof(cytnx_complex64));
-      for (auto i = 0; i < L; i++) h_I[i * L + i] = cytnx_complex64(1, 0);
+      utils_internal::DeviceBuffer<cytnx_complex64> d_I(L * L);
+      std::vector<cytnx_complex64> h_I(L * L, 0);
+      for (cytnx_int64 i = 0; i < L; i++) h_I[i * L + i] = cytnx_complex64(1, 0);
 
       checkCudaErrors(
-        cudaMemcpy(d_I, h_I, sizeof(cytnx_complex64) * L * L, cudaMemcpyHostToDevice));
+        cudaMemcpy(d_I.get(), h_I.data(), sizeof(cytnx_complex64) * L * L, cudaMemcpyHostToDevice));
 
-      checkCudaErrors(cusolverDnCgetrs(cusolverH, CUBLAS_OP_N, L, L, (cuFloatComplex *)ten->data(),
-                                       L, ipiv, (cuFloatComplex *)d_I, L, devinfo));
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(cusolverDnCgetrs(cusolverH.get(), CUBLAS_OP_N, L, L,
+                                       (cuFloatComplex *)ten->data(), L, ipiv.get(),
+                                       (cuFloatComplex *)d_I.get(), L, devinfo.get()));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_error_msg(info != 0, "%s %d",
                       "ERROR in cuSolver function 'cusolverDnCgetrs': cuBlas INFO = ", info);
 
-      checkCudaErrors(
-        cudaMemcpy(ten->data(), d_I, sizeof(cytnx_complex64) * L * L, cudaMemcpyDeviceToDevice));
-
-      cudaFree(d_I);
-      cudaFree(d_work);
-      cudaFree(devinfo);
-      cudaFree(ipiv);
-      free(h_I);
-      cusolverDnDestroy(cusolverH);
+      checkCudaErrors(cudaMemcpy(ten->data(), d_I.get(), sizeof(cytnx_complex64) * L * L,
+                                 cudaMemcpyDeviceToDevice));
     }
 
   }  // namespace linalg_internal

--- a/src/backend/linalg_internal_gpu/cuSvd_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuSvd_internal.cu
@@ -1,5 +1,8 @@
 #include "cuSvd_internal.hpp"
 #include "backend/linalg_internal_interface.hpp"
+#include "backend/utils_internal_gpu/cuScopedResource_gpu.hpp"
+
+#include <vector>
 
 namespace cytnx {
 
@@ -25,29 +28,37 @@ namespace cytnx {
       cytnx_int32 econ = 1; /* i.e. 'S' in gesvd  */
 
       // create handles:
-      cusolverDnHandle_t cusolverH = nullptr;
-      checkCudaErrors(cusolverDnCreate(&cusolverH));
+      // Scoped resources (#1146): the info check below throws, so ownership -- not the cleanup
+      // block that used to sit at the tail of this function -- is what prevents a leak.
+      utils_internal::CusolverDnHandle cusolverH;
 
-      cuDoubleComplex *Mij;
-      checkCudaErrors(cudaMalloc((void **)&Mij, M * N * sizeof(data_type)));
+      utils_internal::DeviceBuffer<data_type> Mij(M * N);
       checkCudaErrors(
-        cudaMemcpy(Mij, in->data(), sizeof(data_type) * M * N, cudaMemcpyDeviceToDevice));
+        cudaMemcpy(Mij.get(), in->data(), sizeof(data_type) * M * N, cudaMemcpyDeviceToDevice));
       cytnx_int64 min = std::min(M, N);
       cytnx_int64 max = std::max(M, N);
       cytnx_int64 ldA = N, ldu = N, ldvT = M;
 
+      // UMem/vTMem alias U's and vT's storage when it exists and are temporaries otherwise; the
+      // owned_* buffers are non-empty only in the temporary case, matching the old conditional
+      // cudaFree on `dtype() == Type.Void`.
       void *UMem = nullptr, *vTMem = nullptr;
+      utils_internal::DeviceBuffer<data_type> owned_UMem, owned_vTMem;
       if (U->data()) {
         UMem = U->data();
       } else {
-        if (jobz == CUSOLVER_EIG_MODE_VECTOR)
-          checkCudaErrors(cudaMalloc(&UMem, max * max * sizeof(data_type)));
+        if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
+          owned_UMem = utils_internal::DeviceBuffer<data_type>(max * max);
+          UMem = owned_UMem.get();
+        }
       }
       if (vT->data()) {
         vTMem = vT->data();
       } else {
-        if (jobz == CUSOLVER_EIG_MODE_VECTOR)
-          checkCudaErrors(cudaMalloc(&vTMem, max * max * sizeof(data_type)));
+        if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
+          owned_vTMem = utils_internal::DeviceBuffer<data_type>(max * max);
+          vTMem = owned_vTMem.get();
+        }
       }
 
       std::size_t d_lwork = 0; /* size of workspace */
@@ -56,9 +67,9 @@ namespace cytnx {
       void *h_work = nullptr; /* host workspace for getrf */
       cytnx_double h_err_sigma;
       // query working space :
-      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH, nullptr, /* params */
+      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH.get(), nullptr, /* params */
                                                    jobz, econ, N, M, cuda_data_type, /* dataTypeA */
-                                                   Mij, ldA, cuda_data_typeR, /* dataTypeS */
+                                                   Mij.get(), ldA, cuda_data_typeR, /* dataTypeS */
                                                    S->data(), cuda_data_type, /* dataTypeU */
                                                    vTMem, ldu, /* ldu */
                                                    cuda_data_type, /* dataTypeV */
@@ -67,35 +78,38 @@ namespace cytnx {
                                                    &d_lwork, &h_lwork));
 
       // allocate working space:
-      checkCudaErrors(cudaMalloc(reinterpret_cast<void **>(&d_work), sizeof(data_type) * d_lwork));
+      utils_internal::DeviceBuffer<data_type> owned_d_work(d_lwork);
+      d_work = owned_d_work.get();
+      std::vector<char> owned_h_work;
       if (0 < h_lwork) {
-        h_work = reinterpret_cast<void *>(malloc(h_lwork));
+        owned_h_work.resize(h_lwork);
+        h_work = owned_h_work.data();
         if (d_work == nullptr) {
           throw std::runtime_error("Error: d_work not allocated.");
         }
       }
 
-      cytnx_int32 *devinfo;
-      checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
-      checkCudaErrors(cudaMemset(devinfo, 0, sizeof(cytnx_int32)));
+      utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
+      checkCudaErrors(cudaMemset(devinfo.get(), 0, sizeof(cytnx_int32)));
 
       cytnx_int32 info;
       /// compute:
-      cusolverDnXgesvdp(cusolverH, nullptr, /* params */
+      cusolverDnXgesvdp(cusolverH.get(), nullptr, /* params */
                         jobz, econ, N, M, cuda_data_type, /* dataTypeA */
-                        Mij, ldA, cuda_data_typeR, /* dataTypeS */
+                        Mij.get(), ldA, cuda_data_typeR, /* dataTypeS */
                         S->data(), cuda_data_type, /* dataTypeU */
                         vTMem, ldu, /* ldu */
                         cuda_data_type, /* dataTypeV */
                         UMem, ldvT, /* ldv */
                         cuda_data_type, /* computeType */
-                        d_work, d_lwork, h_work, h_lwork, devinfo, &h_err_sigma);
+                        d_work, d_lwork, h_work, h_lwork, devinfo.get(), &h_err_sigma);
       if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
         U->Move_memory_({(cytnx_uint64)min, (cytnx_uint64)M}, {1, 0}, {1, 0});
         linalg_internal::cuConj_inplace_internal_cd(U, M * min);
       }
       // get info
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_warning_msg(
         h_err_sigma > 1e-12,
@@ -103,18 +117,6 @@ namespace cytnx {
         h_err_sigma);
       cytnx_error_msg(info != 0, "%s %d",
                       "Error in cuBlas function 'cusolverDnXgesvdp': cuBlas INFO = ", info);
-
-      checkCudaErrors(cudaFree(Mij));
-      if (UMem != nullptr and U->dtype() == Type.Void) {
-        checkCudaErrors(cudaFree(UMem));
-      }
-      if (vTMem != nullptr and vT->dtype() == Type.Void) {
-        checkCudaErrors(cudaFree(vTMem));
-      }
-      checkCudaErrors(cudaFree(devinfo));
-      checkCudaErrors(cudaFree(d_work));
-      free(h_work);
-      checkCudaErrors(cusolverDnDestroy(cusolverH));
     }
     void cuSvd_internal_cf(const boost::intrusive_ptr<Storage_base> &in,
                            boost::intrusive_ptr<Storage_base> &U,
@@ -135,30 +137,38 @@ namespace cytnx {
       cytnx_int32 econ = 1; /* i.e. 'S' in gesvd  */
 
       // create handles:
-      cusolverDnHandle_t cusolverH = nullptr;
-      checkCudaErrors(cusolverDnCreate(&cusolverH));
+      // Scoped resources (#1146): the info check below throws, so ownership -- not the cleanup
+      // block that used to sit at the tail of this function -- is what prevents a leak.
+      utils_internal::CusolverDnHandle cusolverH;
 
-      cuDoubleComplex *Mij;
-      checkCudaErrors(cudaMalloc((void **)&Mij, M * N * sizeof(data_type)));
+      utils_internal::DeviceBuffer<data_type> Mij(M * N);
       checkCudaErrors(
-        cudaMemcpy(Mij, in->data(), sizeof(data_type) * M * N, cudaMemcpyDeviceToDevice));
+        cudaMemcpy(Mij.get(), in->data(), sizeof(data_type) * M * N, cudaMemcpyDeviceToDevice));
 
       cytnx_int64 min = std::min(M, N);
       cytnx_int64 max = std::max(M, N);
       cytnx_int64 ldA = N, ldu = N, ldvT = M;
 
+      // UMem/vTMem alias U's and vT's storage when it exists and are temporaries otherwise; the
+      // owned_* buffers are non-empty only in the temporary case, matching the old conditional
+      // cudaFree on `dtype() == Type.Void`.
       void *UMem = nullptr, *vTMem = nullptr;
+      utils_internal::DeviceBuffer<data_type> owned_UMem, owned_vTMem;
       if (U->data()) {
         UMem = U->data();
       } else {
-        if (jobz == CUSOLVER_EIG_MODE_VECTOR)
-          checkCudaErrors(cudaMalloc(&UMem, max * max * sizeof(data_type)));
+        if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
+          owned_UMem = utils_internal::DeviceBuffer<data_type>(max * max);
+          UMem = owned_UMem.get();
+        }
       }
       if (vT->data()) {
         vTMem = vT->data();
       } else {
-        if (jobz == CUSOLVER_EIG_MODE_VECTOR)
-          checkCudaErrors(cudaMalloc(&vTMem, max * max * sizeof(data_type)));
+        if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
+          owned_vTMem = utils_internal::DeviceBuffer<data_type>(max * max);
+          vTMem = owned_vTMem.get();
+        }
       }
 
       std::size_t d_lwork = 0; /* size of workspace */
@@ -167,9 +177,9 @@ namespace cytnx {
       void *h_work = nullptr; /* host workspace for getrf */
       cytnx_double h_err_sigma;
       // query working space :
-      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH, nullptr, /* params */
+      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH.get(), nullptr, /* params */
                                                    jobz, econ, N, M, cuda_data_type, /* dataTypeA */
-                                                   Mij, ldA, cuda_data_typeR, /* dataTypeS */
+                                                   Mij.get(), ldA, cuda_data_typeR, /* dataTypeS */
                                                    S->data(), cuda_data_type, /* dataTypeU */
                                                    vTMem, ldu, /* ldu */
                                                    cuda_data_type, /* dataTypeV */
@@ -178,35 +188,38 @@ namespace cytnx {
                                                    &d_lwork, &h_lwork));
 
       // allocate working space:
-      checkCudaErrors(cudaMalloc(reinterpret_cast<void **>(&d_work), sizeof(data_type) * d_lwork));
+      utils_internal::DeviceBuffer<data_type> owned_d_work(d_lwork);
+      d_work = owned_d_work.get();
+      std::vector<char> owned_h_work;
       if (0 < h_lwork) {
-        h_work = reinterpret_cast<void *>(malloc(h_lwork));
+        owned_h_work.resize(h_lwork);
+        h_work = owned_h_work.data();
         if (d_work == nullptr) {
           throw std::runtime_error("Error: d_work not allocated.");
         }
       }
 
-      cytnx_int32 *devinfo;
-      checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
-      checkCudaErrors(cudaMemset(devinfo, 0, sizeof(cytnx_int32)));
+      utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
+      checkCudaErrors(cudaMemset(devinfo.get(), 0, sizeof(cytnx_int32)));
 
       cytnx_int32 info;
       /// compute:
-      cusolverDnXgesvdp(cusolverH, nullptr, /* params */
+      cusolverDnXgesvdp(cusolverH.get(), nullptr, /* params */
                         jobz, econ, N, M, cuda_data_type, /* dataTypeA */
-                        Mij, ldA, cuda_data_typeR, /* dataTypeS */
+                        Mij.get(), ldA, cuda_data_typeR, /* dataTypeS */
                         S->data(), cuda_data_type, /* dataTypeU */
                         vTMem, ldu, /* ldu */
                         cuda_data_type, /* dataTypeV */
                         UMem, ldvT, /* ldv */
                         cuda_data_type, /* computeType */
-                        d_work, d_lwork, h_work, h_lwork, devinfo, &h_err_sigma);
+                        d_work, d_lwork, h_work, h_lwork, devinfo.get(), &h_err_sigma);
       if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
         U->Move_memory_({(cytnx_uint64)min, (cytnx_uint64)M}, {1, 0}, {1, 0});
         linalg_internal::cuConj_inplace_internal_cf(U, M * min);
       }
       // get info
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_warning_msg(
         h_err_sigma > 1e-12,
@@ -214,18 +227,6 @@ namespace cytnx {
         h_err_sigma);
       cytnx_error_msg(info != 0, "%s %d",
                       "Error in cuBlas function 'cusolverDnXgesvdp': cuBlas INFO = ", info);
-
-      checkCudaErrors(cudaFree(Mij));
-      if (UMem != nullptr and U->dtype() == Type.Void) {
-        checkCudaErrors(cudaFree(UMem));
-      }
-      if (vTMem != nullptr and vT->dtype() == Type.Void) {
-        checkCudaErrors(cudaFree(vTMem));
-      }
-      checkCudaErrors(cudaFree(devinfo));
-      checkCudaErrors(cudaFree(d_work));
-      free(h_work);
-      checkCudaErrors(cusolverDnDestroy(cusolverH));
     }
     void cuSvd_internal_d(const boost::intrusive_ptr<Storage_base> &in,
                           boost::intrusive_ptr<Storage_base> &U,
@@ -245,30 +246,38 @@ namespace cytnx {
       cytnx_int32 econ = 1; /* i.e. 'S' in gesvd  */
 
       // create handles:
-      cusolverDnHandle_t cusolverH = nullptr;
-      checkCudaErrors(cusolverDnCreate(&cusolverH));
+      // Scoped resources (#1146): the info check below throws, so ownership -- not the cleanup
+      // block that used to sit at the tail of this function -- is what prevents a leak.
+      utils_internal::CusolverDnHandle cusolverH;
 
-      cuDoubleComplex *Mij;
-      checkCudaErrors(cudaMalloc((void **)&Mij, M * N * sizeof(data_type)));
+      utils_internal::DeviceBuffer<data_type> Mij(M * N);
       checkCudaErrors(
-        cudaMemcpy(Mij, in->data(), sizeof(data_type) * M * N, cudaMemcpyDeviceToDevice));
+        cudaMemcpy(Mij.get(), in->data(), sizeof(data_type) * M * N, cudaMemcpyDeviceToDevice));
 
       cytnx_int64 min = std::min(M, N);
       cytnx_int64 max = std::max(M, N);
       cytnx_int64 ldA = N, ldu = N, ldvT = M;
 
+      // UMem/vTMem alias U's and vT's storage when it exists and are temporaries otherwise; the
+      // owned_* buffers are non-empty only in the temporary case, matching the old conditional
+      // cudaFree on `dtype() == Type.Void`.
       void *UMem = nullptr, *vTMem = nullptr;
+      utils_internal::DeviceBuffer<data_type> owned_UMem, owned_vTMem;
       if (U->data()) {
         UMem = U->data();
       } else {
-        if (jobz == CUSOLVER_EIG_MODE_VECTOR)
-          checkCudaErrors(cudaMalloc(&UMem, max * max * sizeof(data_type)));
+        if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
+          owned_UMem = utils_internal::DeviceBuffer<data_type>(max * max);
+          UMem = owned_UMem.get();
+        }
       }
       if (vT->data()) {
         vTMem = vT->data();
       } else {
-        if (jobz == CUSOLVER_EIG_MODE_VECTOR)
-          checkCudaErrors(cudaMalloc(&vTMem, max * max * sizeof(data_type)));
+        if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
+          owned_vTMem = utils_internal::DeviceBuffer<data_type>(max * max);
+          vTMem = owned_vTMem.get();
+        }
       }
 
       std::size_t d_lwork = 0; /* size of workspace */
@@ -277,9 +286,9 @@ namespace cytnx {
       void *h_work = nullptr; /* host workspace for getrf */
       cytnx_double h_err_sigma;
       // query working space :
-      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH, nullptr, /* params */
+      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH.get(), nullptr, /* params */
                                                    jobz, econ, N, M, cuda_data_type, /* dataTypeA */
-                                                   Mij, ldA, cuda_data_typeR, /* dataTypeS */
+                                                   Mij.get(), ldA, cuda_data_typeR, /* dataTypeS */
                                                    S->data(), cuda_data_type, /* dataTypeU */
                                                    vTMem, ldu, /* ldu */
                                                    cuda_data_type, /* dataTypeV */
@@ -288,34 +297,37 @@ namespace cytnx {
                                                    &d_lwork, &h_lwork));
 
       // allocate working space:
-      checkCudaErrors(cudaMalloc(reinterpret_cast<void **>(&d_work), sizeof(data_type) * d_lwork));
+      utils_internal::DeviceBuffer<data_type> owned_d_work(d_lwork);
+      d_work = owned_d_work.get();
+      std::vector<char> owned_h_work;
       if (0 < h_lwork) {
-        h_work = reinterpret_cast<void *>(malloc(h_lwork));
+        owned_h_work.resize(h_lwork);
+        h_work = owned_h_work.data();
         if (d_work == nullptr) {
           throw std::runtime_error("Error: d_work not allocated.");
         }
       }
 
-      cytnx_int32 *devinfo;
-      checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
-      checkCudaErrors(cudaMemset(devinfo, 0, sizeof(cytnx_int32)));
+      utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
+      checkCudaErrors(cudaMemset(devinfo.get(), 0, sizeof(cytnx_int32)));
 
       cytnx_int32 info;
       /// compute:
-      cusolverDnXgesvdp(cusolverH, nullptr, /* params */
+      cusolverDnXgesvdp(cusolverH.get(), nullptr, /* params */
                         jobz, econ, N, M, cuda_data_type, /* dataTypeA */
-                        Mij, ldA, cuda_data_typeR, /* dataTypeS */
+                        Mij.get(), ldA, cuda_data_typeR, /* dataTypeS */
                         S->data(), cuda_data_type, /* dataTypeU */
                         vTMem, ldu, /* ldu */
                         cuda_data_type, /* dataTypeV */
                         UMem, ldvT, /* ldv */
                         cuda_data_type, /* computeType */
-                        d_work, d_lwork, h_work, h_lwork, devinfo, &h_err_sigma);
+                        d_work, d_lwork, h_work, h_lwork, devinfo.get(), &h_err_sigma);
       if (jobz == CUSOLVER_EIG_MODE_VECTOR)
         U->Move_memory_({(cytnx_uint64)min, (cytnx_uint64)M}, {1, 0}, {1, 0});
 
       // get info
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_warning_msg(
         h_err_sigma > 1e-12,
@@ -323,18 +335,6 @@ namespace cytnx {
         h_err_sigma);
       cytnx_error_msg(info != 0, "%s %d",
                       "Error in cuBlas function 'cusolverDnXgesvdp': cuBlas INFO = ", info);
-
-      checkCudaErrors(cudaFree(Mij));
-      if (UMem != nullptr and U->dtype() == Type.Void) {
-        checkCudaErrors(cudaFree(UMem));
-      }
-      if (vTMem != nullptr and vT->dtype() == Type.Void) {
-        checkCudaErrors(cudaFree(vTMem));
-      }
-      checkCudaErrors(cudaFree(devinfo));
-      checkCudaErrors(cudaFree(d_work));
-      free(h_work);
-      checkCudaErrors(cusolverDnDestroy(cusolverH));
     }
     void cuSvd_internal_f(const boost::intrusive_ptr<Storage_base> &in,
                           boost::intrusive_ptr<Storage_base> &U,
@@ -354,30 +354,38 @@ namespace cytnx {
       cytnx_int32 econ = 1; /* i.e. 'S' in gesvd  */
 
       // create handles:
-      cusolverDnHandle_t cusolverH = nullptr;
-      checkCudaErrors(cusolverDnCreate(&cusolverH));
+      // Scoped resources (#1146): the info check below throws, so ownership -- not the cleanup
+      // block that used to sit at the tail of this function -- is what prevents a leak.
+      utils_internal::CusolverDnHandle cusolverH;
 
-      cuDoubleComplex *Mij;
-      checkCudaErrors(cudaMalloc((void **)&Mij, M * N * sizeof(data_type)));
+      utils_internal::DeviceBuffer<data_type> Mij(M * N);
       checkCudaErrors(
-        cudaMemcpy(Mij, in->data(), sizeof(data_type) * M * N, cudaMemcpyDeviceToDevice));
+        cudaMemcpy(Mij.get(), in->data(), sizeof(data_type) * M * N, cudaMemcpyDeviceToDevice));
 
       cytnx_int64 min = std::min(M, N);
       cytnx_int64 max = std::max(M, N);
       cytnx_int64 ldA = N, ldu = N, ldvT = M;
 
+      // UMem/vTMem alias U's and vT's storage when it exists and are temporaries otherwise; the
+      // owned_* buffers are non-empty only in the temporary case, matching the old conditional
+      // cudaFree on `dtype() == Type.Void`.
       void *UMem = nullptr, *vTMem = nullptr;
+      utils_internal::DeviceBuffer<data_type> owned_UMem, owned_vTMem;
       if (U->data()) {
         UMem = U->data();
       } else {
-        if (jobz == CUSOLVER_EIG_MODE_VECTOR)
-          checkCudaErrors(cudaMalloc(&UMem, max * max * sizeof(data_type)));
+        if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
+          owned_UMem = utils_internal::DeviceBuffer<data_type>(max * max);
+          UMem = owned_UMem.get();
+        }
       }
       if (vT->data()) {
         vTMem = vT->data();
       } else {
-        if (jobz == CUSOLVER_EIG_MODE_VECTOR)
-          checkCudaErrors(cudaMalloc(&vTMem, max * max * sizeof(data_type)));
+        if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
+          owned_vTMem = utils_internal::DeviceBuffer<data_type>(max * max);
+          vTMem = owned_vTMem.get();
+        }
       }
 
       std::size_t d_lwork = 0; /* size of workspace */
@@ -386,9 +394,9 @@ namespace cytnx {
       void *h_work = nullptr; /* host workspace for getrf */
       cytnx_double h_err_sigma;
       // query working space :
-      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH, nullptr, /* params */
+      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH.get(), nullptr, /* params */
                                                    jobz, econ, N, M, cuda_data_type, /* dataTypeA */
-                                                   Mij, ldA, cuda_data_typeR, /* dataTypeS */
+                                                   Mij.get(), ldA, cuda_data_typeR, /* dataTypeS */
                                                    S->data(), cuda_data_type, /* dataTypeU */
                                                    vTMem, ldu, /* ldu */
                                                    cuda_data_type, /* dataTypeV */
@@ -397,34 +405,37 @@ namespace cytnx {
                                                    &d_lwork, &h_lwork));
 
       // allocate working space:
-      checkCudaErrors(cudaMalloc(reinterpret_cast<void **>(&d_work), sizeof(data_type) * d_lwork));
+      utils_internal::DeviceBuffer<data_type> owned_d_work(d_lwork);
+      d_work = owned_d_work.get();
+      std::vector<char> owned_h_work;
       if (0 < h_lwork) {
-        h_work = reinterpret_cast<void *>(malloc(h_lwork));
+        owned_h_work.resize(h_lwork);
+        h_work = owned_h_work.data();
         if (d_work == nullptr) {
           throw std::runtime_error("Error: d_work not allocated.");
         }
       }
 
-      cytnx_int32 *devinfo;
-      checkCudaErrors(cudaMalloc((void **)&devinfo, sizeof(cytnx_int32)));
-      checkCudaErrors(cudaMemset(devinfo, 0, sizeof(cytnx_int32)));
+      utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
+      checkCudaErrors(cudaMemset(devinfo.get(), 0, sizeof(cytnx_int32)));
 
       cytnx_int32 info;
       /// compute:
-      cusolverDnXgesvdp(cusolverH, nullptr, /* params */
+      cusolverDnXgesvdp(cusolverH.get(), nullptr, /* params */
                         jobz, econ, N, M, cuda_data_type, /* dataTypeA */
-                        Mij, ldA, cuda_data_typeR, /* dataTypeS */
+                        Mij.get(), ldA, cuda_data_typeR, /* dataTypeS */
                         S->data(), cuda_data_type, /* dataTypeU */
                         vTMem, ldu, /* ldu */
                         cuda_data_type, /* dataTypeV */
                         UMem, ldvT, /* ldv */
                         cuda_data_type, /* computeType */
-                        d_work, d_lwork, h_work, h_lwork, devinfo, &h_err_sigma);
+                        d_work, d_lwork, h_work, h_lwork, devinfo.get(), &h_err_sigma);
       if (jobz == CUSOLVER_EIG_MODE_VECTOR)
         U->Move_memory_({(cytnx_uint64)min, (cytnx_uint64)M}, {1, 0}, {1, 0});
 
       // get info
-      checkCudaErrors(cudaMemcpy(&info, devinfo, sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
+      checkCudaErrors(
+        cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
       cytnx_warning_msg(
         h_err_sigma > 1e-12,
@@ -432,18 +443,6 @@ namespace cytnx {
         h_err_sigma);
       cytnx_error_msg(info != 0, "%s %d",
                       "Error in cuBlas function 'cusolverDnXgesvdp': cuBlas INFO = ", info);
-
-      checkCudaErrors(cudaFree(Mij));
-      if (UMem != nullptr and U->dtype() == Type.Void) {
-        checkCudaErrors(cudaFree(UMem));
-      }
-      if (vTMem != nullptr and vT->dtype() == Type.Void) {
-        checkCudaErrors(cudaFree(vTMem));
-      }
-      checkCudaErrors(cudaFree(devinfo));
-      checkCudaErrors(cudaFree(d_work));
-      free(h_work);
-      checkCudaErrors(cusolverDnDestroy(cusolverH));
     }
 
   }  // namespace linalg_internal

--- a/src/backend/linalg_internal_gpu/cuSvd_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuSvd_internal.cu
@@ -43,21 +43,21 @@ namespace cytnx {
       // owned_* buffers are non-empty only in the temporary case, matching the old conditional
       // cudaFree on `dtype() == Type.Void`.
       void *UMem = nullptr, *vTMem = nullptr;
-      utils_internal::DeviceBuffer<data_type> owned_UMem, owned_vTMem;
+      utils_internal::DeviceBuffer<data_type> owned_u_mem, owned_vt_mem;
       if (U->data()) {
         UMem = U->data();
       } else {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
-          owned_UMem = utils_internal::DeviceBuffer<data_type>(max * max);
-          UMem = owned_UMem.get();
+          owned_u_mem = utils_internal::DeviceBuffer<data_type>(max * max);
+          UMem = owned_u_mem.get();
         }
       }
       if (vT->data()) {
         vTMem = vT->data();
       } else {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
-          owned_vTMem = utils_internal::DeviceBuffer<data_type>(max * max);
-          vTMem = owned_vTMem.get();
+          owned_vt_mem = utils_internal::DeviceBuffer<data_type>(max * max);
+          vTMem = owned_vt_mem.get();
         }
       }
 
@@ -153,21 +153,21 @@ namespace cytnx {
       // owned_* buffers are non-empty only in the temporary case, matching the old conditional
       // cudaFree on `dtype() == Type.Void`.
       void *UMem = nullptr, *vTMem = nullptr;
-      utils_internal::DeviceBuffer<data_type> owned_UMem, owned_vTMem;
+      utils_internal::DeviceBuffer<data_type> owned_u_mem, owned_vt_mem;
       if (U->data()) {
         UMem = U->data();
       } else {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
-          owned_UMem = utils_internal::DeviceBuffer<data_type>(max * max);
-          UMem = owned_UMem.get();
+          owned_u_mem = utils_internal::DeviceBuffer<data_type>(max * max);
+          UMem = owned_u_mem.get();
         }
       }
       if (vT->data()) {
         vTMem = vT->data();
       } else {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
-          owned_vTMem = utils_internal::DeviceBuffer<data_type>(max * max);
-          vTMem = owned_vTMem.get();
+          owned_vt_mem = utils_internal::DeviceBuffer<data_type>(max * max);
+          vTMem = owned_vt_mem.get();
         }
       }
 
@@ -262,21 +262,21 @@ namespace cytnx {
       // owned_* buffers are non-empty only in the temporary case, matching the old conditional
       // cudaFree on `dtype() == Type.Void`.
       void *UMem = nullptr, *vTMem = nullptr;
-      utils_internal::DeviceBuffer<data_type> owned_UMem, owned_vTMem;
+      utils_internal::DeviceBuffer<data_type> owned_u_mem, owned_vt_mem;
       if (U->data()) {
         UMem = U->data();
       } else {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
-          owned_UMem = utils_internal::DeviceBuffer<data_type>(max * max);
-          UMem = owned_UMem.get();
+          owned_u_mem = utils_internal::DeviceBuffer<data_type>(max * max);
+          UMem = owned_u_mem.get();
         }
       }
       if (vT->data()) {
         vTMem = vT->data();
       } else {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
-          owned_vTMem = utils_internal::DeviceBuffer<data_type>(max * max);
-          vTMem = owned_vTMem.get();
+          owned_vt_mem = utils_internal::DeviceBuffer<data_type>(max * max);
+          vTMem = owned_vt_mem.get();
         }
       }
 
@@ -370,21 +370,21 @@ namespace cytnx {
       // owned_* buffers are non-empty only in the temporary case, matching the old conditional
       // cudaFree on `dtype() == Type.Void`.
       void *UMem = nullptr, *vTMem = nullptr;
-      utils_internal::DeviceBuffer<data_type> owned_UMem, owned_vTMem;
+      utils_internal::DeviceBuffer<data_type> owned_u_mem, owned_vt_mem;
       if (U->data()) {
         UMem = U->data();
       } else {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
-          owned_UMem = utils_internal::DeviceBuffer<data_type>(max * max);
-          UMem = owned_UMem.get();
+          owned_u_mem = utils_internal::DeviceBuffer<data_type>(max * max);
+          UMem = owned_u_mem.get();
         }
       }
       if (vT->data()) {
         vTMem = vT->data();
       } else {
         if (jobz == CUSOLVER_EIG_MODE_VECTOR) {
-          owned_vTMem = utils_internal::DeviceBuffer<data_type>(max * max);
-          vTMem = owned_vTMem.get();
+          owned_vt_mem = utils_internal::DeviceBuffer<data_type>(max * max);
+          vTMem = owned_vt_mem.get();
         }
       }
 

--- a/src/backend/utils_internal_gpu/CMakeLists.txt
+++ b/src/backend/utils_internal_gpu/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(cytnx
     cuGetElems_gpu.hpp
     cuGetElems_contiguous_gpu.hpp
     cuMovemem_gpu.hpp
+    cuScopedResource_gpu.hpp
     cuSetArange_gpu.hpp
     cuSetElems_gpu.hpp
     cuSetElems_contiguous_gpu.hpp

--- a/src/backend/utils_internal_gpu/cuScopedResource_gpu.hpp
+++ b/src/backend/utils_internal_gpu/cuScopedResource_gpu.hpp
@@ -1,24 +1,35 @@
 #ifndef CYTNX_BACKEND_UTILS_INTERNAL_GPU_CUSCOPEDRESOURCE_GPU_H_
 #define CYTNX_BACKEND_UTILS_INTERNAL_GPU_CUSCOPEDRESOURCE_GPU_H_
 
+// backend/utils_internal_gpu and backend/linalg_internal_gpu are added by CMake only under
+// USE_CUDA, so this header can never legitimately be compiled without UNI_GPU. Fail loudly rather
+// than expanding to nothing: an accidental include from a CPU translation unit would otherwise
+// surface as "DeviceBuffer is not a member of cytnx::utils_internal", pointing at the use site
+// instead of the include.
+#if !defined(UNI_GPU)
+  #error "cuScopedResource_gpu.hpp is CUDA-only; include it from a .cu under backend/*_gpu."
+#endif
+
 #include <cstddef>
 #include <utility>
 
+#include <cuda_runtime.h>
+#include <cusolverDn.h>
+
 #include "cytnx_error.hpp"
 #include "Type.hpp"
-
-#if defined(UNI_GPU)
-  #include <cuda_runtime.h>
-  #include <cusolverDn.h>
-#endif
+#include "backend/utils_internal_gpu/cuAlloc_gpu.hpp"
 
 namespace cytnx {
   namespace utils_internal {
 
-#if defined(UNI_GPU)
-
     /**
      * @brief Owns a `cudaMalloc`ed device buffer and frees it on scope exit.
+     *
+     * `T` is the element type only: it fixes `sizeof(T)` for the allocation and the pointer type
+     * `get()` hands back. It carries no CUDA-specific requirement -- these buffers hold `int`,
+     * `cytnx_double` and `cuDoubleComplex` alike, and nothing here is ever dereferenced on the
+     * host unless the storage came from `managed()`.
      *
      * The cuSOLVER wrappers in `linalg_internal_gpu/` raise their LAPACK-`info` error *before*
      * their cleanup block, so an unconverged factorization used to leak every device allocation
@@ -61,16 +72,20 @@ namespace cytnx {
       }
 
       /**
-       * @brief Takes ownership of a pointer allocated elsewhere, e.g. by `cuMalloc_gpu`.
+       * @brief Allocates `count` elements of CUDA *managed* memory and owns them.
        *
-       * Needed where the buffer must be *managed* memory rather than plain device memory --
-       * `cuDet_internal` reads the factorized diagonal from the host, which only works because
-       * `cuMalloc_gpu` returns `cudaMallocManaged` memory. `cudaFree` releases both kinds, so
-       * ownership is uniform even though allocation is not.
+       * The constructor uses `cudaMalloc`, whose memory is device-only. This factory uses
+       * `cuMalloc_gpu` (`cudaMallocManaged`), which is also host-accessible -- `cuDet_internal`
+       * needs that, because it reads the factorized diagonal directly from the host after the
+       * cuSOLVER call.
+       *
+       * Only the allocation differs: `cudaFree` releases both kinds, so teardown, move semantics
+       * and the zero-element case are identical to the constructor's.
        */
-      static DeviceBuffer adopt(T *p) {
+      static DeviceBuffer managed(std::size_t count) {
         DeviceBuffer buffer;
-        buffer.ptr = p;
+        if (count == 0) return buffer;
+        buffer.ptr = reinterpret_cast<T *>(cuMalloc_gpu(count * sizeof(T)));
         return buffer;
       }
 
@@ -121,8 +136,6 @@ namespace cytnx {
      private:
       gesvdjInfo_t info = nullptr;
     };
-
-#endif  // UNI_GPU
 
   }  // namespace utils_internal
 }  // namespace cytnx

--- a/src/backend/utils_internal_gpu/cuScopedResource_gpu.hpp
+++ b/src/backend/utils_internal_gpu/cuScopedResource_gpu.hpp
@@ -1,0 +1,130 @@
+#ifndef CYTNX_BACKEND_UTILS_INTERNAL_GPU_CUSCOPEDRESOURCE_GPU_H_
+#define CYTNX_BACKEND_UTILS_INTERNAL_GPU_CUSCOPEDRESOURCE_GPU_H_
+
+#include <cstddef>
+#include <utility>
+
+#include "cytnx_error.hpp"
+#include "Type.hpp"
+
+#if defined(UNI_GPU)
+  #include <cuda_runtime.h>
+  #include <cusolverDn.h>
+#endif
+
+namespace cytnx {
+  namespace utils_internal {
+
+#if defined(UNI_GPU)
+
+    /**
+     * @brief Owns a `cudaMalloc`ed device buffer and frees it on scope exit.
+     *
+     * The cuSOLVER wrappers in `linalg_internal_gpu/` raise their LAPACK-`info` error *before*
+     * their cleanup block, so an unconverged factorization used to leak every device allocation
+     * in the function (#1146). Ownership makes cleanup independent of the exit path, which manual
+     * `cudaFree` calls at the tail of a function cannot be -- especially where a function has more
+     * than one throw site and each has a different set of live allocations.
+     *
+     * A zero-element request leaves the buffer empty and allocates nothing. `cudaMalloc(ptr, 0)`
+     * yields a pointer that cannot be freed, which is the defect fixed for `Storage` in #1126;
+     * `lwork` legitimately comes back as 0 from the cuSOLVER buffer-size queries, so this case is
+     * reachable here rather than hypothetical.
+     */
+    template <class T>
+    class DeviceBuffer {
+     public:
+      DeviceBuffer() = default;
+
+      explicit DeviceBuffer(std::size_t count) {
+        if (count == 0) return;
+        checkCudaErrors(cudaMalloc(reinterpret_cast<void **>(&ptr), count * sizeof(T)));
+      }
+
+      ~DeviceBuffer() {
+        // Deliberately unchecked: a destructor must not terminate the process, and
+        // `checkCudaErrors` exits on failure.
+        if (ptr) cudaFree(ptr);
+      }
+
+      DeviceBuffer(const DeviceBuffer &) = delete;
+      DeviceBuffer &operator=(const DeviceBuffer &) = delete;
+
+      DeviceBuffer(DeviceBuffer &&other) noexcept : ptr(std::exchange(other.ptr, nullptr)) {}
+
+      DeviceBuffer &operator=(DeviceBuffer &&other) noexcept {
+        if (this != &other) {
+          if (ptr) cudaFree(ptr);
+          ptr = std::exchange(other.ptr, nullptr);
+        }
+        return *this;
+      }
+
+      /**
+       * @brief Takes ownership of a pointer allocated elsewhere, e.g. by `cuMalloc_gpu`.
+       *
+       * Needed where the buffer must be *managed* memory rather than plain device memory --
+       * `cuDet_internal` reads the factorized diagonal from the host, which only works because
+       * `cuMalloc_gpu` returns `cudaMallocManaged` memory. `cudaFree` releases both kinds, so
+       * ownership is uniform even though allocation is not.
+       */
+      static DeviceBuffer adopt(T *p) {
+        DeviceBuffer buffer;
+        buffer.ptr = p;
+        return buffer;
+      }
+
+      T *get() const { return ptr; }
+
+     private:
+      T *ptr = nullptr;
+    };
+
+    /// Owns a cuSOLVER dense handle and destroys it on scope exit.
+    class CusolverDnHandle {
+     public:
+      CusolverDnHandle() { checkCudaErrors(cusolverDnCreate(&handle)); }
+
+      ~CusolverDnHandle() {
+        if (handle) cusolverDnDestroy(handle);
+      }
+
+      CusolverDnHandle(const CusolverDnHandle &) = delete;
+      CusolverDnHandle &operator=(const CusolverDnHandle &) = delete;
+
+      cusolverDnHandle_t get() const { return handle; }
+
+     private:
+      cusolverDnHandle_t handle = nullptr;
+    };
+
+    /**
+     * @brief Owns a `gesvdjInfo_t` (Jacobi SVD parameters) and destroys it on scope exit.
+     *
+     * `cuGeSvd_internal.cu` created one per call and never destroyed it -- `cusolverDnDestroy-
+     * GesvdjInfo` appeared nowhere in the repo -- leaking ~2 KB of host memory per GPU SVD
+     * (#1145).
+     */
+    class GesvdjInfo {
+     public:
+      GesvdjInfo() { checkCudaErrors(cusolverDnCreateGesvdjInfo(&info)); }
+
+      ~GesvdjInfo() {
+        if (info) cusolverDnDestroyGesvdjInfo(info);
+      }
+
+      GesvdjInfo(const GesvdjInfo &) = delete;
+      GesvdjInfo &operator=(const GesvdjInfo &) = delete;
+
+      gesvdjInfo_t get() const { return info; }
+
+     private:
+      gesvdjInfo_t info = nullptr;
+    };
+
+#endif  // UNI_GPU
+
+  }  // namespace utils_internal
+}  // namespace cytnx
+
+#endif  // CYTNX_BACKEND_UTILS_INTERNAL_GPU_CUSCOPEDRESOURCE_GPU_H_

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   linalg_test/InplacePromote_test.cpp
   linalg_test/NonContigElementwise_test.cpp
   linalg_test/Outer_test.cpp
+  linalg_test/CusolverResourceLeak_test.cpp
   linalg_test/Det_test.cpp
   linalg_test/Directsum_test.cpp
   linalg_test/ExpH_test.cpp

--- a/tests/gpu/linalg_test/CusolverResourceLeak_test.cpp
+++ b/tests/gpu/linalg_test/CusolverResourceLeak_test.cpp
@@ -1,7 +1,10 @@
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstddef>
+#include <functional>
+#include <limits>
 
 #include "cytnx.hpp"
 
@@ -23,6 +26,29 @@ namespace {
     return static_cast<double>(free_bytes) / (1024.0 * 1024.0);
   }
 
+  // Runs `body` and reports the device memory it failed to give back, in MiB.
+  //
+  // `cudaMemGetInfo` reports free memory for the whole *device*, not for this process, so any
+  // other CUDA process on the same GPU moves the number under our feet. That is not hypothetical
+  // here: the self-hosted machine that runs this suite also serves GPU CI, and a concurrent job
+  // made the success-path test below report 68 MiB against its 64 MiB threshold in 1 run out of 5.
+  //
+  // A genuine leak reproduces on every attempt; contention does not. So measure the loop up to
+  // `attempts` times and keep the smallest delta, stopping early as soon as one attempt comes in
+  // under `slack`. The bias is deliberate and one-sided: if a neighbouring process *frees* during
+  // our window the delta is understated, so this errs toward a false pass rather than a false
+  // failure. For a guard, an intermittent red is worse than a missed regression -- and the leaks
+  // these tests exist to catch are orders of magnitude above the threshold, not marginal.
+  double MeasureLeakMiB(const std::function<void()> &body, int attempts, double slack) {
+    double best = std::numeric_limits<double>::max();
+    for (int i = 0; i < attempts && best >= slack; ++i) {
+      const double before = FreeDeviceMiB();
+      body();
+      best = std::min(best, before - FreeDeviceMiB());
+    }
+    return best;
+  }
+
 }  // namespace
 
 // #1146: the GPU cuSOLVER wrappers used to raise their LAPACK-`info` error *before* the cleanup
@@ -39,6 +65,7 @@ namespace {
 TEST(CusolverResourceLeak, GpuInvMErrorPathDoesNotLeakDeviceMemory) {
   constexpr int kCalls = 100;
   constexpr double kSlackMiB = 64.0;
+  constexpr int kAttempts = 5;
 
   // Warm up so one-time CUDA context and cuSOLVER library allocation is outside the measurement.
   {
@@ -46,24 +73,32 @@ TEST(CusolverResourceLeak, GpuInvMErrorPathDoesNotLeakDeviceMemory) {
     EXPECT_THROW(linalg::InvM(warm), cytnx::error);
   }
 
-  const double free_before = FreeDeviceMiB();
+  const double leaked = MeasureLeakMiB(
+    [] {
+      for (int i = 0; i < kCalls; ++i) {
+        Tensor a = MakeSingular(4);
+        EXPECT_THROW(linalg::InvM(a), cytnx::error);
+      }
+    },
+    kAttempts, kSlackMiB);
 
-  for (int i = 0; i < kCalls; ++i) {
-    Tensor a = MakeSingular(4);
-    EXPECT_THROW(linalg::InvM(a), cytnx::error);
-  }
-
-  const double leaked = free_before - FreeDeviceMiB();
   EXPECT_LT(leaked, kSlackMiB) << "leaked " << leaked << " MiB of device memory over " << kCalls
-                               << " failing InvM calls";
+                               << " failing InvM calls (best of " << kAttempts << " attempts)";
 }
 
 // Companion guard for the same change: converting five files to scoped ownership must not break
 // release on the *success* path either (a missing free, or a double free via a stale alias). This
 // direction passed before the fix, so it is not a regression test -- it guards the refactor.
+//
+// Note on what this can still detect once #1144 lands: caching the cuSOLVER handle per device
+// removes ~12 MB per call from the set of leakable resources, leaving the small work buffers
+// (~82 KiB per call) as the only signal. At 20 rounds that is well under the threshold, so this
+// guard catches a gross regression -- a whole workspace never freed -- and not a single small
+// buffer. Raising the threshold would not help; the limit is the measurement, not the number.
 TEST(CusolverResourceLeak, GpuCusolverSuccessPathsDoNotLeakDeviceMemory) {
   constexpr int kCalls = 20;
   constexpr double kSlackMiB = 64.0;
+  constexpr int kAttempts = 5;
 
   Tensor a = zeros({8, 8}, Type.Double);
   for (cytnx_uint64 i = 0; i < 8; ++i) a.at({i, i}) = static_cast<double>(i + 1);
@@ -78,19 +113,21 @@ TEST(CusolverResourceLeak, GpuCusolverSuccessPathsDoNotLeakDeviceMemory) {
     auto inv = linalg::InvM(a);
   }
 
-  const double free_before = FreeDeviceMiB();
+  const double leaked = MeasureLeakMiB(
+    [&a] {
+      for (int i = 0; i < kCalls; ++i) {
+        auto svd = linalg::Svd(a);
+        auto gesvd = linalg::Gesvd(a);
+        auto eigh = linalg::Eigh(a);
+        auto det = linalg::Det(a);
+        auto inv = linalg::InvM(a);
+      }
+    },
+    kAttempts, kSlackMiB);
 
-  for (int i = 0; i < kCalls; ++i) {
-    auto svd = linalg::Svd(a);
-    auto gesvd = linalg::Gesvd(a);
-    auto eigh = linalg::Eigh(a);
-    auto det = linalg::Det(a);
-    auto inv = linalg::InvM(a);
-  }
-
-  const double leaked = free_before - FreeDeviceMiB();
   EXPECT_LT(leaked, kSlackMiB) << "leaked " << leaked << " MiB of device memory over " << kCalls
-                               << " successful Svd/Gesvd/Eigh/Det/InvM rounds";
+                               << " successful Svd/Gesvd/Eigh/Det/InvM rounds (best of "
+                               << kAttempts << " attempts)";
 }
 
 // The inverse of a diagonal matrix is the reciprocal diagonal -- an independently known value, not

--- a/tests/gpu/linalg_test/CusolverResourceLeak_test.cpp
+++ b/tests/gpu/linalg_test/CusolverResourceLeak_test.cpp
@@ -1,0 +1,113 @@
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+
+#include "cytnx.hpp"
+
+using namespace cytnx;
+
+namespace {
+
+  // Identity with the last diagonal entry left at zero: singular, so getrf reports info > 0 and
+  // InvM raises. Built on the CPU and moved, per the usual rule for GPU test inputs.
+  Tensor MakeSingular(cytnx_uint64 n) {
+    Tensor a = zeros({n, n}, Type.Double);
+    for (cytnx_uint64 i = 0; i + 1 < n; ++i) a.at({i, i}) = 1.0;
+    return a.to(Device.cuda);
+  }
+
+  double FreeDeviceMiB() {
+    std::size_t free_bytes = 0, total_bytes = 0;
+    EXPECT_EQ(cudaMemGetInfo(&free_bytes, &total_bytes), cudaSuccess);
+    return static_cast<double>(free_bytes) / (1024.0 * 1024.0);
+  }
+
+}  // namespace
+
+// #1146: the GPU cuSOLVER wrappers used to raise their LAPACK-`info` error *before* the cleanup
+// block at the tail of the function. `cytnx_error_msg` is [[noreturn]], so unwinding skipped every
+// cudaFree and the cuSOLVER handle -- and a leaked handle alone is ~12 MB of device memory.
+//
+// Measured on the pre-fix code, this exact loop at 200 calls leaked 2,465,792 KB (~2.4 GB, ~12.6 MB
+// per call) and drove device free memory from 15393 MB to 12985 MB. After the fix the same loop
+// leaks nothing. The threshold below therefore sits orders of magnitude below the regression while
+// leaving generous slack for allocator caching.
+//
+// Reachable from user code: cytnx::error surfaces in Python as CytnxError, which is catchable, so
+// retrying a failing inverse in a loop is the natural thing to write.
+TEST(CusolverResourceLeak, GpuInvMErrorPathDoesNotLeakDeviceMemory) {
+  constexpr int kCalls = 100;
+  constexpr double kSlackMiB = 64.0;
+
+  // Warm up so one-time CUDA context and cuSOLVER library allocation is outside the measurement.
+  {
+    Tensor warm = MakeSingular(4);
+    EXPECT_THROW(linalg::InvM(warm), cytnx::error);
+  }
+
+  const double free_before = FreeDeviceMiB();
+
+  for (int i = 0; i < kCalls; ++i) {
+    Tensor a = MakeSingular(4);
+    EXPECT_THROW(linalg::InvM(a), cytnx::error);
+  }
+
+  const double leaked = free_before - FreeDeviceMiB();
+  EXPECT_LT(leaked, kSlackMiB) << "leaked " << leaked << " MiB of device memory over " << kCalls
+                               << " failing InvM calls";
+}
+
+// Companion guard for the same change: converting five files to scoped ownership must not break
+// release on the *success* path either (a missing free, or a double free via a stale alias). This
+// direction passed before the fix, so it is not a regression test -- it guards the refactor.
+TEST(CusolverResourceLeak, GpuCusolverSuccessPathsDoNotLeakDeviceMemory) {
+  constexpr int kCalls = 20;
+  constexpr double kSlackMiB = 64.0;
+
+  Tensor a = zeros({8, 8}, Type.Double);
+  for (cytnx_uint64 i = 0; i < 8; ++i) a.at({i, i}) = static_cast<double>(i + 1);
+  a = a.to(Device.cuda);
+
+  // Warm up every library path before measuring.
+  {
+    auto svd = linalg::Svd(a);
+    auto gesvd = linalg::Gesvd(a);
+    auto eigh = linalg::Eigh(a);
+    auto det = linalg::Det(a);
+    auto inv = linalg::InvM(a);
+  }
+
+  const double free_before = FreeDeviceMiB();
+
+  for (int i = 0; i < kCalls; ++i) {
+    auto svd = linalg::Svd(a);
+    auto gesvd = linalg::Gesvd(a);
+    auto eigh = linalg::Eigh(a);
+    auto det = linalg::Det(a);
+    auto inv = linalg::InvM(a);
+  }
+
+  const double leaked = free_before - FreeDeviceMiB();
+  EXPECT_LT(leaked, kSlackMiB) << "leaked " << leaked << " MiB of device memory over " << kCalls
+                               << " successful Svd/Gesvd/Eigh/Det/InvM rounds";
+}
+
+// The inverse of a diagonal matrix is the reciprocal diagonal -- an independently known value, not
+// another Cytnx path. Confirms the converted cuInvM still computes correctly, since the conversion
+// rewired which pointers the cuSOLVER calls receive.
+TEST(CusolverResourceLeak, GpuInvMStillCorrectAfterScopedResources) {
+  Tensor a = zeros({4, 4}, Type.Double);
+  const double diag[4] = {2.0, -4.0, 0.5, 8.0};
+  for (cytnx_uint64 i = 0; i < 4; ++i) a.at({i, i}) = diag[i];
+
+  Tensor inv = linalg::InvM(a.to(Device.cuda)).to(Device.cpu);
+
+  for (cytnx_uint64 i = 0; i < 4; ++i) {
+    for (cytnx_uint64 j = 0; j < 4; ++j) {
+      const double expected = (i == j) ? 1.0 / diag[i] : 0.0;
+      EXPECT_NEAR(inv.at<cytnx_double>({i, j}), expected, 1e-12)
+        << "element (" << i << ", " << j << ")";
+    }
+  }
+}


### PR DESCRIPTION
Closes #1145. Closes #1146.

Fixes both together because #1146's fix subsumes #1145: adding the missing `cusolverDnDestroyGesvdjInfo` at the tail of `cuGeSvd_internal` would have been skipped by the very throw that #1146 is about.

## Problem

Every live cuSOLVER wrapper in `linalg_internal_gpu/` raised its LAPACK-`info` error *before* the cleanup block at the end of the function:

```cpp
cytnx_error_msg(info != 0, ... "possibly svd not converge" ...);   // cuGeSvd_internal.cu:82
checkCudaErrors(cudaFree(d_work));                                 // :86  never runs
checkCudaErrors(cudaFree(Mij));
```

`cytnx_error_msg` expands to a `[[noreturn]]` call, so unwinding skipped every `cudaFree` and the handle. Note what the message says the trigger is — non-convergence is a normal outcome on ill-conditioned input, not a programming error, so this leaked on an expected path. `cytnx::error` surfaces in Python as the catchable `CytnxError`, making the obvious retry loop a VRAM exhaustion loop.

Separately, `cuGeSvd_internal.cu` never destroyed its `gesvdjInfo_t` at all, on any path (#1145).

Five files, four dtype specialisations each: `cuGeSvd`, `cuSvd`, `cuEigh`, `cuDet`, `cuInvM_inplace`. `cuInvM` has two throw sites with *different* sets of live allocations, and `cuSvd` has a third exit via `throw std::runtime_error`.

## Measured, before and after

The same 200-call loop over a singular matrix (`InvM` on a rank-deficient 4×4, which makes `getrf` report `info > 0`):

| | leaked | per call |
|---|---|---|
| **pre-fix** | **2,465,792 KiB (~2.4 GB)** | ~12.6 MB |
| **post-fix** | −16,384 KiB (16 MB *more* free) | none |

Device free memory went 15393 MB → 12985 MB pre-fix, and did not fall at all post-fix. The negative post-fix figure is the allocator releasing cached blocks.

**12.6 MB per call for a 4×4 matrix is the interesting part**: the dominant leak is the leaked `cusolverDnHandle_t` itself, not the small work buffers. I had expected the buffers to matter most and was wrong — the handle carries the cost, which also means #1144 (caching these handles) and this fix interact.

## Fix

A new `utils_internal/cuScopedResource_gpu.hpp` with three owning types — `DeviceBuffer<T>`, `CusolverDnHandle`, `GesvdjInfo` — and all 20 functions converted so cleanup is independent of the exit path. No manual `cudaFree`, `cusolverDnCreate`/`Destroy`, or `CreateGesvdjInfo` remains in any of the five files.

Reordering the frees before the throw was the smaller change, but it does not work here: `cuInvM`'s first throw site must free only what has been allocated *so far*, and hand-tracking that per site is exactly the bug class being fixed.

Three details worth review:

**Conditional ownership is preserved exactly.** `cuEigh`'s `tA` aliases `v`'s storage when eigenvectors are wanted and is a temporary otherwise; `cuSvd`/`cuGeSvd`'s `UMem`/`vTMem` likewise. The old code expressed this as `if (dtype() == Type.Void) cudaFree(...)`. The converted code keeps a separate `owned_*` buffer that is non-empty only in the temporary case, so ownership matches the old conditional rather than approximating it.

**Zero-size allocations are handled deliberately.** `DeviceBuffer(0)` allocates nothing and stays null. `lwork` legitimately comes back as 0 from the cuSOLVER buffer-size queries, and `cudaMalloc(ptr, 0)` yields a pointer that cannot be freed — the defect fixed for `Storage` in #1126. This is a behaviour change in that edge case, in the safe direction.

**`checkCudaErrors` does not throw** — it prints and calls `exit(EXIT_FAILURE)` (`cytnx_error.hpp:526`). I checked this before choosing the fix: it means `cytnx_error_msg` is the *only* exception source in these functions, so the throw sites above are the complete set rather than a sample.

`cuDet` also allocates via `cuMalloc_gpu` (managed memory, since it reads the factorized diagonal from the host), so `DeviceBuffer::adopt` takes ownership of a pointer allocated elsewhere. `cudaFree` releases both kinds, so ownership is uniform even though allocation is not.

Host allocations on the same paths are now `std::vector` rather than `malloc`/`new[]`, which also removes their leak on the throw.

## Testing

`tests/gpu/linalg_test/CusolverResourceLeak_test.cpp`:

- **`GpuInvMErrorPathDoesNotLeakDeviceMemory`** — the regression test. Shown to fail pre-fix: the pre-fix code leaks ~2.4 GB where the threshold is 64 MiB, a margin of ~40×, so it is not threshold-sensitive.
- **`GpuCusolverSuccessPathsDoNotLeakDeviceMemory`** — passed before the fix, so not a regression test; it guards the refactor itself against a missed free or a double free via a stale alias, across all five converted paths.
- **`GpuInvMStillCorrectAfterScopedResources`** — checks the inverse of a diagonal matrix against the independently known reciprocal diagonal, not against another Cytnx path. The conversion rewired which pointers the cuSOLVER calls receive, so numerical confirmation is warranted.

Full GPU suite locally, `ctest -L gpu`:

```
100% tests passed, 0 tests failed out of 820
Total Test time (real) = 1686.34 sec
```

817 pre-existing plus the 3 added here. The 4 skips are pre-existing `GTEST_SKIP`s in files this PR does not touch.

**One gap, stated rather than papered over:** #1145's leak is ~2 KB of *host* memory per call, so a CI-robust threshold test would need ~20,000 GPU SVDs to clear allocator noise — too slow to be worth it. I verified it directly instead: 100,000 `gesvdjInfo_t` created without destroy grew host RSS by 2064 bytes each, and the same loop with `cusolverDnDestroyGesvdjInfo` grew it by 4 KB in total. In this PR it is covered structurally by the `GesvdjInfo` type and by the device-memory test exercising the same code path.
