### PR TITLE
test(linalg): GPU mixed real/complex coverage for Sub/Mul/Div/Cpr (#1003)

### DIFF
--- a/include/backend/Storage.hpp
+++ b/include/backend/Storage.hpp
@@ -75,9 +75,11 @@ namespace cytnx {
     //     call sites than the six arithmetic families converted in #941's
     //     first pass (Add/Sub/Mul/Div/Cpr/Mod) and is out of scope for that
     //     task.
-    //   - GPU kernel dispatch (src/backend/linalg_internal_gpu/*, the
-    //     cuAri_ii table) -- ruling 3 keeps GPU on the legacy table; see GPU
-    //     tracking issue #1013.
+    //   - GPU kernel launches (src/backend/linalg_internal_gpu/*). The dtype
+    //     *dispatch* there is typed now -- as_storage_variant() + type_promote_t,
+    //     with the legacy cuAri_ii table removed (#1003, #1013) -- but the launch
+    //     helpers still reinterpret_cast this erased pointer to the CUDA-native
+    //     kernel type, because CUDA needs the raw device address.
     // New code should use StorageImplementation<T>::data() (typed) via
     // as_storage_variant()/storage_cast<T> instead. Do not add new callers of
     // this accessor.

--- a/tests/gpu/linalg_test/Cpr_test.cpp
+++ b/tests/gpu/linalg_test/Cpr_test.cpp
@@ -214,6 +214,46 @@ namespace cytnx {
         }
       }
 
+      // Cpr's promotion is invisible in the output dtype -- the result is always Bool -- so
+      // a wrong comparison type here cannot be caught by a dtype assertion the way it can
+      // for Add/Sub/Mul/Div. What pins it is a pair of values whose equality *depends* on
+      // the comparison type (#1003).
+      //
+      // Type.type_promote(ComplexFloat, Double) is ComplexDouble, so both operands widen to
+      // double before comparing. 0.5 is exactly representable in float32, so it compares
+      // equal either way. 0.1 is not: as a float it is 0.100000001490116119384765625, which
+      // is a different double from 0.1, so the correct answer is *false*. An implementation
+      // that compared in ComplexFloat instead would narrow the double 0.1 to the same float
+      // and wrongly report true. The third pair is unequal under any comparison type and
+      // guards against a kernel that returns a constant.
+      TEST(CprMixedDtypeTest, GpuComplexFloatVsDoubleComparesInComplexDouble) {
+        Tensor cf = zeros({3}, Type.ComplexFloat);
+        cf.at<cytnx_complex64>({0}) = cytnx_complex64(0.5f, 0.0f);
+        cf.at<cytnx_complex64>({1}) = cytnx_complex64(0.1f, 0.0f);
+        cf.at<cytnx_complex64>({2}) = cytnx_complex64(2.0f, 0.0f);
+        Tensor d = zeros({3}, Type.Double);
+        d.at<cytnx_double>({0}) = 0.5;
+        d.at<cytnx_double>({1}) = 0.1;
+        d.at<cytnx_double>({2}) = -7.0;
+
+        const bool expected[3] = {true, false, false};
+
+        {
+          SCOPED_TRACE("ComplexFloat == Double");
+          Tensor out = linalg::Cpr(cf.to(Device.cuda), d.to(Device.cuda)).to(Device.cpu);
+          ASSERT_EQ(out.dtype(), Type.Bool);
+          for (std::size_t k = 0; k < 3; ++k)
+            EXPECT_EQ(out.at<cytnx_bool>({k}), expected[k]) << "element " << k;
+        }
+        {
+          SCOPED_TRACE("Double == ComplexFloat (equality is symmetric)");
+          Tensor out = linalg::Cpr(d.to(Device.cuda), cf.to(Device.cuda)).to(Device.cpu);
+          ASSERT_EQ(out.dtype(), Type.Bool);
+          for (std::size_t k = 0; k < 3; ++k)
+            EXPECT_EQ(out.at<cytnx_bool>({k}), expected[k]) << "element " << k;
+        }
+      }
+
       INSTANTIATE_TEST_SUITE_P(CprTests, CprTestAllShapes, ::testing::ValuesIn(GetTestShapes()));
 
       // Non-contiguous tensor(==)tensor on the GPU (#1003, #988): the GPU front end used to

--- a/tests/gpu/linalg_test/Div_test.cpp
+++ b/tests/gpu/linalg_test/Div_test.cpp
@@ -236,6 +236,52 @@ namespace cytnx {
           AreNearlyEqTensor(gpu_result_r_cpu, expected_r, GetTolerance(gpu_result_r.dtype())));
       }
 
