### PR TITLE
fix(backend): detect failed CUDA kernel launches instead of returning zeros

### DIFF
--- a/include/cytnx_error.hpp
+++ b/include/cytnx_error.hpp
@@ -543,6 +543,32 @@ void check(T result, char const *const func, const char *const file, int const l
 
   #endif
 
+  // Raise if the kernel launch immediately preceding this call failed.
+  //
+  // A launch that never runs leaves the output buffer holding whatever it
+  // already contained -- usually zeros from a fresh allocation -- so an
+  // unchecked failure is indistinguishable from a numerical bug. The launch
+  // status is not reported by the launch expression itself; it has to be read
+  // back with cudaGetLastError().
+  //
+  // This reads (and thereby clears) the pending status without synchronizing,
+  // so it stays cheap enough to sit after every launch. That also means it
+  // catches launch-time failures -- a fat binary with no image for the running
+  // device, a bad launch configuration -- and not errors raised while the
+  // kernel executes, which surface asynchronously at the next synchronizing
+  // call.
+  //
+  // Raising through cytnx_error_msg (rather than the exit() that checkCudaErrors
+  // performs) keeps the failure catchable and reports the calling function,
+  // file, and line of the launch site.
+  #define CYTNX_CHECK_CUDA_LAUNCH(kernel_name)                                \
+    do {                                                                      \
+      const cudaError_t cytnx_cuda_launch_status = cudaGetLastError();        \
+      cytnx_error_msg(cytnx_cuda_launch_status != cudaSuccess,                \
+                      "CUDA kernel launch failed for '%s': %s", #kernel_name, \
+                      cudaGetErrorString(cytnx_cuda_launch_status));          \
+    } while (0)
+
 #endif  // End of #if defined(UNI_GPU)
 
 #endif  // CYTNX_CYTNX_ERROR_H_

--- a/src/backend/linalg_internal_gpu/cuArithmeticDispatch.cuh
+++ b/src/backend/linalg_internal_gpu/cuArithmeticDispatch.cuh
@@ -109,17 +109,22 @@ namespace cytnx {
 
         if (Lin->size() == 1 and Rin->size() == 1) {
           constconst_kernel<op_code><<<NBlocks, 512>>>(_out, _Lin[0], len, _Rin[0]);
+          CYTNX_CHECK_CUDA_LAUNCH(constconst_kernel);
         } else if (Lin->size() == 1) {
           lconst_kernel<op_code><<<NBlocks, 512>>>(_out, _Lin[0], len, _Rin);
+          CYTNX_CHECK_CUDA_LAUNCH(lconst_kernel);
         } else if (Rin->size() == 1) {
           rconst_kernel<op_code><<<NBlocks, 512>>>(_out, _Lin, len, _Rin[0]);
+          CYTNX_CHECK_CUDA_LAUNCH(rconst_kernel);
         } else {
           if (shape.size() == 0) {
             tn_kernel<op_code><<<NBlocks, 512>>>(_out, _Lin, len, _Rin);
+            CYTNX_CHECK_CUDA_LAUNCH(tn_kernel);
           } else {
             const gpu_layout::GpuNonContigLayout layout =
               gpu_layout::make_gpu_non_contig_layout(shape, invmapper_L, invmapper_R);
             tn_kernel_nonconti<op_code><<<NBlocks, 512>>>(_out, _Lin, len, _Rin, layout);
+            CYTNX_CHECK_CUDA_LAUNCH(tn_kernel_nonconti);
           }
         }
       }

--- a/src/backend/linalg_internal_gpu/cuCpr_dispatch.cu
+++ b/src/backend/linalg_internal_gpu/cuCpr_dispatch.cu
@@ -92,17 +92,22 @@ namespace cytnx {
 
         if (Lin->size() == 1 and Rin->size() == 1) {
           cuCpr_dispatch_constconst_kernel<TO><<<NBlocks, 512>>>(_out, _Lin[0], len, _Rin[0]);
+          CYTNX_CHECK_CUDA_LAUNCH(cuCpr_dispatch_constconst_kernel);
         } else if (Lin->size() == 1) {
           cuCpr_dispatch_lconst_kernel<TO><<<NBlocks, 512>>>(_out, _Lin[0], len, _Rin);
+          CYTNX_CHECK_CUDA_LAUNCH(cuCpr_dispatch_lconst_kernel);
         } else if (Rin->size() == 1) {
           cuCpr_dispatch_rconst_kernel<TO><<<NBlocks, 512>>>(_out, _Lin, len, _Rin[0]);
+          CYTNX_CHECK_CUDA_LAUNCH(cuCpr_dispatch_rconst_kernel);
         } else {
           if (shape.size() == 0) {
             cuCpr_dispatch_tn_kernel<TO><<<NBlocks, 512>>>(_out, _Lin, len, _Rin);
+            CYTNX_CHECK_CUDA_LAUNCH(cuCpr_dispatch_tn_kernel);
           } else {
             const gpu_layout::GpuNonContigLayout layout =
               gpu_layout::make_gpu_non_contig_layout(shape, invmapper_L, invmapper_R);
             cuCpr_dispatch_tn_kernel_nonconti<TO><<<NBlocks, 512>>>(_out, _Lin, len, _Rin, layout);
+            CYTNX_CHECK_CUDA_LAUNCH(cuCpr_dispatch_tn_kernel_nonconti);
           }
         }
       }

--- a/src/backend/linalg_internal_gpu/cuDiag_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuDiag_internal.cu
@@ -35,12 +35,15 @@ namespace cytnx {
                            const bool &isrank2) {
       cytnx_uint32 NBlocks = L / 512;
       if (L % 512) NBlocks += 1;
-      if (isrank2)
+      if (isrank2) {
         cuDiag_internal_kernel<<<NBlocks, 512>>>((cytnx_bool *)out->data(),
                                                  (cytnx_bool *)ten->data(), L);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_kernel);
+      } else {
         cuDiag_internal_getdiag_kernel<<<NBlocks, 512>>>((cytnx_bool *)out->data(),
                                                          (cytnx_bool *)ten->data(), L);
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_getdiag_kernel);
+      }
     }
 
     void cuDiag_internal_i16(boost::intrusive_ptr<Storage_base> &out,
@@ -48,12 +51,15 @@ namespace cytnx {
                              const bool &isrank2) {
       cytnx_uint32 NBlocks = L / 512;
       if (L % 512) NBlocks += 1;
-      if (isrank2)
+      if (isrank2) {
         cuDiag_internal_kernel<<<NBlocks, 512>>>((cytnx_int16 *)out->data(),
                                                  (cytnx_int16 *)ten->data(), L);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_kernel);
+      } else {
         cuDiag_internal_getdiag_kernel<<<NBlocks, 512>>>((cytnx_int16 *)out->data(),
                                                          (cytnx_int16 *)ten->data(), L);
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_getdiag_kernel);
+      }
     }
 
     void cuDiag_internal_u16(boost::intrusive_ptr<Storage_base> &out,
@@ -61,12 +67,15 @@ namespace cytnx {
                              const bool &isrank2) {
       cytnx_uint32 NBlocks = L / 512;
       if (L % 512) NBlocks += 1;
-      if (isrank2)
+      if (isrank2) {
         cuDiag_internal_kernel<<<NBlocks, 512>>>((cytnx_uint16 *)out->data(),
                                                  (cytnx_uint16 *)ten->data(), L);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_kernel);
+      } else {
         cuDiag_internal_getdiag_kernel<<<NBlocks, 512>>>((cytnx_uint16 *)out->data(),
                                                          (cytnx_uint16 *)ten->data(), L);
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_getdiag_kernel);
+      }
     }
 
     void cuDiag_internal_i32(boost::intrusive_ptr<Storage_base> &out,
@@ -74,12 +83,15 @@ namespace cytnx {
                              const bool &isrank2) {
       cytnx_uint32 NBlocks = L / 512;
       if (L % 512) NBlocks += 1;
-      if (isrank2)
+      if (isrank2) {
         cuDiag_internal_kernel<<<NBlocks, 512>>>((cytnx_int32 *)out->data(),
                                                  (cytnx_int32 *)ten->data(), L);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_kernel);
+      } else {
         cuDiag_internal_getdiag_kernel<<<NBlocks, 512>>>((cytnx_int32 *)out->data(),
                                                          (cytnx_int32 *)ten->data(), L);
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_getdiag_kernel);
+      }
     }
 
     void cuDiag_internal_u32(boost::intrusive_ptr<Storage_base> &out,
@@ -87,12 +99,15 @@ namespace cytnx {
                              const bool &isrank2) {
       cytnx_uint32 NBlocks = L / 512;
       if (L % 512) NBlocks += 1;
-      if (isrank2)
+      if (isrank2) {
         cuDiag_internal_kernel<<<NBlocks, 512>>>((cytnx_uint32 *)out->data(),
                                                  (cytnx_uint32 *)ten->data(), L);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_kernel);
+      } else {
         cuDiag_internal_getdiag_kernel<<<NBlocks, 512>>>((cytnx_uint32 *)out->data(),
                                                          (cytnx_uint32 *)ten->data(), L);
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_getdiag_kernel);
+      }
     }
 
     void cuDiag_internal_i64(boost::intrusive_ptr<Storage_base> &out,
@@ -100,12 +115,15 @@ namespace cytnx {
                              const bool &isrank2) {
       cytnx_uint32 NBlocks = L / 512;
       if (L % 512) NBlocks += 1;
-      if (isrank2)
+      if (isrank2) {
         cuDiag_internal_kernel<<<NBlocks, 512>>>((cytnx_int64 *)out->data(),
                                                  (cytnx_int64 *)ten->data(), L);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_kernel);
+      } else {
         cuDiag_internal_getdiag_kernel<<<NBlocks, 512>>>((cytnx_int64 *)out->data(),
                                                          (cytnx_int64 *)ten->data(), L);
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_getdiag_kernel);
+      }
     }
 
     void cuDiag_internal_u64(boost::intrusive_ptr<Storage_base> &out,
@@ -113,12 +131,15 @@ namespace cytnx {
                              const bool &isrank2) {
       cytnx_uint32 NBlocks = L / 512;
       if (L % 512) NBlocks += 1;
-      if (isrank2)
+      if (isrank2) {
         cuDiag_internal_kernel<<<NBlocks, 512>>>((cytnx_uint64 *)out->data(),
                                                  (cytnx_uint64 *)ten->data(), L);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_kernel);
+      } else {
         cuDiag_internal_getdiag_kernel<<<NBlocks, 512>>>((cytnx_uint64 *)out->data(),
                                                          (cytnx_uint64 *)ten->data(), L);
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_getdiag_kernel);
+      }
     }
 
     void cuDiag_internal_d(boost::intrusive_ptr<Storage_base> &out,
@@ -126,12 +147,15 @@ namespace cytnx {
                            const bool &isrank2) {
       cytnx_uint32 NBlocks = L / 512;
       if (L % 512) NBlocks += 1;
-      if (isrank2)
+      if (isrank2) {
         cuDiag_internal_kernel<<<NBlocks, 512>>>((cytnx_double *)out->data(),
                                                  (cytnx_double *)ten->data(), L);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_kernel);
+      } else {
         cuDiag_internal_getdiag_kernel<<<NBlocks, 512>>>((cytnx_double *)out->data(),
                                                          (cytnx_double *)ten->data(), L);
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_getdiag_kernel);
+      }
     }
 
     void cuDiag_internal_f(boost::intrusive_ptr<Storage_base> &out,
@@ -139,12 +163,15 @@ namespace cytnx {
                            const bool &isrank2) {
       cytnx_uint32 NBlocks = L / 512;
       if (L % 512) NBlocks += 1;
-      if (isrank2)
+      if (isrank2) {
         cuDiag_internal_kernel<<<NBlocks, 512>>>((cytnx_float *)out->data(),
                                                  (cytnx_float *)ten->data(), L);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_kernel);
+      } else {
         cuDiag_internal_getdiag_kernel<<<NBlocks, 512>>>((cytnx_float *)out->data(),
                                                          (cytnx_float *)ten->data(), L);
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_getdiag_kernel);
+      }
     }
 
     void cuDiag_internal_cd(boost::intrusive_ptr<Storage_base> &out,
@@ -152,12 +179,15 @@ namespace cytnx {
                             const bool &isrank2) {
       cytnx_uint32 NBlocks = L / 256;
       if (L % 256) NBlocks += 1;
-      if (isrank2)
+      if (isrank2) {
         cuDiag_internal_kernel<<<NBlocks, 256>>>((cuDoubleComplex *)out->data(),
                                                  (cuDoubleComplex *)ten->data(), L);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_kernel);
+      } else {
         cuDiag_internal_getdiag_kernel<<<NBlocks, 256>>>((cuDoubleComplex *)out->data(),
                                                          (cuDoubleComplex *)ten->data(), L);
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_getdiag_kernel);
+      }
     }
 
     void cuDiag_internal_cf(boost::intrusive_ptr<Storage_base> &out,
@@ -165,12 +195,15 @@ namespace cytnx {
                             const bool &isrank2) {
       cytnx_uint32 NBlocks = L / 256;
       if (L % 256) NBlocks += 1;
-      if (isrank2)
+      if (isrank2) {
         cuDiag_internal_kernel<<<NBlocks, 256>>>((cuFloatComplex *)out->data(),
                                                  (cuFloatComplex *)ten->data(), L);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_kernel);
+      } else {
         cuDiag_internal_getdiag_kernel<<<NBlocks, 256>>>((cuFloatComplex *)out->data(),
                                                          (cuFloatComplex *)ten->data(), L);
+        CYTNX_CHECK_CUDA_LAUNCH(cuDiag_internal_getdiag_kernel);
+      }
     }
 
   }  // namespace linalg_internal

