### PR TITLE
fix(network): validate ORDER expressions

### DIFF
--- a/include/Gncon.hpp
+++ b/include/Gncon.hpp
@@ -207,6 +207,7 @@ namespace cytnx {
     }
     ///@endcond
 
+    // clang-format off
     /**
     @brief Construct Gncon from Gncon file.
     @param fname The Gncon file path
@@ -222,7 +223,7 @@ namespace cytnx {
         Format of a Gncon file:
 
         - each line defines a UniTensor, that takes the format '[name] : [Labels]'
-        - the name can be any alphabets A-Z, a-z
+        - tensor names may contain nonalphabetic characters
         - There are two reserved name: 'TOUT' and 'ORDER' (all capital)
         - One can use 'TOUT' line to specify the output UniTensor's bond order using labels
         - The 'ORDER' line is used to specify the contraction order
@@ -234,9 +235,11 @@ namespace cytnx {
 
         About [ORDER]:
 
-        - The contraction order, it can be specify using the standard mathmetical bracket ruls.
-        - Without specify this line, the default contraction order will be from the first line to
-    the last line
+        - ORDER is a binary tree: each contraction has the form (left,right).
+        - Each operand is a tensor name or another binary contraction.
+        - The root parentheses may be omitted, as in (A,B),(C,D).
+        - Every tensor name must appear exactly once in ORDER.
+        - Without ORDER, tensors are contracted from the first to the last.
 
 
     ##example Gncon file:
@@ -254,6 +257,7 @@ namespace cytnx {
 
 
     */
