### PR TITLE
fix(ci): disable IPO for test coverage builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,7 +310,7 @@ endif()
 # the rest of this script, so skipping the set() when the variable is
 # already DEFINED is what lets a caller's override actually take effect.
 if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
-  IF (APPLE)
+  IF (APPLE OR RUN_TESTS)
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)
   ELSE ()
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)


### PR DESCRIPTION
## Summary

- Disable `CMAKE_INTERPROCEDURAL_OPTIMIZATION` when `RUN_TESTS=ON`.
- Preserve the existing IPO behavior for non-test builds.

## Why

LTO can cause the `pybind/` translation units to disappear from Codecov coverage attribution. Disabling IPO for coverage builds keeps source-level coverage data associated with the original files.

## Validation

No local tests were run per request; CI should verify the change.

Fixes #1162