+      // The #984/#999 promotion discriminator on the GPU Div path (#1003): ComplexFloat
+      // (/) Double must produce ComplexDouble, with the quotient computed and stored
+      // through that output type. Div's output rule is
+      // make_floating_point_t<type_promote_t<TL, TR>>, and ComplexDouble is already
+      // floating, so the expected dtype is the plain promotion.
+      //
+      // See Sub_test's twin for why the Double operands are float32-inexact (0.1, 3.3):
+      // computing through ComplexFloat lands ~1e-8 away, far past the tolerance here.
+      // Both operand orders are checked because division does not commute, and the two
+      // orders exercise different arithmetic -- dividing by a real-valued complex reduces
+      // to a componentwise divide, while dividing by a complex with a non-zero imaginary
+      // part goes through the full complex-division formula. Expected values are evaluated
+      // in host double arithmetic from that formula, not taken from the CPU Div path.
+      TEST(DivMixedDtypeTest, GpuComplexFloatDoublePromotesToComplexDouble) {
+        Tensor cf = zeros({2}, Type.ComplexFloat);
+        cf.at<cytnx_complex64>({0}) = cytnx_complex64(1.5f, -2.5f);
+        cf.at<cytnx_complex64>({1}) = cytnx_complex64(0.0f, 4.0f);
+        Tensor d = zeros({2}, Type.Double);
+        d.at<cytnx_double>({0}) = 0.1;
+        d.at<cytnx_double>({1}) = 3.3;
+
+        {
+          SCOPED_TRACE("ComplexFloat / Double");
+          Tensor out = linalg::Div(cf.to(Device.cuda), d.to(Device.cuda)).to(Device.cpu);
+          ASSERT_EQ(out.dtype(), Type.ComplexDouble);
+          // Dividing by a real: (a + bi) / c = a/c + (b/c)i.
+          Tensor expected = zeros({2}, Type.ComplexDouble);
+          expected.at<cytnx_complex128>({0}) = cytnx_complex128(1.5 / 0.1, -2.5 / 0.1);
+          expected.at<cytnx_complex128>({1}) = cytnx_complex128(0.0 / 3.3, 4.0 / 3.3);
+          EXPECT_TRUE(AreNearlyEqTensor(out, expected, 1e-12));
+        }
+        {
+          SCOPED_TRACE("Double / ComplexFloat");
+          Tensor out = linalg::Div(d.to(Device.cuda), cf.to(Device.cuda)).to(Device.cpu);
+          ASSERT_EQ(out.dtype(), Type.ComplexDouble);
+          // (a + bi) / (c + di) = ((ac + bd) + (bc - ad)i) / (c^2 + d^2), with b = 0 here.
+          const double den0 = 1.5 * 1.5 + 2.5 * 2.5;
+          const double den1 = 4.0 * 4.0;
+          Tensor expected = zeros({2}, Type.ComplexDouble);
+          expected.at<cytnx_complex128>({0}) =
+            cytnx_complex128(0.1 * 1.5 / den0, -(0.1 * -2.5) / den0);
+          expected.at<cytnx_complex128>({1}) = cytnx_complex128(0.0, -(3.3 * 4.0) / den1);
+          EXPECT_TRUE(AreNearlyEqTensor(out, expected, 1e-12));
+        }
+      }
+
       INSTANTIATE_TEST_SUITE_P(DivTests, DivTestAllShapes, ::testing::ValuesIn(GetTestShapes()));
 
       // Non-contiguous tensor(/)tensor on the GPU (#1003, #988): the GPU front end used to

