### PR TITLE
refactor(linalg): pass the GPU Kron layout by value (#1003 step 4)

### DIFF
--- a/src/backend/linalg_internal_gpu/cuKron_internal.cuh
+++ b/src/backend/linalg_internal_gpu/cuKron_internal.cuh
@@ -1,111 +1,118 @@
 #ifndef CYTNX_BACKEND_LINALG_INTERNAL_GPU_CUKRON_INTERNAL_H_
 #define CYTNX_BACKEND_LINALG_INTERNAL_GPU_CUKRON_INTERNAL_H_
 
-#include "backend/utils_internal_interface.hpp"
-#include "utils/utils.hpp"
-#include "backend/utils_internal_gpu/cuAlloc_gpu.hpp"
-#include <algorithm>
+#include <vector>
 
-#include "cytnx_error.hpp"
 #include "Type.hpp"
-#include "backend/lapack_wrapper.hpp"
-#include <iostream>
+#include "cytnx_error.hpp"
 
 #ifndef __CUDACC__
   #error This file requires a CUDA compiler
 #endif
 
+// GPU Kronecker product. The kernel needs, per output dimension d, three strides --
+// the output stride (to decompose a linear output index into the output coordinate),
+// each operand's stride in its own buffer -- plus the rhs extent, which splits the
+// output coordinate into the lhs coordinate (quotient) and the rhs coordinate
+// (remainder).
+//
+// That is launch-time metadata, not tensor data. It used to be assembled on *every*
+// call (#1003) into one cuMalloc_gpu'd array (cudaMallocManaged) filled by four
+// pageable cudaMemcpy's, staged into dynamic shared memory by the kernel, and then
+// cudaFree'd -- six API calls that each synchronize with the device, so all of them
+// serialize against the launch they exist to configure. The shared-memory staging was
+// unsound on top of that: it copied 4*rank entries using only blockDim.x threads, so a
+// rank above 64 silently read uninitialised shared memory. Both go away by packing the
+// metadata into one POD passed to the kernel BY VALUE, which rides in the kernel's
+// parameter space with no device allocation and no shared memory. This mirrors
+// GpuNonContigLayout for the elementwise binary kernels (cuNonContigLayout.cuh).
+
 namespace cytnx {
 
   namespace linalg_internal {
 
-    template <class TO, class TL, class TR>
-    __global__ void cuKron_kernel(TO *out, const TL *Lin, const TR *Rin, cytnx_uint64 *meta_infos,
-                                  int len_nsa, int offset1, int offset2, int offset3,
-                                  cytnx_uint64 Nelem) {
-      extern __shared__ cytnx_uint64 info[];
+    namespace gpu_kron {
 
-      // copy data into shared mem:
-      if (threadIdx.x < offset3) {
-        info[threadIdx.x] = meta_infos[threadIdx.x];
-      }
-      __syncthreads();
+      // Bounds the four rank-sized arrays carried by value in GpuKronLayout:
+      // 4 * kGpuKronMaxRank * sizeof(cytnx_uint64) + 16 B (= 1040 B at 32), well within
+      // the >=4 KB CUDA kernel parameter budget. Matches kGpuNonContigMaxRank so the GPU
+      // elementwise paths share one documented rank limit.
+      constexpr int kGpuKronMaxRank = 32;
 
-      // cytnx_uint64 *new_shape_acc = info;
-      // cytnx_uint64 *shape1_acc = &info[len_nsa];
-      // cytnx_uint64 *shape2_acc = &info[offset1];
-      // cytnx_uint64 *shape2 = &info[offset2];
+      constexpr int kKronThreadsPerBlock = 256;
 
-      if (blockIdx.x * blockDim.x + threadIdx.x < Nelem) {
-        cytnx_uint64 tmp = blockIdx.x * blockDim.x + threadIdx.x;
-        cytnx_uint64 tmp2;
-        cytnx_uint64 x = 0, y = 0;
-        for (cytnx_uint64 j = 0; j < len_nsa; j++) {
-          tmp2 = tmp / info[j];
-          tmp %= info[j];
-          x += cytnx_uint64(tmp2 / info[offset2 + j]) * info[len_nsa + j];
-          y += cytnx_uint64(tmp2 % info[offset2 + j]) * info[offset1 + j];
+      struct GpuKronLayout {
+        cytnx_uint64 out_stride[kGpuKronMaxRank];  // output stride per output dim
+        cytnx_uint64 lhs_stride[kGpuKronMaxRank];  // lhs stride per output dim
+        cytnx_uint64 rhs_stride[kGpuKronMaxRank];  // rhs stride per output dim
+        cytnx_uint64 rhs_shape[kGpuKronMaxRank];  // rhs extent per output dim
+        cytnx_uint64 rank;
+        cytnx_uint64 total_elems;
+      };
+
+      // Host-side builder. Both shapes are the operands' shapes after Kron's rank
+      // padding, so they have one entry per output dimension and equal length. Output
+      // dimension d has extent shape_lhs[d] * shape_rhs[d]; the strides are the usual
+      // row-major suffix products of each shape, and total_elems is the output size.
+      inline GpuKronLayout make_gpu_kron_layout(const std::vector<cytnx_uint64> &shape_lhs,
+                                                const std::vector<cytnx_uint64> &shape_rhs) {
+        cytnx_error_msg(shape_lhs.size() != shape_rhs.size(),
+                        "[ERROR][Internal cuKron] T1 rank != T2 rank %s", "\n");
+        const cytnx_uint64 rank = shape_lhs.size();
+        cytnx_error_msg(rank > static_cast<cytnx_uint64>(kGpuKronMaxRank),
+                        "[ERROR][Internal cuKron] rank %d exceeds the supported GPU maximum %d.%s",
+                        static_cast<int>(rank), kGpuKronMaxRank, "\n");
+
+        GpuKronLayout layout{};
+        layout.rank = rank;
+        cytnx_uint64 out_accu = 1, lhs_accu = 1, rhs_accu = 1;
+        for (cytnx_uint64 i = 0; i < rank; i++) {
+          const cytnx_uint64 d = rank - 1 - i;
+          layout.out_stride[d] = out_accu;
+          layout.lhs_stride[d] = lhs_accu;
+          layout.rhs_stride[d] = rhs_accu;
+          layout.rhs_shape[d] = shape_rhs[d];
+          out_accu *= shape_lhs[d] * shape_rhs[d];
+          lhs_accu *= shape_lhs[d];
+          rhs_accu *= shape_rhs[d];
         }
-        out[blockIdx.x * blockDim.x + threadIdx.x] = TO(Lin[x]) * TO(Rin[y]);
+        layout.total_elems = out_accu;
+        return layout;
       }
-    }
 
-#define _TNinB_KRON_ 256
+    }  // namespace gpu_kron
+
+    template <class TO, class TL, class TR>
+    __global__ void cuKron_kernel(TO *out, const TL *Lin, const TR *Rin,
+                                  const gpu_kron::GpuKronLayout layout) {
+      const cytnx_uint64 idx = blockIdx.x * blockDim.x + threadIdx.x;
+      if (idx >= layout.total_elems) return;
+
+      cytnx_uint64 tmp = idx;
+      cytnx_uint64 x = 0, y = 0;
+      for (cytnx_uint64 j = 0; j < layout.rank; j++) {
+        const cytnx_uint64 coord = tmp / layout.out_stride[j];
+        tmp %= layout.out_stride[j];
+        x += (coord / layout.rhs_shape[j]) * layout.lhs_stride[j];
+        y += (coord % layout.rhs_shape[j]) * layout.rhs_stride[j];
+      }
+      // Compute through the operation's output type (#1003): TO is the promoted dtype the
+      // caller already allocated, so converting both operands first keeps the arithmetic on
+      // Cytnx's promotion rules instead of C++'s native ones.
+      out[idx] = static_cast<TO>(Lin[x]) * static_cast<TO>(Rin[y]);
+    }
 
     template <class TO, class TL, class TR>
     void cuKron_general(TO *out, const TL *Lin, const TR *Rin,
                         const std::vector<cytnx_uint64> &shape1,
                         const std::vector<cytnx_uint64> &shape2) {
-      cytnx_error_msg(shape1.size() != shape2.size(),
-                      "[ERROR][Internal cuKron] T1 rank != T2 rank %s", "\n");
+      const gpu_kron::GpuKronLayout layout = gpu_kron::make_gpu_kron_layout(shape1, shape2);
+      if (layout.total_elems == 0) return;
 
-      std::vector<cytnx_uint64> new_shape_acc(shape1.size());
-      std::vector<cytnx_uint64> shape1_acc(shape1.size());
-      std::vector<cytnx_uint64> shape2_acc(shape2.size());
-      new_shape_acc.back() = 1;
-      shape1_acc.back() = 1;
-      shape2_acc.back() = 1;
-      cytnx_uint64 TotalElem = shape1[0] * shape2[0];
+      cytnx_uint64 nblocks = layout.total_elems / gpu_kron::kKronThreadsPerBlock;
+      if (layout.total_elems % gpu_kron::kKronThreadsPerBlock) nblocks += 1;
 
-      for (unsigned long long i = 1; i < new_shape_acc.size(); i++) {
-        new_shape_acc[new_shape_acc.size() - 1 - i] = new_shape_acc[new_shape_acc.size() - i] *
-                                                      shape1[new_shape_acc.size() - i] *
-                                                      shape2[new_shape_acc.size() - i];
-        TotalElem *= shape1[i] * shape2[i];
-        shape1_acc[shape1_acc.size() - 1 - i] =
-          shape1_acc[shape1_acc.size() - i] * shape1[shape1_acc.size() - i];
-        shape2_acc[shape2_acc.size() - 1 - i] =
-          shape2_acc[shape2_acc.size() - i] * shape2[shape2_acc.size() - i];
-      }
-
-      int offset1 = new_shape_acc.size() + shape1_acc.size();
-      int offset2 = offset1 + shape2_acc.size();
-      int offset3 = offset2 + shape2.size();
-
-      cytnx_uint64 *dshare_info = (cytnx_uint64 *)utils_internal::cuMalloc_gpu(
-        (new_shape_acc.size() + shape1_acc.size() + shape2_acc.size() + shape2.size()) *
-        sizeof(cytnx_uint64));
-      checkCudaErrors(cudaMemcpy(dshare_info, &new_shape_acc[0],
-                                 new_shape_acc.size() * sizeof(cytnx_uint64),
-                                 cudaMemcpyHostToDevice));
-      checkCudaErrors(cudaMemcpy((char *)dshare_info + new_shape_acc.size() * sizeof(cytnx_uint64),
-                                 shape1_acc.data(), shape1_acc.size() * sizeof(cytnx_uint64),
-                                 cudaMemcpyHostToDevice));
-      checkCudaErrors(cudaMemcpy((char *)dshare_info + offset1 * sizeof(cytnx_uint64),
-                                 shape2_acc.data(), shape2_acc.size() * sizeof(cytnx_uint64),
-                                 cudaMemcpyHostToDevice));
-      checkCudaErrors(cudaMemcpy((char *)dshare_info + offset2 * sizeof(cytnx_uint64),
-                                 shape2.data(), shape2.size() * sizeof(cytnx_uint64),
-                                 cudaMemcpyHostToDevice));
-
-      cytnx_uint64 NBlocks = TotalElem / _TNinB_KRON_;
-      if (TotalElem % _TNinB_KRON_) NBlocks += 1;
-
-      // cudaDeviceSynchronize(); // not needed, cudaMemcpy is synchronous
-      cuKron_kernel<<<NBlocks, _TNinB_KRON_, offset3 * sizeof(cytnx_uint64)>>>(
-        out, Lin, Rin, dshare_info, new_shape_acc.size(), offset1, offset2, offset3, TotalElem);
-
-      cudaFree(dshare_info);
+      cuKron_kernel<<<nblocks, gpu_kron::kKronThreadsPerBlock>>>(out, Lin, Rin, layout);
     }
 
   }  // namespace linalg_internal

--- a/tests/gpu/linalg_test/Kron_test.cpp
+++ b/tests/gpu/linalg_test/Kron_test.cpp
@@ -29,6 +29,11 @@ namespace cytnx {
   namespace gpu_test {
     namespace {
 
+      // Mirrors gpu_kron::kGpuKronMaxRank in
+      // src/backend/linalg_internal_gpu/cuKron_internal.cuh, which this test cannot
+      // include (that header requires a CUDA compiler).
+      constexpr cytnx_uint64 kGpuKronMaxRank = 32;
+
       // Builds a sweep operand, bounding Uint16 away from signed-overflow UB.
       //
       // GetRandRange gives the narrow types their full numeric_limits range, so Uint16 draws
@@ -190,6 +195,100 @@ namespace cytnx {
         ASSERT_EQ(out.dtype(), Type.Int16);
         const cytnx_int16 expect[4] = {12, 15, -8, -10};
         for (std::size_t k = 0; k < 4; ++k) EXPECT_EQ(out.at<cytnx_int16>({k}), expect[k]);
+      }
+
+      // Rank 3, the case that actually exercises the multi-dimensional index decompose
+      // in the GPU kernel -- every other value test above is rank 1 or rank 2, where the
+      // decompose degenerates. Both operands carry a length-1 dimension (in different
+      // slots) so the per-dimension strides are non-uniform and a stride built from the
+      // wrong extent cannot cancel out. Expected values come from the Kronecker
+      // definition applied to the CPU inputs,
+      //     out[i1*b1 + j1, i2*b2 + j2, i3*b3 + j3] = a[i1,i2,i3] * b[j1,j2,j3],
+      // not from another Cytnx Kron call. Both factors are exact in double and so is
+      // their product, hence EXPECT_DOUBLE_EQ rather than a tolerance.
+      TEST(Kron, GpuRank3MatchesDefinition) {
+        const std::vector<cytnx_uint64> a_shape = {2, 1, 3};
+        const std::vector<cytnx_uint64> b_shape = {1, 2, 2};
+        Tensor a = zeros(a_shape, Type.Double);
+        Tensor b = zeros(b_shape, Type.Double);
+        for (cytnx_uint64 i = 0; i < a_shape[0]; i++)
+          for (cytnx_uint64 j = 0; j < a_shape[1]; j++)
+            for (cytnx_uint64 k = 0; k < a_shape[2]; k++)
+              a.at<cytnx_double>({i, j, k}) = 0.5 * (3 * i + k) - 1.25;
+        for (cytnx_uint64 i = 0; i < b_shape[0]; i++)
+          for (cytnx_uint64 j = 0; j < b_shape[1]; j++)
+            for (cytnx_uint64 k = 0; k < b_shape[2]; k++)
+              b.at<cytnx_double>({i, j, k}) = 2.0 - 0.75 * (2 * j + k);
+
+        Tensor out = linalg::Kron(a.to(Device.cuda), b.to(Device.cuda)).to(Device.cpu);
+
+        ASSERT_EQ(out.dtype(), Type.Double);
+        ASSERT_EQ(out.shape(), (std::vector<cytnx_uint64>{2, 2, 6}));
+        for (cytnx_uint64 i1 = 0; i1 < a_shape[0]; i1++)
+          for (cytnx_uint64 i2 = 0; i2 < a_shape[1]; i2++)
+            for (cytnx_uint64 i3 = 0; i3 < a_shape[2]; i3++)
+              for (cytnx_uint64 j1 = 0; j1 < b_shape[0]; j1++)
+                for (cytnx_uint64 j2 = 0; j2 < b_shape[1]; j2++)
+                  for (cytnx_uint64 j3 = 0; j3 < b_shape[2]; j3++) {
+                    const double expected =
+                      a.at<cytnx_double>({i1, i2, i3}) * b.at<cytnx_double>({j1, j2, j3});
+                    EXPECT_DOUBLE_EQ(
+                      out.at<cytnx_double>(
+                        {i1 * b_shape[0] + j1, i2 * b_shape[1] + j2, i3 * b_shape[2] + j3}),
+                      expected)
+                      << "at a(" << i1 << "," << i2 << "," << i3 << ") b(" << j1 << "," << j2 << ","
+                      << j3 << ")";
+                  }
+      }
+
+      // Unequal ranks: Kron pads the shorter operand's shape with trailing ones (the
+      // default lhs_pad_left/rhs_pad_left = false), so a rank-3 (x) rank-1 pair becomes
+      // {2,1,2} (x) {3,1,1} -> {6,1,2}. The padded dimensions make two of the rhs strides
+      // degenerate, which is exactly where an index decompose built from the unpadded
+      // shape would go wrong. Expected values again from the definition, with the rhs
+      // index taken at the padded coordinates (j2 = j3 = 0).
+      TEST(Kron, GpuUnequalRankPadsWithTrailingOnes) {
+        Tensor a = zeros({2, 1, 2}, Type.Double);
+        for (cytnx_uint64 i = 0; i < 2; i++)
+          for (cytnx_uint64 k = 0; k < 2; k++)
+            a.at<cytnx_double>({i, 0, k}) = 1.5 * (2 * i + k) - 2.0;
+        Tensor b = zeros({3}, Type.Double);
+        b.at<cytnx_double>({0}) = -0.5;
+        b.at<cytnx_double>({1}) = 2.25;
+        b.at<cytnx_double>({2}) = 0.0;
+
+        Tensor out = linalg::Kron(a.to(Device.cuda), b.to(Device.cuda)).to(Device.cpu);
+
+        ASSERT_EQ(out.dtype(), Type.Double);
+        ASSERT_EQ(out.shape(), (std::vector<cytnx_uint64>{6, 1, 2}));
+        for (cytnx_uint64 i1 = 0; i1 < 2; i1++)
+          for (cytnx_uint64 i3 = 0; i3 < 2; i3++)
+            for (cytnx_uint64 j1 = 0; j1 < 3; j1++) {
+              const double expected = a.at<cytnx_double>({i1, 0, i3}) * b.at<cytnx_double>({j1});
+              EXPECT_DOUBLE_EQ(out.at<cytnx_double>({i1 * 3 + j1, 0, i3}), expected)
+                << "at a(" << i1 << ",0," << i3 << ") b(" << j1 << ")";
+            }
+      }
+
+      // The GPU kernel carries its layout metadata (output strides, per-operand strides
+      // and the rhs extents) by value in one POD, which bounds the supported rank at
+      // gpu_kron::kGpuKronMaxRank = 32. Past that the front end must raise rather than
+      // truncate: the previous device-array kernel staged 4*rank entries into shared
+      // memory with only blockDim.x threads, so rank > 64 silently produced garbage.
+      // This limit is GPU-only -- the CPU path has no such bound, so the same Kron on
+      // the CPU still succeeds.
+      TEST(Kron, GpuRankAboveLayoutLimitThrows) {
+        const std::vector<cytnx_uint64> deep(kGpuKronMaxRank + 1, 1);
+        Tensor a = zeros(deep, Type.Double);
+        Tensor b = zeros(deep, Type.Double);
+        a.at<cytnx_double>(std::vector<cytnx_uint64>(deep.size(), 0)) = 2.0;
+        b.at<cytnx_double>(std::vector<cytnx_uint64>(deep.size(), 0)) = -3.0;
+
+        EXPECT_THROW(linalg::Kron(a.to(Device.cuda), b.to(Device.cuda)), cytnx::error);
+
+        Tensor cpu_out = linalg::Kron(a, b);
+        ASSERT_EQ(cpu_out.shape().size(), deep.size());
+        EXPECT_DOUBLE_EQ(cpu_out.at<cytnx_double>(std::vector<cytnx_uint64>(deep.size(), 0)), -6.0);
       }
 
       // Kron short-circuits on a rank-0 operand -- `if (lhs.is_scalar() || rhs.is_scalar())


### PR DESCRIPTION
## Problem

`cuKron_general` was the last GPU elementwise path still building its kernel
metadata on the device. Every call assembled the per-dimension index metadata
(output strides, both operands' strides, the rhs extents) into one
`cudaMallocManaged`'d array via four pageable `cudaMemcpy`s, staged it into
dynamic shared memory inside the kernel, and `cudaFree`'d it afterwards. Those
six API calls each synchronize with the device, so they serialize against the
very launch they exist to configure — and shape/stride data is launch-time
metadata, not tensor data.

This is the outstanding item in #1003's acceptance criteria:

> elementwise layout metadata is passed as kernel parameters, not via per-call
> `cudaMalloc` / `cudaMemcpy` / `cudaFree` of tiny arrays

The shared-memory staging was also unsound: it copied `4 * rank` entries using
only `blockDim.x` threads (`if (threadIdx.x < offset3)`), so at 256 threads per
block any rank above 64 silently read uninitialised shared memory and produced
garbage rather than failing.

## Fix

Pack the metadata into one POD, `gpu_kron::GpuKronLayout`, built on the host by
`make_gpu_kron_layout()` and passed to the kernel **by value** — it rides in the
kernel's parameter space with no device allocation and no shared memory. This
mirrors `GpuNonContigLayout` (`cuNonContigLayout.cuh`), which did the same for
the binary elementwise kernels in an earlier step of #1003.

The index math is unchanged: per output dimension the layout stores the output
stride, each operand's stride, and the rhs extent that splits the output
coordinate into the lhs (quotient) and rhs (remainder) coordinates.

Incidental cleanups in the touched file: the `_TNinB_KRON_` macro becomes
`constexpr int kKronThreadsPerBlock`, the `&vec[0]` raw-memory idiom disappears
with the copies, and the includes shrink to what the file actually uses.

### Behavior change to flag

Carrying the arrays by value bounds the supported rank at
`kGpuKronMaxRank = 32` (`4 * 32 * 8 + 16 = 1040 B`, well inside the >= 4 KB
kernel parameter budget), matching `kGpuNonContigMaxRank` so the GPU elementwise
paths share one documented rank limit. Above it, `cytnx_error_msg` now raises.
Previously ranks 33–64 worked and ranks above 64 silently corrupted, so this
replaces an unchecked cliff with an explicit error — but it *is* a new hard
limit on the GPU path. The CPU path is unbounded and unchanged.

## Testing

`tests/gpu/linalg_test/Kron_test.cpp` — the existing value tests are all rank 1
or rank 2, where the multi-dimensional index decompose degenerates, so the
rewritten decompose had no real coverage:

- `Kron.GpuRank3MatchesDefinition` — rank-3 ⊗ rank-3 with a length-1 dimension
  in a different slot on each side, checked against the Kronecker definition
  applied to the CPU inputs (not against another Cytnx `Kron` call).
- `Kron.GpuUnequalRankPadsWithTrailingOnes` — rank-3 ⊗ rank-1, which exercises
  the trailing-ones shape padding and the degenerate rhs strides it produces.
- `Kron.GpuRankAboveLayoutLimitThrows` — guards the new rank limit, and asserts
  the same `Kron` still succeeds on the CPU.

Verified on an A100 with the `debug-openblas-cuda` preset: all 11 GPU `Kron`
tests and all 6 GPU `Outer` tests (which route through `cuKron` since #1105)
pass. The rank-limit guard was confirmed to fail against the pre-change kernel;
the two new value tests pass on both revisions, which is what a refactor guard
should do. `pre-commit run` is clean.

No performance claim is made here — the change is structural (six synchronizing
API calls per launch removed). A `cross-revision-benchmark` run can follow if
numbers are wanted.

Part of #1003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)