--- a/src/backend/linalg_internal_gpu/cuInv_inplace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuInv_inplace_internal.cu
@@ -59,6 +59,7 @@ namespace cytnx {
       cytnx_uint32 NBlocks = Nelem / 512;
       if (Nelem % 512) NBlocks += 1;
       cuInv_internal_kernel_d<<<NBlocks, 512>>>((cytnx_double *)ten->data(), Nelem, clip);
+      CYTNX_CHECK_CUDA_LAUNCH(cuInv_internal_kernel_d);
     }
 
     void cuInv_inplace_internal_f(boost::intrusive_ptr<Storage_base> &ten,
@@ -66,6 +67,7 @@ namespace cytnx {
       cytnx_uint32 NBlocks = Nelem / 512;
       if (Nelem % 512) NBlocks += 1;
       cuInv_internal_kernel_f<<<NBlocks, 512>>>((cytnx_float *)ten->data(), Nelem, clip);
+      CYTNX_CHECK_CUDA_LAUNCH(cuInv_internal_kernel_f);
     }
 
     void cuInv_inplace_internal_cd(boost::intrusive_ptr<Storage_base> &ten,
@@ -74,6 +76,7 @@ namespace cytnx {
       if (Nelem % 256) NBlocks += 1;
       const double clipsq = (clip < 0. ? -1. : clip * clip);  // because std::norm is squared norm
       cuInv_internal_kernel_cd<<<NBlocks, 256>>>((cuDoubleComplex *)ten->data(), Nelem, clipsq);
+      CYTNX_CHECK_CUDA_LAUNCH(cuInv_internal_kernel_cd);
     }
 
     void cuInv_inplace_internal_cf(boost::intrusive_ptr<Storage_base> &ten,
@@ -82,6 +85,7 @@ namespace cytnx {
       if (Nelem % 256) NBlocks += 1;
       const float clipsq = (clip < 0.f ? -1.f : clip * clip);  // because std::norm is squared norm
       cuInv_internal_kernel_cf<<<NBlocks, 256>>>((cuFloatComplex *)ten->data(), Nelem, clipsq);
+      CYTNX_CHECK_CUDA_LAUNCH(cuInv_internal_kernel_cf);
     }
 
   }  // namespace linalg_internal

--- a/src/backend/linalg_internal_gpu/cuKron_internal.cuh
+++ b/src/backend/linalg_internal_gpu/cuKron_internal.cuh
@@ -113,6 +113,7 @@ namespace cytnx {
       if (layout.total_elems % gpu_kron::kKronThreadsPerBlock) nblocks += 1;
 
       cuKron_kernel<<<nblocks, gpu_kron::kKronThreadsPerBlock>>>(out, Lin, Rin, layout);
+      CYTNX_CHECK_CUDA_LAUNCH(cuKron_kernel);
     }
 
   }  // namespace linalg_internal

--- a/src/backend/linalg_internal_gpu/cuMatmul_dg_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuMatmul_dg_internal.cu
@@ -140,10 +140,13 @@ namespace cytnx {
 
       cytnx_uint64 Nblocks = (cytnx_uint64(Ml) * Nr) / 512;
       if ((cytnx_uint64(Ml) * Nr) % 512) Nblocks += 1;
-      if (diag_L)
+      if (diag_L) {
         cuMatMul_dg_kernel_diagL<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_dg_kernel_diagL);
+      } else {
         cuMatMul_dg_kernel_diagR<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
+        CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_dg_kernel_diagR);
+      }
     }
     void cuMatmul_dg_internal_u64(boost::intrusive_ptr<Storage_base> &out,
                                   const boost::intrusive_ptr<Storage_base> &inl,
@@ -157,10 +160,13 @@ namespace cytnx {
       cytnx_uint64 Nblocks = (cytnx_uint64(Ml) * Nr) / 512;
       if ((cytnx_uint64(Ml) * Nr) % 512) Nblocks += 1;
 
-      if (diag_L)
+      if (diag_L) {
         cuMatMul_dg_kernel_diagL<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_dg_kernel_diagL);
+      } else {
         cuMatMul_dg_kernel_diagR<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
+        CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_dg_kernel_diagR);
+      }
     }
     void cuMatmul_dg_internal_i32(boost::intrusive_ptr<Storage_base> &out,
                                   const boost::intrusive_ptr<Storage_base> &inl,
@@ -174,10 +180,13 @@ namespace cytnx {
       cytnx_uint64 Nblocks = (cytnx_uint64(Ml) * Nr) / 512;
       if ((cytnx_uint64(Ml) * Nr) % 512) Nblocks += 1;
 
-      if (diag_L)
+      if (diag_L) {
         cuMatMul_dg_kernel_diagL<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_dg_kernel_diagL);
+      } else {
         cuMatMul_dg_kernel_diagR<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
+        CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_dg_kernel_diagR);
+      }
     }
     void cuMatmul_dg_internal_u32(boost::intrusive_ptr<Storage_base> &out,
                                   const boost::intrusive_ptr<Storage_base> &inl,
@@ -191,10 +200,13 @@ namespace cytnx {
       cytnx_uint64 Nblocks = (cytnx_uint64(Ml) * Nr) / 512;
       if ((cytnx_uint64(Ml) * Nr) % 512) Nblocks += 1;
 
-      if (diag_L)
+      if (diag_L) {
         cuMatMul_dg_kernel_diagL<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_dg_kernel_diagL);
+      } else {
         cuMatMul_dg_kernel_diagR<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
+        CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_dg_kernel_diagR);
+      }
     }
     void cuMatmul_dg_internal_i16(boost::intrusive_ptr<Storage_base> &out,
                                   const boost::intrusive_ptr<Storage_base> &inl,
@@ -208,10 +220,13 @@ namespace cytnx {
       cytnx_uint64 Nblocks = (cytnx_uint64(Ml) * Nr) / 512;
       if ((cytnx_uint64(Ml) * Nr) % 512) Nblocks += 1;
 
-      if (diag_L)
+      if (diag_L) {
         cuMatMul_dg_kernel_diagL<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_dg_kernel_diagL);
+      } else {
         cuMatMul_dg_kernel_diagR<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
+        CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_dg_kernel_diagR);
+      }
     }
     void cuMatmul_dg_internal_u16(boost::intrusive_ptr<Storage_base> &out,
                                   const boost::intrusive_ptr<Storage_base> &inl,
@@ -225,10 +240,13 @@ namespace cytnx {
       cytnx_uint64 Nblocks = (cytnx_uint64(Ml) * Nr) / 512;
       if ((cytnx_uint64(Ml) * Nr) % 512) Nblocks += 1;
 
-      if (diag_L)
+      if (diag_L) {
         cuMatMul_dg_kernel_diagL<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_dg_kernel_diagL);
+      } else {
         cuMatMul_dg_kernel_diagR<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
+        CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_dg_kernel_diagR);
+      }
     }
     void cuMatmul_dg_internal_b(boost::intrusive_ptr<Storage_base> &out,
                                 const boost::intrusive_ptr<Storage_base> &inl,
@@ -242,10 +260,13 @@ namespace cytnx {
       cytnx_uint64 Nblocks = (cytnx_uint64(Ml) * Nr) / 512;
       if ((cytnx_uint64(Ml) * Nr) % 512) Nblocks += 1;
 
-      if (diag_L)
+      if (diag_L) {
         cuMatMul_dg_kernel_diagL<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
-      else
+        CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_dg_kernel_diagL);
+      } else {
         cuMatMul_dg_kernel_diagR<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
+        CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_dg_kernel_diagR);
+      }
     }
 
   }  // namespace linalg_internal

