### PR TITLE
fix(ptr): replace deprecated Boost atomic count

### DIFF
--- a/include/intrusive_ptr_base.hpp
+++ b/include/intrusive_ptr_base.hpp
@@ -1,11 +1,12 @@
 #ifndef CYTNX_INTRUSIVE_PTR_BASE_H_
 #define CYTNX_INTRUSIVE_PTR_BASE_H_
 
-#include <ostream>
 #include <cassert>
-#include <boost/smart_ptr/intrusive_ptr.hpp>
+#include <atomic>
+#include <ostream>
+
 #include <boost/checked_delete.hpp>
-#include <boost/detail/atomic_count.hpp>
+#include <boost/smart_ptr/intrusive_ptr.hpp>
 
 namespace cytnx {
   /// @cond
@@ -56,7 +57,7 @@ namespace cytnx {
 
    private:
     // should be modifiable within the class.
-    mutable boost::detail::atomic_count ref_count;
+    mutable std::atomic<int> ref_count;
   };
   ///@endcond
 }  // namespace cytnx


### PR DESCRIPTION
## Problem

`intrusive_ptr_base.hpp` includes Boost's deprecated `boost/detail/atomic_count.hpp`, and tons of deprecation warning occupy the CI logs.

## Fix

Replace the internal reference counter with `std::atomic<int>` while preserving the existing intrusive-pointer reference-count operations.

## Testing

Not run locally at request; CI will verify.

Closes #1121.