### PR TITLE
test(gpu): name the GPU arange cases after their suite, not a Gpu prefix

### DIFF
--- a/tests/gpu/arange_test.cpp
+++ b/tests/gpu/arange_test.cpp
@@ -28,14 +28,14 @@ namespace cytnx {
         EXPECT_EQ(host.storage().template at<T>(2), static_cast<T>(30));
       }
 
-      TEST(GpuArange, GpuNonUnitStepRealDtypes) {
+      TEST(Arange, GpuNonUnitStepRealDtypes) {
         ExpectNonUnitStep<cytnx::cytnx_int64>(Type.Int64);
         ExpectNonUnitStep<cytnx::cytnx_int32>(Type.Int32);
         ExpectNonUnitStep<cytnx::cytnx_double>(Type.Double);
         ExpectNonUnitStep<cytnx::cytnx_float>(Type.Float);
       }
 
-      TEST(GpuArange, GpuMultiBlockStepScaling) {
+      TEST(Arange, GpuMultiBlockStepScaling) {
         // 1000 elements span more than one 512-thread block, so the block-boundary indices
         // (511 -> 512) exercise the full linear index. value[i] == 3*i (hand-computed).
         const cytnx::cytnx_uint64 n = 1000;
@@ -47,7 +47,7 @@ namespace cytnx {
         EXPECT_EQ(host.storage().at<cytnx::cytnx_int64>(999), 2997);
       }
 
-      TEST(GpuArange, GpuFractionalStepDouble) {
+      TEST(Arange, GpuFractionalStepDouble) {
         auto host = cytnx::arange(0, 1, 0.25, Type.Double, Device.cuda).to(Device.cpu);
         ASSERT_EQ(host.shape()[0], 4u);
         EXPECT_DOUBLE_EQ(host.storage().at<cytnx::cytnx_double>(0), 0.0);
@@ -56,7 +56,7 @@ namespace cytnx {
         EXPECT_DOUBLE_EQ(host.storage().at<cytnx::cytnx_double>(3), 0.75);
       }
 
-      TEST(GpuArange, GpuEmptyRangeZeroExtent) {
+      TEST(Arange, GpuEmptyRangeZeroExtent) {
         auto g = cytnx::arange(5, 5, 1, Type.Int64, Device.cuda);
         ASSERT_EQ(g.shape().size(), 1u);
         EXPECT_EQ(g.shape()[0], 0u);


### PR DESCRIPTION
## Problem

`tests/gpu/arange_test.cpp` declares its cases as `TEST(GpuArange, Gpu…)` — the `Gpu` marker appears in both the suite and the test name, and the suite does not match the operation being tested.

Every other GPU suite puts the marker in the test name only. Across `tests/gpu/` the split is **406 tests as `TEST(Suite, GpuName)` against these 4**, and the CPU counterpart in `tests/arange_test.cpp` already uses `TEST(Arange, …)`.

@IvanaGyro raised this reviewing #1108, where the same inconsistency had spread into the Kron/Outer GPU tests. It is fixed there in `6b96e072`; this file is where it originated.

## Fix

```
- TEST(GpuArange, GpuNonUnitStepRealDtypes)     + TEST(Arange, GpuNonUnitStepRealDtypes)
- TEST(GpuArange, GpuMultiBlockStepScaling)     + TEST(Arange, GpuMultiBlockStepScaling)
- TEST(GpuArange, GpuFractionalStepDouble)      + TEST(Arange, GpuFractionalStepDouble)
- TEST(GpuArange, GpuEmptyRangeZeroExtent)      + TEST(Arange, GpuEmptyRangeZeroExtent)
```

The GPU cases now pair with the CPU `Arange` suite the same way `Kron`, `Outer`, `Svd` and `ExpM` do. Renames only — no assertion, input, tolerance or expected value is touched. `git grep GpuArange` returns nothing; the only stale references were regenerated `ctest` registrations under `build_gpu/`, which `gtest_discover_tests` rewrites at test time.

This is deliberately not folded into #1108: `arange_test.cpp` has nothing to do with that PR's Kron/Outer coverage, and a reviewer there should not have to read around it.

## Testing

```
[----------] 4 tests from Arange
[       OK ] Arange.GpuNonUnitStepRealDtypes (259 ms)
[       OK ] Arange.GpuMultiBlockStepScaling (0 ms)
[       OK ] Arange.GpuFractionalStepDouble (0 ms)
[       OK ] Arange.GpuEmptyRangeZeroExtent (0 ms)
[  PASSED  ] 4 tests.
```

RTX 4070 Ti SUPER (sm_89), CUDA 13.0, cuTENSOR 2.4.1, `USE_CUDA=ON`. `pre-commit run --files` clean (clang-format v14).

Refs #1108.