--- a/src/backend/linalg_internal_gpu/cuMatmul_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuMatmul_internal.cu
@@ -113,6 +113,7 @@ namespace cytnx {
       if ((cytnx_uint64(Ml) * Nr) % 512) Nblocks += 1;
 
       cuMatMul_kernel<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
+      CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_kernel);
     }
     void cuMatmul_internal_u64(boost::intrusive_ptr<Storage_base> &out,
                                const boost::intrusive_ptr<Storage_base> &inl,
@@ -126,6 +127,7 @@ namespace cytnx {
       if ((cytnx_uint64(Ml) * Nr) % 512) Nblocks += 1;
 
       cuMatMul_kernel<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
+      CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_kernel);
     }
     void cuMatmul_internal_i32(boost::intrusive_ptr<Storage_base> &out,
                                const boost::intrusive_ptr<Storage_base> &inl,
@@ -139,6 +141,7 @@ namespace cytnx {
       if ((cytnx_uint64(Ml) * Nr) % 512) Nblocks += 1;
 
       cuMatMul_kernel<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
+      CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_kernel);
     }
     void cuMatmul_internal_u32(boost::intrusive_ptr<Storage_base> &out,
                                const boost::intrusive_ptr<Storage_base> &inl,
@@ -152,6 +155,7 @@ namespace cytnx {
       if ((cytnx_uint64(Ml) * Nr) % 512) Nblocks += 1;
 
       cuMatMul_kernel<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
+      CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_kernel);
     }
     void cuMatmul_internal_i16(boost::intrusive_ptr<Storage_base> &out,
                                const boost::intrusive_ptr<Storage_base> &inl,
@@ -165,6 +169,7 @@ namespace cytnx {
       if ((cytnx_uint64(Ml) * Nr) % 512) Nblocks += 1;
 
       cuMatMul_kernel<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
+      CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_kernel);
     }
     void cuMatmul_internal_u16(boost::intrusive_ptr<Storage_base> &out,
                                const boost::intrusive_ptr<Storage_base> &inl,
@@ -178,6 +183,7 @@ namespace cytnx {
       if ((cytnx_uint64(Ml) * Nr) % 512) Nblocks += 1;
 
       cuMatMul_kernel<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
+      CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_kernel);
     }
     void cuMatmul_internal_b(boost::intrusive_ptr<Storage_base> &out,
                              const boost::intrusive_ptr<Storage_base> &inl,
@@ -191,6 +197,7 @@ namespace cytnx {
       if ((cytnx_uint64(Ml) * Nr) % 512) Nblocks += 1;
 
       cuMatMul_kernel<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Comm, Nr);
+      CYTNX_CHECK_CUDA_LAUNCH(cuMatMul_kernel);
     }
 
   }  // namespace linalg_internal

