### PR TITLE
build: stop tuning HPTT for the build host, and add Windows CUDA presets

### DIFF
--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -129,11 +129,19 @@ jobs:
         # build-dir=build pins scikit-build-core's build tree (it defaults
         # to a temp dir) so the subsequent ctest and gcovr steps have a
         # stable path to point at.
+        #
+        #   HPTT_ENABLE_AVX=ON
+        #     Compiles HPTT's AVX micro-kernels, which is what the released
+        #     x86_64 wheels ship (see release_pypi.yml). This runner is
+        #     ubuntu-latest, i.e. always x86_64; HPTT fails the configure
+        #     outright if this option ever reaches a non-x86 target, so the
+        #     hardcoded choice cannot silently go wrong.
         run: |
           pip install --editable '.[dev]' --verbose \
             --config-settings=build-dir=build \
             --config-settings=cmake.define.CMAKE_BUILD_TYPE=Debug \
-            --config-settings=cmake.define.RUN_TESTS=ON
+            --config-settings=cmake.define.RUN_TESTS=ON \
+            --config-settings=cmake.define.HPTT_ENABLE_AVX=ON
 
       - name: Sanity-check the install
         run: python -c "import cytnx; print('cytnx', cytnx.__version__)"

--- a/.github/workflows/ci-downstream-find-package.yml
+++ b/.github/workflows/ci-downstream-find-package.yml
@@ -130,17 +130,24 @@ jobs:
             blas=*=openblas "libopenblas=*=*openmp*" liblapacke arpack
 
       - name: Configure cytnx (openblas-cpu preset, USE_HPTT=ON)
-        # The openblas-cpu preset inherits USE_HPTT=ON + HPTT_ENABLE_FINE_TUNE=ON.
-        # Override BUILD_PYTHON=OFF (this job is about the C++ package export,
-        # not the Python wheel) and RUN_TESTS=OFF (keeps the build free of the
+        # The openblas-cpu preset inherits USE_HPTT=ON. Override
+        # BUILD_PYTHON=OFF (this job is about the C++ package export, not the
+        # Python wheel) and RUN_TESTS=OFF (keeps the build free of the
         # --coverage usage requirement; see the file header). Pin the build dir
         # and install prefix so later steps have stable paths.
+        #
+        # HPTT_ENABLE_AVX=ON matches what the released x86_64 wheels ship, so
+        # the exported Cytnx::hptt_static a downstream project links here is
+        # the same one users get. This runner is ubuntu-latest, i.e. always
+        # x86_64, and HPTT fails the configure outright if the option ever
+        # reaches a non-x86 target.
         run: |
           cmake -S . -B "$CYTNX_BUILD_DIR" \
             --preset=openblas-cpu \
             -G "Unix Makefiles" \
             -DBUILD_PYTHON=OFF \
             -DRUN_TESTS=OFF \
+            -DHPTT_ENABLE_AVX=ON \
             -DCMAKE_INSTALL_PREFIX="$CYTNX_INSTALL_DIR"
 
       - name: Build cytnx

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -229,6 +229,18 @@ jobs:
         CCACHE_BASEDIR: ${{ runner.os == 'Linux' && '/project/build' || github.workspace }}
         CIBW_CONTAINER_ENGINE: "docker; create_args: --volume ${{ env.HOST_CCACHE_DIR }}:/host_ccache"
         CIBW_TEST_COMMAND: "python {project}/tools/validate_ccache_stats.py"
+        # Compile HPTT's hand-vectorized kernels for the architecture this
+        # wheel targets. Every matrix entry builds natively (cibuildwheel's
+        # default CIBW_ARCHS=auto), so runner.arch names the wheel's target:
+        # ubuntu-24.04-arm and macos-14 are ARM64, the other two X64. HPTT
+        # fails the configure if an option reaches an architecture it cannot
+        # serve, so a matrix entry added without revisiting this line errors
+        # out rather than silently shipping the scalar fallback.
+        #
+        # scikit-build-core reads cmake.define from SKBUILD_CMAKE_DEFINE; the
+        # Linux wheels build inside a container, so pyproject.toml's
+        # [tool.cibuildwheel.linux].environment-pass forwards this in.
+        SKBUILD_CMAKE_DEFINE: HPTT_ENABLE_${{ runner.arch == 'ARM64' && 'ARM' || 'AVX' }}=ON
         # CYTNX_VERSION_TAG is sourced from the DetermineChannel job
         # output so every matrix entry sees the same dev tag for one
         # workflow run. It is the empty string for stable builds, in

