### PR TITLE
fix(build): keep the portable CUDA architecture list across reconfigures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,9 +258,22 @@ if(USE_CUDA)
   # a preset's cacheVariables, or the CUDAARCHS environment variable, before
   # enable_language(CUDA) fills CMAKE_CUDA_ARCHITECTURES with its own default
   # and makes the "not specified" case impossible to detect.
+  #
+  # A *re*configure of an existing build dir needs more than that check: the
+  # first configure leaves a CMAKE_CUDA_ARCHITECTURES cache entry behind, so
+  # every later run sees a non-empty value and would mistake it for a caller's
+  # choice, silently collapsing the portable fat binary below onto whatever
+  # single architecture CMake defaulted to. CYTNX_CUDA_ARCHITECTURES_APPLIED
+  # remembers the list this project installed, so a cache entry that still
+  # matches it is recognized as ours and re-derived, while any other value --
+  # including a -D given on a later configure -- is honored as the caller's.
   set(_cytnx_user_set_cuda_architectures FALSE)
   if(CMAKE_CUDA_ARCHITECTURES OR DEFINED ENV{CUDAARCHS})
     set(_cytnx_user_set_cuda_architectures TRUE)
+    if(DEFINED CYTNX_CUDA_ARCHITECTURES_APPLIED
+       AND CMAKE_CUDA_ARCHITECTURES STREQUAL CYTNX_CUDA_ARCHITECTURES_APPLIED)
+      set(_cytnx_user_set_cuda_architectures FALSE)
+    endif()
   endif()
   # enable_language(CUDA) runs its own internal compiler ABI-detection compile
   # using whatever CMAKE_CUDA_ARCHITECTURES is set to at this point, so our own
@@ -277,10 +290,21 @@ if(USE_CUDA)
     # https://docs.nvidia.com/cuda/archive/13.0.0/cuda-toolkit-release-notes/),
     # so the floor is Turing (sm_75) on CUDA >=13 and Volta (sm_70) below that.
     if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL 13.0)
-      set(CMAKE_CUDA_ARCHITECTURES 75-real 80-real 86-real 89-real 90-real 90-virtual)
+      set(_cytnx_cuda_architectures 75-real 80-real 86-real 89-real 90-real 90-virtual)
     else()
-      set(CMAKE_CUDA_ARCHITECTURES 70-real 75-real 80-real 86-real 89-real 90-real 90-virtual)
+      set(_cytnx_cuda_architectures 70-real 75-real 80-real 86-real 89-real 90-real 90-virtual)
     endif()
+    # Write the list to the cache rather than shadowing it with a normal
+    # variable: the cache is what a reconfigure, an IDE, and anything else
+    # reading CMakeCache.txt actually see, and leaving CMake's single-
+    # architecture default sitting there is what made this collapse silent.
+    set(CMAKE_CUDA_ARCHITECTURES "${_cytnx_cuda_architectures}" CACHE STRING
+        "CUDA architectures to generate device code for" FORCE)
+    set(CYTNX_CUDA_ARCHITECTURES_APPLIED "${_cytnx_cuda_architectures}" CACHE INTERNAL
+        "Architecture list this project defaulted to; distinguishes it from a caller's choice")
+    unset(_cytnx_cuda_architectures)
+  else()
+    unset(CYTNX_CUDA_ARCHITECTURES_APPLIED CACHE)
   endif()
   unset(_cytnx_user_set_cuda_architectures)
   # Disable generation of "--option-file" flag in compile_commands.json.


### PR DESCRIPTION
Relates to #1171 (deliberately does not close it — see *Scope* below).

## Problem

`enable_language(CUDA)` writes CMake's own single-architecture default into the
cache on the first configure. The guard at `CMakeLists.txt:262` that detects a
caller-supplied `CMAKE_CUDA_ARCHITECTURES` then sees that cached value on every
later run and mistakes it for the caller's choice, so the portable fat-binary
default added in #870 is skipped.

Measured on this tree (CUDA 13.0, CMake 4.0.2), configuring the same build dir
repeatedly with identical flags:

| configure | emitted codegen |
|---|---|
| 1st (fresh dir) | `lto_75 lto_80 lto_86 lto_89 lto_90 compute_90` |
| 2nd (same dir) | `compute_75` only |
| 3rd (bare re-run) | `compute_75` only |

Any reconfigure triggers it — a preset re-run, an IDE, or a changed flag — so in
practice a build dir holds the portable list only until the next `cmake` run.
After that the device link emits a single `sm_75` cubin, and every GPU other than
Turing falls back to JIT'ing PTX instead of running the SASS #870 meant to ship.

This also explains the `CMAKE_CUDA_ARCHITECTURES:STRING=75` cache entry noted in
#1171. It is not cosmetic: it is the value that becomes authoritative on the
next configure.

## Fix

Record the list this project installs in an internal cache marker
(`CYTNX_CUDA_ARCHITECTURES_APPLIED`). A cached value that still matches it is
recognized as ours and re-derived; any other value — including a `-D` supplied on
a later configure — is honored as the caller's. The list is written to the cache
rather than shadowing it with a normal variable, so `CMakeCache.txt` and anything
reading it agree with the compile lines.

## Scope

This restores the portable fat binary. It is **not** the wrong-answers bug in
#1171's title, so that issue stays open.

I could not reproduce silent zeros from any build state on sm_89: even the
collapsed single-architecture build computes correctly, because the device link
emits `code=[compute_75,sm_75]` and the driver JITs the PTX. The failure
signature itself does reproduce in isolation — a fatbin carrying SASS with no
compatible PTX gives `value=0, launch=cudaErrorNoKernelImageForDevice`, i.e.
wrong numbers and no error — which is why the launch-error checking in part 2 of
#1171 is the change that would actually have surfaced the A100 session.

Two premises in the #1171 thread are also contradicted by this tree, noted here
so nobody builds on them: `CUDA_SEPARABLE_COMPILATION` and
`CUDA_RESOLVE_DEVICE_SYMBOLS` **are** set (`CytnxBKNDCMakeLists.cmake:253`,
`:255`), a device-link step **is** generated (221 rule lines in
`CMakeFiles/cytnx.dir/build.make`), and the pinned-arch build's archive contains
a real `sm_89.cubin` — so that build executed native SASS rather than JIT'd PTX.
CMake 3.28.3 (the version in the report) generates byte-identical flags.

## Testing

- Configure sequence 1/2/3 above now yields the six-architecture list every time,
  and `CMakeCache.txt` reads
  `75-real;80-real;86-real;89-real;90-real;90-virtual`.
- `-DCMAKE_CUDA_ARCHITECTURES=80` on a later configure is honored and survives a
  subsequent bare re-run.
- Built after a reconfigure, `cmake_device_link.o` contains
  `sm_75/80/86/89/90.cubin` — pre-fix it contained only `sm_75.cubin`.
- Full GPU suite on an RTX 4070 Ti SUPER (sm_89): `ctest -L gpu` → **841/841
  passed**, 4 pre-existing skips.
- `pre-commit run --files CMakeLists.txt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)