--- a/src/backend/linalg_internal_gpu/cuMatvec_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuMatvec_internal.cu
@@ -120,6 +120,7 @@ namespace cytnx {
       if ((cytnx_uint64(Ml)) % 512) Nblocks += 1;
 
       cuMatVec_kernel<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Nr);
+      CYTNX_CHECK_CUDA_LAUNCH(cuMatVec_kernel);
     }
     void cuMatvec_internal_u64(boost::intrusive_ptr<Storage_base> &out,
                                const boost::intrusive_ptr<Storage_base> &inl,
@@ -133,6 +134,7 @@ namespace cytnx {
       if ((cytnx_uint64(Ml)) % 512) Nblocks += 1;
 
       cuMatVec_kernel<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Nr);
+      CYTNX_CHECK_CUDA_LAUNCH(cuMatVec_kernel);
     }
     void cuMatvec_internal_i32(boost::intrusive_ptr<Storage_base> &out,
                                const boost::intrusive_ptr<Storage_base> &inl,
@@ -146,6 +148,7 @@ namespace cytnx {
       if ((cytnx_uint64(Ml)) % 512) Nblocks += 1;
 
       cuMatVec_kernel<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Nr);
+      CYTNX_CHECK_CUDA_LAUNCH(cuMatVec_kernel);
     }
     void cuMatvec_internal_u32(boost::intrusive_ptr<Storage_base> &out,
                                const boost::intrusive_ptr<Storage_base> &inl,
@@ -159,6 +162,7 @@ namespace cytnx {
       if ((cytnx_uint64(Ml)) % 512) Nblocks += 1;
 
       cuMatVec_kernel<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Nr);
+      CYTNX_CHECK_CUDA_LAUNCH(cuMatVec_kernel);
     }
     void cuMatvec_internal_i16(boost::intrusive_ptr<Storage_base> &out,
                                const boost::intrusive_ptr<Storage_base> &inl,
@@ -172,6 +176,7 @@ namespace cytnx {
       if ((cytnx_uint64(Ml)) % 512) Nblocks += 1;
 
       cuMatVec_kernel<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Nr);
+      CYTNX_CHECK_CUDA_LAUNCH(cuMatVec_kernel);
     }
     void cuMatvec_internal_u16(boost::intrusive_ptr<Storage_base> &out,
                                const boost::intrusive_ptr<Storage_base> &inl,
@@ -185,6 +190,7 @@ namespace cytnx {
       if ((cytnx_uint64(Ml)) % 512) Nblocks += 1;
 
       cuMatVec_kernel<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Nr);
+      CYTNX_CHECK_CUDA_LAUNCH(cuMatVec_kernel);
     }
     void cuMatvec_internal_b(boost::intrusive_ptr<Storage_base> &out,
                              const boost::intrusive_ptr<Storage_base> &inl,
@@ -198,6 +204,7 @@ namespace cytnx {
       if ((cytnx_uint64(Ml)) % 512) Nblocks += 1;
 
       cuMatVec_kernel<<<Nblocks, 512>>>(_out, _inl, _inr, Ml, Nr);
+      CYTNX_CHECK_CUDA_LAUNCH(cuMatVec_kernel);
     }
 
   }  // namespace linalg_internal

