### PR TITLE
perf(backend): cache cuBLAS/cuSOLVER handles per device instead of per call (#1144)

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(
   benchmarks_main.cpp
   Tensor_bm.cpp
   UniTensor_bm.cpp
+  cublas_handle_bm.cpp
   search_tree_bm.cpp
   algo/Vsplit_bm.cpp
   algo/Vstack_bm.cpp

--- a/benchmarks/cublas_handle_bm.cpp
+++ b/benchmarks/cublas_handle_bm.cpp
@@ -1,0 +1,105 @@
+#include <benchmark/benchmark.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "cytnx.hpp"
+
+#ifdef UNI_GPU
+  #include <cuda_runtime.h>
+#endif
+
+// Cytnx wrapped every cuBLAS and cuSOLVER call in a create/destroy pair for the library handle
+// (#1144). Steady-state cost measured in isolation on an RTX 4070 Ti SUPER:
+//
+//     cublasCreate     + cublasDestroy      ~330 us
+//     cusolverDnCreate + cusolverDnDestroy  ~456 us
+//
+// Neither scales with problem size, so on small operands the handle dominates. Measured directly
+// against cublasDgemm in the same process, handle setup cost 19.6x the multiply at n=32 and still
+// 3.5x at n=256, crossing over only around n=400.
+//
+// These benchmarks span n=32..512 so the crossover is visible: the saving should be a roughly
+// constant per-call amount, large relative to the work at small n and negligible at large n. A
+// constant absolute delta is the evidence that the change removes overhead rather than work.
+//
+// GPU kernel launches are asynchronous, so every timed region ends in cudaDeviceSynchronize().
+namespace BMTest_CublasHandle {
+
+#ifdef UNI_GPU
+
+  using cytnx::cytnx_double;
+  using cytnx::cytnx_uint64;
+  using cytnx::Tensor;
+
+  namespace {
+
+    void SyncDevice() { cudaDeviceSynchronize(); }
+
+    Tensor MakeMatrix(cytnx_uint64 n, unsigned int seed) {
+      const cytnx_double kLow = -1.0;
+      const cytnx_double kHigh = 1.0;
+      return cytnx::random::random_tensor({n, n}, kLow, kHigh, cytnx::Device.cuda, seed,
+                                          cytnx::Type.Double);
+    }
+
+  }  // namespace
+
+  // Matmul -> cuMatmul_internal, one cublasCreate/Destroy per call before this change.
+  static void BM_GpuMatmul(benchmark::State& state) {
+    const auto n = static_cast<cytnx_uint64>(state.range(0));
+    const Tensor a = MakeMatrix(n, 0);
+    const Tensor b = MakeMatrix(n, 1);
+    SyncDevice();
+    for (auto _ : state) {
+      auto result = cytnx::linalg::Matmul(a, b);
+      SyncDevice();
+      benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * n * n);
+  }
+  BENCHMARK(BM_GpuMatmul)
+    ->Arg(32)
+    ->Arg(64)
+    ->Arg(128)
+    ->Arg(256)
+    ->Arg(512)
+    ->Unit(benchmark::kMicrosecond);
+
+  // Vectordot -> cuVectordot_internal. A dot product is nearly free, so this is close to a pure
+  // measurement of the per-call handle overhead.
+  static void BM_GpuVectordot(benchmark::State& state) {
+    const auto n = static_cast<cytnx_uint64>(state.range(0));
+    const cytnx_double kLow = -1.0;
+    const cytnx_double kHigh = 1.0;
+    const Tensor v =
+      cytnx::random::random_tensor({n}, kLow, kHigh, cytnx::Device.cuda, 0, cytnx::Type.Double);
+    const Tensor w =
+      cytnx::random::random_tensor({n}, kLow, kHigh, cytnx::Device.cuda, 1, cytnx::Type.Double);
+    SyncDevice();
+    for (auto _ : state) {
+      auto result = cytnx::linalg::Vectordot(v, w);
+      SyncDevice();
+      benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * n);
+  }
+  BENCHMARK(BM_GpuVectordot)->Arg(64)->Arg(1024)->Arg(65536)->Unit(benchmark::kMicrosecond);
+
+  // Det -> cuDet_internal, exercising the cuSOLVER handle rather than the cuBLAS one.
+  static void BM_GpuDet(benchmark::State& state) {
+    const auto n = static_cast<cytnx_uint64>(state.range(0));
+    const Tensor a = MakeMatrix(n, 0);
+    SyncDevice();
+    for (auto _ : state) {
+      auto result = cytnx::linalg::Det(a);
+      SyncDevice();
+      benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * n * n);
+  }
+  BENCHMARK(BM_GpuDet)->Arg(32)->Arg(128)->Arg(512)->Unit(benchmark::kMicrosecond);
+
+#endif  // UNI_GPU
+
+}  // namespace BMTest_CublasHandle

--- a/src/backend/linalg_internal_gpu/cuDet_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuDet_internal.cu
@@ -7,6 +7,7 @@
 #include "backend/utils_internal_gpu/cuScopedResource_gpu.hpp"
 
 #include <vector>
+#include "backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp"
 
 namespace cytnx {
 
@@ -22,16 +23,18 @@ namespace cytnx {
       checkCudaErrors(cudaMemcpy(_in.get(), in->data(), sizeof(cytnx_complex128) * in->size(),
                                  cudaMemcpyDeviceToDevice));
 
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       utils_internal::DeviceBuffer<int> devIpiv(L);
       utils_internal::DeviceBuffer<int> devInfo(1);
 
       int workspace_size = 0;
-      cusolverDnZgetrf_bufferSize(cusolverH.get(), L, L, _in.get(), L, &workspace_size);
+      cusolverDnZgetrf_bufferSize(cusolverH, L, L, _in.get(), L, &workspace_size);
       utils_internal::DeviceBuffer<cuDoubleComplex> workspace(workspace_size);
 
-      cusolverDnZgetrf(cusolverH.get(), L, L, _in.get(), L, workspace.get(), devIpiv.get(),
+      cusolverDnZgetrf(cusolverH, L, L, _in.get(), L, workspace.get(), devIpiv.get(),
                        devInfo.get());
 
       int info;
@@ -61,16 +64,18 @@ namespace cytnx {
       checkCudaErrors(cudaMemcpy(_in.get(), in->data(), sizeof(cytnx_complex64) * in->size(),
                                  cudaMemcpyDeviceToDevice));
 
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       utils_internal::DeviceBuffer<int> devIpiv(L);
       utils_internal::DeviceBuffer<int> devInfo(1);
 
       int workspace_size = 0;
-      cusolverDnCgetrf_bufferSize(cusolverH.get(), L, L, _in.get(), L, &workspace_size);
+      cusolverDnCgetrf_bufferSize(cusolverH, L, L, _in.get(), L, &workspace_size);
       utils_internal::DeviceBuffer<cuFloatComplex> workspace(workspace_size);
 
-      cusolverDnCgetrf(cusolverH.get(), L, L, _in.get(), L, workspace.get(), devIpiv.get(),
+      cusolverDnCgetrf(cusolverH, L, L, _in.get(), L, workspace.get(), devIpiv.get(),
                        devInfo.get());
 
       int info;
@@ -100,16 +105,18 @@ namespace cytnx {
       checkCudaErrors(cudaMemcpy(_in.get(), in->data(), sizeof(cytnx_double) * in->size(),
                                  cudaMemcpyDeviceToDevice));
 
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       utils_internal::DeviceBuffer<int> devIpiv(L);
       utils_internal::DeviceBuffer<int> devInfo(1);
 
       int workspace_size = 0;
-      cusolverDnDgetrf_bufferSize(cusolverH.get(), L, L, _in.get(), L, &workspace_size);
+      cusolverDnDgetrf_bufferSize(cusolverH, L, L, _in.get(), L, &workspace_size);
       utils_internal::DeviceBuffer<cytnx_double> workspace(workspace_size);
 
-      cusolverDnDgetrf(cusolverH.get(), L, L, _in.get(), L, workspace.get(), devIpiv.get(),
+      cusolverDnDgetrf(cusolverH, L, L, _in.get(), L, workspace.get(), devIpiv.get(),
                        devInfo.get());
 
       int info;
@@ -139,16 +146,18 @@ namespace cytnx {
       checkCudaErrors(cudaMemcpy(_in.get(), in->data(), sizeof(cytnx_float) * in->size(),
                                  cudaMemcpyDeviceToDevice));
 
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       utils_internal::DeviceBuffer<int> devIpiv(L);
       utils_internal::DeviceBuffer<int> devInfo(1);
 
       int workspace_size = 0;
-      cusolverDnSgetrf_bufferSize(cusolverH.get(), L, L, _in.get(), L, &workspace_size);
+      cusolverDnSgetrf_bufferSize(cusolverH, L, L, _in.get(), L, &workspace_size);
       utils_internal::DeviceBuffer<cytnx_float> workspace(workspace_size);
 
-      cusolverDnSgetrf(cusolverH.get(), L, L, _in.get(), L, workspace.get(), devIpiv.get(),
+      cusolverDnSgetrf(cusolverH, L, L, _in.get(), L, workspace.get(), devIpiv.get(),
                        devInfo.get());
 
       int info;

--- a/src/backend/linalg_internal_gpu/cuEigh_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuEigh_internal.cu
@@ -3,6 +3,7 @@
 #include "Type.hpp"
 #include "backend/lapack_wrapper.hpp"
 #include "backend/utils_internal_gpu/cuScopedResource_gpu.hpp"
+#include "backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp"
 
 namespace cytnx {
 
@@ -18,7 +19,9 @@ namespace cytnx {
       // create handles:
       // Scoped resources (#1146): the info check below throws, so ownership -- not the cleanup
       // block that used to sit at the tail of this function -- is what prevents a leak.
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       // `tA` aliases v's storage when eigenvectors are wanted and is a temporary otherwise;
       // `owned_ta` is non-empty only in the second case, matching the old conditional cudaFree.
@@ -39,8 +42,8 @@ namespace cytnx {
       // query buffer:
       cytnx_int32 lwork = 0;
       cytnx_int32 b32L = L;
-      checkCudaErrors(cusolverDnZheevd_bufferSize(cusolverH.get(), jobz, CUBLAS_FILL_MODE_UPPER,
-                                                  b32L, (cuDoubleComplex *)tA, b32L,
+      checkCudaErrors(cusolverDnZheevd_bufferSize(cusolverH, jobz, CUBLAS_FILL_MODE_UPPER, b32L,
+                                                  (cuDoubleComplex *)tA, b32L,
                                                   (cytnx_double *)e->data(), &lwork));
 
       // allocate working space:
@@ -49,7 +52,7 @@ namespace cytnx {
       // call :
       cytnx_int32 info;
       utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
-      checkCudaErrors(cusolverDnZheevd(cusolverH.get(), jobz, CUBLAS_FILL_MODE_UPPER, b32L,
+      checkCudaErrors(cusolverDnZheevd(cusolverH, jobz, CUBLAS_FILL_MODE_UPPER, b32L,
                                        (cuDoubleComplex *)tA, b32L, (cytnx_double *)e->data(),
                                        (cuDoubleComplex *)work.get(), lwork, devinfo.get()));
 
@@ -67,7 +70,9 @@ namespace cytnx {
       if (v->dtype() == Type.Void) jobz = CUSOLVER_EIG_MODE_NOVECTOR;
 
       // create handles:
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       cytnx_complex64 *tA;
       utils_internal::DeviceBuffer<cytnx_complex64> owned_ta;
@@ -86,8 +91,8 @@ namespace cytnx {
       // query buffer:
       cytnx_int32 lwork = 0;
       cytnx_int32 b32L = L;
-      checkCudaErrors(cusolverDnCheevd_bufferSize(cusolverH.get(), jobz, CUBLAS_FILL_MODE_UPPER,
-                                                  b32L, (cuFloatComplex *)tA, b32L,
+      checkCudaErrors(cusolverDnCheevd_bufferSize(cusolverH, jobz, CUBLAS_FILL_MODE_UPPER, b32L,
+                                                  (cuFloatComplex *)tA, b32L,
                                                   (cytnx_float *)e->data(), &lwork));
 
       // allocate working space:
@@ -96,7 +101,7 @@ namespace cytnx {
       // call :
       cytnx_int32 info;
       utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
-      checkCudaErrors(cusolverDnCheevd(cusolverH.get(), jobz, CUBLAS_FILL_MODE_UPPER, b32L,
+      checkCudaErrors(cusolverDnCheevd(cusolverH, jobz, CUBLAS_FILL_MODE_UPPER, b32L,
                                        (cuFloatComplex *)tA, b32L, (cytnx_float *)e->data(),
                                        (cuFloatComplex *)work.get(), lwork, devinfo.get()));
 
@@ -114,7 +119,9 @@ namespace cytnx {
       if (v->dtype() == Type.Void) jobz = CUSOLVER_EIG_MODE_NOVECTOR;
 
       // create handles:
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       cytnx_double *tA;
       utils_internal::DeviceBuffer<cytnx_double> owned_ta;
@@ -133,9 +140,8 @@ namespace cytnx {
       // query buffer:
       cytnx_int32 lwork = 0;
       cytnx_int32 b32L = L;
-      checkCudaErrors(cusolverDnDsyevd_bufferSize(cusolverH.get(), jobz, CUBLAS_FILL_MODE_UPPER,
-                                                  b32L, tA, b32L, (cytnx_double *)e->data(),
-                                                  &lwork));
+      checkCudaErrors(cusolverDnDsyevd_bufferSize(cusolverH, jobz, CUBLAS_FILL_MODE_UPPER, b32L, tA,
+                                                  b32L, (cytnx_double *)e->data(), &lwork));
 
       // allocate working space:
       utils_internal::DeviceBuffer<cytnx_double> work(lwork);
@@ -143,8 +149,8 @@ namespace cytnx {
       // call :
       cytnx_int32 info;
       utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
-      checkCudaErrors(cusolverDnDsyevd(cusolverH.get(), jobz, CUBLAS_FILL_MODE_UPPER, b32L, tA,
-                                       b32L, (cytnx_double *)e->data(), work.get(), lwork,
+      checkCudaErrors(cusolverDnDsyevd(cusolverH, jobz, CUBLAS_FILL_MODE_UPPER, b32L, tA, b32L,
+                                       (cytnx_double *)e->data(), work.get(), lwork,
                                        devinfo.get()));
 
       // get info
@@ -161,7 +167,9 @@ namespace cytnx {
       if (v->dtype() == Type.Void) jobz = CUSOLVER_EIG_MODE_NOVECTOR;
 
       // create handles:
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       cytnx_float *tA;
       utils_internal::DeviceBuffer<cytnx_float> owned_ta;
@@ -179,9 +187,8 @@ namespace cytnx {
       // query buffer:
       cytnx_int32 lwork = 0;
       cytnx_int32 b32L = L;
-      checkCudaErrors(cusolverDnSsyevd_bufferSize(cusolverH.get(), jobz, CUBLAS_FILL_MODE_UPPER,
-                                                  b32L, tA, b32L, (cytnx_float *)e->data(),
-                                                  &lwork));
+      checkCudaErrors(cusolverDnSsyevd_bufferSize(cusolverH, jobz, CUBLAS_FILL_MODE_UPPER, b32L, tA,
+                                                  b32L, (cytnx_float *)e->data(), &lwork));
 
       // allocate working space:
       utils_internal::DeviceBuffer<cytnx_float> work(lwork);
@@ -189,9 +196,8 @@ namespace cytnx {
       // call :
       cytnx_int32 info;
       utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
-      checkCudaErrors(cusolverDnSsyevd(cusolverH.get(), jobz, CUBLAS_FILL_MODE_UPPER, b32L, tA,
-                                       b32L, (cytnx_float *)e->data(), work.get(), lwork,
-                                       devinfo.get()));
+      checkCudaErrors(cusolverDnSsyevd(cusolverH, jobz, CUBLAS_FILL_MODE_UPPER, b32L, tA, b32L,
+                                       (cytnx_float *)e->data(), work.get(), lwork, devinfo.get()));
 
       // get info
       checkCudaErrors(

--- a/src/backend/linalg_internal_gpu/cuGeSvd_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuGeSvd_internal.cu
@@ -1,6 +1,7 @@
 #include "cuGeSvd_internal.hpp"
 #include "cuConj_inplace_internal.hpp"
 #include "backend/utils_internal_gpu/cuScopedResource_gpu.hpp"
+#include "backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp"
 
 namespace cytnx {
 
@@ -25,7 +26,9 @@ namespace cytnx {
       // create handles:
       // Scoped resources (#1145, #1146): the info check below throws, so ownership -- not the
       // cleanup block that used to sit at the tail of this function -- is what prevents a leak.
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       utils_internal::DeviceBuffer<data_type> Mij(M * N);
       checkCudaErrors(
@@ -64,7 +67,7 @@ namespace cytnx {
 
       cytnx_int32 lwork = 0;
       checkCudaErrors(cusolverDnZgesvdj_bufferSize(
-        cusolverH.get(), jobz, econ, N, M, (d_data_type *)Mij.get(), ldA, (cytnx_double *)S->data(),
+        cusolverH, jobz, econ, N, M, (d_data_type *)Mij.get(), ldA, (cytnx_double *)S->data(),
         (d_data_type *)vTMem, ldu, (d_data_type *)UMem, ldvT, &lwork, gesvdj_params.get()));
 
       utils_internal::DeviceBuffer<data_type> d_work(lwork);
@@ -72,8 +75,8 @@ namespace cytnx {
       utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
       checkCudaErrors(cudaMemset(devinfo.get(), 0, sizeof(cytnx_int32)));
 
-      checkCudaErrors(cusolverDnZgesvdj(cusolverH.get(), jobz, econ, N, M, (d_data_type *)Mij.get(),
-                                        ldA, (cytnx_double *)S->data(), (d_data_type *)vTMem, ldu,
+      checkCudaErrors(cusolverDnZgesvdj(cusolverH, jobz, econ, N, M, (d_data_type *)Mij.get(), ldA,
+                                        (cytnx_double *)S->data(), (d_data_type *)vTMem, ldu,
                                         (d_data_type *)UMem, ldvT, (d_data_type *)d_work.get(),
                                         lwork, devinfo.get(), gesvdj_params.get()));
       if (U->data() and jobz == CUSOLVER_EIG_MODE_VECTOR) {
@@ -108,7 +111,9 @@ namespace cytnx {
       // create handles:
       // Scoped resources (#1145, #1146): the info check below throws, so ownership -- not the
       // cleanup block that used to sit at the tail of this function -- is what prevents a leak.
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       utils_internal::DeviceBuffer<data_type> Mij(M * N);
       checkCudaErrors(
@@ -147,7 +152,7 @@ namespace cytnx {
 
       cytnx_int32 lwork = 0;
       checkCudaErrors(cusolverDnCgesvdj_bufferSize(
-        cusolverH.get(), jobz, econ, N, M, (d_data_type *)Mij.get(), ldA, (cytnx_float *)S->data(),
+        cusolverH, jobz, econ, N, M, (d_data_type *)Mij.get(), ldA, (cytnx_float *)S->data(),
         (d_data_type *)vTMem, ldu, (d_data_type *)UMem, ldvT, &lwork, gesvdj_params.get()));
 
       utils_internal::DeviceBuffer<data_type> d_work(lwork);
@@ -155,8 +160,8 @@ namespace cytnx {
       utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
       checkCudaErrors(cudaMemset(devinfo.get(), 0, sizeof(cytnx_int32)));
 
-      checkCudaErrors(cusolverDnCgesvdj(cusolverH.get(), jobz, econ, N, M, (d_data_type *)Mij.get(),
-                                        ldA, (cytnx_float *)S->data(), (d_data_type *)vTMem, ldu,
+      checkCudaErrors(cusolverDnCgesvdj(cusolverH, jobz, econ, N, M, (d_data_type *)Mij.get(), ldA,
+                                        (cytnx_float *)S->data(), (d_data_type *)vTMem, ldu,
                                         (d_data_type *)UMem, ldvT, (d_data_type *)d_work.get(),
                                         lwork, devinfo.get(), gesvdj_params.get()));
       if (U->data() and jobz == CUSOLVER_EIG_MODE_VECTOR) {
@@ -190,7 +195,9 @@ namespace cytnx {
       // create handles:
       // Scoped resources (#1145, #1146): the info check below throws, so ownership -- not the
       // cleanup block that used to sit at the tail of this function -- is what prevents a leak.
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       utils_internal::DeviceBuffer<data_type> Mij(M * N);
       checkCudaErrors(
@@ -229,7 +236,7 @@ namespace cytnx {
 
       cytnx_int32 lwork = 0;
       checkCudaErrors(cusolverDnDgesvdj_bufferSize(
-        cusolverH.get(), jobz, econ, N, M, (data_type *)Mij.get(), ldA, (data_type *)S->data(),
+        cusolverH, jobz, econ, N, M, (data_type *)Mij.get(), ldA, (data_type *)S->data(),
         (data_type *)vTMem, ldu, (data_type *)UMem, ldvT, &lwork, gesvdj_params.get()));
 
       utils_internal::DeviceBuffer<data_type> d_work(lwork);
@@ -237,8 +244,8 @@ namespace cytnx {
       utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
       checkCudaErrors(cudaMemset(devinfo.get(), 0, sizeof(cytnx_int32)));
 
-      checkCudaErrors(cusolverDnDgesvdj(cusolverH.get(), jobz, econ, N, M, (data_type *)Mij.get(),
-                                        ldA, (data_type *)S->data(), (data_type *)vTMem, ldu,
+      checkCudaErrors(cusolverDnDgesvdj(cusolverH, jobz, econ, N, M, (data_type *)Mij.get(), ldA,
+                                        (data_type *)S->data(), (data_type *)vTMem, ldu,
                                         (data_type *)UMem, ldvT, (data_type *)d_work.get(), lwork,
                                         devinfo.get(), gesvdj_params.get()));
       if (U->data() and jobz == CUSOLVER_EIG_MODE_VECTOR) {
@@ -271,7 +278,9 @@ namespace cytnx {
       // create handles:
       // Scoped resources (#1145, #1146): the info check below throws, so ownership -- not the
       // cleanup block that used to sit at the tail of this function -- is what prevents a leak.
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       utils_internal::DeviceBuffer<data_type> Mij(M * N);
       checkCudaErrors(
@@ -310,7 +319,7 @@ namespace cytnx {
 
       cytnx_int32 lwork = 0;
       checkCudaErrors(cusolverDnSgesvdj_bufferSize(
-        cusolverH.get(), jobz, econ, N, M, (data_type *)Mij.get(), ldA, (data_type *)S->data(),
+        cusolverH, jobz, econ, N, M, (data_type *)Mij.get(), ldA, (data_type *)S->data(),
         (data_type *)vTMem, ldu, (data_type *)UMem, ldvT, &lwork, gesvdj_params.get()));
 
       utils_internal::DeviceBuffer<data_type> d_work(lwork);
@@ -318,8 +327,8 @@ namespace cytnx {
       utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
       checkCudaErrors(cudaMemset(devinfo.get(), 0, sizeof(cytnx_int32)));
 
-      checkCudaErrors(cusolverDnSgesvdj(cusolverH.get(), jobz, econ, N, M, (data_type *)Mij.get(),
-                                        ldA, (data_type *)S->data(), (data_type *)vTMem, ldu,
+      checkCudaErrors(cusolverDnSgesvdj(cusolverH, jobz, econ, N, M, (data_type *)Mij.get(), ldA,
+                                        (data_type *)S->data(), (data_type *)vTMem, ldu,
                                         (data_type *)UMem, ldvT, (data_type *)d_work.get(), lwork,
                                         devinfo.get(), gesvdj_params.get()));
       if (U->data() and jobz == CUSOLVER_EIG_MODE_VECTOR) {

--- a/src/backend/linalg_internal_gpu/cuGemm_Batch_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuGemm_Batch_internal.cu
@@ -2,6 +2,7 @@
 #include "cytnx_error.hpp"
 #include "Type.hpp"
 #include "backend/lapack_wrapper.hpp"
+#include "backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp"
 
 namespace cytnx {
 
@@ -50,15 +51,15 @@ namespace cytnx {
               break;
           }
           // create handles:
-          cublasHandle_t cublasH = nullptr;
-          checkCudaErrors(cublasCreate(&cublasH));
+          // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+          // up to 20x the cost of the small GEMMs it wraps.
+          cublasHandle_t cublasH = utils_internal::get_cublas_handle();
           checkCudaErrors(cublasZgemm(
             cublasH, transa, transb, m_array[i], n_array[i], k_array[i],
             (cuDoubleComplex *)&alphas[i], (cuDoubleComplex *)a_array[idx], lda_array[i],
             (cuDoubleComplex *)b_array[idx], ldb_array[i], (cuDoubleComplex *)&betas[i],
             (cuDoubleComplex *)c_array[idx], ldc_array[i]));
           idx++;
-          checkCudaErrors(cublasDestroy(cublasH));
         }
       }
     }
@@ -107,15 +108,15 @@ namespace cytnx {
               break;
           }
           // create handles:
-          cublasHandle_t cublasH = nullptr;
-          checkCudaErrors(cublasCreate(&cublasH));
+          // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+          // up to 20x the cost of the small GEMMs it wraps.
+          cublasHandle_t cublasH = utils_internal::get_cublas_handle();
           checkCudaErrors(cublasCgemm(cublasH, transa, transb, m_array[i], n_array[i], k_array[i],
                                       (cuFloatComplex *)&alphas[i], (cuFloatComplex *)a_array[idx],
                                       lda_array[i], (cuFloatComplex *)b_array[idx], ldb_array[i],
                                       (cuFloatComplex *)&betas[i], (cuFloatComplex *)c_array[idx],
                                       ldc_array[i]));
           idx++;
-          checkCudaErrors(cublasDestroy(cublasH));
         }
       }
     }
@@ -164,14 +165,14 @@ namespace cytnx {
               break;
           }
           // create handles:
-          cublasHandle_t cublasH = nullptr;
-          checkCudaErrors(cublasCreate(&cublasH));
+          // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+          // up to 20x the cost of the small GEMMs it wraps.
+          cublasHandle_t cublasH = utils_internal::get_cublas_handle();
           checkCudaErrors(cublasDgemm(
             cublasH, transa, transb, m_array[i], n_array[i], k_array[i], (cytnx_double *)&alphas[i],
             (cytnx_double *)a_array[idx], lda_array[i], (cytnx_double *)b_array[idx], ldb_array[i],
             (cytnx_double *)&betas[i], (cytnx_double *)c_array[idx], ldc_array[i]));
           idx++;
-          checkCudaErrors(cublasDestroy(cublasH));
         }
       }
       // checkCudaErrors(cudaDeviceSynchronize());
@@ -220,14 +221,14 @@ namespace cytnx {
               break;
           }
           // create handles:
-          cublasHandle_t cublasH = nullptr;
-          checkCudaErrors(cublasCreate(&cublasH));
+          // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+          // up to 20x the cost of the small GEMMs it wraps.
+          cublasHandle_t cublasH = utils_internal::get_cublas_handle();
           checkCudaErrors(cublasSgemm(
             cublasH, transa, transb, m_array[i], n_array[i], k_array[i], (cytnx_float *)&alphas[i],
             (cytnx_float *)a_array[idx], lda_array[i], (cytnx_float *)b_array[idx], ldb_array[i],
             (cytnx_float *)&betas[i], (cytnx_float *)c_array[idx], ldc_array[i]));
           idx++;
-          checkCudaErrors(cublasDestroy(cublasH));
         }
       }
     }

--- a/src/backend/linalg_internal_gpu/cuGemm_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuGemm_internal.cu
@@ -2,6 +2,7 @@
 #include "cytnx_error.hpp"
 #include "Type.hpp"
 #include "backend/lapack_wrapper.hpp"
+#include "backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp"
 
 namespace cytnx {
 
@@ -12,8 +13,9 @@ namespace cytnx {
                             const cytnx_int64 &Comm, const cytnx_int64 &Nr, const Scalar &a,
                             const Scalar &b) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       cytnx_complex128 alpha = complex128(a), beta = complex128(b);
 
       cuDoubleComplex *_out = (cuDoubleComplex *)out->data();
@@ -25,8 +27,6 @@ namespace cytnx {
       checkCudaErrors(cublasZgemm(cublasH, CUBLAS_OP_N, CUBLAS_OP_N, blsNr, blsMl, blsComm,
                                   (cuDoubleComplex *)&alpha, _inr, blsNr, _inl, blsComm,
                                   (cuDoubleComplex *)&beta, _out, blsNr));
-
-      cublasDestroy(cublasH);
     }
     void cuGemm_internal_cf(boost::intrusive_ptr<Storage_base> &out,
                             const boost::intrusive_ptr<Storage_base> &inl,
@@ -34,8 +34,9 @@ namespace cytnx {
                             const cytnx_int64 &Comm, const cytnx_int64 &Nr, const Scalar &a,
                             const Scalar &b) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       cytnx_complex64 alpha = complex64(a), beta = complex64(b);
 
       cuFloatComplex *_out = (cuFloatComplex *)out->data();
@@ -47,8 +48,6 @@ namespace cytnx {
       checkCudaErrors(cublasCgemm(cublasH, CUBLAS_OP_N, CUBLAS_OP_N, blsNr, blsMl, blsComm,
                                   (cuFloatComplex *)&alpha, _inr, blsNr, _inl, blsComm,
                                   (cuFloatComplex *)&beta, _out, blsNr));
-
-      cublasDestroy(cublasH);
     }
 
     void cuGemm_internal_d(boost::intrusive_ptr<Storage_base> &out,
@@ -57,8 +56,9 @@ namespace cytnx {
                            const cytnx_int64 &Comm, const cytnx_int64 &Nr, const Scalar &a,
                            const Scalar &b) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       cytnx_double alpha = double(a), beta = double(b);
 
       cytnx_double *_out = (cytnx_double *)out->data();
@@ -69,8 +69,6 @@ namespace cytnx {
       cytnx_int32 blsMl = Ml, blsNr = Nr, blsComm = Comm;
       checkCudaErrors(cublasDgemm(cublasH, CUBLAS_OP_N, CUBLAS_OP_N, blsNr, blsMl, blsComm, &alpha,
                                   _inr, blsNr, _inl, blsComm, &beta, _out, blsNr));
-
-      cublasDestroy(cublasH);
     }
     void cuGemm_internal_f(boost::intrusive_ptr<Storage_base> &out,
                            const boost::intrusive_ptr<Storage_base> &inl,
@@ -78,8 +76,9 @@ namespace cytnx {
                            const cytnx_int64 &Comm, const cytnx_int64 &Nr, const Scalar &a,
                            const Scalar &b) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       cytnx_float alpha = float(a), beta = float(b);
 
       cytnx_float *_out = (cytnx_float *)out->data();
@@ -90,8 +89,6 @@ namespace cytnx {
       cytnx_int32 blsMl = Ml, blsNr = Nr, blsComm = Comm;
       checkCudaErrors(cublasSgemm(cublasH, CUBLAS_OP_N, CUBLAS_OP_N, blsNr, blsMl, blsComm, &alpha,
                                   _inr, blsNr, _inl, blsComm, &beta, _out, blsNr));
-
-      cublasDestroy(cublasH);
     }
 
   }  // namespace linalg_internal

--- a/src/backend/linalg_internal_gpu/cuGer_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuGer_internal.cu
@@ -2,6 +2,7 @@
 #include "backend/utils_internal_interface.hpp"
 
 #include "backend/lapack_wrapper.hpp"
+#include "backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp"
 
 namespace cytnx {
   namespace linalg_internal {
@@ -10,8 +11,9 @@ namespace cytnx {
                            const boost::intrusive_ptr<Storage_base> &x,
                            const boost::intrusive_ptr<Storage_base> &y, const Scalar &a) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       cytnx_complex128 alpha = complex128(a);
 
       cuDoubleComplex *_A = (cuDoubleComplex *)A->data();
@@ -20,16 +22,15 @@ namespace cytnx {
 
       checkCudaErrors(cublasZgeru(cublasH, y->size(), x->size(), (cuDoubleComplex *)&alpha, _y, 1,
                                   _x, 1, _A, y->size()));
-
-      cublasDestroy(cublasH);
     }
 
     void cuGer_internal_cf(boost::intrusive_ptr<Storage_base> &A,
                            const boost::intrusive_ptr<Storage_base> &x,
                            const boost::intrusive_ptr<Storage_base> &y, const Scalar &a) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       cytnx_complex64 alpha = complex64(a);
 
       cuFloatComplex *_A = (cuFloatComplex *)A->data();
@@ -38,16 +39,15 @@ namespace cytnx {
 
       checkCudaErrors(cublasCgeru(cublasH, y->size(), x->size(), (cuFloatComplex *)&alpha, _y, 1,
                                   _x, 1, _A, y->size()));
-
-      cublasDestroy(cublasH);
     }
 
     void cuGer_internal_d(boost::intrusive_ptr<Storage_base> &A,
                           const boost::intrusive_ptr<Storage_base> &x,
                           const boost::intrusive_ptr<Storage_base> &y, const Scalar &a) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       cytnx_double alpha = cytnx_double(a);
 
       cytnx_double *_A = (cytnx_double *)A->data();
@@ -56,16 +56,15 @@ namespace cytnx {
 
       checkCudaErrors(
         cublasDger(cublasH, y->size(), x->size(), &alpha, _y, 1, _x, 1, _A, y->size()));
-
-      cublasDestroy(cublasH);
     }
 
     void cuGer_internal_f(boost::intrusive_ptr<Storage_base> &A,
                           const boost::intrusive_ptr<Storage_base> &x,
                           const boost::intrusive_ptr<Storage_base> &y, const Scalar &a) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       cytnx_float alpha = cytnx_float(a);
 
       cytnx_float *_A = (cytnx_float *)A->data();
@@ -74,8 +73,6 @@ namespace cytnx {
 
       checkCudaErrors(
         cublasSger(cublasH, y->size(), x->size(), &alpha, _y, 1, _x, 1, _A, y->size()));
-
-      cublasDestroy(cublasH);
     }
 
   }  // namespace linalg_internal

--- a/src/backend/linalg_internal_gpu/cuInvM_inplace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuInvM_inplace_internal.cu
@@ -5,6 +5,7 @@
 #include "backend/utils_internal_gpu/cuScopedResource_gpu.hpp"
 
 #include <vector>
+#include "backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp"
 
 namespace cytnx {
   namespace linalg_internal {
@@ -12,7 +13,9 @@ namespace cytnx {
     void cuInvM_inplace_internal_d(boost::intrusive_ptr<Storage_base> &ten, const cytnx_int64 &L) {
       // Scoped resources (#1146): the info checks below throw, so ownership -- not a cleanup block
       // at the tail of the function -- is what keeps these from leaking.
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       cytnx_int32 info;
       cytnx_int32 lwork = 0;
@@ -20,10 +23,10 @@ namespace cytnx {
       utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
       // trf:
       checkCudaErrors(
-        cusolverDnDgetrf_bufferSize(cusolverH.get(), L, L, (cytnx_double *)ten->data(), L, &lwork));
+        cusolverDnDgetrf_bufferSize(cusolverH, L, L, (cytnx_double *)ten->data(), L, &lwork));
       utils_internal::DeviceBuffer<cytnx_double> d_work(lwork);
 
-      checkCudaErrors(cusolverDnDgetrf(cusolverH.get(), L, L, (cytnx_double *)ten->data(), L,
+      checkCudaErrors(cusolverDnDgetrf(cusolverH, L, L, (cytnx_double *)ten->data(), L,
                                        d_work.get(), ipiv.get(), devinfo.get()));
       checkCudaErrors(
         cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
@@ -39,9 +42,8 @@ namespace cytnx {
       checkCudaErrors(
         cudaMemcpy(d_I.get(), h_I.data(), sizeof(cytnx_double) * L * L, cudaMemcpyHostToDevice));
 
-      checkCudaErrors(cusolverDnDgetrs(cusolverH.get(), CUBLAS_OP_N, L, L,
-                                       (cytnx_double *)ten->data(), L, ipiv.get(), d_I.get(), L,
-                                       devinfo.get()));
+      checkCudaErrors(cusolverDnDgetrs(cusolverH, CUBLAS_OP_N, L, L, (cytnx_double *)ten->data(), L,
+                                       ipiv.get(), d_I.get(), L, devinfo.get()));
       checkCudaErrors(
         cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
@@ -53,7 +55,9 @@ namespace cytnx {
     }
 
     void cuInvM_inplace_internal_f(boost::intrusive_ptr<Storage_base> &ten, const cytnx_int64 &L) {
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       cytnx_int32 info;
       cytnx_int32 lwork = 0;
@@ -61,11 +65,11 @@ namespace cytnx {
       utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
       // trf:
       checkCudaErrors(
-        cusolverDnSgetrf_bufferSize(cusolverH.get(), L, L, (cytnx_float *)ten->data(), L, &lwork));
+        cusolverDnSgetrf_bufferSize(cusolverH, L, L, (cytnx_float *)ten->data(), L, &lwork));
       utils_internal::DeviceBuffer<cytnx_float> d_work(lwork);
 
-      checkCudaErrors(cusolverDnSgetrf(cusolverH.get(), L, L, (cytnx_float *)ten->data(), L,
-                                       d_work.get(), ipiv.get(), devinfo.get()));
+      checkCudaErrors(cusolverDnSgetrf(cusolverH, L, L, (cytnx_float *)ten->data(), L, d_work.get(),
+                                       ipiv.get(), devinfo.get()));
       checkCudaErrors(
         cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
@@ -80,9 +84,8 @@ namespace cytnx {
       checkCudaErrors(
         cudaMemcpy(d_I.get(), h_I.data(), sizeof(cytnx_float) * L * L, cudaMemcpyHostToDevice));
 
-      checkCudaErrors(cusolverDnSgetrs(cusolverH.get(), CUBLAS_OP_N, L, L,
-                                       (cytnx_float *)ten->data(), L, ipiv.get(), d_I.get(), L,
-                                       devinfo.get()));
+      checkCudaErrors(cusolverDnSgetrs(cusolverH, CUBLAS_OP_N, L, L, (cytnx_float *)ten->data(), L,
+                                       ipiv.get(), d_I.get(), L, devinfo.get()));
       checkCudaErrors(
         cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
@@ -94,18 +97,20 @@ namespace cytnx {
     }
 
     void cuInvM_inplace_internal_cd(boost::intrusive_ptr<Storage_base> &ten, const cytnx_int64 &L) {
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       cytnx_int32 info;
       cytnx_int32 lwork = 0;
       utils_internal::DeviceBuffer<cytnx_int32> ipiv(L + 1);
       utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
       // trf:
-      checkCudaErrors(cusolverDnZgetrf_bufferSize(cusolverH.get(), L, L,
-                                                  (cuDoubleComplex *)ten->data(), L, &lwork));
+      checkCudaErrors(
+        cusolverDnZgetrf_bufferSize(cusolverH, L, L, (cuDoubleComplex *)ten->data(), L, &lwork));
       utils_internal::DeviceBuffer<cytnx_complex128> d_work(lwork);
 
-      checkCudaErrors(cusolverDnZgetrf(cusolverH.get(), L, L, (cuDoubleComplex *)ten->data(), L,
+      checkCudaErrors(cusolverDnZgetrf(cusolverH, L, L, (cuDoubleComplex *)ten->data(), L,
                                        (cuDoubleComplex *)d_work.get(), ipiv.get(), devinfo.get()));
       checkCudaErrors(
         cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
@@ -121,9 +126,9 @@ namespace cytnx {
       checkCudaErrors(cudaMemcpy(d_I.get(), h_I.data(), sizeof(cytnx_complex128) * L * L,
                                  cudaMemcpyHostToDevice));
 
-      checkCudaErrors(cusolverDnZgetrs(cusolverH.get(), CUBLAS_OP_N, L, L,
-                                       (cuDoubleComplex *)ten->data(), L, ipiv.get(),
-                                       (cuDoubleComplex *)d_I.get(), L, devinfo.get()));
+      checkCudaErrors(cusolverDnZgetrs(cusolverH, CUBLAS_OP_N, L, L, (cuDoubleComplex *)ten->data(),
+                                       L, ipiv.get(), (cuDoubleComplex *)d_I.get(), L,
+                                       devinfo.get()));
       checkCudaErrors(
         cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 
@@ -135,18 +140,20 @@ namespace cytnx {
     }
 
     void cuInvM_inplace_internal_cf(boost::intrusive_ptr<Storage_base> &ten, const cytnx_int64 &L) {
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       cytnx_int32 info;
       cytnx_int32 lwork = 0;
       utils_internal::DeviceBuffer<cytnx_int32> ipiv(L + 1);
       utils_internal::DeviceBuffer<cytnx_int32> devinfo(1);
       // trf:
-      checkCudaErrors(cusolverDnCgetrf_bufferSize(cusolverH.get(), L, L,
-                                                  (cuFloatComplex *)ten->data(), L, &lwork));
+      checkCudaErrors(
+        cusolverDnCgetrf_bufferSize(cusolverH, L, L, (cuFloatComplex *)ten->data(), L, &lwork));
       utils_internal::DeviceBuffer<cytnx_complex64> d_work(lwork);
 
-      checkCudaErrors(cusolverDnCgetrf(cusolverH.get(), L, L, (cuFloatComplex *)ten->data(), L,
+      checkCudaErrors(cusolverDnCgetrf(cusolverH, L, L, (cuFloatComplex *)ten->data(), L,
                                        (cuFloatComplex *)d_work.get(), ipiv.get(), devinfo.get()));
       checkCudaErrors(
         cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
@@ -162,9 +169,9 @@ namespace cytnx {
       checkCudaErrors(
         cudaMemcpy(d_I.get(), h_I.data(), sizeof(cytnx_complex64) * L * L, cudaMemcpyHostToDevice));
 
-      checkCudaErrors(cusolverDnCgetrs(cusolverH.get(), CUBLAS_OP_N, L, L,
-                                       (cuFloatComplex *)ten->data(), L, ipiv.get(),
-                                       (cuFloatComplex *)d_I.get(), L, devinfo.get()));
+      checkCudaErrors(cusolverDnCgetrs(cusolverH, CUBLAS_OP_N, L, L, (cuFloatComplex *)ten->data(),
+                                       L, ipiv.get(), (cuFloatComplex *)d_I.get(), L,
+                                       devinfo.get()));
       checkCudaErrors(
         cudaMemcpy(&info, devinfo.get(), sizeof(cytnx_int32), cudaMemcpyDeviceToHost));
 

--- a/src/backend/linalg_internal_gpu/cuMatmul_dg_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuMatmul_dg_internal.cu
@@ -2,6 +2,7 @@
 #include "cytnx_error.hpp"
 #include "Type.hpp"
 #include "backend/lapack_wrapper.hpp"
+#include "backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp"
 
 // this use dgmm
 
@@ -36,8 +37,9 @@ namespace cytnx {
                                  const cytnx_int64 &Ml, const cytnx_int64 &Comm,
                                  const cytnx_int64 &Nr, const int &diag_L) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       // cytnx_complex128 alpha = cytnx_complex128(1,0), beta=cytnx_complex128(0,0);
 
       cuDoubleComplex *_out = (cuDoubleComplex *)out->data();
@@ -52,8 +54,6 @@ namespace cytnx {
       else
         checkCudaErrors(
           cublasZdgmm(cublasH, CUBLAS_SIDE_LEFT, blsNr, blsMl, _inl, blsNr, _inr, 1, _out, blsNr));
-
-      cublasDestroy(cublasH);
     }
     void cuMatmul_dg_internal_cf(boost::intrusive_ptr<Storage_base> &out,
                                  const boost::intrusive_ptr<Storage_base> &inl,
@@ -61,8 +61,9 @@ namespace cytnx {
                                  const cytnx_int64 &Ml, const cytnx_int64 &Comm,
                                  const cytnx_int64 &Nr, const int &diag_L) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       // cytnx_complex64 alpha = cytnx_complex64(1,0), beta=cytnx_complex64(0,0);
 
       cuFloatComplex *_out = (cuFloatComplex *)out->data();
@@ -77,8 +78,6 @@ namespace cytnx {
       else
         checkCudaErrors(
           cublasCdgmm(cublasH, CUBLAS_SIDE_LEFT, blsNr, blsMl, _inl, blsNr, _inr, 1, _out, blsNr));
-
-      cublasDestroy(cublasH);
     }
 
     void cuMatmul_dg_internal_d(boost::intrusive_ptr<Storage_base> &out,
@@ -87,8 +86,9 @@ namespace cytnx {
                                 const cytnx_int64 &Ml, const cytnx_int64 &Comm,
                                 const cytnx_int64 &Nr, const int &diag_L) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       // cytnx_double alpha = 1, beta=0;
 
       cytnx_double *_out = (cytnx_double *)out->data();
@@ -104,8 +104,6 @@ namespace cytnx {
       else
         checkCudaErrors(
           cublasDdgmm(cublasH, CUBLAS_SIDE_LEFT, blsNr, blsMl, _inl, blsNr, _inr, 1, _out, blsNr));
-
-      cublasDestroy(cublasH);
     }
     void cuMatmul_dg_internal_f(boost::intrusive_ptr<Storage_base> &out,
                                 const boost::intrusive_ptr<Storage_base> &inl,
@@ -113,8 +111,9 @@ namespace cytnx {
                                 const cytnx_int64 &Ml, const cytnx_int64 &Comm,
                                 const cytnx_int64 &Nr, const int &diag_L) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       // cytnx_float alpha = 1, beta=0;
 
       cytnx_float *_out = (cytnx_float *)out->data();
@@ -129,8 +128,6 @@ namespace cytnx {
       else
         checkCudaErrors(
           cublasSdgmm(cublasH, CUBLAS_SIDE_LEFT, blsNr, blsMl, _inl, blsNr, _inr, 1, _out, blsNr));
-
-      cublasDestroy(cublasH);
     }
     void cuMatmul_dg_internal_i64(boost::intrusive_ptr<Storage_base> &out,
                                   const boost::intrusive_ptr<Storage_base> &inl,

--- a/src/backend/linalg_internal_gpu/cuMatmul_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuMatmul_internal.cu
@@ -2,6 +2,7 @@
 #include "cytnx_error.hpp"
 #include "Type.hpp"
 #include "backend/lapack_wrapper.hpp"
+#include "backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp"
 
 namespace cytnx {
 
@@ -26,8 +27,9 @@ namespace cytnx {
                               const boost::intrusive_ptr<Storage_base> &inr, const cytnx_int64 &Ml,
                               const cytnx_int64 &Comm, const cytnx_int64 &Nr) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       cytnx_complex128 alpha = cytnx_complex128(1, 0), beta = cytnx_complex128(0, 0);
 
       cuDoubleComplex *_out = (cuDoubleComplex *)out->data();
@@ -39,16 +41,15 @@ namespace cytnx {
       checkCudaErrors(cublasZgemm(cublasH, CUBLAS_OP_N, CUBLAS_OP_N, blsNr, blsMl, blsComm,
                                   (cuDoubleComplex *)&alpha, _inr, blsNr, _inl, blsComm,
                                   (cuDoubleComplex *)&beta, _out, blsNr));
-
-      cublasDestroy(cublasH);
     }
     void cuMatmul_internal_cf(boost::intrusive_ptr<Storage_base> &out,
                               const boost::intrusive_ptr<Storage_base> &inl,
                               const boost::intrusive_ptr<Storage_base> &inr, const cytnx_int64 &Ml,
                               const cytnx_int64 &Comm, const cytnx_int64 &Nr) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       cytnx_complex64 alpha = cytnx_complex64(1, 0), beta = cytnx_complex64(0, 0);
 
       cuFloatComplex *_out = (cuFloatComplex *)out->data();
@@ -60,8 +61,6 @@ namespace cytnx {
       checkCudaErrors(cublasCgemm(cublasH, CUBLAS_OP_N, CUBLAS_OP_N, blsNr, blsMl, blsComm,
                                   (cuFloatComplex *)&alpha, _inr, blsNr, _inl, blsComm,
                                   (cuFloatComplex *)&beta, _out, blsNr));
-
-      cublasDestroy(cublasH);
     }
 
     void cuMatmul_internal_d(boost::intrusive_ptr<Storage_base> &out,
@@ -69,8 +68,9 @@ namespace cytnx {
                              const boost::intrusive_ptr<Storage_base> &inr, const cytnx_int64 &Ml,
                              const cytnx_int64 &Comm, const cytnx_int64 &Nr) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       cytnx_double alpha = 1, beta = 0;
 
       cytnx_double *_out = (cytnx_double *)out->data();
@@ -81,16 +81,15 @@ namespace cytnx {
       cytnx_int32 blsMl = Ml, blsNr = Nr, blsComm = Comm;
       checkCudaErrors(cublasDgemm(cublasH, CUBLAS_OP_N, CUBLAS_OP_N, blsNr, blsMl, blsComm, &alpha,
                                   _inr, blsNr, _inl, blsComm, &beta, _out, blsNr));
-
-      cublasDestroy(cublasH);
     }
     void cuMatmul_internal_f(boost::intrusive_ptr<Storage_base> &out,
                              const boost::intrusive_ptr<Storage_base> &inl,
                              const boost::intrusive_ptr<Storage_base> &inr, const cytnx_int64 &Ml,
                              const cytnx_int64 &Comm, const cytnx_int64 &Nr) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       cytnx_float alpha = 1, beta = 0;
 
       cytnx_float *_out = (cytnx_float *)out->data();
@@ -101,8 +100,6 @@ namespace cytnx {
       cytnx_int32 blsMl = Ml, blsNr = Nr, blsComm = Comm;
       checkCudaErrors(cublasSgemm(cublasH, CUBLAS_OP_N, CUBLAS_OP_N, blsNr, blsMl, blsComm, &alpha,
                                   _inr, blsNr, _inl, blsComm, &beta, _out, blsNr));
-
-      cublasDestroy(cublasH);
     }
     void cuMatmul_internal_i64(boost::intrusive_ptr<Storage_base> &out,
                                const boost::intrusive_ptr<Storage_base> &inl,

--- a/src/backend/linalg_internal_gpu/cuMatvec_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuMatvec_internal.cu
@@ -2,6 +2,7 @@
 #include "cytnx_error.hpp"
 #include "Type.hpp"
 #include "backend/lapack_wrapper.hpp"
+#include "backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp"
 
 namespace cytnx {
 
@@ -26,8 +27,9 @@ namespace cytnx {
                               const boost::intrusive_ptr<Storage_base> &inr, const cytnx_int64 &Ml,
                               const cytnx_int64 &Nr) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       cytnx_complex128 alpha = cytnx_complex128(1, 0), beta = cytnx_complex128(0, 0);
 
       cuDoubleComplex *_out = (cuDoubleComplex *)out->data();
@@ -40,16 +42,15 @@ namespace cytnx {
       //                             _inl, blsMl, _inr, 1, (cuDoubleComplex *)&beta, _out, 1));
       checkCudaErrors(cublasZgemv(cublasH, CUBLAS_OP_T, blsNr, blsMl, (cuDoubleComplex *)&alpha,
                                   _inl, blsMl, _inr, 1, (cuDoubleComplex *)&beta, _out, 1));
-
-      cublasDestroy(cublasH);
     }
     void cuMatvec_internal_cf(boost::intrusive_ptr<Storage_base> &out,
                               const boost::intrusive_ptr<Storage_base> &inl,
                               const boost::intrusive_ptr<Storage_base> &inr, const cytnx_int64 &Ml,
                               const cytnx_int64 &Nr) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       cytnx_complex64 alpha = cytnx_complex64(1, 0), beta = cytnx_complex64(0, 0);
 
       cuFloatComplex *_out = (cuFloatComplex *)out->data();
@@ -62,8 +63,6 @@ namespace cytnx {
       //                             _inl, blsMl, _inr, 1, (cuFloatComplex *)&beta, _out, 1));
       checkCudaErrors(cublasCgemv(cublasH, CUBLAS_OP_T, blsNr, blsMl, (cuFloatComplex *)&alpha,
                                   _inl, blsMl, _inr, 1, (cuFloatComplex *)&beta, _out, 1));
-
-      cublasDestroy(cublasH);
     }
 
     void cuMatvec_internal_d(boost::intrusive_ptr<Storage_base> &out,
@@ -71,8 +70,9 @@ namespace cytnx {
                              const boost::intrusive_ptr<Storage_base> &inr, const cytnx_int64 &Ml,
                              const cytnx_int64 &Nr) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       cytnx_double alpha = 1, beta = 0;
 
       cytnx_double *_out = (cytnx_double *)out->data();
@@ -85,16 +85,15 @@ namespace cytnx {
       // 1, &beta, _out, 1));
       checkCudaErrors(cublasDgemv(cublasH, CUBLAS_OP_T, blsNr, blsMl, &alpha, _inl, blsNr, _inr, 1,
                                   &beta, _out, 1));
-
-      cublasDestroy(cublasH);
     }
     void cuMatvec_internal_f(boost::intrusive_ptr<Storage_base> &out,
                              const boost::intrusive_ptr<Storage_base> &inl,
                              const boost::intrusive_ptr<Storage_base> &inr, const cytnx_int64 &Ml,
                              const cytnx_int64 &Nr) {
       // create handles:
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       cytnx_float alpha = 1, beta = 0;
 
       cytnx_float *_out = (cytnx_float *)out->data();
@@ -108,8 +107,6 @@ namespace cytnx {
       //                             &beta, _out, 1));
       checkCudaErrors(cublasSgemv(cublasH, CUBLAS_OP_T, blsNr, blsMl, &alpha, _inl, blsNr, _inr, 1,
                                   &beta, _out, 1));
-
-      cublasDestroy(cublasH);
     }
     void cuMatvec_internal_i64(boost::intrusive_ptr<Storage_base> &out,
                                const boost::intrusive_ptr<Storage_base> &inl,

--- a/src/backend/linalg_internal_gpu/cuNorm_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuNorm_internal.cu
@@ -3,6 +3,7 @@
 #include "utils/utils.hpp"
 #include "cytnx_error.hpp"
 #include "backend/lapack_wrapper.hpp"
+#include "backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp"
 
 namespace cytnx {
 
@@ -10,36 +11,33 @@ namespace cytnx {
 
     /// cuNorm
     void cuNorm_internal_cd(void *out, const boost::intrusive_ptr<Storage_base> &Rin) {
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
 
       checkCudaErrors(
         cublasDznrm2(cublasH, Rin->size(), (cuDoubleComplex *)Rin->data(), 1, (double *)out));
-
-      cublasDestroy(cublasH);
     }
     void cuNorm_internal_cf(void *out, const boost::intrusive_ptr<Storage_base> &Rin) {
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
 
       checkCudaErrors(
         cublasScnrm2(cublasH, Rin->size(), (cuComplex *)Rin->data(), 1, (float *)out));
-
-      cublasDestroy(cublasH);
     }
     void cuNorm_internal_d(void *out, const boost::intrusive_ptr<Storage_base> &Rin) {
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
 
       checkCudaErrors(cublasDnrm2(cublasH, Rin->size(), (double *)Rin->data(), 1, (double *)out));
-
-      cublasDestroy(cublasH);
     }
     void cuNorm_internal_f(void *out, const boost::intrusive_ptr<Storage_base> &Rin) {
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
       checkCudaErrors(cublasSnrm2(cublasH, Rin->size(), (float *)Rin->data(), 1, (float *)out));
-      cublasDestroy(cublasH);
     }
 
   }  // namespace linalg_internal

--- a/src/backend/linalg_internal_gpu/cuSvd_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuSvd_internal.cu
@@ -3,6 +3,7 @@
 #include "backend/utils_internal_gpu/cuScopedResource_gpu.hpp"
 
 #include <vector>
+#include "backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp"
 
 namespace cytnx {
 
@@ -30,7 +31,9 @@ namespace cytnx {
       // create handles:
       // Scoped resources (#1146): the info check below throws, so ownership -- not the cleanup
       // block that used to sit at the tail of this function -- is what prevents a leak.
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       utils_internal::DeviceBuffer<data_type> Mij(M * N);
       checkCudaErrors(
@@ -67,7 +70,7 @@ namespace cytnx {
       void *h_work = nullptr; /* host workspace for getrf */
       cytnx_double h_err_sigma;
       // query working space :
-      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH.get(), nullptr, /* params */
+      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH, nullptr, /* params */
                                                    jobz, econ, N, M, cuda_data_type, /* dataTypeA */
                                                    Mij.get(), ldA, cuda_data_typeR, /* dataTypeS */
                                                    S->data(), cuda_data_type, /* dataTypeU */
@@ -94,7 +97,7 @@ namespace cytnx {
 
       cytnx_int32 info;
       /// compute:
-      cusolverDnXgesvdp(cusolverH.get(), nullptr, /* params */
+      cusolverDnXgesvdp(cusolverH, nullptr, /* params */
                         jobz, econ, N, M, cuda_data_type, /* dataTypeA */
                         Mij.get(), ldA, cuda_data_typeR, /* dataTypeS */
                         S->data(), cuda_data_type, /* dataTypeU */
@@ -139,7 +142,9 @@ namespace cytnx {
       // create handles:
       // Scoped resources (#1146): the info check below throws, so ownership -- not the cleanup
       // block that used to sit at the tail of this function -- is what prevents a leak.
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       utils_internal::DeviceBuffer<data_type> Mij(M * N);
       checkCudaErrors(
@@ -177,7 +182,7 @@ namespace cytnx {
       void *h_work = nullptr; /* host workspace for getrf */
       cytnx_double h_err_sigma;
       // query working space :
-      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH.get(), nullptr, /* params */
+      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH, nullptr, /* params */
                                                    jobz, econ, N, M, cuda_data_type, /* dataTypeA */
                                                    Mij.get(), ldA, cuda_data_typeR, /* dataTypeS */
                                                    S->data(), cuda_data_type, /* dataTypeU */
@@ -204,7 +209,7 @@ namespace cytnx {
 
       cytnx_int32 info;
       /// compute:
-      cusolverDnXgesvdp(cusolverH.get(), nullptr, /* params */
+      cusolverDnXgesvdp(cusolverH, nullptr, /* params */
                         jobz, econ, N, M, cuda_data_type, /* dataTypeA */
                         Mij.get(), ldA, cuda_data_typeR, /* dataTypeS */
                         S->data(), cuda_data_type, /* dataTypeU */
@@ -248,7 +253,9 @@ namespace cytnx {
       // create handles:
       // Scoped resources (#1146): the info check below throws, so ownership -- not the cleanup
       // block that used to sit at the tail of this function -- is what prevents a leak.
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       utils_internal::DeviceBuffer<data_type> Mij(M * N);
       checkCudaErrors(
@@ -286,7 +293,7 @@ namespace cytnx {
       void *h_work = nullptr; /* host workspace for getrf */
       cytnx_double h_err_sigma;
       // query working space :
-      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH.get(), nullptr, /* params */
+      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH, nullptr, /* params */
                                                    jobz, econ, N, M, cuda_data_type, /* dataTypeA */
                                                    Mij.get(), ldA, cuda_data_typeR, /* dataTypeS */
                                                    S->data(), cuda_data_type, /* dataTypeU */
@@ -313,7 +320,7 @@ namespace cytnx {
 
       cytnx_int32 info;
       /// compute:
-      cusolverDnXgesvdp(cusolverH.get(), nullptr, /* params */
+      cusolverDnXgesvdp(cusolverH, nullptr, /* params */
                         jobz, econ, N, M, cuda_data_type, /* dataTypeA */
                         Mij.get(), ldA, cuda_data_typeR, /* dataTypeS */
                         S->data(), cuda_data_type, /* dataTypeU */
@@ -356,7 +363,9 @@ namespace cytnx {
       // create handles:
       // Scoped resources (#1146): the info check below throws, so ownership -- not the cleanup
       // block that used to sit at the tail of this function -- is what prevents a leak.
-      utils_internal::CusolverDnHandle cusolverH;
+      // Shared per-device handle (#1144): cusolverDnCreate costs ~456 us per call
+      // and its ~12 MB device workspace was reallocated every time.
+      cusolverDnHandle_t cusolverH = utils_internal::get_cusolverdn_handle();
 
       utils_internal::DeviceBuffer<data_type> Mij(M * N);
       checkCudaErrors(
@@ -394,7 +403,7 @@ namespace cytnx {
       void *h_work = nullptr; /* host workspace for getrf */
       cytnx_double h_err_sigma;
       // query working space :
-      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH.get(), nullptr, /* params */
+      checkCudaErrors(cusolverDnXgesvdp_bufferSize(cusolverH, nullptr, /* params */
                                                    jobz, econ, N, M, cuda_data_type, /* dataTypeA */
                                                    Mij.get(), ldA, cuda_data_typeR, /* dataTypeS */
                                                    S->data(), cuda_data_type, /* dataTypeU */
@@ -421,7 +430,7 @@ namespace cytnx {
 
       cytnx_int32 info;
       /// compute:
-      cusolverDnXgesvdp(cusolverH.get(), nullptr, /* params */
+      cusolverDnXgesvdp(cusolverH, nullptr, /* params */
                         jobz, econ, N, M, cuda_data_type, /* dataTypeA */
                         Mij.get(), ldA, cuda_data_typeR, /* dataTypeS */
                         S->data(), cuda_data_type, /* dataTypeU */

--- a/src/backend/linalg_internal_gpu/cuVectordot_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuVectordot_internal.cu
@@ -3,6 +3,7 @@
 #include "Type.hpp"
 #include "backend/lapack_wrapper.hpp"
 #include "backend/utils_internal_gpu/cuReduce_gpu.hpp"
+#include "backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp"
 
 namespace cytnx {
 
@@ -11,8 +12,9 @@ namespace cytnx {
                                  const boost::intrusive_ptr<Storage_base> &Lin,
                                  const boost::intrusive_ptr<Storage_base> &Rin,
                                  const unsigned long long &len, const bool &is_conj) {
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
 
       cuDoubleComplex *_out = (cuDoubleComplex *)out->data();
       cuDoubleComplex *_Lin = (cuDoubleComplex *)Lin->data();
@@ -64,14 +66,14 @@ namespace cytnx {
       free(hacres);
       */
       cudaFree(dacres);
-      cublasDestroy(cublasH);
     }
     void cuVectordot_internal_cf(boost::intrusive_ptr<Storage_base> &out,
                                  const boost::intrusive_ptr<Storage_base> &Lin,
                                  const boost::intrusive_ptr<Storage_base> &Rin,
                                  const unsigned long long &len, const bool &is_conj) {
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
 
       cuFloatComplex *_out = (cuFloatComplex *)out->data();
       cuFloatComplex *_Lin = (cuFloatComplex *)Lin->data();
@@ -123,14 +125,14 @@ namespace cytnx {
       free(hacres);
       */
       cudaFree(dacres);
-      cublasDestroy(cublasH);
     }
     void cuVectordot_internal_d(boost::intrusive_ptr<Storage_base> &out,
                                 const boost::intrusive_ptr<Storage_base> &Lin,
                                 const boost::intrusive_ptr<Storage_base> &Rin,
                                 const unsigned long long &len, const bool &is_conj) {
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
 
       cytnx_double *_out = (cytnx_double *)out->data();
       cytnx_double *_Lin = (cytnx_double *)Lin->data();
@@ -177,14 +179,14 @@ namespace cytnx {
       free(hacres);
       */
       cudaFree(dacres);
-      cublasDestroy(cublasH);
     }
     void cuVectordot_internal_f(boost::intrusive_ptr<Storage_base> &out,
                                 const boost::intrusive_ptr<Storage_base> &Lin,
                                 const boost::intrusive_ptr<Storage_base> &Rin,
                                 const unsigned long long &len, const bool &is_conj) {
-      cublasHandle_t cublasH = nullptr;
-      checkCudaErrors(cublasCreate(&cublasH));
+      // Shared per-device handle (#1144): cublasCreate costs ~330 us per call,
+      // up to 20x the cost of the small GEMMs it wraps.
+      cublasHandle_t cublasH = utils_internal::get_cublas_handle();
 
       cytnx_float *_out = (cytnx_float *)out->data();
       cytnx_float *_Lin = (cytnx_float *)Lin->data();
@@ -231,7 +233,6 @@ namespace cytnx {
       free(hacres);
       */
       cudaFree(dacres);
-      cublasDestroy(cublasH);
     }
     void cuVectordot_internal_i64(boost::intrusive_ptr<Storage_base> &out,
                                   const boost::intrusive_ptr<Storage_base> &Lin,

--- a/src/backend/utils_internal_gpu/CMakeLists.txt
+++ b/src/backend/utils_internal_gpu/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(cytnx
     cuTypeTraits_gpu.hpp
     cuGetElems_gpu.hpp
     cuGetElems_contiguous_gpu.hpp
+    cuLibraryHandle_gpu.hpp
     cuMovemem_gpu.hpp
     cuScopedResource_gpu.hpp
     cuSetArange_gpu.hpp
@@ -19,6 +20,7 @@ target_sources(cytnx
     cuFill_gpu.cu
     cuGetElems_gpu.cu
     cuGetElems_contiguous_gpu.cu
+    cuLibraryHandle_gpu.cu
     cuMovemem_gpu.cu
     cuSetArange_gpu.cu
     cuSetElems_gpu.cu

--- a/src/backend/utils_internal_gpu/cuLibraryHandle_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuLibraryHandle_gpu.cu
@@ -1,0 +1,56 @@
+#include "cuLibraryHandle_gpu.hpp"
+
+#if defined(UNI_GPU)
+
+  #include <mutex>
+  #include <unordered_map>
+
+  #include "cuda_runtime_api.h"
+
+namespace cytnx {
+  namespace utils_internal {
+
+    cublasHandle_t get_cublas_handle() {
+      int device = -1;
+      checkCudaErrors(cudaGetDevice(&device));
+
+      // Never destroyed by design -- see the note on the declaration. Function-local statics also
+      // keep initialization lazy, so a CPU-only run never creates a CUDA context here.
+      static std::mutex mutex;
+      static auto* handles = new std::unordered_map<int, cublasHandle_t>();
+
+      std::lock_guard<std::mutex> lock(mutex);
+      auto found = handles->find(device);
+      if (found != handles->end()) {
+        return found->second;
+      }
+
+      cublasHandle_t handle;
+      checkCudaErrors(cublasCreate(&handle));
+      handles->emplace(device, handle);
+      return handle;
+    }
+
+    cusolverDnHandle_t get_cusolverdn_handle() {
+      int device = -1;
+      checkCudaErrors(cudaGetDevice(&device));
+
+      static std::mutex mutex;
+      static auto* handles = new std::unordered_map<int, cusolverDnHandle_t>();
+
+      std::lock_guard<std::mutex> lock(mutex);
+      auto found = handles->find(device);
+      if (found != handles->end()) {
+        return found->second;
+      }
+
+      cusolverDnHandle_t handle;
+      checkCudaErrors(cusolverDnCreate(&handle));
+      handles->emplace(device, handle);
+      return handle;
+    }
+
+  }  // namespace utils_internal
+}  // namespace cytnx
+
+#endif

--- a/src/backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp
+++ b/src/backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp
@@ -1,0 +1,69 @@
+#ifndef CYTNX_BACKEND_UTILS_INTERNAL_GPU_CULIBRARYHANDLE_GPU_H_
+#define CYTNX_BACKEND_UTILS_INTERNAL_GPU_CULIBRARYHANDLE_GPU_H_
+
+#include "cytnx_error.hpp"
+#include "Type.hpp"
+
+#if defined(UNI_GPU)
+  #include <cublas_v2.h>
+  #include <cusolverDn.h>
+#endif
+
+namespace cytnx {
+  namespace utils_internal {
+
+#if defined(UNI_GPU)
+
+    /**
+     * @brief The shared cuBLAS handle for the CUDA device current at the time of the call,
+     * creating it on first use.
+     *
+     * `cublasCreate` + `cublasDestroy` costs ~330 us in steady state, and `linalg_internal_gpu/`
+     * used to pay it around every single call (#1144). Measured against the work it wraps, a
+     * `cublasDgemm` on an n x n double matrix:
+     *
+     *     n=32   dgemm   9.5 us   handle  186.5 us   handle is 19.6x the work
+     *     n=128  dgemm  31.1 us   handle  195.3 us   handle is  6.3x the work
+     *     n=512  dgemm 462.4 us   handle  299.3 us   handle is  0.6x the work
+     *
+     * Below roughly n=400 the handle cost more than the multiply it existed to perform, and
+     * tensor-network workloads spend much of their time under that size.
+     *
+     * Keyed by device, not global: a handle is bound to whichever device was current when it was
+     * created, so one process-wide handle would silently drive the wrong GPU in a multi-device
+     * process. Callers get the handle for the current device, which preserves each call site's
+     * existing device selection exactly.
+     *
+     * Sharing is safe here because no live call site mutates handle state -- there is no
+     * `cublasSetStream`, `cublasSetPointerMode`, `cublasSetMathMode` or `cublasSetAtomicsMode`
+     * anywhere in the compiled sources. If per-call streams are ever introduced, that state must
+     * be set per call or this cache revisited.
+     *
+     * Thread-safe. Handles intentionally live for the whole process and are never destroyed: a
+     * static destructor would run after main, by which point the CUDA runtime may already have
+     * torn down the context that owns them, making `cublasDestroy` undefined behaviour. The cost
+     * is bounded at one handle per device actually used.
+     */
+    cublasHandle_t get_cublas_handle();
+
+    /**
+     * @brief The shared cuSOLVER dense handle for the CUDA device current at the time of the call,
+     * creating it on first use.
+     *
+     * `cusolverDnCreate` + `cusolverDnDestroy` costs ~456 us in steady state and was likewise paid
+     * per call (#1144). A cuSOLVER handle also holds a substantial device-side workspace -- ~12 MB,
+     * which is why leaking one per call dominated #1146 -- so reusing it removes repeated
+     * allocation of that workspace as well as the setup cost.
+     *
+     * Same device-keying, thread-safety and lifetime rationale as `get_cublas_handle`. The only
+     * `cusolverDnSetStream` in the tree is in `cuEig_internal.cu`, which is orphaned source that
+     * is never compiled (#1142), so no live call site mutates handle state.
+     */
+    cusolverDnHandle_t get_cusolverdn_handle();
+
+#endif  // UNI_GPU
+
+  }  // namespace utils_internal
+}  // namespace cytnx
+
+#endif  // CYTNX_BACKEND_UTILS_INTERNAL_GPU_CULIBRARYHANDLE_GPU_H_

--- a/src/backend/utils_internal_gpu/cuScopedResource_gpu.hpp
+++ b/src/backend/utils_internal_gpu/cuScopedResource_gpu.hpp
@@ -95,23 +95,11 @@ namespace cytnx {
       T *ptr = nullptr;
     };
 
-    /// Owns a cuSOLVER dense handle and destroys it on scope exit.
-    class CusolverDnHandle {
-     public:
-      CusolverDnHandle() { checkCudaErrors(cusolverDnCreate(&handle)); }
-
-      ~CusolverDnHandle() {
-        if (handle) cusolverDnDestroy(handle);
-      }
-
-      CusolverDnHandle(const CusolverDnHandle &) = delete;
-      CusolverDnHandle &operator=(const CusolverDnHandle &) = delete;
-
-      cusolverDnHandle_t get() const { return handle; }
-
-     private:
-      cusolverDnHandle_t handle = nullptr;
-    };
+    // [Note] There is no scoped cuSOLVER handle type here. #1146 originally gave the handle
+    // scope-bound ownership so a throwing `info` check could not leak it; #1144 then made handles
+    // shared per device and process-lifetime, which removes them from the set of leakable
+    // resources entirely rather than freeing them correctly. See
+    // `cuLibraryHandle_gpu.hpp::get_cusolverdn_handle`.
 
     /**
      * @brief Owns a `gesvdjInfo_t` (Jacobi SVD parameters) and destroys it on scope exit.

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   linalg_test/InplacePromote_test.cpp
   linalg_test/NonContigElementwise_test.cpp
   linalg_test/Outer_test.cpp
+  linalg_test/CuLibraryHandle_test.cpp
   linalg_test/CusolverResourceLeak_test.cpp
   linalg_test/Det_test.cpp
   linalg_test/Directsum_test.cpp
@@ -55,6 +56,10 @@ target_include_directories(
   gpu_test_main
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
+  # Internal backend headers (e.g. utils_internal_gpu/cuLibraryHandle_gpu.hpp) live under src/
+  # and are PRIVATE to the cytnx target; expose them to the test binary so internal utilities
+  # can be unit-tested directly. Mirrors what tests/CMakeLists.txt does for test_main.
+  ${CMAKE_SOURCE_DIR}/src
 )
 target_link_libraries(
   gpu_test_main

--- a/tests/gpu/linalg_test/CuLibraryHandle_test.cpp
+++ b/tests/gpu/linalg_test/CuLibraryHandle_test.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+
+#include "backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp"
+#include "cytnx.hpp"
+
+using namespace cytnx;
+
+// #1144: cuBLAS and cuSOLVER handles were created and destroyed around every call, at 52 live
+// sites. They are now cached per device, so repeated calls must hand back the identical handle --
+// this is the direct assertion of the change, and it does not depend on timing or on memory
+// thresholds.
+TEST(CuLibraryHandle, CublasHandleIsSharedAcrossCalls) {
+  const cublasHandle_t first = utils_internal::get_cublas_handle();
+  EXPECT_NE(first, nullptr);
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(utils_internal::get_cublas_handle(), first);
+  }
+}
+
+TEST(CuLibraryHandle, CusolverDnHandleIsSharedAcrossCalls) {
+  const cusolverDnHandle_t first = utils_internal::get_cusolverdn_handle();
+  EXPECT_NE(first, nullptr);
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(utils_internal::get_cusolverdn_handle(), first);
+  }
+}
+
+// The behaviour change is that many operations now run through one long-lived handle instead of a
+// fresh one each time. These check results against values computed by hand -- not against another
+// Cytnx path, which could share the same fault -- and interleave the operations so that each one
+// runs on a handle already used by the others.
+TEST(CuLibraryHandle, SharedHandleGivesCorrectResultsWhenInterleaved) {
+  // A = [[1, 2], [3, 4]], B = [[5, 6], [7, 8]]  =>  A*B = [[19, 22], [43, 50]]
+  Tensor a = zeros({2, 2}, Type.Double);
+  Tensor b = zeros({2, 2}, Type.Double);
+  const double av[4] = {1, 2, 3, 4};
+  const double bv[4] = {5, 6, 7, 8};
+  for (cytnx_uint64 i = 0; i < 2; ++i) {
+    for (cytnx_uint64 j = 0; j < 2; ++j) {
+      a.at({i, j}) = av[i * 2 + j];
+      b.at({i, j}) = bv[i * 2 + j];
+    }
+  }
+  const Tensor ga = a.to(Device.cuda);
+  const Tensor gb = b.to(Device.cuda);
+
+  // v = [1, 2, 3], w = [4, 5, 6]  =>  v.w = 32;  n = [3, 4]  =>  ||n|| = 5
+  Tensor v = zeros({3}, Type.Double), w = zeros({3}, Type.Double), n = zeros({2}, Type.Double);
+  const double vv[3] = {1, 2, 3};
+  const double wv[3] = {4, 5, 6};
+  for (cytnx_uint64 i = 0; i < 3; ++i) {
+    v.at({i}) = vv[i];
+    w.at({i}) = wv[i];
+  }
+  n.at({0}) = 3.0;
+  n.at({1}) = 4.0;
+  const Tensor gv = v.to(Device.cuda), gw = w.to(Device.cuda), gn = n.to(Device.cuda);
+
+  const double kExpectedAb[4] = {19, 22, 43, 50};
+
+  // Three rounds so every operation runs on a handle already used by the other two.
+  for (int round = 0; round < 3; ++round) {
+    const Tensor ab = linalg::Matmul(ga, gb).to(Device.cpu);
+    for (cytnx_uint64 i = 0; i < 2; ++i) {
+      for (cytnx_uint64 j = 0; j < 2; ++j) {
+        EXPECT_NEAR(ab.at<cytnx_double>({i, j}), kExpectedAb[i * 2 + j], 1e-12)
+          << "round " << round << " element (" << i << ", " << j << ")";
+      }
+    }
+
+    // Vectordot, Norm and Det all return rank-0 tensors (Init({}, ...)), so the scalar
+    // accessor is required -- at({0}) would be a rank mismatch.
+    const Tensor dot = linalg::Vectordot(gv, gw).to(Device.cpu);
+    EXPECT_NEAR(dot.item<cytnx_double>(), 32.0, 1e-12) << "round " << round;
+
+    const Tensor norm = linalg::Norm(gn).to(Device.cpu);
+    EXPECT_NEAR(norm.item<cytnx_double>(), 5.0, 1e-12) << "round " << round;
+
+    // det [[1, 2], [3, 4]] = 1*4 - 2*3 = -2  (cuSOLVER path, shared cusolverDn handle)
+    const Tensor det = linalg::Det(ga).to(Device.cpu);
+    EXPECT_NEAR(det.item<cytnx_double>(), -2.0, 1e-12) << "round " << round;
+  }
+}

--- a/tests/gpu/linalg_test/CuLibraryHandle_test.cpp
+++ b/tests/gpu/linalg_test/CuLibraryHandle_test.cpp
@@ -1,7 +1,10 @@
+#include <cstddef>
+
 #include <gtest/gtest.h>
 
 #include "backend/utils_internal_gpu/cuLibraryHandle_gpu.hpp"
 #include "cytnx.hpp"
+#include "gpu_test_tools.h"
 
 using namespace cytnx;
 
@@ -35,8 +38,8 @@ TEST(CuLibraryHandle, SharedHandleGivesCorrectResultsWhenInterleaved) {
   Tensor b = zeros({2, 2}, Type.Double);
   const double av[4] = {1, 2, 3, 4};
   const double bv[4] = {5, 6, 7, 8};
-  for (cytnx_uint64 i = 0; i < 2; ++i) {
-    for (cytnx_uint64 j = 0; j < 2; ++j) {
+  for (std::size_t i = 0; i < 2; ++i) {
+    for (std::size_t j = 0; j < 2; ++j) {
       a.at({i, j}) = av[i * 2 + j];
       b.at({i, j}) = bv[i * 2 + j];
     }
@@ -48,7 +51,7 @@ TEST(CuLibraryHandle, SharedHandleGivesCorrectResultsWhenInterleaved) {
   Tensor v = zeros({3}, Type.Double), w = zeros({3}, Type.Double), n = zeros({2}, Type.Double);
   const double vv[3] = {1, 2, 3};
   const double wv[3] = {4, 5, 6};
-  for (cytnx_uint64 i = 0; i < 3; ++i) {
+  for (std::size_t i = 0; i < 3; ++i) {
     v.at({i}) = vv[i];
     w.at({i}) = wv[i];
   }
@@ -57,16 +60,14 @@ TEST(CuLibraryHandle, SharedHandleGivesCorrectResultsWhenInterleaved) {
   const Tensor gv = v.to(Device.cuda), gw = w.to(Device.cuda), gn = n.to(Device.cuda);
 
   const double kExpectedAb[4] = {19, 22, 43, 50};
+  Tensor expected_ab = zeros({2, 2}, Type.Double);
+  for (std::size_t i = 0; i < 2; ++i)
+    for (std::size_t j = 0; j < 2; ++j) expected_ab.at({i, j}) = kExpectedAb[i * 2 + j];
 
   // Three rounds so every operation runs on a handle already used by the other two.
   for (int round = 0; round < 3; ++round) {
     const Tensor ab = linalg::Matmul(ga, gb).to(Device.cpu);
-    for (cytnx_uint64 i = 0; i < 2; ++i) {
-      for (cytnx_uint64 j = 0; j < 2; ++j) {
-        EXPECT_NEAR(ab.at<cytnx_double>({i, j}), kExpectedAb[i * 2 + j], 1e-12)
-          << "round " << round << " element (" << i << ", " << j << ")";
-      }
-    }
+    EXPECT_TRUE(gpu_test::AreNearlyEqTensor(ab, expected_ab, 1e-12)) << "round " << round;
 
     // Vectordot, Norm and Det all return rank-0 tensors (Init({}, ...)), so the scalar
     // accessor is required -- at({0}) would be a rank mismatch.


### PR DESCRIPTION
Closes #1144.

> [!IMPORTANT]
> **Stacked on #1147** (`fix/1145-1146-cusolver-leaks`) and must merge after it. Review the two commits here, not the whole diff. The ordering is not cosmetic — see "Interaction with #1147" below.

## Problem

`linalg_internal_gpu/` created and destroyed a library handle around **every single call**, at **52 live sites across 13 files** (4 per file, one per dtype specialisation).

```cpp
// cuMatmul_internal.cu:30 -- and 51 more like it
checkCudaErrors(cublasCreate(&cublasH));
...
cublasDestroy(cublasH);
```

Steady-state cost, measured in isolation on an RTX 4070 Ti SUPER:

| | first call | steady state |
|---|---|---|
| `cublasCreate` + `cublasDestroy` | 2761.9 µs | **326.5 µs** |
| `cusolverDnCreate` + `cusolverDnDestroy` | 647.6 µs | **456.4 µs** |

Neither scales with problem size. Against `cublasDgemm` in the same process the handle cost **19.6× the multiply at n=32**, 6.3× at n=128, 3.5× at n=256, crossing over only near n=400 — so for tensor-network sized operands the handle cost more than the work it existed to perform.

All 13 files verified live: present in `linalg_internal_gpu/CMakeLists.txt`, with object files in a CUDA build and 5–12 undefined references each from other translation units.

## Fix

`utils_internal::get_cublas_handle()` and `get_cusolverdn_handle()` — keyed by the current device, created on first use, never destroyed. Same pattern as `get_cutensor_handle()` in #1143. No raw `cublasCreate`/`cusolverDnCreate` remains outside the two accessors.

**Sharing is safe here, verified rather than assumed.** No live call site mutates handle state: there is no `cublasSetStream`, `cublasSetPointerMode`, `cublasSetMathMode` or `cublasSetAtomicsMode` anywhere in the compiled sources. The only `cusolverDnSetStream` in the tree is in `cuEig_internal.cu` — orphaned source that is never compiled (#1142) and left untouched here. That is the one file that would have needed care, and it is dead. If per-call streams are ever introduced, this must be revisited.

**Keyed by device, not global**, because a handle is bound to whichever device was current when it was created; one process-wide handle would silently drive the wrong GPU in a multi-device process.

**Never destroyed, deliberately**: a static destructor runs after `main`, when the CUDA runtime may already have torn down the owning context. Bounded at one handle per device actually used.

## Measured

Both columns same machine and session, mean of 5 repetitions, µs, with warmup (the *first* handle creation is ~2.8 ms because it loads the library; without warmup that one-time cost masks the effect). Base = `fee3f871` (benchmark only), tip = `c955830d`.

| benchmark | base | tip | speedup | **delta** |
|---|---|---|---|---|
| `BM_GpuMatmul/32` | 312.0 | 26.9 | **11.6×** | 285.1 |
| `BM_GpuMatmul/64` | 325.0 | 33.8 | **9.6×** | 291.2 |
| `BM_GpuMatmul/128` | 334.0 | 49.8 | **6.7×** | 284.2 |
| `BM_GpuMatmul/256` | 365.0 | 76.0 | **4.8×** | 289.0 |
| `BM_GpuMatmul/512` | 1098.0 | 735.0 | **1.5×** | 363.0 |
| `BM_GpuVectordot/64` | 334.0 | 43.2 | **7.7×** | 290.8 |
| `BM_GpuVectordot/1024` | 336.0 | 42.4 | **7.9×** | 293.6 |
| `BM_GpuVectordot/65536` | 342.0 | 44.1 | **7.8×** | 297.9 |
| `BM_GpuDet/32` | 555.0 | 106.0 | **5.2×** | 449.0 |
| `BM_GpuDet/128` | 920.0 | 390.0 | **2.4×** | 530.0 |
| `BM_GpuDet/512` | 3378.0 | 2536.0 | **1.3×** | 842.0 |

`Vectordot` is the cleanest evidence: the delta is **constant at 291–298 µs across a 1000× range in n**, which is the flat per-call cost and matches the 326.5 µs measured for `cublasCreate` in isolation. The cuBLAS deltas are all ~285–295 µs; the varying speedup column is that same constant against different amounts of real work.

One honest caveat: `Det`'s delta is *not* constant (449 → 530 → 842 µs as n grows). It starts at the ~456 µs measured for `cusolverDnCreate`, so the baseline matches, but I have not established what makes it grow with n and am not going to guess in a PR description.

## Interaction with #1147 — this PR reduces that test's sensitivity

Worth stating plainly rather than leaving for someone to discover.

#1146's leak was dominated by the leaked `cusolverDnHandle_t` (~12 MB of device workspace each), not by the small work buffers — that is why 200 failing `InvM` calls on a **4×4** matrix leaked 2.4 GB. Caching handles removes them from the set of leakable resources entirely, so `GpuInvMErrorPathDoesNotLeakDeviceMemory` loses most of its signal. I built the hybrid (ownership regressed, handles cached) and measured:

| L | leaked over 100 failing calls |
|---|---|
| 4 (what the test uses) | none |
| 2048 | 8 MiB |

The residual buffer leak is ~82 KiB/call, below the ±72 MiB allocator noise in `cudaMemGetInfo`, so a threshold test cannot reliably catch it after this change.

This does not invalidate #1147's proof — that was demonstrated against #1147's own base, where the test failed at 1140 MiB against a 64 MiB threshold. But it does mean **#1147 should merge first**, which the stacking enforces. It also means the error-path ownership in those five files is, after this PR, guarded by code review rather than by a test. I did not try to paper over that with a threshold tuned so finely it would flake in CI.

The now-unused scoped `CusolverDnHandle` from #1147 is removed rather than left as dead code; `DeviceBuffer` and `GesvdjInfo` remain scoped and still matter.

## Testing

`tests/gpu/linalg_test/CuLibraryHandle_test.cpp`:

- **`CublasHandleIsSharedAcrossCalls`** / **`CusolverDnHandleIsSharedAcrossCalls`** — assert handle identity across repeated calls. This is the direct assertion of the change and depends on neither timing nor memory thresholds.
- **`SharedHandleGivesCorrectResultsWhenInterleaved`** — the behaviour change is that many operations now run through one long-lived handle. Checks `Matmul`, `Vectordot`, `Norm` and `Det` against hand-computed values (`[[19,22],[43,50]]`, `32`, `5`, `-2`) — not against another Cytnx path, which could share the same fault — over three rounds so each operation runs on a handle already used by the others.

`tests/gpu/CMakeLists.txt` gains `${CMAKE_SOURCE_DIR}/src` on the include path so the internal accessor can be unit-tested directly, mirroring what `tests/CMakeLists.txt` already does for `test_main`.

Full GPU suite locally, `ctest -L gpu`:

```
100% tests passed, 0 tests failed out of 823
Total Test time (real) = 1833.79 sec
```

820 from #1147's branch plus the 3 added here. The 4 skips are pre-existing `GTEST_SKIP`s in files neither PR touches.