--- a/.github/workflows/release_pypi_cuda.yml
+++ b/.github/workflows/release_pypi_cuda.yml
@@ -205,6 +205,10 @@ jobs:
         CIBW_TEST_COMMAND: >-
           python {project}/tools/validate_ccache_stats.py &&
           python -c "import cytnx; assert cytnx.Device.Ngpus == 0, cytnx.Device.Ngpus"
+        # Compile HPTT's hand-vectorized kernels for the architecture this
+        # wheel targets; see release_pypi.yml's equivalent for why runner.arch
+        # names the target and how the value reaches the container.
+        SKBUILD_CMAKE_DEFINE: HPTT_ENABLE_${{ runner.arch == 'ARM64' && 'ARM' || 'AVX' }}=ON
         CYTNX_VERSION_TAG: ${{ needs.DetermineChannel.outputs.dev_tag }}
 
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,11 +172,16 @@ option(BUILD_PYTHON "Build Python API. Requires Python and pybind11 installed." 
 option(BACKEND_TORCH "Use PyTorch as a backend container for tensors." OFF)
 cmake_dependent_option(USE_MKL "Use MKL as a BLAS provider otherwise use OpenBLAS." OFF "NOT BACKEND_TORCH" OFF)
 cmake_dependent_option(USE_HPTT "Use HPTT library to accelerate tensor transpose." OFF "NOT BACKEND_TORCH" OFF)
-cmake_dependent_option(HPTT_ENABLE_FINE_TUNE "Enable fine-tune HPTT for the native hardware." OFF "USE_HPTT" OFF)
+cmake_dependent_option(HPTT_ENABLE_FINE_TUNE "Tune HPTT for the CPU running the build (-march=native and friends). The objects then require whatever that CPU supports, so leave it OFF for any build that will be redistributed." OFF "USE_HPTT" OFF)
 # TODO: use variable instead of option to handle HPTT variant.
-cmake_dependent_option(HPTT_ENABLE_ARM "HPTT variant" OFF "USE_HPTT;NOT HPTT_ENABLE_AVX; NOT HPTT_ENABLE_IBM" OFF)
-cmake_dependent_option(HPTT_ENABLE_AVX "HPTT variant" OFF "USE_HPTT;NOT HPTT_ENABLE_ARM; NOT HPTT_ENABLE_IBM" OFF)
-cmake_dependent_option(HPTT_ENABLE_IBM "HPTT variant" OFF "USE_HPTT;NOT HPTT_ENABLE_ARM; NOT HPTT_ENABLE_AVX" OFF)
+# Each variant compiles HPTT's hand-vectorized micro-kernels for one
+# architecture and assumes that architecture's ISA floor: ARM needs ARMv8-A
+# arm64, AVX needs x86-64-v3 (AVX, AVX2, FMA), IBM needs POWER with AltiVec.
+# HPTT raises a FATAL_ERROR when the one that is ON cannot be served by the
+# build's target architecture, so a wrong choice fails during configure.
+cmake_dependent_option(HPTT_ENABLE_ARM "Compile HPTT's Neon kernels; requires an ARMv8-A arm64 target." OFF "USE_HPTT;NOT HPTT_ENABLE_AVX; NOT HPTT_ENABLE_IBM" OFF)
+cmake_dependent_option(HPTT_ENABLE_AVX "Compile HPTT's AVX kernels; requires an x86-64-v3 target." OFF "USE_HPTT;NOT HPTT_ENABLE_ARM; NOT HPTT_ENABLE_IBM" OFF)
+cmake_dependent_option(HPTT_ENABLE_IBM "Compile HPTT's AltiVec kernels; requires a POWER target." OFF "USE_HPTT;NOT HPTT_ENABLE_ARM; NOT HPTT_ENABLE_AVX" OFF)
 cmake_dependent_option(USE_CUDA "Enable CUDA support." OFF "NOT BACKEND_TORCH" OFF)
 # cmake_dependent_option(USE_CUTT "Use CUTT library to accelrate tensor transpose." OFF "USE_CUDA" OFF)
 # cmake_dependent_option(CUTT_ENABLE_FINE_TUNE "Enable CUTT fine tune for the native hardware." OFF "USE_CUTT" OFF)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -64,9 +64,10 @@
     {
       "name": "windows-cuda",
       "hidden": true,
-      "description": "A base preset overriding the CUDA variables NVIDIA does not ship for Windows.",
+      "description": "A base preset overriding the variables a Windows build cannot satisfy.",
       "cacheVariables": {
-        "USE_CUQUANTUM": "OFF"
+        "USE_CUQUANTUM": "OFF",
+        "USE_HPTT": "OFF"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -62,6 +62,24 @@
       "inherits": ["mkl", "openblas-cuda"]
     },
     {
+      "name": "windows-cuda",
+      "hidden": true,
+      "description": "A base preset overriding the CUDA variables NVIDIA does not ship for Windows.",
+      "cacheVariables": {
+        "USE_CUQUANTUM": "OFF"
+      }
+    },
+    {
+      "name": "openblas-cuda-windows",
+      "description": "Windows build: OpenBLAS as the BLAS vendor with CUDA support, without cuQuantum.",
+      "inherits": ["windows-cuda", "openblas-cuda"]
+    },
+    {
+      "name": "mkl-cuda-windows",
+      "description": "Windows build: Intel MKL as the BLAS vendor with CUDA support, without cuQuantum.",
+      "inherits": ["windows-cuda", "mkl-cuda"]
+    },
+    {
       "name": "openblas-apple",
       "description": "OpenBLAS as the BLAS vendor with CUDA support on Apple.",
       "inherits": [ "default"]
@@ -100,6 +118,16 @@
       "name": "debug-mkl-cuda",
       "description": "Debug build: Intel MKL as the BLAS vendor with CUDA support.",
       "inherits": ["debug", "mkl-cuda"]
+    },
+    {
+      "name": "debug-openblas-cuda-windows",
+      "description": "Debug build for Windows: OpenBLAS as the BLAS vendor with CUDA support, without cuQuantum.",
+      "inherits": ["debug", "openblas-cuda-windows"]
+    },
+    {
+      "name": "debug-mkl-cuda-windows",
+      "description": "Debug build for Windows: Intel MKL as the BLAS vendor with CUDA support, without cuQuantum.",
+      "inherits": ["debug", "mkl-cuda-windows"]
     },
     {
       "name": "debug-openblas-apple",
@@ -141,6 +169,18 @@
       "inherits": "default"
     },
     {
+      "name": "openblas-cuda-windows",
+      "description": "Windows build using OpenBLAS with CUDA support, without cuQuantum.",
+      "configurePreset": "openblas-cuda-windows",
+      "inherits": "default"
+    },
+    {
+      "name": "mkl-cuda-windows",
+      "description": "Windows build using Intel MKL with CUDA support, without cuQuantum.",
+      "configurePreset": "mkl-cuda-windows",
+      "inherits": "default"
+    },
+    {
       "name": "openblas-apple",
       "description": "Build using OpenBLAS with CUDA support on Apple.",
       "configurePreset": "openblas-apple",
@@ -168,6 +208,18 @@
       "name": "debug-mkl-cuda",
       "description": "Debug build using Intel MKL with CUDA support.",
       "configurePreset": "debug-mkl-cuda",
+      "inherits": "default"
+    },
+    {
+      "name": "debug-openblas-cuda-windows",
+      "description": "Windows debug build using OpenBLAS with CUDA support, without cuQuantum.",
+      "configurePreset": "debug-openblas-cuda-windows",
+      "inherits": "default"
+    },
+    {
+      "name": "debug-mkl-cuda-windows",
+      "description": "Windows debug build using Intel MKL with CUDA support, without cuQuantum.",
+      "configurePreset": "debug-mkl-cuda-windows",
       "inherits": "default"
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,7 +18,7 @@
         "BUILD_PYTHON": "ON",
         "BACKEND_TORCH": "OFF",
         "USE_HPTT": "ON",
-        "HPTT_ENABLE_FINE_TUNE": "ON",
+        "HPTT_ENABLE_FINE_TUNE": "OFF",
         "USE_CUDA": "OFF",
         "RUN_TESTS": "OFF",
         "RUN_BENCHMARKS": "OFF",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -62,7 +62,7 @@
       "inherits": ["mkl", "openblas-cuda"]
     },
     {
-      "name": "windows-cuda",
+      "name": "cuda-windows",
       "hidden": true,
       "description": "A base preset overriding the CUDA variables NVIDIA does not ship for Windows.",
       "cacheVariables": {
@@ -72,12 +72,12 @@
     {
       "name": "openblas-cuda-windows",
       "description": "Windows build: OpenBLAS as the BLAS vendor with CUDA support, without cuQuantum.",
-      "inherits": ["windows-cuda", "openblas-cuda"]
+      "inherits": ["cuda-windows", "openblas-cuda"]
     },
     {
       "name": "mkl-cuda-windows",
       "description": "Windows build: Intel MKL as the BLAS vendor with CUDA support, without cuQuantum.",
-      "inherits": ["windows-cuda", "mkl-cuda"]
+      "inherits": ["cuda-windows", "mkl-cuda"]
     },
     {
       "name": "openblas-apple",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -64,10 +64,9 @@
     {
       "name": "windows-cuda",
       "hidden": true,
-      "description": "A base preset overriding the variables a Windows build cannot satisfy.",
+      "description": "A base preset overriding the CUDA variables NVIDIA does not ship for Windows.",
       "cacheVariables": {
-        "USE_CUQUANTUM": "OFF",
-        "USE_HPTT": "OFF"
+        "USE_CUQUANTUM": "OFF"
       }
     },
     {

--- a/conda_build/build.sh
+++ b/conda_build/build.sh
@@ -11,10 +11,18 @@ install_log=$(mktemp)
 
 run_pip_install() {
   set -o pipefail
+  # meta.yaml sets CYTNX_HPTT_ISA_OPTION for the architectures HPTT has
+  # hand-vectorized kernels for, and leaves it unset elsewhere so those
+  # builds keep HPTT's scalar fallback.
+  local isa_args=()
+  if [ -n "${CYTNX_HPTT_ISA_OPTION:-}" ]; then
+    isa_args=(--config-settings "skbuild.cmake.args=-D${CYTNX_HPTT_ISA_OPTION}=ON")
+  fi
   $PYTHON -m pip install . -vv --no-deps --ignore-installed \
     --config-settings skbuild.build-dir=build \
     --config-settings "skbuild.cmake.args=--preset=$CMAKE_PRESET" \
-    --config-settings "skbuild.cmake.args=-G Unix Makefiles" 2>&1 | tee "$install_log"
+    --config-settings "skbuild.cmake.args=-G Unix Makefiles" \
+    "${isa_args[@]}" 2>&1 | tee "$install_log"
   local status=$?
   set +o pipefail
   return $status

--- a/conda_build/meta.yaml
+++ b/conda_build/meta.yaml
@@ -21,6 +21,12 @@ build:
     - CMAKE_CUDA_COMPILER_LAUNCHER
     - CMAKE_PRESET=mkl-cpu            # [x86]
     - CMAKE_PRESET=openblas-cpu       # [not x86]
+    # Which of HPTT's hand-vectorized kernel families to compile. They are
+    # opt-in per target architecture and HPTT rejects an option its target
+    # cannot serve, so build.sh passes this one through only when a selector
+    # below matched; any other architecture builds HPTT's scalar fallback.
+    - CYTNX_HPTT_ISA_OPTION=HPTT_ENABLE_AVX     # [x86_64]
+    - CYTNX_HPTT_ISA_OPTION=HPTT_ENABLE_ARM     # [aarch64 or arm64]
 
 requirements:
   build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,10 @@ before-all = "bash ./tools/cibuildwheel_before_all.sh"
 # own openblas-dev headers were never confirmed to need it, but removing it
 # is unverified and this is a no-op wherever it isn't needed.
 environment = { CMAKE_PREFIX_PATH = "/opt/cytnx-deps", LD_LIBRARY_PATH = "/opt/cytnx-deps/lib", CMAKE_INCLUDE_PATH = "/usr/include/openblas", CCACHE_DEBUG = "true", CCACHE_DEBUGLEVEL = "1", CCACHE_LOGFILE = "/tmp/cytnx-ccache.log" }
-environment-pass = ["CMAKE_C_COMPILER_LAUNCHER", "CMAKE_CXX_COMPILER_LAUNCHER", "CMAKE_CUDA_COMPILER_LAUNCHER", "CCACHE_COMPILERCHECK", "CCACHE_MAXSIZE", "CCACHE_DIR", "CCACHE_BASEDIR", "CCACHE_DEBUG", "CCACHE_DEBUGLEVEL", "CCACHE_LOGFILE", "CYTNX_VERSION_TAG"]
+# SKBUILD_CMAKE_DEFINE carries the per-architecture HPTT ISA option the
+# release workflows set (see release_pypi.yml); it has to cross into the
+# manylinux/musllinux container, where the wheel is actually configured.
+environment-pass = ["CMAKE_C_COMPILER_LAUNCHER", "CMAKE_CXX_COMPILER_LAUNCHER", "CMAKE_CUDA_COMPILER_LAUNCHER", "CCACHE_COMPILERCHECK", "CCACHE_MAXSIZE", "CCACHE_DIR", "CCACHE_BASEDIR", "CCACHE_DEBUG", "CCACHE_DEBUGLEVEL", "CCACHE_LOGFILE", "CYTNX_VERSION_TAG", "SKBUILD_CMAKE_DEFINE"]
 
 [tool.cibuildwheel.macos]
 before-all = "bash ./tools/cibuildwheel_before_all_macos.sh"


### PR DESCRIPTION
Three build-configuration changes: update the bundled HPTT, replace host fine-tuning with per-architecture ISA kernels, and give Windows a CUDA preset it can actually use.

## Problem

**1. Every cytnx build had both HPTT switches set the wrong way.** The `default` preset in `CMakePresets.json` set `HPTT_ENABLE_FINE_TUNE=ON` and left `HPTT_ENABLE_AVX` / `_ARM` / `_IBM` OFF, so every build that goes through a preset — the PyPI wheels (`pyproject.toml` pins `--preset=openblas-cpu`), the conda packages, the downstream `find_package` job, and every contributor build — got the worst of both:

- `FINE_TUNE=ON` compiles HPTT with `-march=native`, so the objects require whatever the machine that ran the build supported. In a redistributed wheel that is a defect, not a tuning choice: on a Cascade Lake builder `-march=native` emits AVX-512, and the result faults on any AMD Zen 1–3 or Intel 12th-generation-or-later consumer part — all of which report `x86_64`, and all of which pip will hand the wheel to.
- The ISA options being OFF meant HPTT's hand-vectorized micro-kernels were **never compiled into cytnx at all**, only its scalar fallback. `-march=native` does not reach them; they are guarded by the `HPTT_ARCH_AVX` / `HPTT_ARCH_ARM` macros that `HPTT_ENABLE_AVX` / `HPTT_ENABLE_ARM` define. The build paid for non-portability without buying the kernels it was paying for.

**2. Windows had no usable CUDA preset.** Every CUDA preset sets `USE_CUQUANTUM=ON`, which no Windows build can satisfy — NVIDIA publishes no Windows build of cuTensorNet or cuStateVec (#1111), so `CUQUANTUM_ROOT` cannot be pointed anywhere and `require_dependent_variable()` fails the configure before a compiler runs. A Windows CUDA build had to spell out `-DUSE_CUDA=ON -DUSE_CUTENSOR=ON -DUSE_CUQUANTUM=OFF` by hand and keep the rest of the preset's cache values by repetition.

**3. The bundled HPTT itself decided some of this behind cytnx's back.** At the pinned revision, HPTT appended `-mcpu=native` on Apple Silicon, `-mtune=native` under `ENABLE_IBM`, and `-xhost` under ICC *regardless* of `FINE_TUNE`, and defined `HPTT_ARCH_AVX` / `HPTT_ARCH_ARM` from an `APPLE` branch that ignored the options — so macOS selected different kernels, and a different `REGISTER_BITS`, than Linux and Windows did from an identical cytnx preset.

## Fix

**`thirdparty/hptt` 0b4f9b5 → 98c5de5.** Upstream now makes all four options opt-in on every platform and lets the target architecture only *reject* an option it cannot honour. For cytnx that means `HPTT_ENABLE_*` fully determines which kernels are compiled everywhere, `HPTT_ENABLE_FINE_TUNE=OFF` produces genuinely portable objects, `HPTT_ENABLE_FINE_TUNE=ON` reaches the compilers it used to silently miss (GNU on macOS, MSVC, `icpx`), and a wrong-architecture option raises `FATAL_ERROR` during configure instead of failing later inside a kernel compile.

**`FINE_TUNE` off in the `default` preset; each build path names its own ISA option.**

| build path | option | how the architecture is decided |
|---|---|---|
| `ci-cmake_tests.yml`, `ci-downstream-find-package.yml` | `HPTT_ENABLE_AVX` | hardcoded — both run on `ubuntu-latest` |
| `release_pypi.yml`, `release_pypi_cuda.yml` | AVX or ARM | `runner.arch`; every leg builds natively under cibuildwheel's default `CIBW_ARCHS=auto`, so the runner's architecture *is* the wheel's target |
| `conda_build/meta.yaml` | AVX or ARM | the recipe's `x86_64` / `aarch64` / `arm64` selectors; any other architecture leaves the variable unset and keeps the scalar fallback |

Hardcoding is safe because HPTT rejects an option its target cannot serve, so a mapping that ever goes wrong fails the configure rather than quietly shipping the scalar path. `ci-gpu_tests.yml` is left alone: it configures without a preset and without `-DUSE_HPTT=ON`, so `USE_HPTT` keeps its OFF default and that job builds no HPTT.

For the wheels the value travels as `SKBUILD_CMAKE_DEFINE`, which scikit-build-core reads into `cmake.define`; `pyproject.toml`'s `environment-pass` now forwards it into the manylinux/musllinux container.

**A hidden `cuda-windows` base preset** that overrides `USE_CUQUANTUM` to OFF — same shape as the existing hidden `mkl` and `debug` bases — plus a Windows counterpart for every CUDA preset (`openblas-cuda-windows`, `mkl-cuda-windows`, `debug-openblas-cuda-windows`, `debug-mkl-cuda-windows`) and their build presets. `USE_CUTENSOR` stays ON, because cuTENSOR does publish a Windows package, and so does `USE_HPTT`: the HPTT revision this PR pins is the one that builds with MSVC (see the follow-ups below).

The `HPTT_ENABLE_*` help strings, previously `"HPTT variant"`, now state each option's ISA floor.

### What this is worth

The x86_64 wheels move from "whatever the builder's CPU supported" to a fixed x86-64-v3 floor (AVX, AVX2, FMA — Haswell 2013 and Excavator 2015 onward), and gain the AVX kernels for the first time.

That is **wider** compatibility than what ships today, not narrower. Disassembling the current `cytnx-1.1.1-cp311-cp311-manylinux_2_28_x86_64.whl` from PyPI: its extension module already contains 41,023 `ymm` references, 27,093 `vfmadd`/`vfmsub` instructions and 205 BMI1/BMI2 instructions — 63,377 of those 63,388 AVX2/FMA sites inside `hptt::` symbols, 11 everywhere else. The published wheel already requires AVX2+FMA in exactly this code; the floor is simply unwritten and varies per build. (The 11-vs-63,377 split also confirms HPTT applies its architecture flags as `PRIVATE` compile options: the rest of libcytnx stays on the compiler default.)

On the performance side, measured upstream in the HPTT tree on its own benchmark harness (best-of-5, 4 threads, one Cascade Lake host): raising `-march` alone was within noise of the baseline, while `HPTT_ARCH_AVX` at a v3 floor gave ~1.8–2.1× on genuine transposes. Cytnx-level end-to-end throughput was **not** re-measured here.

## Testing

- `debug-openblas-cpu`, x86_64 / GCC 13.3 — full build, **1821/1821 ctest cases pass**.
- `debug-mkl-cpu` — full build, **1855/1855 ctest cases pass**. The first run reported 258 failures; every one of them was a LeakSanitizer report of a 112-byte allocation in Intel OpenMP's `__kmp_allocate_align` at runtime startup, in a test GoogleTest had already reported as passed. Suppressing that one allocation gives 1855/1855 with leak detection otherwise on.
- HPTT entries of `compile_commands.json` for a `debug-openblas-cpu` configure:

  | configure | HPTT compile line |
  |---|---|
  | no ISA option | `-march=x86-64 -mtune=generic`, no `HPTT_ARCH_*` |
  | `-DHPTT_ENABLE_AVX=ON` | `-march=x86-64-v3 -mtune=generic -DHPTT_ARCH_AVX` |
  | `-DHPTT_ENABLE_ARM=ON` | configure fails: *"ENABLE_ARM=ON is valid only on a 64-bit ARM target, but this build targets 'x86_64'"* |

- With `CUQUANTUM_ROOT` unset: `cmake --preset openblas-cuda` stops with *"Cache variable 'CUQUANTUM_ROOT' is required under dependency conditions (USE_CUQUANTUM)"*, while `cmake --preset mkl-cuda-windows` configures to completion and still finds and links cuTENSOR. The resolved cache variables of all four new presets were diffed against their non-Windows originals: only `USE_CUQUANTUM` differs.
- `SKBUILD_CMAKE_DEFINE=HPTT_ENABLE_AVX=ON` was confirmed to reach scikit-build-core's `cmake.define` without displacing the `cmake.args` preset or the `build-dir` config-setting.
- `conda_build/build.sh` was exercised with and without `CYTNX_HPTT_ISA_OPTION` set.

Not verifiable here: the Windows and arm64 legs have no runner in this environment; they are exercised by CI on this PR.

## Follow-ups this opens

**#1112 looks closeable on this submodule revision.** Everything on its blocker list is fixed upstream, and all of it arrives with this bump — `0b4f9b5` had none of it:

- `include/hptt_types.h` defines `HPTT_RESTRICT` as `__restrict` under MSVC and `__restrict__` elsewhere, applied to the `transpose.h` members that carried the GNU-only spelling.
- `include/macros.h` maps `INLINE` to `__forceinline` for MSVC.
- `src/transpose.cpp` has no variable-length arrays left.
- `hptt_dyn` carries `ARCHIVE_OUTPUT_NAME hptt_dyn`, so the DLL's import library no longer claims `hptt.lib` alongside the static archive — the Ninja "multiple rules generate hptt.lib" collision that opened the issue. It also gets `WINDOWS_EXPORT_ALL_SYMBOLS`, without which the DLL would export nothing and no import library would be produced.
- The AVX kernels compile with `/arch:AVX2` under MSVC instead of `-mavx`.

Still unverified from here — this environment has no Windows runner, so the MSVC build of HPTT has not been compiled by me.

**`HPTT_BUILD_SHARED`.** The new revision adds it. cytnx links only `hptt_static`, so setting it OFF in `CytnxBKNDCMakeLists.cmake` would skip building `libhptt.so` on every platform. Left out to keep this PR scoped.

**Runtime ISA dispatch.** A generic `manylinux_x86_64` tag is only truthful with runtime kernel selection, which HPTT does not do — it picks kernels through the compile-time `HPTT_ARCH_AVX` macro. Worth its own issue upstream.

Part of #1114; the `cuda-windows` preset is the configuration #1111 describes.