+    // clang-format on
     void Fromfile(const std::string &fname, const int &Gncon_type = GNType.Regular) {
       if (Gncon_type == GNType.Regular) {
         boost::intrusive_ptr<Gncon_base> tmp(new RegularGncon());

--- a/include/Gncon.hpp
+++ b/include/Gncon.hpp
@@ -207,7 +207,6 @@ namespace cytnx {
     }
     ///@endcond
 
-    // clang-format off
     /**
     @brief Construct Gncon from Gncon file.
     @param fname The Gncon file path
@@ -223,9 +222,12 @@ namespace cytnx {
         Format of a Gncon file:
 
         - each line defines a UniTensor, that takes the format '[name] : [Labels]'
-        - tensor names may contain nonalphabetic characters
-        - There are two reserved name: 'TOUT' and 'ORDER' (all capital)
-        - One can use 'TOUT' line to specify the output UniTensor's bond order using labels
+        - tensor
+names may contain nonalphabetic characters
+        - There are two reserved name: 'TOUT' and 'ORDER'
+(all capital)
+        - One can use 'TOUT' line to specify the output UniTensor's bond order using
+labels
         - The 'ORDER' line is used to specify the contraction order
 
         About [Labels]:
@@ -235,10 +237,13 @@ namespace cytnx {
 
         About [ORDER]:
 
-        - ORDER is a binary tree: each contraction has the form (left,right).
+        - ORDER is a binary tree: each contraction has the form
+(left,right).
         - Each operand is a tensor name or another binary contraction.
-        - The root parentheses may be omitted, as in (A,B),(C,D).
-        - Every tensor name must appear exactly once in ORDER.
+        - The
+root parentheses may be omitted, as in (A,B),(C,D).
+        - Every tensor name must appear exactly
+once in ORDER.
         - Without ORDER, tensors are contracted from the first to the last.
 
 
@@ -257,7 +262,6 @@ namespace cytnx {
 
 
     */
-    // clang-format on
     void Fromfile(const std::string &fname, const int &Gncon_type = GNType.Regular) {
       if (Gncon_type == GNType.Regular) {
         boost::intrusive_ptr<Gncon_base> tmp(new RegularGncon());

--- a/include/Network.hpp
+++ b/include/Network.hpp
@@ -270,7 +270,6 @@ namespace cytnx {
     }
     ///@endcond
 
-    // clang-format off
     /**
     @brief Construct Network from network file.
     @param fname The network file path
@@ -286,9 +285,12 @@ namespace cytnx {
         Format of a network file:
 
         - each line defines a UniTensor, that takes the format '[name] : [Labels]'
-        - tensor names may contain nonalphabetic characters
-        - There are two reserved name: 'TOUT' and 'ORDER' (all capital)
-        - One can use 'TOUT' line to specify the output UniTensor's bond order using labels
+        - tensor
+names may contain nonalphabetic characters
+        - There are two reserved name: 'TOUT' and 'ORDER'
+(all capital)
+        - One can use 'TOUT' line to specify the output UniTensor's bond order using
+labels
         - The 'ORDER' line is used to specify the contraction order
 
         About [Labels]:
@@ -298,10 +300,13 @@ namespace cytnx {
 
         About [ORDER]:
 
-        - ORDER is a binary tree: each contraction has the form (left,right).
+        - ORDER is a binary tree: each contraction has the form
+(left,right).
         - Each operand is a tensor name or another binary contraction.
-        - The root parentheses may be omitted, as in (A,B),(C,D).
-        - Every tensor name must appear exactly once in ORDER.
+        - The
+root parentheses may be omitted, as in (A,B),(C,D).
+        - Every tensor name must appear exactly
+once in ORDER.
         - Without ORDER, tensors are contracted from the first to the last.
 
 
@@ -320,7 +325,6 @@ namespace cytnx {
 
 
     */
-    // clang-format on
     void Fromfile(const std::string &fname, const int &network_type = NtType.Regular) {
       if (network_type == NtType.Regular) {
         boost::intrusive_ptr<Network_base> tmp(new RegularNetwork());

--- a/include/Network.hpp
+++ b/include/Network.hpp
@@ -270,6 +270,7 @@ namespace cytnx {
     }
     ///@endcond
 
+    // clang-format off
     /**
     @brief Construct Network from network file.
     @param fname The network file path
@@ -285,7 +286,7 @@ namespace cytnx {
         Format of a network file:
 
         - each line defines a UniTensor, that takes the format '[name] : [Labels]'
-        - the name can be any alphabets A-Z, a-z
+        - tensor names may contain nonalphabetic characters
         - There are two reserved name: 'TOUT' and 'ORDER' (all capital)
         - One can use 'TOUT' line to specify the output UniTensor's bond order using labels
         - The 'ORDER' line is used to specify the contraction order
@@ -297,9 +298,11 @@ namespace cytnx {
 
         About [ORDER]:
 
-        - The contraction order, it can be specify using the standard mathmetical bracket ruls.
-        - Without specify this line, the default contraction order will be from the first line to
-    the last line
+        - ORDER is a binary tree: each contraction has the form (left,right).
+        - Each operand is a tensor name or another binary contraction.
+        - The root parentheses may be omitted, as in (A,B),(C,D).
+        - Every tensor name must appear exactly once in ORDER.
+        - Without ORDER, tensors are contracted from the first to the last.
 
 
     ##example network file:
@@ -317,6 +320,7 @@ namespace cytnx {
 
 
     */
+    // clang-format on
     void Fromfile(const std::string &fname, const int &network_type = NtType.Regular) {
       if (network_type == NtType.Regular) {
         boost::intrusive_ptr<Network_base> tmp(new RegularNetwork());

--- a/src/RegularGncon.cpp
+++ b/src/RegularGncon.cpp
@@ -6,6 +6,7 @@
 #include <typeinfo>
 
 #include "search_tree.hpp"
+#include "utils/order_parser.hpp"
 
 #ifdef BACKEND_TORCH
 #else
@@ -55,27 +56,6 @@ namespace cytnx {
     }
   }
 
-  void _parse_ORDER_line_(std::vector<std::string> &tokens, const std::string &line,
-                          const cytnx_uint64 &line_num) {
-    cytnx_error_msg((line.find_first_of("\t;\n:") != std::string::npos),
-                    "[ERROR][Gncon][Fromfile] line:%d invalid ORDER line format.%s", line_num,
-                    "\n");
-    cytnx_error_msg((line.find_first_of("(),") == std::string::npos),
-                    "[ERROR][Gncon][Fromfile] line:%d invalid ORDER line format.%s", line_num,
-                    " tensors should be seperate by delimiter \',\' (comma), and/or wrapped with "
-                    "\'(\' and \')\'");
-
-    // check mismatch:
-    std::size_t lbrac_n = std::count(line.begin(), line.end(), '(');
-    std::size_t rbrac_n = std::count(line.begin(), line.end(), ')');
-    cytnx_error_msg(lbrac_n != rbrac_n, "[ERROR][Gncon][Fromfile] parentheses mismatch.%s", "\n");
-
-    // slice the line into pieces by parentheses and comma
-    tokens = str_findall(line, "(),");
-
-    cytnx_error_msg(tokens.size() == 0, "[ERROR][Gncon][Fromfile] line:%d invalid ORDER line.%s",
-                    line_num, "\n");
-  }
   void _parse_TOUT_line_(std::vector<cytnx_int64> &lbls, cytnx_uint64 &TOUT_iBondNum,
                          std::vector<std::vector<std::pair<std::string, std::string>>> &table,
                          std::map<std::string, cytnx_uint64> name2pos, const std::string &line,
@@ -184,7 +164,7 @@ namespace cytnx {
     // // reading
     // if (contract_order.length()) {
     //   // ORDER assigned
-    //   _parse_ORDER_line_(this->ORDER_tokens, contract_order, 0);
+    //   this->ORDER_tokens = network_internal::parse_order_line(contract_order, 0);
     //   isORDER_exist = true;
     // }
     // if (Tout.length()) {
@@ -342,7 +322,7 @@ namespace cytnx {
           if (content.length()) {
             // cut the line into tokens,
             // and leave it to process by CtTree after read all lines.
-            _parse_ORDER_line_(this->ORDER_tokens, content, i);
+            this->ORDER_tokens = network_internal::parse_order_line(content, i);
             isORDER_exist = true;
           }
         } else if (command == "TOUT") {
@@ -649,11 +629,11 @@ namespace cytnx {
       if (optimal == true) {
         std::string Optim_ORDERline = this->getOptimalOrder();
         this->ORDER_tokens.clear();
-        _parse_ORDER_line_(ORDER_tokens, Optim_ORDERline, 999999);
+        ORDER_tokens = network_internal::parse_order_line(Optim_ORDERline, 999999);
         CtTree.build_contraction_tree_by_tokens(this->name2pos, ORDER_tokens);
       } else if (contract_order != "") {
         this->ORDER_tokens.clear();
-        _parse_ORDER_line_(ORDER_tokens, contract_order, 999999);
+        ORDER_tokens = network_internal::parse_order_line(contract_order, 999999);
         CtTree.build_contraction_tree_by_tokens(this->name2pos, ORDER_tokens);
       } else {
         CtTree.build_default_contraction_tree();

--- a/src/RegularNetwork.cpp
+++ b/src/RegularNetwork.cpp
@@ -8,6 +8,7 @@
 #include "Device.hpp"
 #include "Generator.hpp"
 #include "search_tree.hpp"
+#include "utils/order_parser.hpp"
 
 #ifdef BACKEND_TORCH
 #else
@@ -16,30 +17,6 @@
 namespace cytnx {
 
   namespace {
-    std::vector<std::string> ParseOrderLineInternal(const std::string &line,
-                                                    const cytnx_uint64 &line_num) {
-      cytnx_error_msg((line.find_first_of("\t;\n:") != std::string::npos),
-                      "[ERROR][Network][Fromfile] line:%d invalid ORDER line format.%s", line_num,
-                      "\n");
-      cytnx_error_msg((line.find_first_of("(),") == std::string::npos),
-                      "[ERROR][Network][Fromfile] line:%d invalid ORDER line format.%s", line_num,
-                      " tensors should be seperate by delimiter \',\' (comma), and/or wrapped with "
-                      "\'(\' and \')\'");
-
-      // check mismatch:
-      std::size_t lbrac_n = std::count(line.begin(), line.end(), '(');
-      std::size_t rbrac_n = std::count(line.begin(), line.end(), ')');
-      cytnx_error_msg(lbrac_n != rbrac_n, "[ERROR][Network][Fromfile] parentheses mismatch.%s",
-                      "\n");
-
-      // slice the line into pieces by parentheses and comma
-      std::vector<std::string> tokens = str_findall(line, "(),");
-
-      cytnx_error_msg(tokens.size() == 0,
-                      "[ERROR][Network][Fromfile] line:%d invalid ORDER line.%s", line_num, "\n");
-      return tokens;
-    }
-
     std::vector<std::string> ParseToutLineInternal(cytnx_uint64 &TOUT_iBondNum,
                                                    const std::string &line,
                                                    const cytnx_uint64 &line_num) {
@@ -259,7 +236,7 @@ namespace cytnx {
     // reading
     if (contract_order.length()) {
       // ORDER assigned
-      this->ORDER_tokens = ParseOrderLineInternal(contract_order, 0);
+      this->ORDER_tokens = network_internal::parse_order_line(contract_order, 0);
       isORDER_exist = true;
     }
     if (Tout.length()) {
@@ -427,7 +404,7 @@ namespace cytnx {
           // cut the line into tokens,
           // and leave it to process by CtTree after read all lines.
           this->order_line = content;
-          this->ORDER_tokens = ParseOrderLineInternal(content, i);
+          this->ORDER_tokens = network_internal::parse_order_line(content, i);
           isORDER_exist = true;
         }
       } else if (name == "TOUT") {
@@ -824,14 +801,14 @@ namespace cytnx {
       if (this->tensors[0].device() == Device.cpu) {
         std::string Optim_ORDERline = this->getOptimalOrder();
         this->order_line = Optim_ORDERline;
-        ORDER_tokens = ParseOrderLineInternal(Optim_ORDERline, 999999);
+        ORDER_tokens = network_internal::parse_order_line(Optim_ORDERline, 999999);
       } else {
   #ifdef UNI_GPU
     #ifdef UNI_CUQUANTUM
         if (this->tensors[0].uten_type() != UTenType.Dense) {
           std::string Optim_ORDERline = this->getOptimalOrder();
           this->order_line = Optim_ORDERline;
-          ORDER_tokens = ParseOrderLineInternal(Optim_ORDERline, 999999);
+          ORDER_tokens = network_internal::parse_order_line(Optim_ORDERline, 999999);
         } else {
           std::vector<cytnx_uint64> out_shape;
           for (int i = 0; i < this->TOUT_labels.size(); i++) {
@@ -866,7 +843,7 @@ namespace cytnx {
         //                 without " "CUQUANTUM support.\n");
         std::string Optim_ORDERline = this->getOptimalOrder();
         this->order_line = Optim_ORDERline;
-        ORDER_tokens = ParseOrderLineInternal(Optim_ORDERline, 999999);
+        ORDER_tokens = network_internal::parse_order_line(Optim_ORDERline, 999999);
     #endif
 
   #else
@@ -878,7 +855,7 @@ namespace cytnx {
     } else {
       this->order_line = contract_order;
       if (contract_order != "") {
-        ORDER_tokens = ParseOrderLineInternal(contract_order, 999999);
+        ORDER_tokens = network_internal::parse_order_line(contract_order, 999999);
         CtTree.build_contraction_tree_by_tokens(this->name2pos, ORDER_tokens);
         this->einsum_path = CtTreeToEinsumpathInternal(CtTree, names);
       } else {
@@ -1027,7 +1004,7 @@ namespace cytnx {
     if (order.length()) {
       this->order_line = order;
       // checking if all TN are set in ORDER.
-      this->ORDER_tokens = ParseOrderLineInternal(order, 0);
+      this->ORDER_tokens = network_internal::parse_order_line(order, 0);
       std::vector<std::string> TN_names;
       TN_names = ExtractTnsFromOrderInternal(this->ORDER_tokens);
       for (int i = 0; i < this->names.size(); i++) {

--- a/src/contraction_tree.cpp
+++ b/src/contraction_tree.cpp
@@ -2,6 +2,8 @@
 
 #include <stack>
 
+#include "utils/order_parser.hpp"
+
 #ifdef BACKEND_TORCH
 #else
 
@@ -44,6 +46,37 @@ namespace cytnx {
       "[ERROR][ContractionTree][build_contraction_order_by_tokens] Cannot have empty tokens.%s",
       "\n");
 
+    std::string order_line;
+    for (const std::string &token : tokens) order_line += token;
+    const std::vector<std::string> validated_tokens =
+      network_internal::parse_order_line(order_line, 0);
+
+    std::vector<bool> seen_tensors(this->base_nodes.size(), false);
+    std::size_t leaf_count = 0;
+    for (const std::string &raw_token : validated_tokens) {
+      const std::string token = str_strip(raw_token);
+      if (token.empty() || token == "(" || token == ")" || token == ",") continue;
+
+      const auto name_position = name2pos.find(token);
+      cytnx_error_msg(name_position == name2pos.end(),
+                      "[ERROR][ContractionTree] ORDER contains undefined tensor name: %s.\n",
+                      token.c_str());
+      const std::size_t tensor_index = name_position->second;
+      cytnx_error_msg(tensor_index >= seen_tensors.size(),
+                      "[ERROR][ContractionTree] ORDER tensor index is out of range: %zu.\n",
+                      tensor_index);
+      cytnx_error_msg(seen_tensors[tensor_index],
+                      "[ERROR][ContractionTree] ORDER contains duplicate tensor name: %s.\n",
+                      token.c_str());
+      seen_tensors[tensor_index] = true;
+      ++leaf_count;
+    }
+    cytnx_error_msg(
+      leaf_count != this->base_nodes.size(),
+      "[ERROR][ContractionTree] ORDER must contain every tensor exactly once; found %zu tensor "
+      "names for %zu tensors.\n",
+      leaf_count, this->base_nodes.size());
+
     std::stack<std::shared_ptr<Node>> stk;
     std::shared_ptr<Node> left, right;
     std::stack<char> operators;
@@ -55,8 +88,8 @@ namespace cytnx {
     this->nodes_container.reserve(
       this->base_nodes.size());  // reserve a contiguous memeory address to prevent re-allocate that
                                  // change address.
-    for (cytnx_uint64 i = 0; i < tokens.size(); i++) {
-      tok = str_strip(tokens[i]);  // remove space.
+    for (cytnx_uint64 i = 0; i < validated_tokens.size(); i++) {
+      tok = str_strip(validated_tokens[i]);  // remove space.
       if (tok.length() == 0) continue;
       if (tok == "(") {
         operators.push(tok.c_str()[0]);
@@ -124,6 +157,10 @@ namespace cytnx {
       this->nodes_container.push_back(new_node);
       stk.push(this->nodes_container.back());
     }
+
+    cytnx_error_msg(stk.size() != 1 || this->nodes_container.size() + 1 != leaf_count,
+                    "[ERROR][ContractionTree] ORDER did not produce one complete binary tree.%s",
+                    "\n");
   }
 
 }  // namespace cytnx

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(cytnx
     #utils_internal_interface.hpp
     cartesian.cpp
     is.cpp
+    order_parser.cpp
     str_utils.cpp
     dynamic_arg_resolver.cpp
     utils.cpp

--- a/src/utils/order_parser.cpp
+++ b/src/utils/order_parser.cpp
@@ -1,8 +1,10 @@
 #include "utils/order_parser.hpp"
 
 #include <cctype>
+#include <cstddef>
 #include <cstdlib>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "cytnx_error.hpp"
@@ -12,103 +14,110 @@ namespace cytnx {
   namespace network_internal {
     namespace {
 
+      constexpr std::size_t kMaximumOrderNesting = 1024;
+
       class OrderParser {
        public:
         OrderParser(const std::string& line, std::size_t line_num)
-            : input_line(line), source_line_num(line_num) {}
+            : input_line_(line), source_line_num_(line_num) {}
 
         std::vector<std::string> parse() {
           validate_line_characters();
           skip_whitespace();
-          if (cursor == input_line.size()) fail(cursor, "expected a tensor name or '('");
+          if (cursor_ == input_line_.size()) fail(cursor_, "expected a tensor name or '('");
 
-          parse_tree();
+          parse_tree(0);
           skip_whitespace();
 
           // The documented examples omit the parentheses around the root, as in
           // "(A,B),(C,D)". Permit exactly one such top-level comma.
-          if (cursor < input_line.size() && input_line[cursor] == ',') {
-            parsed_tokens.emplace_back(",");
-            ++cursor;
-            parse_tree();
+          if (cursor_ < input_line_.size() && input_line_[cursor_] == ',') {
+            parsed_tokens_.emplace_back(",");
+            ++cursor_;
+            parse_tree(0);
             skip_whitespace();
           }
 
-          if (cursor != input_line.size()) {
-            fail(cursor, "expected the end of the ORDER expression");
+          if (cursor_ != input_line_.size()) {
+            fail(cursor_, "expected the end of the ORDER expression");
           }
-          if (leaf_count < 2) {
-            fail(cursor, "expected at least two tensor names");
+          if (leaf_count_ < 2) {
+            fail(cursor_, "expected at least two tensor names");
           }
-          return parsed_tokens;
+          return std::move(parsed_tokens_);
         }
 
        private:
-        const std::string& input_line;
-        std::size_t source_line_num;
-        std::size_t cursor = 0;
-        std::size_t leaf_count = 0;
-        std::vector<std::string> parsed_tokens;
-
         static bool is_structural(char character) {
           return character == '(' || character == ')' || character == ',';
         }
 
         void validate_line_characters() const {
-          const std::size_t invalid = input_line.find_first_of("\t;\n:");
+          const std::size_t invalid = input_line_.find_first_of("\t;\n:");
           if (invalid != std::string::npos) {
             fail(invalid, "found a character that is not allowed in an ORDER expression");
           }
         }
 
         void skip_whitespace() {
-          while (cursor < input_line.size() &&
-                 std::isspace(static_cast<unsigned char>(input_line[cursor]))) {
-            ++cursor;
+          while (cursor_ < input_line_.size() &&
+                 std::isspace(static_cast<unsigned char>(input_line_[cursor_]))) {
+            ++cursor_;
           }
         }
 
-        void parse_tree() {
+        void parse_tree(std::size_t nesting_depth) {
           skip_whitespace();
-          if (cursor == input_line.size()) fail(cursor, "expected a tensor name or '('");
+          if (cursor_ == input_line_.size()) fail(cursor_, "expected a tensor name or '('");
 
-          if (input_line[cursor] != '(') {
+          if (input_line_[cursor_] != '(') {
             parse_name();
             return;
           }
+          if (nesting_depth == kMaximumOrderNesting) {
+            fail(cursor_, "ORDER nesting exceeds maximum depth of 1024");
+          }
 
-          parsed_tokens.emplace_back("(");
-          ++cursor;
-          parse_tree();
+          parsed_tokens_.emplace_back("(");
+          ++cursor_;
+          parse_tree(nesting_depth + 1);
           consume(',', "expected ',' between the two contraction operands");
-          parse_tree();
+          parse_tree(nesting_depth + 1);
           consume(')', "expected ')' after the two contraction operands");
         }
 
         void parse_name() {
-          const std::size_t start = cursor;
-          while (cursor < input_line.size() && !is_structural(input_line[cursor])) ++cursor;
+          const std::size_t start = cursor_;
+          while (cursor_ < input_line_.size() && !is_structural(input_line_[cursor_])) ++cursor_;
 
-          const std::string name = str_strip(input_line.substr(start, cursor - start));
+          const std::string name = str_strip(input_line_.substr(start, cursor_ - start));
           if (name.empty()) fail(start, "expected a nonempty tensor name");
 
-          parsed_tokens.push_back(name);
-          ++leaf_count;
+          parsed_tokens_.push_back(name);
+          ++leaf_count_;
         }
 
         void consume(char expected, const char* reason) {
           skip_whitespace();
-          if (cursor == input_line.size() || input_line[cursor] != expected) fail(cursor, reason);
-          parsed_tokens.emplace_back(1, expected);
-          ++cursor;
+          if (cursor_ == input_line_.size() || input_line_[cursor_] != expected) {
+            fail(cursor_, reason);
+          }
+          parsed_tokens_.emplace_back(1, expected);
+          ++cursor_;
         }
 
         [[noreturn]] void fail(std::size_t error_cursor, const char* reason) const {
           cytnx_error_msg(true,
                           "[ERROR][ORDER] line:%zu column:%zu invalid contraction order: %s\n",
-                          source_line_num, error_cursor + 1, reason);
+                          source_line_num_, error_cursor + 1, reason);
           std::abort();
         }
+
+        const std::string& input_line_;
+        std::size_t source_line_num_;
+        std::size_t cursor_ = 0;
+        std::size_t leaf_count_ = 0;
+        std::vector<std::string> parsed_tokens_;
       };
 
     }  // namespace

--- a/src/utils/order_parser.cpp
+++ b/src/utils/order_parser.cpp
@@ -1,0 +1,121 @@
+#include "utils/order_parser.hpp"
+
+#include <cctype>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include "cytnx_error.hpp"
+#include "utils/str_utils.hpp"
+
+namespace cytnx {
+  namespace network_internal {
+    namespace {
+
+      class OrderParser {
+       public:
+        OrderParser(const std::string& line, std::size_t line_num)
+            : input_line(line), source_line_num(line_num) {}
+
+        std::vector<std::string> parse() {
+          validate_line_characters();
+          skip_whitespace();
+          if (cursor == input_line.size()) fail(cursor, "expected a tensor name or '('");
+
+          parse_tree();
+          skip_whitespace();
+
+          // The documented examples omit the parentheses around the root, as in
+          // "(A,B),(C,D)". Permit exactly one such top-level comma.
+          if (cursor < input_line.size() && input_line[cursor] == ',') {
+            parsed_tokens.emplace_back(",");
+            ++cursor;
+            parse_tree();
+            skip_whitespace();
+          }
+
+          if (cursor != input_line.size()) {
+            fail(cursor, "expected the end of the ORDER expression");
+          }
+          if (leaf_count < 2) {
+            fail(cursor, "expected at least two tensor names");
+          }
+          return parsed_tokens;
+        }
+
+       private:
+        const std::string& input_line;
+        std::size_t source_line_num;
+        std::size_t cursor = 0;
+        std::size_t leaf_count = 0;
+        std::vector<std::string> parsed_tokens;
+
+        static bool is_structural(char character) {
+          return character == '(' || character == ')' || character == ',';
+        }
+
+        void validate_line_characters() const {
+          const std::size_t invalid = input_line.find_first_of("\t;\n:");
+          if (invalid != std::string::npos) {
+            fail(invalid, "found a character that is not allowed in an ORDER expression");
+          }
+        }
+
+        void skip_whitespace() {
+          while (cursor < input_line.size() &&
+                 std::isspace(static_cast<unsigned char>(input_line[cursor]))) {
+            ++cursor;
+          }
+        }
+
+        void parse_tree() {
+          skip_whitespace();
+          if (cursor == input_line.size()) fail(cursor, "expected a tensor name or '('");
+
+          if (input_line[cursor] != '(') {
+            parse_name();
+            return;
+          }
+
+          parsed_tokens.emplace_back("(");
+          ++cursor;
+          parse_tree();
+          consume(',', "expected ',' between the two contraction operands");
+          parse_tree();
+          consume(')', "expected ')' after the two contraction operands");
+        }
+
+        void parse_name() {
+          const std::size_t start = cursor;
+          while (cursor < input_line.size() && !is_structural(input_line[cursor])) ++cursor;
+
+          const std::string name = str_strip(input_line.substr(start, cursor - start));
+          if (name.empty()) fail(start, "expected a nonempty tensor name");
+
+          parsed_tokens.push_back(name);
+          ++leaf_count;
+        }
+
+        void consume(char expected, const char* reason) {
+          skip_whitespace();
+          if (cursor == input_line.size() || input_line[cursor] != expected) fail(cursor, reason);
+          parsed_tokens.emplace_back(1, expected);
+          ++cursor;
+        }
+
+        [[noreturn]] void fail(std::size_t error_cursor, const char* reason) const {
+          cytnx_error_msg(true,
+                          "[ERROR][ORDER] line:%zu column:%zu invalid contraction order: %s\n",
+                          source_line_num, error_cursor + 1, reason);
+          std::abort();
+        }
+      };
+
+    }  // namespace
+
+    std::vector<std::string> parse_order_line(const std::string& line, std::size_t line_num) {
+      return OrderParser(line, line_num).parse();
+    }
+
+  }  // namespace network_internal
+}  // namespace cytnx

--- a/src/utils/order_parser.hpp
+++ b/src/utils/order_parser.hpp
@@ -1,0 +1,18 @@
+#ifndef CYTNX_UTILS_ORDER_PARSER_H_
+#define CYTNX_UTILS_ORDER_PARSER_H_
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace cytnx {
+  namespace network_internal {
+
+    // Parse a binary contraction order. A tree is either a tensor name or
+    // "(" tree "," tree ")"; the outermost parentheses may be omitted.
+    std::vector<std::string> parse_order_line(const std::string& line, std::size_t line_num);
+
+  }  // namespace network_internal
+}  // namespace cytnx
+
+#endif  // CYTNX_UTILS_ORDER_PARSER_H_

--- a/tests/Network_test.cpp
+++ b/tests/Network_test.cpp
@@ -124,6 +124,24 @@ namespace cytnx {
         }
       }
 
+      TEST_F(NetworkTest, NetworkOrderLimitsNestingDepth) {
+        constexpr std::size_t nesting_depth = 1025;
+        std::string order(nesting_depth, '(');
+        order += "A,B";
+        order += std::string(nesting_depth, ')');
+
+        auto net = Network();
+        try {
+          net.FromString({"A: a,b", "B: b,c", "C: c,d", "D: d,e", "TOUT: a;e", "ORDER: " + order});
+          FAIL() << "accepted an excessively nested ORDER expression";
+        } catch (const error &exception) {
+          const std::string message = exception.what();
+          EXPECT_NE(message.find("[ERROR][ORDER]"), std::string::npos);
+          EXPECT_NE(message.find("column:1025"), std::string::npos);
+          EXPECT_NE(message.find("ORDER nesting exceeds maximum depth of 1024"), std::string::npos);
+        }
+      }
+
       TEST_F(NetworkTest, NetworkSetOrderRequiresEveryTensorExactlyOnce) {
         struct OrderErrorCase {
           std::string order;

--- a/tests/Network_test.cpp
+++ b/tests/Network_test.cpp
@@ -31,6 +31,96 @@ namespace cytnx {
         net.FromString(network_def);
       }
 
+      TEST_F(NetworkTest, NetworkOrderAcceptsBinaryGrammar) {
+        struct OrderCase {
+          std::string order;
+          std::string expected_root;
+        };
+        const std::vector<OrderCase> order_cases = {
+          {"(A,B),(C,D)", "((A,B),(C,D))"},
+          {"((A,B),(C,D))", "((A,B),(C,D))"},
+          {"(((A,B),C),D)", "(((A,B),C),D)"},
+          {"(A,(B,(C,D)))", "(A,(B,(C,D)))"},
+          {" ( A , B ) , ( C , D ) ", "((A,B),(C,D))"},
+        };
+
+        for (const OrderCase &order_case : order_cases) {
+          SCOPED_TRACE(order_case.order);
+          auto net = Network();
+          net.FromString(
+            {"A: a,b", "B: b,c", "C: c,d", "D: d,e", "TOUT: a;e", "ORDER: " + order_case.order});
+
+          ASSERT_EQ(net._impl->CtTree.nodes_container.size(), 3);
+          EXPECT_EQ(net._impl->CtTree.nodes_container.back()->name, order_case.expected_root);
+        }
+
+        for (const std::string &order : {"(A,B)", "A,B"}) {
+          SCOPED_TRACE(order);
+          auto net = Network();
+          net.FromString({"A: a,b", "B: b,c", "TOUT: a;c", "ORDER: " + order});
+          ASSERT_EQ(net._impl->CtTree.nodes_container.size(), 1);
+          EXPECT_EQ(net._impl->CtTree.nodes_container.back()->name, "(A,B)");
+        }
+
+        auto named_net = Network();
+        named_net.FromString({"A1: a,b", "B_Conj: b,c", "C2: c,d", "D_3: d,e", "TOUT: a;e",
+                              "ORDER: (A1,B_Conj),(C2,D_3)"});
+        ASSERT_EQ(named_net._impl->CtTree.nodes_container.size(), 3);
+        EXPECT_EQ(named_net._impl->CtTree.nodes_container.back()->name, "((A1,B_Conj),(C2,D_3))");
+      }
+
+      TEST_F(NetworkTest, NetworkOrderRejectsMalformedExpressions) {
+        struct MalformedOrderCase {
+          std::string order;
+          std::size_t expected_column;
+        };
+        const std::vector<MalformedOrderCase> malformed_orders = {
+          {"A,B,C,D", 4},    {"(A,B,C,D)", 5},    {"((A,B)),(C,D)", 7}, {"(A,B,)", 5},
+          {"),A,B,(", 1},    {"()(),A,B,C,D", 2}, {"(A,(B,C,D))", 8},   {"A,,B", 3},
+          {"(A,B)(C,D)", 6}, {"(A,(B,C)", 9},     {"(A,B))", 6},
+        };
+
+        for (const MalformedOrderCase &order_case : malformed_orders) {
+          SCOPED_TRACE(order_case.order);
+          auto net = Network();
+          try {
+            net.FromString(
+              {"A: a,b", "B: b,c", "C: c,d", "D: d,e", "TOUT: a;e", "ORDER: " + order_case.order});
+            FAIL() << "accepted malformed ORDER expression: " << order_case.order;
+          } catch (const error &exception) {
+            const std::string message = exception.what();
+            EXPECT_NE(message.find("[ERROR][ORDER]"), std::string::npos);
+            EXPECT_NE(message.find("column:" + std::to_string(order_case.expected_column)),
+                      std::string::npos);
+          }
+        }
+      }
+
+      TEST_F(NetworkTest, NetworkSetOrderRequiresEveryTensorExactlyOnce) {
+        struct OrderErrorCase {
+          std::string order;
+          std::string expected_message;
+        };
+        const std::vector<OrderErrorCase> order_cases = {
+          {"(A,(B,(C,C)))", "duplicate tensor name: C"},
+          {"(A,(B,(C,E)))", "undefined tensor name: E"},
+          {"(A,(B,C))", "every tensor exactly once"},
+        };
+
+        for (const OrderErrorCase &order_case : order_cases) {
+          SCOPED_TRACE(order_case.order);
+          auto net = Network();
+          net.FromString({"A: a,b", "B: b,c", "C: c,d", "D: d,e", "TOUT: a;e"});
+          try {
+            net.setOrder(false, order_case.order);
+            FAIL() << "accepted incomplete ORDER expression: " << order_case.order;
+          } catch (const error &exception) {
+            EXPECT_NE(std::string(exception.what()).find(order_case.expected_message),
+                      std::string::npos);
+          }
+        }
+      }
+
       TEST_F(NetworkTest, NetworkDenseNoOrder) {
         auto net = Network();
         net.FromString({"A: a,b,c", "B: c,d", "C: d,e", "TOUT: a,b;e"});
@@ -93,8 +183,8 @@ namespace cytnx {
 
       // Helper: Contract three tensors directly with Contract, and permute the open legs into the
       // requested TOUT order.
-      static UniTensor BlockNetworkReference(const UniTensor& A, const UniTensor& B,
-                                             const UniTensor& C) {
+      static UniTensor BlockNetworkReference(const UniTensor &A, const UniTensor &B,
+                                             const UniTensor &C) {
         UniTensor a = A.relabel({"a", "e"});
         UniTensor b = B.relabel({"a", "c_", "d_", "h"});
         UniTensor c = C.relabel({"e", "f_", "g_", "h"});
@@ -178,7 +268,7 @@ namespace cytnx {
 
       // Helper: build a permuted (consistent {1,0,3,2}) copy and assert it carries non-trivial sign
       // flips.
-      inline UniTensor permute_with_signflips(const UniTensor& M) {
+      inline UniTensor permute_with_signflips(const UniTensor &M) {
         UniTensor Mp = M.permute({1, 0, 3, 2}).contiguous();
         bool anyflip = false;
         for (auto f : Mp.signflip()) anyflip = anyflip || f;

--- a/tests/Network_test.cpp
+++ b/tests/Network_test.cpp
@@ -96,6 +96,34 @@ namespace cytnx {
         }
       }
 
+      TEST_F(NetworkTest, NetworkOrderRejectsSingleTensorAndInvalidCharacters) {
+        struct InvalidOrderCase {
+          std::string order;
+          std::size_t expected_column;
+          std::string expected_message;
+        };
+        const std::vector<InvalidOrderCase> invalid_orders = {
+          {"A", 2, "expected at least two tensor names"},
+          {"A;B", 2, "found a character that is not allowed in an ORDER expression"},
+        };
+
+        for (const InvalidOrderCase &order_case : invalid_orders) {
+          SCOPED_TRACE(order_case.order);
+          auto net = Network();
+          try {
+            net.FromString(
+              {"A: a,b", "B: b,c", "C: c,d", "D: d,e", "TOUT: a;e", "ORDER: " + order_case.order});
+            FAIL() << "accepted invalid ORDER expression: " << order_case.order;
+          } catch (const error &exception) {
+            const std::string message = exception.what();
+            EXPECT_NE(message.find("[ERROR][ORDER]"), std::string::npos);
+            EXPECT_NE(message.find("column:" + std::to_string(order_case.expected_column)),
+                      std::string::npos);
+            EXPECT_NE(message.find(order_case.expected_message), std::string::npos);
+          }
+        }
+      }
+
       TEST_F(NetworkTest, NetworkSetOrderRequiresEveryTensorExactlyOnce) {
         struct OrderErrorCase {
           std::string order;

--- a/tests/gpu/testNet.net
+++ b/tests/gpu/testNet.net
@@ -5,4 +5,4 @@ B  : 3 , 5 , 7; 1
 # this is comment line 2
 TOUT: ;-2, 1 #comment at end
 
-ORDER : B,C,A
+ORDER : ((B,C),A)

--- a/tests/testNet.net
+++ b/tests/testNet.net
@@ -5,4 +5,4 @@ B  : 3 , 5 , 7; 1
 # this is comment line 2
 TOUT: ;-2, 1 #comment at end
 
-ORDER : B,C,A
+ORDER : ((B,C),A)


### PR DESCRIPTION
## Problem

The Network `ORDER` parser only rejected a small character set and compared parenthesis counts. Malformed comma/parenthesis expressions could therefore reach the stack-based contraction-tree builder, where they could be accepted incorrectly or trigger unsafe stack operations.

## Fix

- add a shared recursive-descent parser for binary contraction expressions
- preserve the documented optional outermost parentheses form, including `(A,B),(C,D)`
- reject flat n-ary groups, empty operands, redundant unary groups, misplaced delimiters, and unmatched parentheses with line/column diagnostics
- require every network tensor to appear exactly once before building the contraction tree
- route both RegularNetwork and the legacy RegularGncon parser through the shared implementation
- document the grammar and canonicalize the flat test fixture as `((B,C),A)`

Nonalphabetic tensor names such as digits and underscores remain supported as opaque leaf names.

## Testing

- added focused C++ regression tests for valid trees, whitespace, opaque names, every malformed example from #832, exact error columns, and duplicate/missing/undefined leaves through `setOrder`
- pinned pre-commit hooks pass, including clang-format 14
- local build and test execution intentionally skipped as requested; CI will verify the change

Closes #832