--- a/src/backend/linalg_internal_gpu/cuMaxMin_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuMaxMin_internal.cu
@@ -430,8 +430,10 @@ namespace cytnx {
 
       if (NBlocks == 1) {
         cuMax_kernel<<<NBlocks, _TNinB_REDUCE_>>>(out, in, Nelems);
+        CYTNX_CHECK_CUDA_LAUNCH(cuMax_kernel);
       } else {
         cuMax_kernel<<<NBlocks, _TNinB_REDUCE_>>>(dblk, in, Nelems);
+        CYTNX_CHECK_CUDA_LAUNCH(cuMax_kernel);
       }
       Nelems = NBlocks;
 
@@ -441,11 +443,13 @@ namespace cytnx {
 
         if (NBlocks == 1) {
           cuMax_kernel<<<NBlocks, _TNinB_REDUCE_>>>(out, dblk, Nelems);
+          CYTNX_CHECK_CUDA_LAUNCH(cuMax_kernel);
         } else {
           T *dblk2;
           cudaMalloc((void **)&dblk2, NBlocks * sizeof(T));
           // do something:
           cuMax_kernel<<<NBlocks, _TNinB_REDUCE_>>>(dblk2, dblk, Nelems);
+          CYTNX_CHECK_CUDA_LAUNCH(cuMax_kernel);
 
           swap(dblk2, dblk);  // swap new data to old data, and free the old
           cudaFree(dblk2);
@@ -468,8 +472,10 @@ namespace cytnx {
 
       if (NBlocks == 1) {
         cuMin_kernel<<<NBlocks, _TNinB_REDUCE_>>>(out, in, Nelems);
+        CYTNX_CHECK_CUDA_LAUNCH(cuMin_kernel);
       } else {
         cuMin_kernel<<<NBlocks, _TNinB_REDUCE_>>>(dblk, in, Nelems);
+        CYTNX_CHECK_CUDA_LAUNCH(cuMin_kernel);
       }
       Nelems = NBlocks;
 
@@ -479,11 +485,13 @@ namespace cytnx {
 
         if (NBlocks == 1) {
           cuMin_kernel<<<NBlocks, _TNinB_REDUCE_>>>(out, dblk, Nelems);
+          CYTNX_CHECK_CUDA_LAUNCH(cuMin_kernel);
         } else {
           T *dblk2;
           cudaMalloc((void **)&dblk2, NBlocks * sizeof(T));
           // do something:
           cuMin_kernel<<<NBlocks, _TNinB_REDUCE_>>>(dblk2, dblk, Nelems);
+          CYTNX_CHECK_CUDA_LAUNCH(cuMin_kernel);
 
           swap(dblk2, dblk);  // swap new data to old data, and free the old
           cudaFree(dblk2);

--- a/src/backend/linalg_internal_gpu/cuTrace_internal.cu
+++ b/src/backend/linalg_internal_gpu/cuTrace_internal.cu
@@ -340,7 +340,7 @@ namespace cytnx {
           diagonal_length, diagonal_stride);
         // Surface a launch/configuration failure at the trace call rather than
         // at the next, unrelated CUDA call.
-        checkCudaErrors(cudaGetLastError());
+        CYTNX_CHECK_CUDA_LAUNCH(TraceKernel);
 
         return ComposeTraceOutput(output_storage, output_shape, output_is_scalar);
       }

--- a/src/backend/linalg_internal_gpu/cuUnaryDispatch.cuh
+++ b/src/backend/linalg_internal_gpu/cuUnaryDispatch.cuh
@@ -46,6 +46,7 @@ namespace cytnx {
         const unsigned int num_blocks =
           static_cast<unsigned int>((size + kThreadsPerBlock - 1) / kThreadsPerBlock);
         unary_kernel<<<num_blocks, kThreadsPerBlock>>>(out, in, size, op);
+        CYTNX_CHECK_CUDA_LAUNCH(unary_kernel);
       }
 
       // ---- operation functors -------------------------------------------------------------

--- a/src/backend/linalg_internal_gpu/cuiArithmeticDispatch.cuh
+++ b/src/backend/linalg_internal_gpu/cuiArithmeticDispatch.cuh
@@ -118,12 +118,15 @@ namespace cytnx {
 
         if (rhs_is_scalar) {
           iscalar_kernel<op_code><<<NBlocks, 512>>>(out, lhs, len, rhs[0]);
+          CYTNX_CHECK_CUDA_LAUNCH(iscalar_kernel);
         } else if (shape.size() == 0) {
           itn_kernel<op_code><<<NBlocks, 512>>>(out, lhs, len, rhs);
+          CYTNX_CHECK_CUDA_LAUNCH(itn_kernel);
         } else {
           const gpu_layout::GpuNonContigLayout layout =
             gpu_layout::make_gpu_non_contig_layout(shape, invmapper_L, invmapper_R);
           itn_nonconti_kernel<op_code><<<NBlocks, 512>>>(out, lhs, len, rhs, layout);
+          CYTNX_CHECK_CUDA_LAUNCH(itn_nonconti_kernel);
         }
       }
 

--- a/src/backend/utils_internal_gpu/cuCast_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuCast_gpu.cu
@@ -67,6 +67,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_cd2cf<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_cd2cf);
     }
 
     void cuCast_gpu_cftcd(const boost::intrusive_ptr<Storage_base>& in,
@@ -82,6 +83,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_cf2cd<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_cf2cd);
     }
 
     void cuCast_gpu_cftcf(const boost::intrusive_ptr<Storage_base>& in,
@@ -110,6 +112,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cd<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cd);
     }
 
     void cuCast_gpu_dtcf(const boost::intrusive_ptr<Storage_base>& in,
@@ -126,6 +129,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cf<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cf);
     }
 
     void cuCast_gpu_dtd(const boost::intrusive_ptr<Storage_base>& in,
@@ -151,6 +155,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_dti64(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -164,6 +169,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_dtu64(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -178,6 +184,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_dti32(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -192,6 +199,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_dtu32(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -206,6 +214,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_dti16(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -220,6 +229,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_dtu16(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -234,6 +244,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_dtb(const boost::intrusive_ptr<Storage_base>& in,
                         boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -248,6 +259,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     //-----------------------------
     void cuCast_gpu_ftcd(const boost::intrusive_ptr<Storage_base>& in,
@@ -263,6 +275,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cd<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cd);
     }
 
     void cuCast_gpu_ftcf(const boost::intrusive_ptr<Storage_base>& in,
@@ -278,6 +291,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cf<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cf);
     }
     void cuCast_gpu_ftd(const boost::intrusive_ptr<Storage_base>& in,
                         boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -292,6 +306,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_ftf(const boost::intrusive_ptr<Storage_base>& in,
                         boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -316,6 +331,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_ftu64(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -330,6 +346,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_fti32(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -344,6 +361,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_ftu32(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -358,6 +376,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_fti16(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -372,6 +391,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_ftu16(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -386,6 +406,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_ftb(const boost::intrusive_ptr<Storage_base>& in,
                         boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -400,6 +421,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
 
     //------------------------
@@ -416,6 +438,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cd<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cd);
     }
     void cuCast_gpu_i64tcf(const boost::intrusive_ptr<Storage_base>& in,
                            boost::intrusive_ptr<Storage_base>& out,
@@ -430,6 +453,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cf<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cf);
     }
 
     void cuCast_gpu_i64td(const boost::intrusive_ptr<Storage_base>& in,
@@ -445,6 +469,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i64tf(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -459,6 +484,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i64ti64(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -483,6 +509,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i64ti32(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -497,6 +524,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i64tu32(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -511,6 +539,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i64ti16(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -525,6 +554,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i64tu16(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -539,6 +569,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i64tb(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -553,6 +584,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
 
     //-------------------------------
@@ -569,6 +601,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cd<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cd);
     }
     void cuCast_gpu_u64tcf(const boost::intrusive_ptr<Storage_base>& in,
                            boost::intrusive_ptr<Storage_base>& out,
@@ -583,6 +616,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cf<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cf);
     }
     void cuCast_gpu_u64td(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -597,6 +631,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u64tf(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -611,6 +646,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u64ti64(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -625,6 +661,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u64tu64(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -649,6 +686,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u64tu32(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -663,6 +701,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u64ti16(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -677,6 +716,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u64tu16(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -691,6 +731,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u64tb(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -705,6 +746,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
 
     //--------------------------------
@@ -721,6 +763,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cd<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cd);
     }
     void cuCast_gpu_i32tcf(const boost::intrusive_ptr<Storage_base>& in,
                            boost::intrusive_ptr<Storage_base>& out,
@@ -735,6 +778,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cf<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cf);
     }
     void cuCast_gpu_i32td(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -749,6 +793,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i32tf(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -763,6 +808,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i32ti64(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -777,6 +823,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i32tu64(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -791,6 +838,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i32ti32(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -815,6 +863,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i32tu16(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -829,6 +878,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i32ti16(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -843,6 +893,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i32tb(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -857,6 +908,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     //----------------------------
     void cuCast_gpu_u32tcd(const boost::intrusive_ptr<Storage_base>& in,
@@ -872,6 +924,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cd<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cd);
     }
     void cuCast_gpu_u32tcf(const boost::intrusive_ptr<Storage_base>& in,
                            boost::intrusive_ptr<Storage_base>& out,
@@ -886,6 +939,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cf<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cf);
     }
     void cuCast_gpu_u32td(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -900,6 +954,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u32tf(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -914,6 +969,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u32ti64(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -928,6 +984,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u32tu64(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -942,6 +999,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u32ti32(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -956,6 +1014,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u32tu32(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -980,6 +1039,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u32ti16(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -994,6 +1054,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u32tb(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -1008,6 +1069,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     //------------------------------
     void cuCast_gpu_u16tcd(const boost::intrusive_ptr<Storage_base>& in,
@@ -1023,6 +1085,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cd<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cd);
     }
     void cuCast_gpu_u16tcf(const boost::intrusive_ptr<Storage_base>& in,
                            boost::intrusive_ptr<Storage_base>& out,
@@ -1037,6 +1100,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cf<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cf);
     }
     void cuCast_gpu_u16td(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -1051,6 +1115,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u16tf(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -1065,6 +1130,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u16ti64(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -1079,6 +1145,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u16tu64(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -1093,6 +1160,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u16ti32(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -1107,6 +1175,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u16tu32(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -1121,6 +1190,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u16tu16(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -1145,6 +1215,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_u16tb(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -1159,6 +1230,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     //------------------------------
     void cuCast_gpu_i16tcd(const boost::intrusive_ptr<Storage_base>& in,
@@ -1174,6 +1246,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cd<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cd);
     }
     void cuCast_gpu_i16tcf(const boost::intrusive_ptr<Storage_base>& in,
                            boost::intrusive_ptr<Storage_base>& out,
@@ -1188,6 +1261,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cf<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cf);
     }
     void cuCast_gpu_i16td(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -1202,6 +1276,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i16tf(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -1216,6 +1291,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i16ti64(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -1230,6 +1306,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i16tu64(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -1244,6 +1321,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i16ti32(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -1258,6 +1336,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i16tu32(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -1272,6 +1351,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i16tu16(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -1286,6 +1366,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_i16ti16(const boost::intrusive_ptr<Storage_base>& in,
                             boost::intrusive_ptr<Storage_base>& out,
@@ -1310,6 +1391,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     //------------------------------
     void cuCast_gpu_btcd(const boost::intrusive_ptr<Storage_base>& in,
@@ -1325,6 +1407,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cd<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cd);
     }
     void cuCast_gpu_btcf(const boost::intrusive_ptr<Storage_base>& in,
                          boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -1339,6 +1422,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2cf<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2cf);
     }
     void cuCast_gpu_btd(const boost::intrusive_ptr<Storage_base>& in,
                         boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -1353,6 +1437,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_btf(const boost::intrusive_ptr<Storage_base>& in,
                         boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -1367,6 +1452,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_bti64(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -1381,6 +1467,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_btu64(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -1395,6 +1482,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_bti32(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -1409,6 +1497,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_btu32(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -1423,6 +1512,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_btu16(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -1437,6 +1527,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_bti16(const boost::intrusive_ptr<Storage_base>& in,
                           boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,
@@ -1451,6 +1542,7 @@ namespace cytnx {
       cytnx_uint64 NBlocks = len_in / 512;
       if (len_in % 512) NBlocks += 1;
       cuCastElem_kernel_r2r<<<NBlocks, 512>>>(_in, _out, len_in);
+      CYTNX_CHECK_CUDA_LAUNCH(cuCastElem_kernel_r2r);
     }
     void cuCast_gpu_btb(const boost::intrusive_ptr<Storage_base>& in,
                         boost::intrusive_ptr<Storage_base>& out, const unsigned long long& len_in,

--- a/src/backend/utils_internal_gpu/cuFill_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuFill_gpu.cu
@@ -35,6 +35,7 @@ namespace cytnx {
       }
 
       FillGpuKernel<<<block_count, 1024>>>(typed_first, cuda_value, count);
+      CYTNX_CHECK_CUDA_LAUNCH(FillGpuKernel);
     }
 
     template void FillGpu<cytnx_complex128>(void*, const cytnx_complex128&, cytnx_uint64);

--- a/src/backend/utils_internal_gpu/cuGetElems_contiguous_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuGetElems_contiguous_gpu.cu
@@ -81,6 +81,7 @@ namespace cytnx {
       cuGetElems_contiguous_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj,
                                                      d_locators, d_picksize, offj.size(), TotalElem,
                                                      Nelem_grp);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_contiguous_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -138,6 +139,7 @@ namespace cytnx {
       cuGetElems_contiguous_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj,
                                                      d_locators, d_picksize, offj.size(), TotalElem,
                                                      Nelem_grp);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_contiguous_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -194,6 +196,7 @@ namespace cytnx {
       cuGetElems_contiguous_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj,
                                                      d_locators, d_picksize, offj.size(), TotalElem,
                                                      Nelem_grp);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_contiguous_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -250,6 +253,7 @@ namespace cytnx {
       cuGetElems_contiguous_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj,
                                                      d_locators, d_picksize, offj.size(), TotalElem,
                                                      Nelem_grp);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_contiguous_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -307,6 +311,7 @@ namespace cytnx {
       cuGetElems_contiguous_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj,
                                                      d_locators, d_picksize, offj.size(), TotalElem,
                                                      Nelem_grp);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_contiguous_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -364,6 +369,7 @@ namespace cytnx {
       cuGetElems_contiguous_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj,
                                                      d_locators, d_picksize, offj.size(), TotalElem,
                                                      Nelem_grp);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_contiguous_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -421,6 +427,7 @@ namespace cytnx {
       cuGetElems_contiguous_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj,
                                                      d_locators, d_picksize, offj.size(), TotalElem,
                                                      Nelem_grp);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_contiguous_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -478,6 +485,7 @@ namespace cytnx {
       cuGetElems_contiguous_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj,
                                                      d_locators, d_picksize, offj.size(), TotalElem,
                                                      Nelem_grp);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_contiguous_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -535,6 +543,7 @@ namespace cytnx {
       cuGetElems_contiguous_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj,
                                                      d_locators, d_picksize, offj.size(), TotalElem,
                                                      Nelem_grp);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_contiguous_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -592,6 +601,7 @@ namespace cytnx {
       cuGetElems_contiguous_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj,
                                                      d_locators, d_picksize, offj.size(), TotalElem,
                                                      Nelem_grp);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_contiguous_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -648,6 +658,7 @@ namespace cytnx {
       cuGetElems_contiguous_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj,
                                                      d_locators, d_picksize, offj.size(), TotalElem,
                                                      Nelem_grp);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_contiguous_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);

--- a/src/backend/utils_internal_gpu/cuGetElems_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuGetElems_gpu.cu
@@ -72,6 +72,7 @@ namespace cytnx {
       if (TotalElem % 256) NBlocks += 1;
       cuGetElems_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj, d_locators,
                                           d_picksize, offj.size(), TotalElem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -127,6 +128,7 @@ namespace cytnx {
       if (TotalElem % 256) NBlocks += 1;
       cuGetElems_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj, d_locators,
                                           d_picksize, offj.size(), TotalElem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -182,6 +184,7 @@ namespace cytnx {
       if (TotalElem % 256) NBlocks += 1;
       cuGetElems_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj, d_locators,
                                           d_picksize, offj.size(), TotalElem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -237,6 +240,7 @@ namespace cytnx {
       if (TotalElem % 256) NBlocks += 1;
       cuGetElems_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj, d_locators,
                                           d_picksize, offj.size(), TotalElem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -292,6 +296,7 @@ namespace cytnx {
       if (TotalElem % 256) NBlocks += 1;
       cuGetElems_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj, d_locators,
                                           d_picksize, offj.size(), TotalElem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -347,6 +352,7 @@ namespace cytnx {
       if (TotalElem % 256) NBlocks += 1;
       cuGetElems_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj, d_locators,
                                           d_picksize, offj.size(), TotalElem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -402,6 +408,7 @@ namespace cytnx {
       if (TotalElem % 256) NBlocks += 1;
       cuGetElems_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj, d_locators,
                                           d_picksize, offj.size(), TotalElem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -457,6 +464,7 @@ namespace cytnx {
       if (TotalElem % 256) NBlocks += 1;
       cuGetElems_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj, d_locators,
                                           d_picksize, offj.size(), TotalElem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -512,6 +520,7 @@ namespace cytnx {
       if (TotalElem % 256) NBlocks += 1;
       cuGetElems_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj, d_locators,
                                           d_picksize, offj.size(), TotalElem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -567,6 +576,7 @@ namespace cytnx {
       if (TotalElem % 256) NBlocks += 1;
       cuGetElems_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj, d_locators,
                                           d_picksize, offj.size(), TotalElem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -622,6 +632,7 @@ namespace cytnx {
       if (TotalElem % 256) NBlocks += 1;
       cuGetElems_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj, d_locators,
                                           d_picksize, offj.size(), TotalElem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuGetElems_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);

--- a/src/backend/utils_internal_gpu/cuMovemem_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuMovemem_gpu.cu
@@ -158,6 +158,7 @@ namespace cytnx {
       }
       cuMovemem_kernel<<<NBlocks, 256, shifter_old.size() * 2 * sizeof(cytnx_uint64)>>>(
         dtmp, (cuT *)in->data(), dshifter_old, dperm_shifter_new, old_shape.size(), Nelem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuMovemem_kernel);
 
       /// house keeping:
       checkCudaErrors(cudaFree(dshifter_old));

--- a/src/backend/utils_internal_gpu/cuReduce_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuReduce_gpu.cu
@@ -101,8 +101,10 @@ namespace cytnx {
       checkCudaErrors(cudaMalloc((void**)&dblk, NBlocks * sizeof(*dblk)));
       if (NBlocks == 1) {
         cuReduce_kernel<<<NBlocks, _TNinB_REDUCE_>>>(out, in, Nelems);
+        CYTNX_CHECK_CUDA_LAUNCH(cuReduce_kernel);
       } else {
         cuReduce_kernel<<<NBlocks, _TNinB_REDUCE_>>>(dblk, in, Nelems);
+        CYTNX_CHECK_CUDA_LAUNCH(cuReduce_kernel);
       }
       Nelems = NBlocks;
 
@@ -112,10 +114,12 @@ namespace cytnx {
 
         if (NBlocks == 1) {
           cuReduce_kernel<<<NBlocks, _TNinB_REDUCE_>>>(out, dblk, Nelems);
+          CYTNX_CHECK_CUDA_LAUNCH(cuReduce_kernel);
         } else {
           CudaT* dblk2;
           cudaMalloc((void**)&dblk2, NBlocks * sizeof(*dblk2));
           cuReduce_kernel<<<NBlocks, _TNinB_REDUCE_>>>(dblk2, dblk, Nelems);
+          CYTNX_CHECK_CUDA_LAUNCH(cuReduce_kernel);
 
           swap(dblk2, dblk);
           cudaFree(dblk2);

--- a/src/backend/utils_internal_gpu/cuSetArange_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuSetArange_gpu.cu
@@ -40,6 +40,7 @@ namespace cytnx {
 
       if (Nelem % 512) NBlocks += 1;
       cuSetArange_kernel<<<NBlocks, 512>>>(ptr, start, step, Nelem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuSetArange_kernel);
     }
     void cuSetArange_gpu_cf(boost::intrusive_ptr<Storage_base> &in, const cytnx_double &start,
                             const cytnx_double &end, const cytnx_double &step,
@@ -49,6 +50,7 @@ namespace cytnx {
 
       if (Nelem % 512) NBlocks += 1;
       cuSetArange_kernel<<<NBlocks, 512>>>(ptr, start, step, Nelem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuSetArange_kernel);
     }
     void cuSetArange_gpu_d(boost::intrusive_ptr<Storage_base> &in, const cytnx_double &start,
                            const cytnx_double &end, const cytnx_double &step,
@@ -58,6 +60,7 @@ namespace cytnx {
 
       if (Nelem % 512) NBlocks += 1;
       cuSetArange_kernel<<<NBlocks, 512>>>(ptr, start, step, Nelem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuSetArange_kernel);
     }
     void cuSetArange_gpu_f(boost::intrusive_ptr<Storage_base> &in, const cytnx_double &start,
                            const cytnx_double &end, const cytnx_double &step,
@@ -67,6 +70,7 @@ namespace cytnx {
 
       if (Nelem % 512) NBlocks += 1;
       cuSetArange_kernel<<<NBlocks, 512>>>(ptr, start, step, Nelem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuSetArange_kernel);
     }
     void cuSetArange_gpu_i64(boost::intrusive_ptr<Storage_base> &in, const cytnx_double &start,
                              const cytnx_double &end, const cytnx_double &step,
@@ -76,6 +80,7 @@ namespace cytnx {
 
       if (Nelem % 512) NBlocks += 1;
       cuSetArange_kernel<<<NBlocks, 512>>>(ptr, start, step, Nelem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuSetArange_kernel);
     }
     void cuSetArange_gpu_u64(boost::intrusive_ptr<Storage_base> &in, const cytnx_double &start,
                              const cytnx_double &end, const cytnx_double &step,
@@ -85,6 +90,7 @@ namespace cytnx {
 
       if (Nelem % 512) NBlocks += 1;
       cuSetArange_kernel<<<NBlocks, 512>>>(ptr, start, step, Nelem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuSetArange_kernel);
     }
     void cuSetArange_gpu_i32(boost::intrusive_ptr<Storage_base> &in, const cytnx_double &start,
                              const cytnx_double &end, const cytnx_double &step,
@@ -94,6 +100,7 @@ namespace cytnx {
 
       if (Nelem % 512) NBlocks += 1;
       cuSetArange_kernel<<<NBlocks, 512>>>(ptr, start, step, Nelem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuSetArange_kernel);
     }
     void cuSetArange_gpu_u32(boost::intrusive_ptr<Storage_base> &in, const cytnx_double &start,
                              const cytnx_double &end, const cytnx_double &step,
@@ -103,6 +110,7 @@ namespace cytnx {
 
       if (Nelem % 512) NBlocks += 1;
       cuSetArange_kernel<<<NBlocks, 512>>>(ptr, start, step, Nelem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuSetArange_kernel);
     }
     void cuSetArange_gpu_i16(boost::intrusive_ptr<Storage_base> &in, const cytnx_double &start,
                              const cytnx_double &end, const cytnx_double &step,
@@ -112,6 +120,7 @@ namespace cytnx {
 
       if (Nelem % 512) NBlocks += 1;
       cuSetArange_kernel<<<NBlocks, 512>>>(ptr, start, step, Nelem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuSetArange_kernel);
     }
     void cuSetArange_gpu_u16(boost::intrusive_ptr<Storage_base> &in, const cytnx_double &start,
                              const cytnx_double &end, const cytnx_double &step,
@@ -121,6 +130,7 @@ namespace cytnx {
 
       if (Nelem % 512) NBlocks += 1;
       cuSetArange_kernel<<<NBlocks, 512>>>(ptr, start, step, Nelem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuSetArange_kernel);
     }
     void cuSetArange_gpu_b(boost::intrusive_ptr<Storage_base> &in, const cytnx_double &start,
                            const cytnx_double &end, const cytnx_double &step,
@@ -130,6 +140,7 @@ namespace cytnx {
 
       if (Nelem % 512) NBlocks += 1;
       cuSetArange_kernel<<<NBlocks, 512>>>(ptr, start, step, Nelem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuSetArange_kernel);
     }
 
   }  // namespace utils_internal

--- a/src/backend/utils_internal_gpu/cuSetElems_contiguous_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuSetElems_contiguous_gpu.cu
@@ -384,6 +384,7 @@ namespace cytnx {
       cuSetElems_conti_gpu_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj,
                                                     d_locators, d_picksize, offj.size(), TotalElem,
                                                     Nunit);
+      CYTNX_CHECK_CUDA_LAUNCH(cuSetElems_conti_gpu_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -441,6 +442,7 @@ namespace cytnx {
       cuSetElems_conti_gpu_scal_kernel<<<NBlocks, 256>>>(new_elem_, elem_ptr_, d_offj, d_new_offj,
                                                          d_locators, d_picksize, offj.size(),
                                                          TotalElem, Nunit);
+      CYTNX_CHECK_CUDA_LAUNCH(cuSetElems_conti_gpu_scal_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);

--- a/src/backend/utils_internal_gpu/cuSetElems_gpu.cu
+++ b/src/backend/utils_internal_gpu/cuSetElems_gpu.cu
@@ -341,6 +341,7 @@ namespace cytnx {
       if (TotalElem % 256) NBlocks += 1;
       cuSetElems_gpu_kernel<<<NBlocks, 256>>>(new_elem_ptr_, elem_ptr_, d_offj, d_new_offj,
                                               d_locators, d_picksize, offj.size(), TotalElem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuSetElems_gpu_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);
@@ -397,6 +398,7 @@ namespace cytnx {
       if (TotalElem % 256) NBlocks += 1;
       cuSetElems_gpu_scal_kernel<<<NBlocks, 256>>>(new_elem_, elem_ptr_, d_offj, d_new_offj,
                                                    d_locators, d_picksize, offj.size(), TotalElem);
+      CYTNX_CHECK_CUDA_LAUNCH(cuSetElems_gpu_scal_kernel);
 
       cudaFree(d_offj);
       cudaFree(d_new_offj);


### PR DESCRIPTION
## Problem

A CUDA kernel launch reports its status only through `cudaGetLastError()` — the
launch expression itself cannot fail visibly. Nothing in the GPU backend read
that status, so a launch that never ran left the output buffer holding whatever
it already contained, usually zeros from a fresh allocation. The failure was
indistinguishable from a numerical bug.

This is part 2 of #1171: on an sm_80 card, a default-architecture build returned
zeros across the entire GPU surface — including tests unrelated to any local
change — with no error raised. As that issue puts it, a launch-status check
turns "your kernel is wrong" into "no kernel image for this device".

## Fix

Add `CYTNX_CHECK_CUDA_LAUNCH` (`include/cytnx_error.hpp`, inside the `UNI_GPU`
guard) and call it after every kernel launch in the built GPU sources — 213
sites across 21 files.

Design notes:

- It reads the status **without synchronizing**, so it stays cheap enough to sit
  after every launch. That scopes it to launch-time failures (no image for the
  running device, bad launch configuration) rather than errors raised during
  execution, which surface asynchronously at the next synchronizing call.
- It raises through `cytnx_error_msg`, so the failure is catchable and names the
  kernel plus the launch site — unlike `checkCudaErrors`, which `exit()`s the
  process.
- The pre-existing `checkCudaErrors(cudaGetLastError())` in
  `cuTrace_internal.cu` becomes the same macro rather than a second read that
  could only ever see success.
- `cuTNPerm_gpu.cu` is deliberately left alone: it is not referenced by any build
  file (#1142).

Some `if`/`else` branches gained braces because the check becomes a second
statement; that is the only other change in the diff.

### Trade-off worth a reviewer's attention

30 of the 213 checked launch sites are followed by `cudaFree` of temporary
device buffers (114 free calls in all), which a throw now skips — so a failed
launch leaks device memory where it previously continued silently. An exception
plus a leak beats silently wrong numbers, but scoping those buffers with RAII is
a genuine follow-up rather than something to mix into this change.

Tracked as #1176, with the affected sites enumerated. The `DeviceBuffer<T>` type
that fixes it already exists (added by #1146 for the same failure mode in the
cuSOLVER wrappers), so the follow-up is reuse rather than new machinery.

## Testing

- **GPU suite:** `ctest -L gpu` on 2x RTX 4070 Ti SUPER (sm_89, arch 89 build) —
  **841/841 passed**, 0 failed, 1726 s. The 4 non-running tests are pre-existing
  source-level `GTEST_SKIP()`s (GPU `ExpM` unimplemented, cuQuantum-dependent QR,
  zero-heavy SVD). This is the no-false-positives evidence: the guard stays quiet
  across the whole GPU surface when launches genuinely succeed.
- **Guard fires correctly:** a standalone probe against the real header confirms
  a valid launch does not throw, while a launch rejected by the driver (2048
  threads/block, over the 1024 limit — the same *launch-rejected* class as "no
  kernel image for this device") throws a catchable `cytnx::error`:
  `CUDA kernel launch failed for 'probe_kernel': invalid argument`.
- **End-to-end arch mismatch**, from the session that wrote the patch: same tree,
  library built for `75-real` (SASS with no JIT-able PTX), run on sm_89.

  ```
  before: linalg::Add -> values = 0 0 0 0, no error
  after:  linalg::Add -> CytnxError "CUDA kernel launch failed for 'tn_kernel':
          named symbol not found" at cuArithmeticDispatch.cuh:122
  ```

- **Formatting:** `pre-commit run --files <changed>` clean (clang-format v14).
- **CPU presets not run, by design:** the only non-`.cu`/`.cuh` change is inside
  `#if defined(UNI_GPU)`, so this commit cannot affect a CPU build. CI's
  `ci-cmake_tests` covers that gate.

No automated regression test accompanies this. Reproducing the bug requires
building the whole library for an architecture the running device cannot execute,
which is not something the test suite can set up — hence the manual
demonstration above.

## Scope

Relates to #1171; does **not** close it. Part 1 of that issue — the multi-arch
`CMAKE_CUDA_ARCHITECTURES` default emitting LTO IR that is never device-linked —
is untouched and still wants a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
