### PR TITLE
fix(Storage): return mutable strings by value

### DIFF
--- a/include/backend/Storage.hpp
+++ b/include/backend/Storage.hpp
@@ -750,10 +750,7 @@ namespace cytnx {
     @brief the dtype (std::string) of current Storage, see cytnx::Type for more details.
     @return [std::string] dtype name
     */
-    const std::string dtype_str() const {
-      std::string out = this->_impl->dtype_str();
-      return out;
-    }
+    std::string dtype_str() const { return this->_impl->dtype_str(); }
     /**
     @brief the device-id of current Storage, see cytnx::Device for more details.
     @return [cytnx_int64] the device-id.
@@ -764,10 +761,7 @@ namespace cytnx {
     @brief the device (std::string) of current Storage, see cytnx::Device for more details.
     @return [std::string] device name
     */
-    const std::string device_str() const {
-      std::string out = this->_impl->device_str();
-      return out;
-    }
+    std::string device_str() const { return this->_impl->device_str(); }
 
     /**
     @brief append a value


### PR DESCRIPTION
## Problem

`Storage::device_str()` returns a newly generated `std::string` as `const std::string`, which blocks normal move semantics for the returned temporary.

## Fix

Return `std::string` directly from `Storage::device_str()`. The return-type audit found the same issue in the adjacent `Storage::dtype_str()` wrapper, so it is fixed in the same change.

## Testing

Not run locally at request; CI will verify.

Closes #1125.