--- a/tests/gpu/linalg_test/Mul_test.cpp
+++ b/tests/gpu/linalg_test/Mul_test.cpp
@@ -162,6 +162,59 @@ namespace cytnx {
         EXPECT_TRUE(AreNearlyEqTensor(gpu_result_r_cpu, expected_r, 1e-6));
       }
 
+      // The #984/#999 promotion discriminator on the GPU Mul path (#1003): ComplexFloat
+      // (x) Double must produce ComplexDouble, with the product computed and stored through
+      // that output type. See Sub_test's twin for why the Double operands are float32-
+      // inexact (0.1, 3.3) and the ComplexFloat components are float-exact -- an
+      // implementation that reports ComplexDouble but multiplies through ComplexFloat lands
+      // ~1e-8 away, far past the tolerance here. Expected values are evaluated in host
+      // double arithmetic, not taken from the CPU Mul path.
+      //
+      // The scalar cases matter separately: a scalar operand takes the lconst/rconst
+      // kernels rather than the tensor(x)tensor one, so its promotion is a distinct code
+      // path in the shared dispatch.
+      TEST(MulMixedDtypeTest, GpuComplexFloatDoublePromotesToComplexDouble) {
+        Tensor cf = zeros({2}, Type.ComplexFloat);
+        cf.at<cytnx_complex64>({0}) = cytnx_complex64(1.5f, -2.5f);
+        cf.at<cytnx_complex64>({1}) = cytnx_complex64(0.0f, 4.0f);
+        Tensor d = zeros({2}, Type.Double);
+        d.at<cytnx_double>({0}) = 0.1;
+        d.at<cytnx_double>({1}) = 3.3;
+
+        Tensor expected = zeros({2}, Type.ComplexDouble);
+        expected.at<cytnx_complex128>({0}) = cytnx_complex128(1.5 * 0.1, -2.5 * 0.1);
+        expected.at<cytnx_complex128>({1}) = cytnx_complex128(0.0, 4.0 * 3.3);
+
+        {
+          SCOPED_TRACE("ComplexFloat x Double");
+          Tensor out = linalg::Mul(cf.to(Device.cuda), d.to(Device.cuda)).to(Device.cpu);
+          ASSERT_EQ(out.dtype(), Type.ComplexDouble);
+          EXPECT_TRUE(AreNearlyEqTensor(out, expected, 1e-12));
+        }
+        {
+          SCOPED_TRACE("Double x ComplexFloat (multiplication commutes)");
+          Tensor out = linalg::Mul(d.to(Device.cuda), cf.to(Device.cuda)).to(Device.cpu);
+          ASSERT_EQ(out.dtype(), Type.ComplexDouble);
+          EXPECT_TRUE(AreNearlyEqTensor(out, expected, 1e-12));
+        }
+        {
+          // Scalar on each side: a ComplexFloat scalar against a Double tensor promotes the
+          // same way, through the lconst/rconst kernels.
+          SCOPED_TRACE("ComplexFloat scalar x Double tensor, both orders");
+          const cytnx_complex64 scalar(1.5f, -2.5f);
+          Tensor scalar_expected = zeros({2}, Type.ComplexDouble);
+          scalar_expected.at<cytnx_complex128>({0}) = cytnx_complex128(1.5 * 0.1, -2.5 * 0.1);
+          scalar_expected.at<cytnx_complex128>({1}) = cytnx_complex128(1.5 * 3.3, -2.5 * 3.3);
+
+          Tensor out_l = linalg::Mul(scalar, d.to(Device.cuda)).to(Device.cpu);
+          Tensor out_r = linalg::Mul(d.to(Device.cuda), scalar).to(Device.cpu);
+          ASSERT_EQ(out_l.dtype(), Type.ComplexDouble);
+          ASSERT_EQ(out_r.dtype(), Type.ComplexDouble);
+          EXPECT_TRUE(AreNearlyEqTensor(out_l, scalar_expected, 1e-12));
+          EXPECT_TRUE(AreNearlyEqTensor(out_r, scalar_expected, 1e-12));
+        }
+      }
+
       INSTANTIATE_TEST_SUITE_P(MulTests, MulTestAllShapes, ::testing::ValuesIn(GetTestShapes()));
 
       ::testing::AssertionResult CheckMulResult(const Tensor& gpu_result, const Tensor& left_tensor,

--- a/tests/gpu/linalg_test/Sub_test.cpp
+++ b/tests/gpu/linalg_test/Sub_test.cpp
@@ -162,6 +162,51 @@ namespace cytnx {
         EXPECT_TRUE(AreNearlyEqTensor(gpu_result_r_cpu, expected_r, 1e-6));
       }
 
+      // The #984/#999 promotion discriminator on the GPU Sub path (#1003): ComplexFloat
+      // (-) Double must produce ComplexDouble -- the higher-precision complex -- with the
+      // subtraction computed and stored through that output type. The sweeps above pair a
+      // dtype with itself and the mixed tests above cover only signed/unsigned, so this
+      // row was untested here.
+      //
+      // The Double operands are deliberately values float32 cannot represent (0.1, 3.3).
+      // An implementation that reports ComplexDouble but computes through ComplexFloat
+      // rounds them first and lands ~1e-8 away -- four orders of magnitude past the
+      // tolerance below, so it fails loudly. The ComplexFloat components stay float-exact
+      // (1.5, -2.5, 0, 4) so float -> double widening of that operand is exact and the
+      // only precision question under test is the one above.
+      //
+      // Both operand orders are checked because subtraction does not commute: a path that
+      // silently swapped or narrowed one side would survive a single-order test. Expected
+      // values are evaluated here in host double arithmetic rather than taken from the CPU
+      // Sub path, so a shared promotion bug cannot hide.
+      TEST(SubMixedDtypeTest, GpuComplexFloatDoublePromotesToComplexDouble) {
+        Tensor cf = zeros({2}, Type.ComplexFloat);
+        cf.at<cytnx_complex64>({0}) = cytnx_complex64(1.5f, -2.5f);
+        cf.at<cytnx_complex64>({1}) = cytnx_complex64(0.0f, 4.0f);
+        Tensor d = zeros({2}, Type.Double);
+        d.at<cytnx_double>({0}) = 0.1;
+        d.at<cytnx_double>({1}) = 3.3;
+
+        {
+          SCOPED_TRACE("ComplexFloat - Double");
+          Tensor out = linalg::Sub(cf.to(Device.cuda), d.to(Device.cuda)).to(Device.cpu);
+          ASSERT_EQ(out.dtype(), Type.ComplexDouble);
+          Tensor expected = zeros({2}, Type.ComplexDouble);
+          expected.at<cytnx_complex128>({0}) = cytnx_complex128(1.5 - 0.1, -2.5);
+          expected.at<cytnx_complex128>({1}) = cytnx_complex128(0.0 - 3.3, 4.0);
+          EXPECT_TRUE(AreNearlyEqTensor(out, expected, 1e-12));
+        }
+        {
+          SCOPED_TRACE("Double - ComplexFloat");
+          Tensor out = linalg::Sub(d.to(Device.cuda), cf.to(Device.cuda)).to(Device.cpu);
+          ASSERT_EQ(out.dtype(), Type.ComplexDouble);
+          Tensor expected = zeros({2}, Type.ComplexDouble);
+          expected.at<cytnx_complex128>({0}) = cytnx_complex128(0.1 - 1.5, 2.5);
+          expected.at<cytnx_complex128>({1}) = cytnx_complex128(3.3 - 0.0, -4.0);
+          EXPECT_TRUE(AreNearlyEqTensor(out, expected, 1e-12));
+        }
+      }
+
       INSTANTIATE_TEST_SUITE_P(SubTests, SubTestAllShapes, ::testing::ValuesIn(GetTestShapes()));
 
       ::testing::AssertionResult CheckSubResult(const Tensor& gpu_result, const Tensor& left_tensor,


### PR DESCRIPTION
## Problem

#1003 requires that *"tests cover dtype and value correctness for mixed
real/complex cases"*, and names the binary matrix explicitly:

```
ComplexFloat op Double  -> ComplexDouble
Double op ComplexFloat  -> ComplexDouble
...
```

Auditing the GPU suite against that list, only two ops actually covered it:

- `Kron`/`Outer` — `GpuMixedComplexFloatDoublePromotesToComplexDouble`, independent oracle.
- `Add` — `AddTestAllShapes.GpuTensorAddTensorMixedTypes` sweeps the full
  ldtype × rdtype cross product (and `AreNearlyEqTensor` does assert dtype),
  though against the CPU path rather than an independent one.

`Sub`, `Mul`, `Div` and `Cpr` had **no** mixed real/complex GPU coverage at all —
their `*TestAllShapes` sweeps pair a dtype with itself, and their existing
`*MixedDtypeTest` cases cover only signed/unsigned promotion. That is precisely
the #984/#999 discriminator the issue was written around.

## Fix

One test per op, with expected values evaluated in host double arithmetic rather
than taken from the CPU path, so a promotion bug shared by both backends cannot
hide (per `CLAUDE.md`'s independent-expected-values rule):

| Op | What it adds |
|---|---|
| `Sub` | both operand orders — subtraction does not commute |
| `Mul` | both orders, plus a `ComplexFloat` **scalar** against a `Double` tensor, which takes the `lconst`/`rconst` kernels rather than the tensor⊗tensor one |
| `Div` | both orders; these exercise *different* arithmetic — dividing by a real-valued complex reduces to a componentwise divide, while dividing by one with a non-zero imaginary part goes through the full complex-division formula |
| `Cpr` | its promotion is invisible in the output dtype (always `Bool`), so the test pins it with values whose equality *depends* on the comparison type: `0.5` is float-exact and must compare equal, `0.1` is not and must compare unequal |

`Mod` is deliberately absent — `cuMod_dispatch` rejects complex dtypes, so the
mixed real/complex row does not exist for it.

Also corrects the `Storage_base::data()` comment, which still claimed *"GPU
kernel dispatch … the `cuAri_ii` table — ruling 3 keeps GPU on the legacy
table"*. That table was removed earlier in #1003; the dtype dispatch is typed
now, and the erased accessor survives only because CUDA launches need the raw
device address.

## Testing

All four new tests pass on an A100 (`debug-openblas-cuda`), as do the 39 tests
in the surrounding `*MixedDtype*`, `*NonContig*`, `Kron.*` and `Outer.*` suites.

These are coverage tests for already-correct behavior, so "fails before the fix"
does not apply — the meaningful check is whether they would *catch* a narrowed
computation. The `Double` operands are deliberately float32-inexact (`0.1`,
`3.3`); measured off-line, each test's largest element-wise gap under a
ComplexFloat-narrowed computation is **1.2e-8 to 1.9e-7**, four to five orders of
magnitude above the asserted `1e-12` tolerance. Individual components that happen
to be float-exact (e.g. `1.5 / 0.1`) are harmless, since `AreNearlyEqTensor`
fails if *any* element differs.

Completes the last open acceptance criterion of #1003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)